### PR TITLE
Fix compile error due to missing header includes

### DIFF
--- a/bitset/bitset_helpers.hpp
+++ b/bitset/bitset_helpers.hpp
@@ -7,6 +7,10 @@
 
 // number representation is sign-magnitude, sign is msb
 
+#include <bitset>
+#include <sstream>
+
+
 namespace sw {
 	namespace unum {
 		template<size_t sign_magnitude>


### PR DESCRIPTION
Sample error:
universal.git/posit/../bitset/bitset_helpers.hpp:13:8: error: ‘bitset’ in namespace ‘std’ does not name a template type