### PR TITLE
Adding small posits

### DIFF
--- a/education/posit/tables.cpp
+++ b/education/posit/tables.cpp
@@ -31,12 +31,10 @@ try {
 
 	cout << "Generate posit configurations" << endl;
 
-	posit<6, 2> p;
-	p.set_raw_bits(0x25);
-	exponent<6, 2> exponent = p.get_exponent();
-	cout << p << " " << components_to_string(p) << " " << exponent << endl;
+	GeneratePositTable<2, 0>(cout);
 
 	GeneratePositTable<3, 0>(cout);
+	GeneratePositTable<3, 1>(cout);
 
 	GeneratePositTable<4, 0>(cout);		
 	GeneratePositTable<4, 1>(cout);

--- a/posit/posit.hpp
+++ b/posit/posit.hpp
@@ -636,7 +636,8 @@ public:
 		int k = 0;   // converted regime scale
 		if (raw_bits[nbits - 2] == 1) {   // run length of 1's
 			m = 1;   // if a run of 1's k = m - 1
-			for (int i = nbits - 3; i >= 0; --i) {
+			int start = (nbits == 2 ? nbits - 2 : nbits - 3);
+			for (int i = start; i >= 0; --i) {
 				if (raw_bits[i] == 1) {
 					m++;
 				}
@@ -648,7 +649,8 @@ public:
 		}
 		else {
 			m = 1;  // if a run of 0's k = -m
-			for (int i = nbits - 3; i >= 0; --i) {
+			int start = (nbits == 2 ? nbits - 2 : nbits - 3);
+			for (int i = start; i >= 0; --i) {
 				if (raw_bits[i] == 0) {
 					m++;
 				}

--- a/posit/posit.hpp
+++ b/posit/posit.hpp
@@ -91,7 +91,7 @@ template<size_t nbits, size_t es> posit<nbits, es> maxpos();
 template<size_t nbits, size_t es>
 class posit {
 
-	static_assert(es + 3 <= nbits, "Value for 'es' is too large for this 'nbits' value");
+	static_assert(es + 2 <= nbits, "Value for 'es' is too large for this 'nbits' value");
 //	static_assert(sizeof(long double) == 16, "Posit library requires compiler support for 128 bit long double.");
 //	static_assert((sizeof(long double) == 16) && (std::numeric_limits<long double>::digits < 113), "C++ math library for long double does not support 128-bit quad precision floats.");
 
@@ -115,13 +115,15 @@ class posit {
 	}
     
 public:
-	static constexpr size_t rbits   = nbits - 1;
-	static constexpr size_t ebits   = es;
-	static constexpr size_t fbits   = nbits - 3 - es;  
-	static constexpr size_t abits   = fbits + 4;       // size of the addend
-	static constexpr size_t fhbits  = fbits + 1;       // size of fraction + hidden bit
-	static constexpr size_t mbits   = 2 * fhbits;      // size of the multiplier output
-	static constexpr size_t divbits = 3 * fhbits + 4;  // size of the divider output
+	static constexpr size_t sbits   = 1;                          // number of sign bits:     specified
+	static constexpr size_t rbits   = nbits - sbits;              // maximum number of regime bits:   derived
+	static constexpr size_t ebits   = es;                         // maximum number of exponent bits: specified
+	static constexpr size_t fbits   = (rbits <= 2 ? nbits - 2 - es : nbits - 3 - es);             // maximum number of fraction bits: derived
+	static constexpr size_t fhbits  = fbits + 1;                  // maximum number of fraction + one hidden bit
+
+	static constexpr size_t abits   = fhbits + 3;                 // size of the addend
+	static constexpr size_t mbits   = 2 * fhbits;                 // size of the multiplier output
+	static constexpr size_t divbits = 3 * fhbits + 4;             // size of the divider output
 
 	posit() { setToZero();  }
 	

--- a/posit/sqrt_tables.hpp
+++ b/posit/sqrt_tables.hpp
@@ -29,12 +29,30 @@ namespace sw {
 
 		// roots for posit<3,0>
 		//   v   r       v   r          high precision root
-		//  000 000      0   0     ref: 0
-		//  001 001      0.5 0.5   ref: 0.70710678118654757274
+		//  000 000      0   0     ref : 0
+		//  001 001      0.5 0.5   ref : 0.70710678118654757274
 		//	010 010      1   1     ref : 1
 		//	011 010      2   1     ref : 1.4142135623730951455
 		posit<3, 0> sqrt(const posit<3, 0>& a) {
 			posit<3, 0> p;
+			if (a.isNegative() || a.isNaR()) {
+				p.setToNaR();
+				return p;
+			}
+			unsigned roots[4] = { 0, 1, 2, 2 };
+			unsigned root = roots[a.get_encoding_as_integer()];
+			p.set_raw_bits(root);
+			return p;
+		}
+
+		// roots for posit<3,1>
+		//   v   r       v   r          high precision root
+		//  000 000      0    0     ref : 0
+		//  001 001      0.25 0.5   ref : 0.5
+		//	010 010      1   1      ref : 1
+		//	011 010      4   1      ref : 1
+		posit<3, 1> sqrt(const posit<3, 1>& a) {
+			posit<3, 1> p;
 			if (a.isNegative() || a.isNaR()) {
 				p.setToNaR();
 				return p;

--- a/tables.txt
+++ b/tables.txt
@@ -1,15 +1,30 @@
 Generate posit configurations
--128         100101         111011 Sign : -1 Regime :   1 Exponent :     8 Fraction :        1 Value :             -128 11
+Generate Posit Lookup table for a POSIT<2,0>
+   #           Binary         Decoded       k    sign   scale          regime        exponent        fraction                         value
+   0:               00              00      -1       1      -1               0               ~               ~                             0
+   1:               01              01       0       1       0               1               ~               ~                             1
+   2:               10              10       1      -1       1               0               ~               ~                           NaR
+   3:               11              11       0      -1       0               1               ~               ~                            -1
 Generate Posit Lookup table for a POSIT<3,0>
    #           Binary         Decoded       k    sign   scale          regime        exponent        fraction                         value
-   0:              000             000      -2       1      -2               00               ~               ~                             0
-   1:              001             001      -1       1      -1               01               ~               ~                           0.5
-   2:              010             010       0       1       0               10               ~               ~                             1
-   3:              011             011       1       1       1               11               ~               ~                             2
-   4:              100             100       2      -1       2               00               ~               ~                           NaR
-   5:              101             111       1      -1       1               11               ~               ~                            -2
-   6:              110             110       0      -1       0               10               ~               ~                            -1
-   7:              111             101      -1      -1      -1               01               ~               ~                          -0.5
+   0:              000             000      -2       1      -2               00               ~               -                             0
+   1:              001             001      -1       1      -1               01               ~               -                           0.5
+   2:              010             010       0       1       0               10               ~               -                             1
+   3:              011             011       1       1       1               11               ~               -                             2
+   4:              100             100       2      -1       2               00               ~               -                           NaR
+   5:              101             111       1      -1       1               11               ~               -                            -2
+   6:              110             110       0      -1       0               10               ~               -                            -1
+   7:              111             101      -1      -1      -1               01               ~               -                          -0.5
+Generate Posit Lookup table for a POSIT<3,1>
+   #           Binary         Decoded       k    sign   scale          regime        exponent        fraction                         value
+   0:              000             000      -2       1      -4               00               -               ~                             0
+   1:              001             001      -1       1      -2               01               -               ~                          0.25
+   2:              010             010       0       1       0               10               -               ~                             1
+   3:              011             011       1       1       2               11               -               ~                             4
+   4:              100             100       2      -1       4               00               -               ~                           NaR
+   5:              101             111       1      -1       2               11               -               ~                            -4
+   6:              110             110       0      -1       0               10               -               ~                            -1
+   7:              111             101      -1      -1      -2               01               -               ~                         -0.25
 Generate Posit Lookup table for a POSIT<4,0>
    #           Binary         Decoded       k    sign   scale          regime        exponent        fraction                         value
    0:             0000            0000      -3       1      -3               000               ~               -                             0

--- a/tests/posit/arithmetic_add.cpp
+++ b/tests/posit/arithmetic_add.cpp
@@ -55,6 +55,7 @@ try {
 
 	// manual exhaustive test
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<3, 0>("Manual Testing", true), "posit<3,0>", "addition");
+	nrOfFailedTestCases += ReportTestResult(ValidateAddition<3, 1>("Manual Testing", true), "posit<3,1>", "addition");
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<5, 0>("Manual Testing", true), "posit<5,0>", "addition");
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<8, 4>("Manual Testing", true), "posit<8,4>", "addition");
 
@@ -65,7 +66,10 @@ try {
 
 	cout << "Posit addition validation" << endl;
 
+	nrOfFailedTestCases += ReportTestResult(ValidateAddition<2, 0>(tag, bReportIndividualTestCases), "posit<2,0>", "addition");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "addition");
+	nrOfFailedTestCases += ReportTestResult(ValidateAddition<3, 1>(tag, bReportIndividualTestCases), "posit<3,1>", "addition");
 
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "addition");
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<4, 1>(tag, bReportIndividualTestCases), "posit<4,1>", "addition");

--- a/tests/posit/arithmetic_divide.cpp
+++ b/tests/posit/arithmetic_divide.cpp
@@ -192,14 +192,19 @@ try {
 	// Generate the worst fraction pressure for different posit configurations
 	EnumerateToughDivisions();
 
-	nrOfFailedTestCases += ReportTestResult(ValidateDivision<3, 0>("Manual Testing", true), "posit<3,0>", "division");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivision<2, 0>("Manual Testing", true), "posit<2,0>", "division");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivision<3, 0>("Manual Testing", true), "posit<3,0>", "division");	
+	nrOfFailedTestCases += ReportTestResult(ValidateDivision<3, 1>("Manual Testing", true), "posit<3,1>", "division");
 	nrOfFailedTestCases += ReportTestResult(ValidateDivision<4, 0>("Manual Testing", true), "posit<4,0>", "division");
 	nrOfFailedTestCases += ReportTestResult(ValidateDivision<5, 0>("Manual Testing", true), "posit<5,0>", "division");
 	nrOfFailedTestCases += ReportTestResult(ValidateDivision<8, 0>("Manual Testing", true), "posit<8,0>", "division");
 
 #else
 
+	nrOfFailedTestCases += ReportTestResult(ValidateDivision<2, 0>(tag, bReportIndividualTestCases), "posit<2,0>", "division");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateDivision<3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "division");
+	nrOfFailedTestCases += ReportTestResult(ValidateDivision<3, 1>(tag, bReportIndividualTestCases), "posit<3,1>", "division");
 
 	nrOfFailedTestCases += ReportTestResult(ValidateDivision<4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "division");
 	nrOfFailedTestCases += ReportTestResult(ValidateDivision<4, 1>(tag, bReportIndividualTestCases), "posit<4,1>", "division");

--- a/tests/posit/arithmetic_multiply.cpp
+++ b/tests/posit/arithmetic_multiply.cpp
@@ -7,9 +7,8 @@
 #include "stdafx.h"
 
 // when you define POSIT_VERBOSE_OUTPUT executing an MUL the code will print intermediate results
-#define POSIT_VERBOSE_OUTPUT
-//#define POSIT_TRACE_MUL
-#define POSIT_TRACE_CONVERSION
+//#define POSIT_VERBOSE_OUTPUT
+#define POSIT_TRACE_MUL
 
 // minimum set of include files to reflect source code dependencies
 #include "../../posit/posit.hpp"
@@ -123,15 +122,20 @@ try {
 	*/
 
 	DifficultRoundingCases();
-	return 0;
+	
 
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<2, 0>("Manual Testing: ", bReportIndividualTestCases), "posit<2,0>", "multiplication");
 	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<3, 0>("Manual Testing: ", bReportIndividualTestCases), "posit<3,0>", "multiplication");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<3, 1>("Manual Testing: ", bReportIndividualTestCases), "posit<3,1>", "multiplication");
 	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<4, 0>("Manual Testing: ", bReportIndividualTestCases), "posit<4,0>", "multiplication");
-	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<5, 0>("Manual Testing: ", bReportIndividualTestCases), "posit<5,0>", "multiplication");
 
 #else
 
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<2, 0>(tag, bReportIndividualTestCases), "posit<2,0>", "multiplication");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "multiplication");
+	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<3, 1>(tag, bReportIndividualTestCases), "posit<3,1>", "multiplication");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "multiplication");
 	nrOfFailedTestCases += ReportTestResult(ValidateMultiplication<4, 1>(tag, bReportIndividualTestCases), "posit<4,1>", "multiplication");
 

