### PR TITLE
Quire

### DIFF
--- a/posit/posit.hpp
+++ b/posit/posit.hpp
@@ -78,6 +78,8 @@ namespace sw {
 template<size_t nbits, size_t es> class posit;
 template<size_t nbits, size_t es> posit<nbits, es> abs(const posit<nbits, es>& p);
 template<size_t nbits, size_t es> posit<nbits, es> sqrt(const posit<nbits, es>& p);
+template<size_t nbits, size_t es> posit<nbits, es> minpos();
+template<size_t nbits, size_t es> posit<nbits, es> maxpos();
 
 // Not A Real is the posit encoding for INFINITY and arithmetic errors that can propagate
 // The symbol NAR can be used to initialize a posit, i.e., posit<nbits,es>(NAR), or posit<nbits,es> p = NAR
@@ -874,9 +876,17 @@ public:
 	// Generalized version
 	template <size_t FBits>
 	inline void convert(const value<FBits>& v) {
+		if (v.isZero()) {
+			setToZero();
+			return;
+		}
+		if (v.isNaN() || v.isInfinite()) {
+			setToNaR();
+			return;
+		}
 		convert(v.sign(), v.scale(), v.fraction());
     }
-
+	// convert assumes that ZERO and NaR cases are handled. Only non-zero and non-NaR values are allowed.
 	template<size_t input_fbits>
 	void convert(bool sign, int scale, std::bitset<input_fbits> input_fraction) {
 		clear();
@@ -1238,10 +1248,27 @@ inline posit<nbits, es> operator/(const posit<nbits, es>& lhs, double rhs) {
 
 #endif // POSIT_ENABLE_LITERALS
 
-/// Magnitude of a posit (equivalent to turning the sign bit off).
+// Magnitude of a posit (equivalent to turning the sign bit off).
 template<size_t nbits, size_t es> 
 posit<nbits, es> abs(const posit<nbits, es>& p) {
     return posit<nbits, es>(false, p.get_regime(), p.get_exponent(), p.get_fraction());
+}
+
+// generate a posit representing minpos
+template<size_t nbits, size_t es>
+posit<nbits, es> minpos() {
+	posit<nbits, es> p;
+	p++;
+	return p;
+}
+
+// generate a posit representing maxpos
+template<size_t nbits, size_t es>
+posit<nbits, es> maxpos() {
+	posit<nbits, es> p;
+	p.setToNaR();
+	--p;
+	return p;
 }
 
 // QUIRE OPERATORS

--- a/posit/quire.hpp
+++ b/posit/quire.hpp
@@ -18,7 +18,7 @@ public:
 	static constexpr size_t range = escale * (4 * nbits - 8); // dynamic range of the posit configuration
 	static constexpr size_t half_range = range >> 1;          // position of the fixed point
 	static constexpr size_t upper_range = half_range + 1;     // size of the upper accumulator
-	static constexpr size_t qbits = range + capacity;         // size of the quire minus the sign bit: we are managing the sign explicitly
+	static constexpr size_t qbits = range + capacity;     // size of the quire minus the sign bit: we are managing the sign explicitly
 	
 	quire() : _sign(false), _capacity(0), _upper(0), _lower(0) {}
 	quire(int8_t initial_value) {
@@ -419,6 +419,23 @@ public:
 	// Return value of the sign bit: true indicates a negative number, false a positive number or zero
 	bool get_sign() const { return _sign; }
 	float sign_value() const {	return (_sign ? -1.0 : 1.0); }
+	std::bitset<qbits+1> get() const {
+		std::bitset<qbits+1> q;
+		int msb = 0;
+		for (int i = 0; i < half_range; i++) {
+			q[msb] = _lower[i];
+			msb++;
+		}
+		for (int i = 0; i < upper_range; i++) {
+			q[msb] = _upper[i];
+			msb++;
+		}
+		for (int i = 0; i < capacity; i++) {
+			q[msb] = _capacity[i];
+			msb++;
+		}
+		return q;
+	}
 	value<qbits> to_value() const {
 		// find the MSB and build the fraction
 		std::bitset<qbits> fraction;

--- a/tests/posit/quire_accumulation.cpp
+++ b/tests/posit/quire_accumulation.cpp
@@ -1,19 +1,35 @@
 ﻿//  quire_accumulations.cpp : computational path experiments with quires
 //
-// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "stdafx.h"
 
+// set to 1 if you want to generate hw test vectors
+#define HARDWARE_QA_OUTPUT 0
+
+// type definitions for the important types, posit<> and quire<>
 #include "../../posit/posit.hpp"
 #include "../../posit/quire.hpp"
+// test support functions
+#include "../tests/test_helpers.hpp"
+#include "../tests/posit_test_helpers.hpp"
+#include "../tests/quire_test_helpers.hpp"
+
 
 using namespace std;
 using namespace sw::unum;
 
+template<size_t nbits, size_t es>
+void PrintTestVector(std::ostream& ostr, const std::vector< posit<nbits,es> >& pv) {
+	for (std::vector< posit<nbits,es> >::const_iterator it = pv.begin(); it != pv.end(); it++) {
+		ostr << *it << std::endl;
+	}
+}
 
-#define MANUAL_TESTING 1
+
+#define MANUAL_TESTING 0
 #define STRESS_TESTING 0
 
 int main()
@@ -21,32 +37,35 @@ try {
 	bool bReportIndividualTestCases = false;
 	int nrOfFailedTestCases = 0;
 
+	cout << "Quire experiments" << endl;
+
 	std::string tag = "Quire Accumulation failed";
 
 #if MANUAL_TESTING
-	const size_t nbits = 8;
-	const size_t es = 1;
-	const size_t capacity = 2; // for testing the accumulation capacity of the quire can be small
-	const size_t fbits = 5;
+	std::vector< posit<16, 1> > t;
 
-	posit<nbits, es> p1, p2, minpos, maxpos;
-	quire<nbits, es, 2> q1, q2;
-	p1 = 1; ++p1;
-	p2 = 1; --p2;
-	std::cout << "p1 : " << p1 << " p2 : " << p2 << endl;
-	//q1 += p1 + p2;    // if we allow posits to be added
-	q1 += (p1 + p2).convert_to_scientific_notation();  // if we force scientific values (sign, scale, fraction) inputs
-	cout << "q  : " << q1 << endl;
-	minpos = 0; ++minpos;
-	maxpos = INFINITY; --maxpos;
-	cout << "minpos : " << minpos << " maxpos : " << maxpos << endl;
-	cout << "minpos * p1 = " << minpos * p1 << " minpos * p2 = " << minpos * p2 << endl;
-	q2 += (maxpos * (minpos * p1 + minpos * p2)).convert_to_scientific_notation();
-	cout << "q  : " << q2 << endl;
+//	t = GenerateVectorForZeroValueFDP(16, maxpos<16,1>());
+//	PrintTestVector(cout, t);
+
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 1, 2>(bReportIndividualTestCases, 16, minpos<8,1>()), "quire<8,1,2>", "accumulation");
+
 #else
 
-	cout << "Quire experiments" << endl;
-	
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 0, 2>(bReportIndividualTestCases, 16, minpos<8, 0>()), "quire<8,0,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 1, 2>(bReportIndividualTestCases, 16, minpos<8, 1>()), "quire<8,1,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 2, 2>(bReportIndividualTestCases, 16, minpos<8, 2>()), "quire<8,2,2>", "accumulation");
+
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<16, 0, 2>(bReportIndividualTestCases, 256, minpos<16, 0>()), "quire<16,0,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<16, 1, 2>(bReportIndividualTestCases, 256, minpos<16, 1>()), "quire<16,1,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<16, 2, 2>(bReportIndividualTestCases, 256, minpos<16, 2>()), "quire<16,2,2>", "accumulation");
+
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<24, 0, 2>(bReportIndividualTestCases, 4096, minpos<24, 0>()), "quire<24,0,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<24, 1, 2>(bReportIndividualTestCases, 4096, minpos<24, 1>()), "quire<24,1,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<24, 2, 2>(bReportIndividualTestCases, 4096, minpos<24, 2>()), "quire<24,2,2>", "accumulation");
+
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<32, 0, 2>(bReportIndividualTestCases, 65536, minpos<32, 0>()), "quire<32,0,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<32, 1, 2>(bReportIndividualTestCases, 65536, minpos<32, 1>()), "quire<32,1,2>", "accumulation");
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<32, 2, 2>(bReportIndividualTestCases, 65536, minpos<32, 2>()), "quire<32,2,2>", "accumulation");
 
 #ifdef STRESS_TESTING
 

--- a/tests/posit/quire_accumulation.cpp
+++ b/tests/posit/quire_accumulation.cpp
@@ -23,7 +23,7 @@ using namespace sw::unum;
 
 template<size_t nbits, size_t es>
 void PrintTestVector(std::ostream& ostr, const std::vector< posit<nbits,es> >& pv) {
-	for (std::vector< posit<nbits,es> >::const_iterator it = pv.begin(); it != pv.end(); it++) {
+	for (typename std::vector< posit<nbits,es> >::const_iterator it = pv.begin(); it != pv.end(); it++) {
 		ostr << *it << std::endl;
 	}
 }

--- a/tests/posit/quire_accumulation.cpp
+++ b/tests/posit/quire_accumulation.cpp
@@ -28,6 +28,15 @@ void PrintTestVector(std::ostream& ostr, const std::vector< posit<nbits,es> >& p
 	}
 }
 
+template<size_t nbits, size_t es, size_t capacity>
+int GenerateQuireAccumulationTestCase(bool bReportIndividualTestCases, size_t nrOfElements, const posit<nbits,es>& seed) {
+	int nrOfFailedTestCases = 0;
+	std::stringstream ss;
+	ss << "quire<" << nbits << "," << es << "," << capacity << ">";
+	std::vector< posit<nbits, es> > t = GenerateVectorForZeroValueFDP(nrOfElements, seed);
+	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<nbits, es, capacity>(bReportIndividualTestCases, t), ss.str(), "accumulation");
+	return nrOfFailedTestCases;
+}
 
 #define MANUAL_TESTING 0
 #define STRESS_TESTING 0
