### PR TITLE
Adding arithmetic literals

### DIFF
--- a/posit/posit
+++ b/posit/posit
@@ -7,6 +7,8 @@
 #ifndef _POSIT_
 #define _POSIT_
 
+// enable/disable the ability to use literals in binary logic and arithmetic operators
+#define POSIT_ENABLE_LITERALS 1
 #include "posit.hpp"
 #include "posit_manipulators.hpp"
 #include "posit_functions.hpp"

--- a/posit/posit.hpp
+++ b/posit/posit.hpp
@@ -83,6 +83,9 @@ template<size_t nbits, size_t es> posit<nbits, es> sqrt(const posit<nbits, es>& 
 // The symbol NAR can be used to initialize a posit, i.e., posit<nbits,es>(NAR), or posit<nbits,es> p = NAR
 #define NAR INFINITY
 
+// define to non-zero if you want to enable arithmetic and logic literals
+// POSIT_ENABLE_LITERALS
+
 /*
  class posit represents arbitrary configuration posits and their basic arithmetic operations (add/sub, mul/div)
  */
@@ -279,6 +282,9 @@ public:
 		}
 		return *this;                
 	}
+	posit<nbits, es>& operator+=(double rhs) {
+		return *this += posit<nbits, es>(rhs);
+	}
 	posit<nbits, es>& operator-=(const posit& rhs) {
 		if (_trace_sub) std::cout << "---------------------- SUB -------------------" << std::endl;
 		// special case handling of the inputs
@@ -311,6 +317,9 @@ public:
 			convert(difference);
 		}
 		return *this;
+	}
+	posit<nbits, es>& operator-=(double rhs) {
+		return *this -= posit<nbits, es>(rhs);
 	}
 	posit<nbits, es>& operator*=(const posit& rhs) {
 		static_assert(fhbits > 0, "posit configuration does not support multiplication");
@@ -345,6 +354,9 @@ public:
 			convert(product);
 		}
 		return *this;
+	}
+	posit<nbits, es>& operator*=(double rhs) {
+		return *this *= posit<nbits, es>(rhs);
 	}
 	posit<nbits, es>& operator/=(const posit& rhs) {
 		if (_trace_div) std::cout << "---------------------- DIV -------------------" << std::endl;
@@ -384,6 +396,9 @@ public:
 		}
 
 		return *this;
+	}
+	posit<nbits, es>& operator/=(double rhs) {
+		return *this /= posit<nbits, es>(rhs);
 	}
 	posit<nbits, es>& operator++() {
 		increment_posit();
@@ -983,6 +998,7 @@ private:
 	template<size_t nnbits, size_t ees>
 	friend bool operator>=(const posit<nnbits, ees>& lhs, const posit<nnbits, ees>& rhs);
 
+#if POSIT_ENABLE_LITERALS
 	// posit - literal logic functions
 	// posit - int
 	template<size_t nnbits, size_t ees>
@@ -1010,6 +1026,8 @@ private:
 	friend bool operator<=(const posit<nnbits, ees>& lhs, double rhs);
 	template<size_t nnbits, size_t ees>
 	friend bool operator>=(const posit<nnbits, ees>& lhs, double rhs);
+#endif // POSIT_ENABLE_LITERALS
+
 };
 
 ////////////////// POSIT operators
@@ -1036,36 +1054,68 @@ inline std::istream& operator>> (std::istream& istr, const posit<nbits, es>& p) 
 	return istr;
 }
 
-// posit - posit logic operators
+// posit - posit binary logic operators
 template<size_t nbits, size_t es>
