### PR TITLE
Fix stringstream incomplete type error

### DIFF
--- a/bitblock/bitblock.hpp
+++ b/bitblock/bitblock.hpp
@@ -5,6 +5,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <sstream>
+
 // this should be removed when we have made the transition away from std::bitset to sw::unum::bitblock
 #include <cassert>
 #include <bitset>


### PR DESCRIPTION
```
/universal/posit/../bitblock/bitblock.hpp: In function 'std::__cxx11::string sw::unum::to_binary(sw::unum::bitblock<nbits>)':
/universal/posit/../bitblock/bitblock.hpp:572:22: error: 'ss' has incomplete type
    std::stringstream ss;
```