### PR TITLE
Adding 48bit extended standard posit test suite

### DIFF
--- a/tests/posit/16bit_posit.cpp
+++ b/tests/posit/16bit_posit.cpp
@@ -1,6 +1,6 @@
 // 16bit_posit.cpp: Functionality tests for standard 16-bit posits
 //
-// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
@@ -16,29 +16,30 @@ using namespace std;
 using namespace sw::unum;
 
 /*
-Standard posits with nbits = 16 have 1 exponent bit.
+Standard posit with nbits = 16 have es = 1 exponent bit.
 */
 
 int main(int argc, char** argv)
 try {
-	const size_t RND_TEST_CASES = 250000;
+	const size_t RND_TEST_CASES = 500000;
 
 	const size_t nbits = 16;
 	const size_t es = 1;
 
 	int nrOfFailedTestCases = 0;
-	bool bReportIndividualTestCases = true;
+	bool bReportIndividualTestCases = false;
 	std::string tag = " posit<16,1>";
 
 	cout << "Standard posit<16,1> configuration tests" << endl;
+
 	posit<nbits, es> p;
 	cout << spec_to_string(p) << endl << endl;
 
 	cout << "Arithmetic tests " << RND_TEST_CASES << " randoms each" << endl;
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<16, 1>(tag, bReportIndividualTestCases, OPCODE_ADD, RND_TEST_CASES), tag, "addition      ");
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<16, 1>(tag, bReportIndividualTestCases, OPCODE_SUB, RND_TEST_CASES), tag, "subtraction   ");
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<16, 1>(tag, bReportIndividualTestCases, OPCODE_MUL, RND_TEST_CASES), tag, "multiplication");
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<16, 1>(tag, bReportIndividualTestCases, OPCODE_DIV, RND_TEST_CASES), tag, "division      ");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_ADD, RND_TEST_CASES), tag, "addition      ");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_SUB, RND_TEST_CASES), tag, "subtraction   ");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_MUL, RND_TEST_CASES), tag, "multiplication");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_DIV, RND_TEST_CASES), tag, "division      ");
 
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/tests/posit/32bit_posit.cpp
+++ b/tests/posit/32bit_posit.cpp
@@ -1,6 +1,6 @@
 // 32bit_posit.cpp: Functionality tests for standard 32-bit posits
 //
-// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
@@ -16,29 +16,30 @@ using namespace std;
 using namespace sw::unum;
 
 /*
-Standard posits with nbits = 32 have 2 exponent bits.
+Standard posit with nbits = 32 have es = 2 exponent bits.
 */
 
 int main(int argc, char** argv)
 try {
-	const size_t RND_TEST_CASES = 100000;
+	const size_t RND_TEST_CASES = 200000;
 
-    const size_t nbits = 32;
-    const size_t es = 2;
+	const size_t nbits = 32;
+	const size_t es = 2;
 
 	int nrOfFailedTestCases = 0;
 	bool bReportIndividualTestCases = false;
 	std::string tag = " posit<32,2>";
 
 	cout << "Standard posit<32,2> configuration tests" << endl;
-    posit<nbits,es> p;
+
+	posit<nbits, es> p;
 	cout << spec_to_string(p) << endl << endl;
 
 	cout << "Arithmetic tests " << RND_TEST_CASES << " randoms each" << endl;
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<32, 2>(tag, bReportIndividualTestCases, OPCODE_ADD, RND_TEST_CASES), tag, "addition      ");
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<32, 2>(tag, bReportIndividualTestCases, OPCODE_SUB, RND_TEST_CASES), tag, "subtraction   ");
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<32, 2>(tag, bReportIndividualTestCases, OPCODE_MUL, RND_TEST_CASES), tag, "multiplication");
-	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<32, 2>(tag, bReportIndividualTestCases, OPCODE_DIV, RND_TEST_CASES), tag, "division      ");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_ADD, RND_TEST_CASES), tag, "addition      ");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_SUB, RND_TEST_CASES), tag, "subtraction   ");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_MUL, RND_TEST_CASES), tag, "multiplication");
+	nrOfFailedTestCases += ReportTestResult(ValidateThroughRandoms<nbits, es>(tag, bReportIndividualTestCases, OPCODE_DIV, RND_TEST_CASES), tag, "division      ");
 
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/tests/posit/48bit_posit.cpp
+++ b/tests/posit/48bit_posit.cpp
@@ -1,4 +1,4 @@
-// 64bit_posit.cpp: Functionality tests for standard 64-bit posits
+// 48bit_posit.cpp: Functionality tests for extended standard 48-bit posits
 //
 // Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