-inline bool operator==(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) { 
+inline bool operator==(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
 	return lhs._raw_bits == rhs._raw_bits;
 }
 template<size_t nbits, size_t es>
-inline bool operator!=(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) { 
-	return !operator==(lhs, rhs); 
+inline bool operator!=(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	return !operator==(lhs, rhs);
 }
 template<size_t nbits, size_t es>
 inline bool operator< (const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
-	return lessThan(lhs._raw_bits, rhs._raw_bits); 
+	return lessThan(lhs._raw_bits, rhs._raw_bits);
 }
 template<size_t nbits, size_t es>
-inline bool operator> (const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) { 
-	return operator< (rhs, lhs); 
+inline bool operator> (const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	return operator< (rhs, lhs);
 }
 template<size_t nbits, size_t es>
-inline bool operator<=(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) { 
-	return operator< (lhs, rhs) || operator==(lhs, rhs); 
+inline bool operator<=(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<size_t nbits, size_t es>
-inline bool operator>=(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) { 
-	return !operator< (lhs, rhs); 
+inline bool operator>=(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	return !operator< (lhs, rhs);
 }
+
+// posit - posit binary arithmetic operators
+// BINARY ADDITION
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator+(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	posit<nbits, es> sum = lhs;
+	sum += rhs;
+	return sum;
+}
+// BINARY SUBTRACTION
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator-(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	posit<nbits, es> diff = lhs;
+	diff -= rhs;
+	return diff;
+}
+// BINARY MULTIPLICATION
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator*(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	posit<nbits, es> mul = lhs;
+	mul *= rhs;
+	return mul;
+}
+// BINARY DIVISION
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator/(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+	posit<nbits, es> ratio = lhs;
+	ratio /= rhs;
+	return ratio;
+}
+
+#if POSIT_ENABLE_LITERALS
 
 // posit - literal int logic operators
 template<size_t nbits, size_t es>
 inline bool operator==(const posit<nbits, es>& lhs, int rhs) {
-	return lhs == posit<nbits,es>(rhs);
+	return lhs == posit<nbits, es>(rhs);
 }
 template<size_t nbits, size_t es>
 inline bool operator!=(const posit<nbits, es>& lhs, int rhs) {
@@ -1088,7 +1138,7 @@ inline bool operator>=(const posit<nbits, es>& lhs, int rhs) {
 	return !operator<(lhs, posit<nbits, es>(rhs));
 }
 
-// posit - literal int logic operators
+// posit - literal double logic operators
 template<size_t nbits, size_t es>
 inline bool operator==(const posit<nbits, es>& lhs, double rhs) {
 	return lhs == posit<nbits, es>(rhs);
@@ -1114,34 +1164,61 @@ inline bool operator>=(const posit<nbits, es>& lhs, double rhs) {
 	return !operator<(lhs, posit<nbits, es>(rhs));
 }
 
-// POSIT BINARY ARITHMETIC OPERATORS
+// BINARY ADDITION
 template<size_t nbits, size_t es>
-inline posit<nbits, es> operator+(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+inline posit<nbits, es> operator+(const posit<nbits, es>& lhs, double rhs) {
+	posit<nbits, es> sum = lhs;
+	sum += rhs;
+	return sum;
+}
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator+(double lhs, const posit<nbits, es>& rhs) {
 	posit<nbits, es> sum = lhs;
 	sum += rhs;
 	return sum;
 }
 
+// BINARY SUBTRACTION
 template<size_t nbits, size_t es>
-inline posit<nbits, es> operator-(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+inline posit<nbits, es> operator-(double lhs, const posit<nbits, es>& rhs) {
+	posit<nbits, es> sum = lhs;
+	sum -= rhs;
+	return sum;
+}
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator-(const posit<nbits, es>& lhs, double rhs) {
 	posit<nbits, es> diff = lhs;
 	diff -= rhs;
 	return diff;
 }
-
+// BINARY MULTIPLICATION
 template<size_t nbits, size_t es>
-inline posit<nbits, es> operator*(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+inline posit<nbits, es> operator*(double lhs, const posit<nbits, es>& rhs) {
+	posit<nbits, es> sum = lhs;
+	sum *= rhs;
+	return sum;
+}
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator*(const posit<nbits, es>& lhs, double rhs) {
 	posit<nbits, es> mul = lhs;
 	mul *= rhs;
 	return mul;
 }
-
+// BINARY DIVISION
 template<size_t nbits, size_t es>
-inline posit<nbits, es> operator/(const posit<nbits, es>& lhs, const posit<nbits, es>& rhs) {
+inline posit<nbits, es> operator/(double lhs, const posit<nbits, es>& rhs) {
+	posit<nbits, es> sum = lhs;
+	sum /= rhs;
+	return sum;
+}
+template<size_t nbits, size_t es>
+inline posit<nbits, es> operator/(const posit<nbits, es>& lhs, double rhs) {
 	posit<nbits, es> ratio = lhs;
 	ratio /= rhs;
 	return ratio;
 }
+
+#endif // POSIT_ENABLE_LITERALS
 
 /// Magnitude of a posit (equivalent to turning the sign bit off).
 template<size_t nbits, size_t es> 

--- a/tests/posit/arithmetic_literals.cpp
+++ b/tests/posit/arithmetic_literals.cpp
@@ -1,0 +1,241 @@
+// arithmetic_literals.cpp: functional tests for addition
+//
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include "stdafx.h"
+
+// when you define POSIT_VERBOSE_OUTPUT executing an ADD the code will print intermediate results
+//#define POSIT_VERBOSE_OUTPUT
+#define POSIT_TRACE_ADD
+
+// minimum set of include files to reflect source code dependencies
+#include "../../bitset/bitset_helpers.hpp"
+// enable/disable the ability to use literals in binary logic and arithmetic operators
+#define POSIT_ENABLE_LITERALS 1
+#include "../../posit/posit.hpp"
+#include "../../posit/posit_manipulators.hpp"
+// generic and posit test helper functions
+#include "../tests/test_helpers.hpp"
+#include "../tests/posit_test_helpers.hpp"
+
+using namespace std;
+using namespace sw::unum;
+
+// enumerate all addition cases for a posit configuration: is within 10sec till about nbits = 14
+template<size_t nbits, size_t es>
+int ValidateAdditionWithLiteral(std::string tag, bool bReportIndividualTestCases) {
+	const int NR_POSITS = (unsigned(1) << nbits);
+	int nrOfFailedTests = 0;
+	posit<nbits, es> pa, pb, psum1, psum2, pref;
+
+	double da, db;
+	for (int i = 0; i < NR_POSITS; i++) {
+		pa.set_raw_bits(i);
+		da = double(pa);
+		for (int j = 0; j < NR_POSITS; j++) {
+			pb.set_raw_bits(j);
+			db = double(pb);
+			psum1 = pa + db;
+			psum2 = da + pb;
+			pref = da + db;
+			if (psum1 != pref || psum2 != pref || psum1 != psum2) {
+				nrOfFailedTests++;
+				if (bReportIndividualTestCases)	ReportBinaryArithmeticError("FAIL", "+", pa, pb, pref, psum1);
+			}
+			else {
+				//if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", "+", pa, pb, pref, psum1);
+			}
+		}
+	}
+
+	return nrOfFailedTests;
+}
+
+// enumerate all subtraction cases for a posit configuration
+template<size_t nbits, size_t es>
+int ValidateSubtractionWithLiteral(std::string tag, bool bReportIndividualTestCases) {
+	const int NR_POSITS = (unsigned(1) << nbits);
+	int nrOfFailedTests = 0;
+	posit<nbits, es> pa, pb, pdiff1, pdiff2, pref;
+
+	double da, db;
+	for (int i = 0; i < NR_POSITS; i++) {
+		pa.set_raw_bits(i);
+		da = double(pa);
+		for (int j = 0; j < NR_POSITS; j++) {
+			pb.set_raw_bits(j);
+			db = double(pb);
+			pdiff1 = pa - db;
+			pdiff2 = da - pb;
+			pref = da - db;
+			if (pdiff1 != pref || pdiff2 != pref || pdiff1 != pdiff2) {
+				nrOfFailedTests++;
+				if (bReportIndividualTestCases)	ReportBinaryArithmeticError("FAIL", "-", pa, pb, pref, pdiff1);
+			}
+			else {
+				//if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", "-", pa, pb, pref, pdiff1);
+			}
+		}
+	}
+
+	return nrOfFailedTests;
+}
+
+// enumerate all multiplication cases for a posit configuration
+template<size_t nbits, size_t es>
+int ValidateMultiplicationWithLiteral(std::string tag, bool bReportIndividualTestCases) {
+	const int NR_POSITS = (unsigned(1) << nbits);
+	int nrOfFailedTests = 0;
+	posit<nbits, es> pa, pb, pmul1, pmul2, pref;
+
+	double da, db;
+	for (int i = 0; i < NR_POSITS; i++) {
+		pa.set_raw_bits(i);
+		da = double(pa);
+		for (int j = 0; j < NR_POSITS; j++) {
+			pb.set_raw_bits(j);
+			db = double(pb);
+			pmul1 = pa * db;
+			pmul2 = da * pb;
+			pref = da * db;
+			if (pmul1 != pref || pmul2 != pref || pmul1 != pmul2) {
+				nrOfFailedTests++;
+				if (bReportIndividualTestCases)	ReportBinaryArithmeticError("FAIL", "*", pa, pb, pref, pmul1);
+			}
+			else {
+				//if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", "*", pa, pb, pref, pmul1);
+			}
+		}
+	}
+
+	return nrOfFailedTests;
+}
+
+// enumerate all division cases for a posit configuration
+template<size_t nbits, size_t es>
+int ValidateDivisionWithLiteral(std::string tag, bool bReportIndividualTestCases) {
+	const int NR_POSITS = (unsigned(1) << nbits);
+	int nrOfFailedTests = 0;
+	posit<nbits, es> pa, pb, pdiv1, pdiv2, pref;
+
+	double da, db;
+	for (int i = 0; i < NR_POSITS; i++) {
+		pa.set_raw_bits(i);
+		da = double(pa);
+		for (int j = 0; j < NR_POSITS; j++) {
+			pb.set_raw_bits(j);
+			db = double(pb);
+			pdiv1 = pa / db;
+			pdiv2 = da / pb;
+			pref = da / db;
+			if (pdiv1 != pref || pdiv2 != pref || pdiv1 != pdiv2) {
+				nrOfFailedTests++;
+				if (bReportIndividualTestCases)	ReportBinaryArithmeticError("FAIL", "+", pa, pb, pref, pdiv1);
+			}
+			else {
+				//if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", "+", pa, pb, pref, pdiv1);
+			}
+		}
+	}
+
+	return nrOfFailedTests;
+}
+
+// generate specific test case that you can trace with the trace conditions in posit.h
+// for most bugs they are traceable with _trace_conversion and _trace_add
+template<size_t nbits, size_t es, typename Ty>
+void GenerateTestCase(Ty a, Ty b) {
+	Ty ref;
+	posit<nbits, es> pa, pb, pref, psum;
+	pa = a;
+	pb = b;
+	ref = a + b;
+	pref = ref;
+	psum = pa + pb;
+	std::cout << std::setprecision(nbits - 2);
+	std::cout << std::setw(nbits) << a << " + " << std::setw(nbits) << b << " = " << std::setw(nbits) << ref << std::endl;
+	std::cout << pa.get() << " + " << pb.get() << " = " << psum.get() << " (reference: " << pref.get() << ")   " ;
+	std::cout << (pref == psum ? "PASS" : "FAIL") << std::endl << std::endl;
+	std::cout << std::setprecision(5);
+}
+
+#define MANUAL_TESTING 0
+#define STRESS_TESTING 0
+
+int main(int argc, char** argv)
+try {
+	bool bReportIndividualTestCases = false;
+	int nrOfFailedTestCases = 0;
+
+	std::string tag = "Arithmetic with literals failed: ";
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+	GenerateTestCase<6, 3, double>(INFINITY, INFINITY);
+	GenerateTestCase<8, 4, float>(0.5f, -0.5f);
+	GenerateTestCase<3, 0>(0.5f, 1.0f);
+
+	constexpr double m_pi = 3.14159265358979323846;
+
+	posit<16, 1> p;
+	p += m_pi;
+	cout << p << endl;
+	p -= m_pi;
+	cout << p << endl;
+
+	// manual exhaustive test
+	nrOfFailedTestCases += ReportTestResult(ValidateAdditionWithLiteral<8, 2>("Manual Testing", true), "posit<8,2>", "addition with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtractionWithLiteral<8, 2>("Manual Testing", true), "posit<8,2>", "subtraction with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplicationWithLiteral<8, 2>("Manual Testing", true), "posit<8,2>", "multiplication with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivisionWithLiteral<8, 2>("Manual Testing", true), "posit<8,2>", "division with literal");
+
+#else
+
+	cout << "Posit addition validation" << endl;
+
+	nrOfFailedTestCases += ReportTestResult(ValidateAdditionWithLiteral<8, 0>(tag, bReportIndividualTestCases), "posit<8,0>", "addition with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateAdditionWithLiteral<8, 1>(tag, bReportIndividualTestCases), "posit<8,1>", "addition with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateAdditionWithLiteral<8, 2>(tag, bReportIndividualTestCases), "posit<8,2>", "addition with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateAdditionWithLiteral<8, 3>(tag, bReportIndividualTestCases), "posit<8,3>", "addition with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateAdditionWithLiteral<8, 4>(tag, bReportIndividualTestCases), "posit<8,4>", "addition with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateAdditionWithLiteral<8, 5>(tag, bReportIndividualTestCases), "posit<8,5>", "addition with literal");
+
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtractionWithLiteral<8, 0>(tag, bReportIndividualTestCases), "posit<8,0>", "subtraction with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtractionWithLiteral<8, 1>(tag, bReportIndividualTestCases), "posit<8,1>", "subtraction with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtractionWithLiteral<8, 2>(tag, bReportIndividualTestCases), "posit<8,2>", "subtraction with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtractionWithLiteral<8, 3>(tag, bReportIndividualTestCases), "posit<8,3>", "subtraction with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtractionWithLiteral<8, 4>(tag, bReportIndividualTestCases), "posit<8,4>", "subtraction with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtractionWithLiteral<8, 5>(tag, bReportIndividualTestCases), "posit<8,5>", "subtraction with literal");
+
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplicationWithLiteral<8, 0>(tag, bReportIndividualTestCases), "posit<8,0>", "multiplication with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplicationWithLiteral<8, 1>(tag, bReportIndividualTestCases), "posit<8,1>", "multiplication with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplicationWithLiteral<8, 2>(tag, bReportIndividualTestCases), "posit<8,2>", "multiplication with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplicationWithLiteral<8, 3>(tag, bReportIndividualTestCases), "posit<8,3>", "multiplication with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplicationWithLiteral<8, 4>(tag, bReportIndividualTestCases), "posit<8,4>", "multiplication with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplicationWithLiteral<8, 5>(tag, bReportIndividualTestCases), "posit<8,5>", "multiplication with literal");
+
+	nrOfFailedTestCases += ReportTestResult(ValidateDivisionWithLiteral<8, 0>(tag, bReportIndividualTestCases), "posit<8,0>", "division with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivisionWithLiteral<8, 1>(tag, bReportIndividualTestCases), "posit<8,1>", "division with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivisionWithLiteral<8, 2>(tag, bReportIndividualTestCases), "posit<8,2>", "division with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivisionWithLiteral<8, 3>(tag, bReportIndividualTestCases), "posit<8,3>", "division with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivisionWithLiteral<8, 4>(tag, bReportIndividualTestCases), "posit<8,4>", "division with literal");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivisionWithLiteral<8, 5>(tag, bReportIndividualTestCases), "posit<8,5>", "division with literal");
+
+#if STRESS_TESTING
+
+#endif  // STRESS_TESTING
+
+#endif  // MANUAL_TESTING
+
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	cerr << msg << endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	cerr << "Caught unknown exception" << endl;
+	return EXIT_FAILURE;
+}

--- a/tests/posit/logic.cpp
+++ b/tests/posit/logic.cpp
@@ -7,6 +7,7 @@
 #include "stdafx.h"
 
 // minimum set of include files to reflect source code dependencies
+#define POSIT_ENABLE_LITERALS 1
 #include "../../posit/posit.hpp"
 #include "../tests/test_helpers.hpp"
 

--- a/tests/posit_test_helpers.hpp
+++ b/tests/posit_test_helpers.hpp
@@ -438,7 +438,7 @@ namespace sw {
 						if (bReportIndividualTestCases)	ReportBinaryArithmeticError("FAIL", "+", pa, pb, pref, psum);
 					}
 					else {
-						if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", "+", pa, pb, pref, psum);
+						//if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", "+", pa, pb, pref, psum);
 					}
 				}
 			}


### PR DESCRIPTION
adding binary arithmetic operator overloads to enable implicit conversions of a literal to a specific posit. This enables algebraic equations like this:

p /= 2;
p = p * 2;
etc.

By default the overloads are enabled in the posit library when including <posit> and disabled when include "posit.hpp". 