@@ -47,25 +56,34 @@ try {
 //	t = GenerateVectorForZeroValueFDP(16, maxpos<16,1>());
 //	PrintTestVector(cout, t);
 
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 1, 2>(bReportIndividualTestCases, 16, minpos<8,1>()), "quire<8,1,2>", "accumulation");
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<8, 1, 2>(bReportIndividualTestCases, 16, minpos<8, 1>());
 
 #else
 
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 0, 2>(bReportIndividualTestCases, 16, minpos<8, 0>()), "quire<8,0,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 1, 2>(bReportIndividualTestCases, 16, minpos<8, 1>()), "quire<8,1,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<8, 2, 2>(bReportIndividualTestCases, 16, minpos<8, 2>()), "quire<8,2,2>", "accumulation");
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<8, 0, 2>(bReportIndividualTestCases, 16, minpos<8, 0>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<8, 1, 2>(bReportIndividualTestCases, 16, minpos<8, 1>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<8, 2, 2>(bReportIndividualTestCases, 16, minpos<8, 2>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<8, 0, 5>(bReportIndividualTestCases, 16, maxpos<8, 0>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<8, 1, 5>(bReportIndividualTestCases, 16, maxpos<8, 1>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<8, 2, 5>(bReportIndividualTestCases, 16, maxpos<8, 2>());
 
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<16, 0, 2>(bReportIndividualTestCases, 256, minpos<16, 0>()), "quire<16,0,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<16, 1, 2>(bReportIndividualTestCases, 256, minpos<16, 1>()), "quire<16,1,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<16, 2, 2>(bReportIndividualTestCases, 256, minpos<16, 2>()), "quire<16,2,2>", "accumulation");
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<16, 0, 2>(bReportIndividualTestCases, 256, minpos<16, 0>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<16, 1, 2>(bReportIndividualTestCases, 256, minpos<16, 1>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<16, 2, 2>(bReportIndividualTestCases, 256, minpos<16, 2>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<16, 0, 5>(bReportIndividualTestCases, 16, maxpos<16, 0>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<16, 1, 5>(bReportIndividualTestCases, 16, maxpos<16, 1>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<16, 2, 5>(bReportIndividualTestCases, 16, maxpos<16, 2>());
 
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<24, 0, 2>(bReportIndividualTestCases, 4096, minpos<24, 0>()), "quire<24,0,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<24, 1, 2>(bReportIndividualTestCases, 4096, minpos<24, 1>()), "quire<24,1,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<24, 2, 2>(bReportIndividualTestCases, 4096, minpos<24, 2>()), "quire<24,2,2>", "accumulation");
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<24, 0, 2>(bReportIndividualTestCases, 4096, minpos<24, 0>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<24, 1, 2>(bReportIndividualTestCases, 4096, minpos<24, 1>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<24, 2, 2>(bReportIndividualTestCases, 4096, minpos<24, 2>());
 
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<32, 0, 2>(bReportIndividualTestCases, 65536, minpos<32, 0>()), "quire<32,0,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<32, 1, 2>(bReportIndividualTestCases, 65536, minpos<32, 1>()), "quire<32,1,2>", "accumulation");
-	nrOfFailedTestCases += ReportTestResult(ValidateQuireAccumulation<32, 2, 2>(bReportIndividualTestCases, 65536, minpos<32, 2>()), "quire<32,2,2>", "accumulation");
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<32, 0, 2>(bReportIndividualTestCases, 65536, minpos<32, 0>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<32, 1, 2>(bReportIndividualTestCases, 65536, minpos<32, 1>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<32, 2, 2>(bReportIndividualTestCases, 65536, minpos<32, 2>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<32, 0, 5>(bReportIndividualTestCases, 16, maxpos<32, 0>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<32, 1, 5>(bReportIndividualTestCases, 16, maxpos<32, 1>());
+	nrOfFailedTestCases += GenerateQuireAccumulationTestCase<32, 2, 5>(bReportIndividualTestCases, 16, maxpos<32, 2>());
 
 #ifdef STRESS_TESTING
 

--- a/tests/posit/quires.cpp
+++ b/tests/posit/quires.cpp
@@ -1,40 +1,21 @@
 ﻿//  quires.cpp : test suite for quires
 //
-// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "stdafx.h"
 
-#include "../../posit/bit_functions.hpp"
-#include "../../posit/posit_functions.hpp"
-#include "../../posit/exceptions.hpp"
-#include "../../posit/trace_constants.hpp"
-#include "../../posit/value.hpp"
+// type definitions for the important types, posit<> and quire<>
+#include "../../posit/posit.hpp"
 #include "../../posit/quire.hpp"
+// test support functions
+#include "../tests/quire_test_helpers.hpp"
 
 using namespace std;
 using namespace sw::unum;
 
-int TestQuireAccumulationResult(int nrOfFailedTests, string descriptor)
-{
-	if (nrOfFailedTests > 0) {
-		std::cout << descriptor << " quire accumulation FAIL" << std::endl;
-	}
-	else {
-		std::cout << descriptor << " quire accumulation PASS" << std::endl;
-	}
-	return nrOfFailedTests;
-}
 
-template<size_t nbits, size_t es, size_t capacity>
-int ValidateQuireAccumulation() {
-	const size_t NR_TEST_CASES = size_t(1) << nbits;
-
-	int nrOfFailedTests = 0;
-
-	return nrOfFailedTests;
-}
 
 template<size_t nbits, size_t es, size_t capacity>
 void GenerateTestCase(int input, const quire<nbits, es, capacity>& reference, const quire<nbits, es, capacity>& qresult) {
@@ -42,76 +23,6 @@ void GenerateTestCase(int input, const quire<nbits, es, capacity>& reference, co
 	std::cout << std::endl;
 }
 
-template<size_t nbits, size_t es, size_t capacity>
-void GenerateUnsignedIntAssignments() {
-	quire<nbits, es, capacity> q;
-	unsigned upper_range = q.upper_range();
-	std::cout << "Upper range = " << upper_range << std::endl;
-	uint64_t i;
-	q = 0; std::cout << q << std::endl;
-	unsigned v = 1;
-	for (i = 1; i < uint64_t(1) << (upper_range + capacity); i <<= 1) {
-		q = i;
-		std::cout << q << std::endl;
-	}
-	i <<= 1;
-	try {
-		q = i;
-	}
-	catch (char const* msg) {
-		std::cerr << "Caught the exception: " << msg << ". Value was " << i << std::endl;
-	}
-}
-
-template<size_t nbits, size_t es, size_t capacity>
-void GenerateSignedIntAssignments() {
-	quire<nbits, es, capacity> q;
-	unsigned upper_range = q.upper_range();
-	std::cout << "Upper range = " << upper_range << std::endl;
-	int64_t i, upper_limit = -(int64_t(1) << (upper_range + capacity));
-	q = 0; std::cout << q << std::endl;
-	unsigned v = 1;
-	for (i = -1; i > upper_limit; i *= 2) {
-		q = i;
-		std::cout << q << std::endl;
-	}
-	i <<= 1;
-	try {
-		q = i;
-	}
-	catch (char const* msg) {
-		std::cerr << "Caught the exception: " << msg << ". RHS was " << i << std::endl;
-	}
-}
-
-template<size_t nbits, size_t es, size_t capacity, size_t fbits = 1>
-void GenerateValueAssignments() {
-	quire<nbits, es, capacity> q;
-
-	// report some parameters about the posit and quire configuration
-	int max_scale = q.max_scale();
-	int min_scale = q.min_scale();
-	std::cout << "Maximum scale  = " << max_scale << " Minimum scale  = " << min_scale << " Dynamic range = " << q.dynamic_range() << std::endl;
-	std::cout << "Maxpos Squared = " << maxpos_scale<nbits,es>() * 2 << " Minpos Squared = " << minpos_scale<nbits, es>() * 2 << std::endl;
-
-	// cover the scales with one order outside of the dynamic range of the quire configuration (minpos^2 and maxpos^2)
-	for (int scale = max_scale + 1; scale >= min_scale - 1; scale--) {  // extend by 1 max and min scale to test edge of the quire
-		value<fbits> v = pow(2.0, scale);
-		try {
-			q = v;
-			std::cout << setw(10) << v << q << std::endl;
-			value<q.qbits> r = q.to_value();
-			double in = (double)v;
-			double out = (double)r;
-			if (std::abs(in - out) > 0.0000001) { 
-				std::cerr << "quire value conversion failed: " << components(v) << " != " << components(r) << std::endl; 
-			}
-		}
-		catch (char const* msg) {
-			std::cerr << "Caught the exception: " << msg << ". RHS was " << v << " " << components(v) << std::endl;
-		}
-	}
-}
 
 #define MANUAL_TESTING 1
 #define STRESS_TESTING 0

--- a/tests/posit_test_helpers.hpp
+++ b/tests/posit_test_helpers.hpp
@@ -3,7 +3,7 @@
 //  posit_test_helpers.cpp : functions to aid in testing and test reporting on posit types.
 // Needs to be included after posit type is declared.
 //
-// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <vector>

--- a/tests/quire_test_helpers.hpp
+++ b/tests/quire_test_helpers.hpp
@@ -237,17 +237,15 @@ namespace sw {
 		// use a well-defined set of vectors with a known fused dot-product result
 		// the biggest stress are vectors where the first half is accumulating and the second half is subtracting
 		template<size_t nbits, size_t es, size_t capacity>
-		int ValidateQuireAccumulation(bool bReportIndividualTestCases, size_t vectorSize, const posit<nbits,es>& seed) {
+		int ValidateQuireAccumulation(bool bReportIndividualTestCases, const std::vector< posit<nbits, es> >& t) {
 			int nrOfFailedTests = 0;
 
 			posit<nbits, es> pa, pb, ponemme, ponepme, pmul;
 			quire<nbits, es, capacity> q;
 
-			std::vector< posit<nbits, es> > t = GenerateVectorForZeroValueFDP(vectorSize, seed);
-
 			// accumulate a progressively larger product result
 			// starting from minpos^2
-			for (size_t i = 0; i < vectorSize; i++) {
+			for (size_t i = 0; i < t.size(); i++) {
 				pa = t[i];
 				//std::cout << "posit pattern: " << pattern << std::endl;
 
@@ -266,10 +264,10 @@ namespace sw {
 
 			if (!presult.isZero()) {
 				nrOfFailedTests++;
-				if (bReportIndividualTestCases)	ReportQuireNonZeroError("FAIL", "fdp", vectorSize, seed, presult);
+				if (bReportIndividualTestCases)	ReportQuireNonZeroError("FAIL", "fdp", t.size(), t[0], presult);
 			}
 			else {
-				if (bReportIndividualTestCases) ReportQuireNonZeroSuccess("PASS", "fdp", vectorSize, seed, presult);
+				if (bReportIndividualTestCases) ReportQuireNonZeroSuccess("PASS", "fdp", t.size(), t[0], presult);
 				//std::cout << to_hex(q0.get()) << " " << to_hex(pa.get()) << " " << to_hex(pb.get()) << " " << to_hex(q.get()) << " " << to_hex(presult.get()) << std::endl;
 			}
 

--- a/tests/quire_test_helpers.hpp
+++ b/tests/quire_test_helpers.hpp
@@ -27,7 +27,7 @@ namespace sw {
 			return nrOfFailedTests;
 		}
 
-		//static constexpr unsigned FLOAT_TABLE_WIDTH = 15;
+		static constexpr unsigned QUIRE_TABLE_WIDTH = 15;
 
 		template<size_t nbits, size_t es>
 		void ReportQuireNonZeroError(std::string test_result, std::string op, size_t nrOfElements, const posit<nbits, es>& seed, const posit<nbits, es>& presult) {
@@ -37,8 +37,8 @@ namespace sw {
 				<< " vector size " << nrOfElements
 				<< " seed " << seed << " "
 				<< " != "
-				<< std::setw(FLOAT_TABLE_WIDTH) << 0 << " instead it yielded "
-				<< std::setw(FLOAT_TABLE_WIDTH) << presult
+				<< std::setw(QUIRE_TABLE_WIDTH) << 0 << " instead it yielded "
+				<< std::setw(QUIRE_TABLE_WIDTH) << presult
 				<< " " << 0 << " vs " << presult.get()
 				<< std::setprecision(5)
 				<< std::endl;
@@ -51,7 +51,7 @@ namespace sw {
 				<< " " << op
 				<< " vector size " << nrOfElements
 				<< " seed " << seed << " "
-				<< std::setw(FLOAT_TABLE_WIDTH) << presult
+				<< std::setw(QUIRE_TABLE_WIDTH) << presult
 				<< " " << presult.get()
 				<< std::setprecision(5)
 				<< std::endl;
@@ -116,7 +116,7 @@ namespace sw {
 				value<fbits> v = pow(2.0, scale);
 				try {
 					q = v;
-					std::cout << setw(10) << v << q << std::endl;
+					std::cout << std::setw(10) << v << q << std::endl;
 					value<q.qbits> r = q.to_value();
 					double in = (double)v;
 					double out = (double)r;
@@ -175,7 +175,7 @@ namespace sw {
 #if CONFIRM_PATTERNS
 			std::cout << hex;
 			for (std::vector<uint64_t>::const_iterator it = patterns.begin(); it != patterns.end(); it++) {
-				std::cout << setw(3) << right << *it << std::endl;
+				std::cout << std::setw(3) << right << *it << std::endl;
 			}
 			std::cout << dec;
 #endif

--- a/tests/quire_test_helpers.hpp
+++ b/tests/quire_test_helpers.hpp
@@ -1,0 +1,283 @@
+#pragma once
+
+//  posit_test_helpers.cpp : functions to aid in testing and test reporting on posit types.
+// Needs to be included after posit type is declared.
+//
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <vector>
+#include <iostream>
+#include <typeinfo>
+#include <random>
+#include <limits>
+
+namespace sw {
+	namespace unum {
+
+
+		int TestQuireAccumulationResult(int nrOfFailedTests, std::string descriptor)
+		{
+			if (nrOfFailedTests > 0) {
+				std::cout << descriptor << " quire accumulation FAIL" << std::endl;
+			}
+			else {
+				std::cout << descriptor << " quire accumulation PASS" << std::endl;
+			}
+			return nrOfFailedTests;
+		}
+
+		//static constexpr unsigned FLOAT_TABLE_WIDTH = 15;
+
+		template<size_t nbits, size_t es>
+		void ReportQuireNonZeroError(std::string test_result, std::string op, size_t nrOfElements, const posit<nbits, es>& seed, const posit<nbits, es>& presult) {
+			std::cerr << test_result << " "
+				<< std::setprecision(20)
+				<< " " << op
+				<< " vector size " << nrOfElements
+				<< " seed " << seed << " "
+				<< " != "
+				<< std::setw(FLOAT_TABLE_WIDTH) << 0 << " instead it yielded "
+				<< std::setw(FLOAT_TABLE_WIDTH) << presult
+				<< " " << 0 << " vs " << presult.get()
+				<< std::setprecision(5)
+				<< std::endl;
+		}
+
+		template<size_t nbits, size_t es>
+		void ReportQuireNonZeroSuccess(std::string test_result, std::string op, size_t nrOfElements, const posit<nbits, es>& seed, const posit<nbits, es>& presult) {
+			std::cerr << test_result
+				<< std::setprecision(20)
+				<< " " << op
+				<< " vector size " << nrOfElements
+				<< " seed " << seed << " "
+				<< std::setw(FLOAT_TABLE_WIDTH) << presult
+				<< " " << presult.get()
+				<< std::setprecision(5)
+				<< std::endl;
+		}
+
+		// quire value conversion tests
+
+		template<size_t nbits, size_t es, size_t capacity>
+		void GenerateUnsignedIntAssignments() {
+			quire<nbits, es, capacity> q;
+			unsigned upper_range = q.upper_range();
+			std::cout << "Upper range = " << upper_range << std::endl;
+			uint64_t i;
+			q = 0; std::cout << q << std::endl;
+			unsigned v = 1;
+			for (i = 1; i < uint64_t(1) << (upper_range + capacity); i <<= 1) {
+				q = i;
+				std::cout << q << std::endl;
+			}
+			i <<= 1;
+			try {
+				q = i;
+			}
+			catch (char const* msg) {
+				std::cerr << "Caught the exception: " << msg << ". Value was " << i << std::endl;
+			}
+		}
+
+		template<size_t nbits, size_t es, size_t capacity>
+		void GenerateSignedIntAssignments() {
+			quire<nbits, es, capacity> q;
+			unsigned upper_range = q.upper_range();
+			std::cout << "Upper range = " << upper_range << std::endl;
+			int64_t i, upper_limit = -(int64_t(1) << (upper_range + capacity));
+			q = 0; std::cout << q << std::endl;
+			unsigned v = 1;
+			for (i = -1; i > upper_limit; i *= 2) {
+				q = i;
+				std::cout << q << std::endl;
+			}
+			i <<= 1;
+			try {
+				q = i;
+			}
+			catch (char const* msg) {
+				std::cerr << "Caught the exception: " << msg << ". RHS was " << i << std::endl;
+			}
+		}
+
+		template<size_t nbits, size_t es, size_t capacity, size_t fbits = 1>
+		void GenerateValueAssignments() {
+			quire<nbits, es, capacity> q;
+
+			// report some parameters about the posit and quire configuration
+			int max_scale = q.max_scale();
+			int min_scale = q.min_scale();
+			std::cout << "Maximum scale  = " << max_scale << " Minimum scale  = " << min_scale << " Dynamic range = " << q.dynamic_range() << std::endl;
+			std::cout << "Maxpos Squared = " << maxpos_scale<nbits, es>() * 2 << " Minpos Squared = " << minpos_scale<nbits, es>() * 2 << std::endl;
+
+			// cover the scales with one order outside of the dynamic range of the quire configuration (minpos^2 and maxpos^2)
+			for (int scale = max_scale + 1; scale >= min_scale - 1; scale--) {  // extend by 1 max and min scale to test edge of the quire
+				value<fbits> v = pow(2.0, scale);
+				try {
+					q = v;
+					std::cout << setw(10) << v << q << std::endl;
+					value<q.qbits> r = q.to_value();
+					double in = (double)v;
+					double out = (double)r;
+					if (std::abs(in - out) > 0.0000001) {
+						std::cerr << "quire value conversion failed: " << components(v) << " != " << components(r) << std::endl;
+					}
+				}
+				catch (char const* msg) {
+					std::cerr << "Caught the exception: " << msg << ". RHS was " << v << " " << components(v) << std::endl;
+				}
+			}
+		}
+
+		// Depends on quire assignment to be correct
+		template<size_t nbits, size_t es, size_t capacity>
+		int GenerateRegimePatternsForQuireAccumulation(bool bReportIndividualTestCases) {
+			int nrOfFailedTests = 0;
+
+			posit<nbits, es> pa, pb, ponemme, ponepme, pmul;
+
+			// generate the minpos to maxpos pattern set
+			// example for a posit with nbits = 10
+			// minpos = 00_0000_0001
+			//        = 00_0000_0011
+			//        = 00_0000_0111
+			//        = 00_0000_1111
+			//        = 00_0001_1111
+			//        = 00_0011_1111
+			//        = 00_0111_1111
+			//        = 00_1111_1111
+			//   1.0  = 01_0000_0000
+			//        = 01_1000_0000
+			//        = 01_1100_0000
+			//        = 01_1110_0000
+			//        = 01_1111_0000
+			//        = 01_1111_1000
+			//        = 01_1111_1100
+			//        = 01_1111_1110
+			// maxpos = 01_1111_1111
+			int nrOfPatterns = int(nbits) - 2;
+			std::vector<uint64_t> patterns(2*nrOfPatterns + 1);
+			for (int i = 0; i < nrOfPatterns; i++) {
+				patterns[i] = ((uint64_t(1) << i) - 1);
+				//std::cout << patterns[i] << std::endl;
+			}
+			uint64_t msb = nbits - 1;
+			uint64_t pattern = ((uint64_t(1) << nbits) - 1) & ~(uint64_t(1) << msb);
+			uint64_t mask = -1;
+			for (int i = 2 * nrOfPatterns; i > nrOfPatterns; i--) {
+				patterns[i] = pattern & mask;
+				//std::cout << patterns[i] << std::endl;
+				mask <<= 1;
+			}
+			patterns[nrOfPatterns] = pattern & mask; // 1.0
+
+#if CONFIRM_PATTERNS
+			std::cout << hex;
+			for (std::vector<uint64_t>::const_iterator it = patterns.begin(); it != patterns.end(); it++) {
+				std::cout << setw(3) << right << *it << std::endl;
+			}
+			std::cout << dec;
+#endif
+
+			quire<nbits, es, capacity> q0;
+			quire<nbits, es, capacity> q;
+
+			// accumulate a progressively larger product result
+			// starting from minpos^2
+			for (size_t i = 0; i < nbits; i++) {
+				pattern = patterns[i];
+				//std::cout << "posit pattern: " << pattern << std::endl;
+				pa.set_raw_bits(pattern);
+				pattern >>= 1;
+
+				ponemme = 1.0f; ponemme--;
+				ponepme = 1.0f; ponepme++;
+				pb = ponemme;
+				pmul = pa * pb;
+
+
+				q += quire_mul(pa, pb);
+				//std::cout << q << std::endl;
+
+				// convert quire to posit
+				posit<nbits, es> presult;
+				presult.convert(q.to_value());
+
+				if (pmul != presult) {
+					nrOfFailedTests++;
+					if (bReportIndividualTestCases)	ReportBinaryArithmeticError("FAIL", "*", pa, pb, pmul, presult);
+				}
+				else {
+					//if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", "*", pa, pb, pmul, presult);
+#if HARDWARE_QA_OUTPUT
+					std::cout << to_hex(q0.get()) << " " << to_hex(pa.get()) << " " << to_hex(pb.get()) << " " << to_hex(q.get()) << " " << to_hex(presult.get()) << std::endl;
+#endif
+				}
+			}
+
+			return nrOfFailedTests;;
+		}
+
+		template<size_t nbits, size_t es>
+		std::vector< posit<nbits, es> > GenerateVectorForZeroValueFDP(size_t nrOfElements, const posit<nbits, es>& seed) {
+			std::vector< posit<nbits, es> > t(nrOfElements);
+			// first half of the vector is positive seed, second half is negative seed
+			if (nrOfElements % 2) nrOfElements++; // vector size has to be even to yield zero
+			size_t half = nrOfElements >> 1;
+			for (size_t i = 0; i < half; i++) {
+				t[i] = seed;
+				t[i + half] = -seed;
+			}
+			return t;
+		}
+
+
+
+		// use a well-defined set of vectors with a known fused dot-product result
+		// the biggest stress are vectors where the first half is accumulating and the second half is subtracting
+		template<size_t nbits, size_t es, size_t capacity>
+		int ValidateQuireAccumulation(bool bReportIndividualTestCases, size_t vectorSize, const posit<nbits,es>& seed) {
+			int nrOfFailedTests = 0;
+
+			posit<nbits, es> pa, pb, ponemme, ponepme, pmul;
+			quire<nbits, es, capacity> q;
+
+			std::vector< posit<nbits, es> > t = GenerateVectorForZeroValueFDP(vectorSize, seed);
+
+			// accumulate a progressively larger product result
+			// starting from minpos^2
+			for (size_t i = 0; i < vectorSize; i++) {
+				pa = t[i];
+				//std::cout << "posit pattern: " << pattern << std::endl;
+
+				ponemme = 1.0f; ponemme--;
+				//ponepme = 1.0f; ponepme++;
+				pb = ponemme;
+				pmul = pa * pb;
+
+				q += quire_mul(pa, pb);
+				//std::cout << q << std::endl;
+			}
+
+			// convert quire to posit
+			posit<nbits, es> presult;
+			presult.convert(q.to_value());
+
+			if (!presult.isZero()) {
+				nrOfFailedTests++;
+				if (bReportIndividualTestCases)	ReportQuireNonZeroError("FAIL", "fdp", vectorSize, seed, presult);
+			}
+			else {
+				if (bReportIndividualTestCases) ReportQuireNonZeroSuccess("PASS", "fdp", vectorSize, seed, presult);
+				//std::cout << to_hex(q0.get()) << " " << to_hex(pa.get()) << " " << to_hex(pb.get()) << " " << to_hex(q.get()) << " " << to_hex(presult.get()) << std::endl;
+			}
+
+			return nrOfFailedTests;;
+		}
+
+
+	}; // namespace unum
+
+}; // namespace sw
+


### PR DESCRIPTION
Adding quire test suites and helpers.

Quire randoms are still a possibility but they would be mostly for regression testing. Structural, sequential algebraic truisms are the key and I have implemented two: 

1-the tapered regime expansion/contraction to push bits in all segments of the quire
2- zero yielding fused dot products that subtract as many values as they are adding