--- a/tests/posit/arithmetic_negate.cpp
+++ b/tests/posit/arithmetic_negate.cpp
@@ -51,7 +51,10 @@ try {
 #else
 
 
+	nrOfFailedTestCases += ReportTestResult(ValidateNegation<2, 0>(tag, bReportIndividualTestCases), "posit<2,0>", "negation");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateNegation<3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "negation");
+	nrOfFailedTestCases += ReportTestResult(ValidateNegation<3, 1>(tag, bReportIndividualTestCases), "posit<3,1>", "negation");
 
 	nrOfFailedTestCases += ReportTestResult(ValidateNegation<4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "negation");
 	nrOfFailedTestCases += ReportTestResult(ValidateNegation<4, 1>(tag, bReportIndividualTestCases), "posit<4,1>", "negation");

--- a/tests/posit/arithmetic_sqrt.cpp
+++ b/tests/posit/arithmetic_sqrt.cpp
@@ -37,7 +37,7 @@ void GenerateTestCase(Ty a) {
 	std::cout << std::setprecision(5);
 }
 
-#define MANUAL_TESTING 0
+#define MANUAL_TESTING 1
 #define STRESS_TESTING 0
 
 
@@ -52,7 +52,11 @@ try {
 	// generate individual testcases to hand trace/debug
 	//GenerateTestCase<6, 3, double>(INFINITY);
 	my_test_sqrt(0.25f);
-	GenerateTestCase<4, 0, float>(0.25f);
+	GenerateTestCase<3, 1, float>(4.0f);
+	posit<3, 1> p(2.0000000001f);
+	cout << p.get() << endl;
+
+	return 0;
 
 #if 0
 	float f = 0.25f;
@@ -99,12 +103,16 @@ try {
 		base *= 2.0f;
 	}
 	cout << "sqrt(2.0) " << sw::unum::my_test_sqrt(2.0f) << endl;
+
 #endif
 
 	cout << endl;
 
 	// manual exhaustive test
+	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<2, 0>("Manual Testing", true), "posit<2,0>", "sqrt");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<3, 0>("Manual Testing", true), "posit<3,0>", "sqrt");
+	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<3, 1>("Manual Testing", true), "posit<3,1>", "sqrt");
 
 	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<4, 0>("Manual Testing", true), "posit<4,0>", "sqrt");
 	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<4, 1>("Manual Testing", true), "posit<4,1>", "sqrt");
