### PR TITLE
Include missing "using namespace std"

### DIFF
--- a/examples/blas/blas_utils.hpp
+++ b/examples/blas/blas_utils.hpp
@@ -4,6 +4,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+using namespace std;
+
 namespace sw {
 	namespace blas {
 


### PR DESCRIPTION
`blas_utils.hpp` was using `cout` and `endl` without reference to the C++ namespace that defines them (`std`).  This caused the C++ compiler (I'm using GCC 7.2.0 on Ubuntu 17.10) to abort with a bunch of error messages.