@@ -16,21 +16,21 @@ using namespace std;
 using namespace sw::unum;
 
 /*
-Standard posit with nbits = 64 have es = 3 exponent bits.
+Extended Standard posit with nbits = 48 have es = 2 exponent bits.
 */
 
 int main(int argc, char** argv)
 try {
-	const size_t RND_TEST_CASES = 100000;
+	const size_t RND_TEST_CASES = 150000;
 
-	const size_t nbits = 64;
-	const size_t es = 3;
+	const size_t nbits = 48;
+	const size_t es = 2;
 
 	int nrOfFailedTestCases = 0;
 	bool bReportIndividualTestCases = false;
-	std::string tag = " posit<64,3>";
+	std::string tag = " posit<48,2>";
 
-	cout << "Standard posit<64,3> configuration tests" << endl;
+	cout << "Extended Standard posit<48,2> configuration tests" << endl;
 
 	posit<nbits, es> p;
 	cout << spec_to_string(p) << endl << endl;
@@ -51,3 +51,4 @@ catch (...) {
 	cerr << "Caught unknown exception" << endl;
 	return EXIT_FAILURE;
 }
+

--- a/tests/posit/8bit_posit.cpp
+++ b/tests/posit/8bit_posit.cpp
@@ -1,6 +1,6 @@
 // 8bit_posit.cpp: Functionality tests for standard 8-bit posits
 //
-// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
@@ -16,31 +16,31 @@ using namespace std;
 using namespace sw::unum;
 
 /*
-Standard posits with nbits = 8 have no exponent bits.
+Standard posits with nbits = 8 have no exponent bits, i.e. es = 0.
 */
 
 int main(int argc, char** argv)
 try {
+	const size_t RND_TEST_CASES = 0;  // no randoms, 8-bit posits can be done exhaustively
+
 	const size_t nbits = 8;
 	const size_t es = 0;
 
 	int nrOfFailedTestCases = 0;
 	bool bReportIndividualTestCases = false;
-
 	std::string tag = " posit<8,0>";
 
 	cout << "Standard posit<8,0> configuration tests" << endl;
 
-    posit<nbits,es> p;
-
+	posit<nbits,es> p;
 	cout << spec_to_string(p) << endl;
 
-	nrOfFailedTestCases = ReportTestResult(ValidateAddition<8,0>       (tag, bReportIndividualTestCases), tag, "add        ") ;
-	nrOfFailedTestCases = ReportTestResult(ValidateSubtraction<8, 0>   (tag, bReportIndividualTestCases), tag, "subtract   ");
-	nrOfFailedTestCases = ReportTestResult(ValidateMultiplication<8, 0>(tag, bReportIndividualTestCases), tag, "multiply   ");
-	nrOfFailedTestCases = ReportTestResult(ValidateDivision<8, 0>      (tag, bReportIndividualTestCases), tag, "divide     ");
-	nrOfFailedTestCases = ReportTestResult(ValidateNegation<8, 0>      (tag, bReportIndividualTestCases), tag, "negate     ");
-	nrOfFailedTestCases = ReportTestResult(ValidateReciprocation<8, 0> (tag, bReportIndividualTestCases), tag, "reciprocate");
+	nrOfFailedTestCases = ReportTestResult( ValidateAddition      <nbits, es>(tag, bReportIndividualTestCases), tag, "add        ") ;
+	nrOfFailedTestCases = ReportTestResult( ValidateSubtraction   <nbits, es>(tag, bReportIndividualTestCases), tag, "subtract   ");
+	nrOfFailedTestCases = ReportTestResult( ValidateMultiplication<nbits, es>(tag, bReportIndividualTestCases), tag, "multiply   ");
+	nrOfFailedTestCases = ReportTestResult( ValidateDivision      <nbits, es>(tag, bReportIndividualTestCases), tag, "divide     ");
+	nrOfFailedTestCases = ReportTestResult( ValidateNegation      <nbits, es>(tag, bReportIndividualTestCases), tag, "negate     ");
+	nrOfFailedTestCases = ReportTestResult( ValidateReciprocation <nbits, es>(tag, bReportIndividualTestCases), tag, "reciprocate");
 
 
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);


### PR DESCRIPTION
Adding a test suite for the extended standard posit configuration of posit<48, 2>.

There are consistent failures of posits bigger than 32, and this creates a mechanism to root cause and regression test any modifications to the core algorithms.