@@ -119,7 +127,10 @@ try {
 
 	cout << "Posit addition validation" << endl;
 
+	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<2, 0>(tag, bReportIndividualTestCases), "posit<2,0>", "sqrt");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "sqrt");
+	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<3, 1>(tag, bReportIndividualTestCases), "posit<3,1>", "sqrt");
 
 	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "sqrt");
 	nrOfFailedTestCases += ReportTestResult(ValidateSqrt<4, 1>(tag, bReportIndividualTestCases), "posit<4,1>", "sqrt");

--- a/tests/posit/arithmetic_subtract.cpp
+++ b/tests/posit/arithmetic_subtract.cpp
@@ -76,7 +76,10 @@ try {
 
 #else
 
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtraction<2, 0>(tag, bReportIndividualTestCases), "posit<2,0>", "subtraction");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateSubtraction<3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "subtraction");
+	nrOfFailedTestCases += ReportTestResult(ValidateSubtraction<3, 1>(tag, bReportIndividualTestCases), "posit<3,1>", "subtraction");
 
 	nrOfFailedTestCases += ReportTestResult(ValidateSubtraction<4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "subtraction");
 	nrOfFailedTestCases += ReportTestResult(ValidateSubtraction<4, 1>(tag, bReportIndividualTestCases), "posit<4,1>", "subtraction");


### PR DESCRIPTION
Turns out that posit<2,0> and posit<3,1> are valid posits. They where getting cut off by the static_assert for the es/nbits constraint.

Did require a couple of edits to better parameterize the fields.