### PR TITLE
Adding classification to posit and quire exceptions

### DIFF
--- a/education/posit/components.cpp
+++ b/education/posit/components.cpp
@@ -79,15 +79,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/education/posit/components.cpp
+++ b/education/posit/components.cpp
@@ -79,8 +79,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/education/posit/discretization_curves.cpp
+++ b/education/posit/discretization_curves.cpp
@@ -28,15 +28,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/education/posit/discretization_curves.cpp
+++ b/education/posit/discretization_curves.cpp
@@ -28,6 +28,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/education/posit/exceptions.cpp
+++ b/education/posit/exceptions.cpp
@@ -5,7 +5,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-// enable posit arithmetic exceptions
+// enable/disable posit arithmetic exceptions
 #define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 
@@ -73,11 +73,17 @@ try {
 	try {
 		pa.setToNaR();
 		pb = 1.0f;
-		pc = pa * pb;
+		pc = pa * pb;	// TODO: operator *= throws the same exception, but for some reason we can't catch it here
 		cout << "Incorrect: operand is nar exception didn't fire" << endl;
 	}
 	catch (const operand_is_nar& err) {
 		std::cerr << "Correctly caught exception: " << err.what() << std::endl;
+	}
+	catch (const posit_arithmetic_exception& err) {
+		std::cerr << "Correctly caught exception: " << err.what() << std::endl;
+	}
+	catch (...) {
+		std::cerr << "Why can't I catch operand_is_nar exception for multiply?\n";
 	}
 
 	quire<nbits, es, capacity> q1, q2, q3;
@@ -109,8 +115,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/education/posit/exceptions.cpp
+++ b/education/posit/exceptions.cpp
@@ -115,15 +115,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/education/posit/signalling_nar.cpp
+++ b/education/posit/signalling_nar.cpp
@@ -109,15 +109,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/education/posit/signalling_nar.cpp
+++ b/education/posit/signalling_nar.cpp
@@ -109,8 +109,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/education/quire/quires.cpp
+++ b/education/quire/quires.cpp
@@ -5,7 +5,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 // type definitions for the important types, posit<> and quire<>
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"    // pretty_print

--- a/examples/blas/l1_axpy.cpp
+++ b/examples/blas/l1_axpy.cpp
@@ -7,8 +7,6 @@
 #include <posit>
 #include "blas_operators.hpp"
 
-
-
 int main(int argc, char** argv)
 try {
 	using namespace std;
@@ -39,15 +37,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/blas/l1_axpy.cpp
+++ b/examples/blas/l1_axpy.cpp
@@ -39,8 +39,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (std::runtime_error& err) {
-	std::cerr << err.what() << std::endl;
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/examples/blas/l1_fused_dot.cpp
+++ b/examples/blas/l1_fused_dot.cpp
@@ -98,15 +98,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/blas/l1_fused_dot.cpp
+++ b/examples/blas/l1_fused_dot.cpp
@@ -8,6 +8,8 @@
 // #define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_MUL
 #define QUIRE_TRACE_ADD
+// enable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "blas_operators.hpp"
 
@@ -96,8 +98,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (std::runtime_error& err) {
-	std::cerr << err.what() << std::endl;
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/examples/blas/l2_fused_mv.cpp
+++ b/examples/blas/l2_fused_mv.cpp
@@ -4,6 +4,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include "common.hpp"
+// enable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "blas_operators.hpp"
 
@@ -66,8 +68,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (std::runtime_error& err) {
-	std::cerr << err.what() << std::endl;
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/examples/blas/l2_fused_mv.cpp
+++ b/examples/blas/l2_fused_mv.cpp
@@ -68,15 +68,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/blas/l3_fused_lu.cpp
+++ b/examples/blas/l3_fused_lu.cpp
@@ -4,6 +4,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include "common.hpp"
+// enable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "blas_operators.hpp"
 

--- a/examples/blas/l3_fused_lu.cpp
+++ b/examples/blas/l3_fused_lu.cpp
@@ -522,6 +522,18 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (std::runtime_error& err) {
 	std::cerr << err.what() << std::endl;
 	return EXIT_FAILURE;

--- a/examples/blas/l3_fused_mm.cpp
+++ b/examples/blas/l3_fused_mm.cpp
@@ -5,8 +5,11 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-#define POSIT_VERBOSE_OUTPUT
+// enable the following define to show the intermediate steps in the fused-dot product
+// #define POSIT_VERBOSE_OUTPUT
 #define QUIRE_TRACE_ADD
+// enable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "blas_operators.hpp"
 

--- a/examples/blas/l3_fused_mm.cpp
+++ b/examples/blas/l3_fused_mm.cpp
@@ -40,6 +40,18 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (std::runtime_error& err) {
 	std::cerr << err.what() << std::endl;
 	return EXIT_FAILURE;

--- a/examples/dsp/fir_filter.cpp
+++ b/examples/dsp/fir_filter.cpp
@@ -64,15 +64,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/dsp/fir_filter.cpp
+++ b/examples/dsp/fir_filter.cpp
@@ -5,7 +5,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include "common.hpp"
 
-#include <vector>
+// enable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 
 /*
@@ -63,8 +64,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (std::runtime_error& err) {
-	std::cerr << err.what() << std::endl;
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/examples/playground/gismo_test.cpp
+++ b/examples/playground/gismo_test.cpp
@@ -16,46 +16,58 @@
 #include <posit>
 
 int main(int argc, char** argv)
-    try {
-        using namespace std;
-        using namespace sw::unum;
+try {
+    using namespace std;
+    using namespace sw::unum;
 
-        typedef posit<32,2> posit_32_2;
+    typedef posit<32,2> posit_32_2;
 
-        { // Test conversion from std::size_t to posits
-            size_t size = 32;
-            posit_32_2 p (size);
-        }
+    { // Test conversion from std::size_t to posits
+        size_t size = 32;
+        posit_32_2 p (size);
+    }
 
-        { // Test reading posit from std::istringstream
+    { // Test reading posit from std::istringstream
 
-            std::string str = "3.141";
-            std::istringstream lnstream;
-            lnstream.unsetf(std::ios_base::skipws);
-            lnstream.clear();
-            lnstream.str(str);
+        std::string str = "3.141";
+        std::istringstream lnstream;
+        lnstream.unsetf(std::ios_base::skipws);
+        lnstream.clear();
+        lnstream.str(str);
                         
-            posit_32_2 p;
-            lnstream >> std::ws >> p;
-			cout << pretty_print(p) << endl;
-        }
+        posit_32_2 p;
+        lnstream >> std::ws >> p;
+		cout << pretty_print(p) << endl;
+    }
 
-	{ // Test conversion from long to posit
+{ // Test conversion from long to posit
 
-	    posit_32_2 p = 1/posit_32_2(10000000000);
-	    cout << pretty_print(p) << endl;
-	}        
-        return 0;
-    }
-    catch (char const* msg) {
-        std::cerr << msg << std::endl;
-        return EXIT_FAILURE;
-    }
-	catch (const std::runtime_error& err) {
-		std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
-		return EXIT_FAILURE;
-	}
-    catch (...) {
-        std::cerr << "Caught unknown exception" << std::endl;
-        return EXIT_FAILURE;
-    }
+	posit_32_2 p = 1/posit_32_2(10000000000);
+	cout << pretty_print(p) << endl;
+}        
+    return 0;
+}
+catch (char const* msg) {
+    std::cerr << msg << std::endl;
+    return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+    std::cerr << "Caught unknown exception" << std::endl;
+    return EXIT_FAILURE;
+}

--- a/examples/playground/gismo_test.cpp
+++ b/examples/playground/gismo_test.cpp
@@ -51,15 +51,15 @@ catch (char const* msg) {
     std::cerr << msg << std::endl;
     return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/playground/math_functions.cpp
+++ b/examples/playground/math_functions.cpp
@@ -82,8 +82,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/examples/playground/math_functions.cpp
+++ b/examples/playground/math_functions.cpp
@@ -82,15 +82,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/playground/serialization.cpp
+++ b/examples/playground/serialization.cpp
@@ -12,61 +12,73 @@
 #include <posit>
 
 int main(int argc, char** argv)
-    try {
-        using namespace std;
-        using namespace sw::unum;
+try {
+    using namespace std;
+    using namespace sw::unum;
 
-		// Test reading posit from std::istringstream
-        posit<32,2> p;
+	// Test reading posit from std::istringstream
+    posit<32,2> p;
 
-        std::string str = "3.1415926535897932384626433832795028841971693993751058209749445923078164062";
-        std::istringstream lnstream;
-        lnstream.unsetf(std::ios_base::skipws);
-        lnstream.clear();
-        lnstream.str(str);                       
-        lnstream >> std::ws >> p;
-		cout << "IEEE float/double format, parsed into a posit<32,2>: " << p << endl;
+    std::string str = "3.1415926535897932384626433832795028841971693993751058209749445923078164062";
+    std::istringstream lnstream;
+    lnstream.unsetf(std::ios_base::skipws);
+    lnstream.clear();
+    lnstream.str(str);                       
+    lnstream >> std::ws >> p;
+	cout << "IEEE float/double format, parsed into a posit<32,2>: " << p << endl;
 
-		lnstream.clear();
-		str = "32.2x40000000p";
-		lnstream.str(str);
-		lnstream >> std::ws >> p;
-		cout << "posit format: " << setw(25) << str << "- parsed into a posit<32,2>: " << p << endl;
+	lnstream.clear();
+	str = "32.2x40000000p";
+	lnstream.str(str);
+	lnstream >> std::ws >> p;
+	cout << "posit format: " << setw(25) << str << "- parsed into a posit<32,2>: " << p << endl;
 
-		lnstream.clear();
-		str = "32.2x80000000p";
-		lnstream.str(str);
-		lnstream >> std::ws >> p;
-		cout << "posit format: " << setw(25) << str << "- parsed into a posit<32,2>: " << p << endl;
+	lnstream.clear();
+	str = "32.2x80000000p";
+	lnstream.str(str);
+	lnstream >> std::ws >> p;
+	cout << "posit format: " << setw(25) << str << "- parsed into a posit<32,2>: " << p << endl;
 
-		lnstream.clear();
-		str = "64.3x8000000000000000p";
-		lnstream.str(str);
-		lnstream >> std::ws >> p;  // TODO: this is truncating the most significant bits, instead of the least significant bits
-		cout << "posit format: " << setw(25) << str << "- parsed into a posit<32,2>: " << p << " <---- TODO fix" << endl;
-		cout << "pretty posit: " << pretty_print(p) << endl;
+	lnstream.clear();
+	str = "64.3x8000000000000000p";
+	lnstream.str(str);
+	lnstream >> std::ws >> p;  // TODO: this is truncating the most significant bits, instead of the least significant bits
+	cout << "posit format: " << setw(25) << str << "- parsed into a posit<32,2>: " << p << " <---- TODO fix" << endl;
+	cout << "pretty posit: " << pretty_print(p) << endl;
 
-		bitblock<1> one; one.set(0, true); str = to_hex(one); cout << "one  : " << str << endl;
-		bitblock<2> two; two.set(1, true); str = to_hex(two); cout << "two  : " << str << endl;
-		bitblock<3> three; three.set(2, true); str = to_hex(three); cout << "three: " << str << endl;
-		bitblock<4> four; four.set(3, true); str = to_hex(four); cout << "four : " << str << endl;
+	bitblock<1> one; one.set(0, true); str = to_hex(one); cout << "one  : " << str << endl;
+	bitblock<2> two; two.set(1, true); str = to_hex(two); cout << "two  : " << str << endl;
+	bitblock<3> three; three.set(2, true); str = to_hex(three); cout << "three: " << str << endl;
+	bitblock<4> four; four.set(3, true); str = to_hex(four); cout << "four : " << str << endl;
 
-		p.setToZero();
-		cout << "posit value     0: " << p << endl;
-		p.setToNaR();
-		cout << "posit value   NaR: " << p << endl;
+	p.setToZero();
+	cout << "posit value     0: " << p << endl;
+	p.setToNaR();
+	cout << "posit value   NaR: " << p << endl;
 
-        return EXIT_SUCCESS;
-    }
-    catch (char const* msg) {
-        std::cerr << msg << std::endl;
-        return EXIT_FAILURE;
-    }
-	catch (const std::runtime_error& err) {
-		std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
-		return EXIT_FAILURE;
-	}
-    catch (...) {
-        std::cerr << "Caught unknown exception" << std::endl;
-        return EXIT_FAILURE;
-    }
+    return EXIT_SUCCESS;
+}
+catch (char const* msg) {
+    std::cerr << msg << std::endl;
+    return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+    std::cerr << "Caught unknown exception" << std::endl;
+    return EXIT_FAILURE;
+}

--- a/examples/playground/serialization.cpp
+++ b/examples/playground/serialization.cpp
@@ -62,15 +62,15 @@ catch (char const* msg) {
     std::cerr << msg << std::endl;
     return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/playground/skeleton.cpp
+++ b/examples/playground/skeleton.cpp
@@ -90,15 +90,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/playground/skeleton.cpp
+++ b/examples/playground/skeleton.cpp
@@ -90,8 +90,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/examples/playground/type_test.cpp
+++ b/examples/playground/type_test.cpp
@@ -82,15 +82,15 @@ catch (char const* msg) {
     std::cerr << msg << std::endl;
     return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/examples/playground/type_test.cpp
+++ b/examples/playground/type_test.cpp
@@ -54,39 +54,51 @@ void test(const std::string& message)
 }
 
 int main(int argc, char** argv)
-    try {
-        using namespace std;
-        using namespace sw::unum;
+try {
+    using namespace std;
+    using namespace sw::unum;
 
-        test<size_t>("size_t");
+    test<size_t>("size_t");
 
-        test<signed char>("signed char");
-        test<short>("short");
-        test<int>("int");
-        test<long>("long");
-        test<long long>("long long");
+    test<signed char>("signed char");
+    test<short>("short");
+    test<int>("int");
+    test<long>("long");
+    test<long long>("long long");
 
-        test<char>("char");
-        test<unsigned short>("unsigned short");
-        test<unsigned int>("unsigned int");
-        test<unsigned long>("unsigned long");
-        test<unsigned long long>("unsigned long long");
+    test<char>("char");
+    test<unsigned short>("unsigned short");
+    test<unsigned int>("unsigned int");
+    test<unsigned long>("unsigned long");
+    test<unsigned long long>("unsigned long long");
         
-        test<float>("float");
-        test<double>("double");
-        test<long double>("long double");
+    test<float>("float");
+    test<double>("double");
+    test<long double>("long double");
 
-        return 0;
-    }
-    catch (char const* msg) {
-        std::cerr << msg << std::endl;
-        return EXIT_FAILURE;
-    }
-	catch (const std::runtime_error& err) {
-		std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
-		return EXIT_FAILURE;
-	}
-    catch (...) {
-        std::cerr << "Caught unknown exception" << std::endl;
-        return EXIT_FAILURE;
-    }
+    return 0;
+}
+catch (char const* msg) {
+    std::cerr << msg << std::endl;
+    return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+    std::cerr << "Caught unknown exception" << std::endl;
+    return EXIT_FAILURE;
+}

--- a/float/quire.hpp
+++ b/float/quire.hpp
@@ -62,10 +62,10 @@ public:
 		_sign = rhs.sign();
 		int i,f, scale = rhs.scale();
 		if (scale > int(half_range)) {
-			throw operand_too_large_for_quire{};
+			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
 		}
 		if (scale < -int(half_range)) {
-			throw operand_too_small_for_quire{};
+			throw sw::unum::operand_too_small_for_quire{};	// TODO: namespace polution
 		}
 		sw::unum::bitblock<fbits+1> fraction = rhs.get_fixed_point();
 		// divide bits between upper and lower accumulator
@@ -114,7 +114,7 @@ public:
 		magnitude = _sign ? -rhs : rhs;
 		unsigned msb = sw::unum::findMostSignificantBit(magnitude);
 		if (msb > half_range + capacity) {
-			throw operand_too_large_for_quire{};
+			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
 		}
 		else {
 			// copy the value into the quire
@@ -137,7 +137,7 @@ public:
 		reset();
 		unsigned msb = sw::unum::findMostSignificantBit(rhs);
 		if (msb > half_range + capacity) {
-			throw operand_too_large_for_quire{};
+			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
 		}
 		else {
 			// copy the value into the quire
@@ -177,10 +177,10 @@ public:
 		if (rhs.isZero()) return *this;
 		int i, f, scale = rhs.scale();
 		if (scale >  int(half_range)) {
-			throw operand_too_large_for_quire{};
+			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
 		}
 		if (scale < -int(half_range)) {
-			throw operand_too_small_for_quire{};
+			throw sw::unum::operand_too_small_for_quire{};	// TODO: namespace polution
 		}
 		if (rhs.sign()) {			// subtract
 			// lsb in the quire of the lowest bit of the explicit fixed point value including the hidden bit of the fraction

--- a/float/quire.hpp
+++ b/float/quire.hpp
@@ -62,10 +62,10 @@ public:
 		_sign = rhs.sign();
 		int i,f, scale = rhs.scale();
 		if (scale > int(half_range)) {
-			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
+			throw operand_too_large_for_quire{};
 		}
 		if (scale < -int(half_range)) {
-			throw sw::unum::operand_too_small_for_quire{};	// TODO: namespace polution
+			throw operand_too_small_for_quire{};
 		}
 		sw::unum::bitblock<fbits+1> fraction = rhs.get_fixed_point();
 		// divide bits between upper and lower accumulator
@@ -114,7 +114,7 @@ public:
 		magnitude = _sign ? -rhs : rhs;
 		unsigned msb = sw::unum::findMostSignificantBit(magnitude);
 		if (msb > half_range + capacity) {
-			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
+			throw operand_too_large_for_quire{};
 		}
 		else {
 			// copy the value into the quire
@@ -137,7 +137,7 @@ public:
 		reset();
 		unsigned msb = sw::unum::findMostSignificantBit(rhs);
 		if (msb > half_range + capacity) {
-			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
+			throw operand_too_large_for_quire{};
 		}
 		else {
 			// copy the value into the quire
@@ -177,10 +177,10 @@ public:
 		if (rhs.isZero()) return *this;
 		int i, f, scale = rhs.scale();
 		if (scale >  int(half_range)) {
-			throw sw::unum::operand_too_large_for_quire{};   // TODO: namespace polution
+			throw operand_too_large_for_quire{};
 		}
 		if (scale < -int(half_range)) {
-			throw sw::unum::operand_too_small_for_quire{};	// TODO: namespace polution
+			throw operand_too_small_for_quire{};
 		}
 		if (rhs.sign()) {			// subtract
 			// lsb in the quire of the lowest bit of the explicit fixed point value including the hidden bit of the fraction

--- a/perf/16b_posit.cpp
+++ b/perf/16b_posit.cpp
@@ -5,13 +5,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-// enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
-//#define POSIT_VERBOSE_OUTPUT
-#define POSIT_TRACE_DEBUG
-#define POSIT_TRACE_MUL
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "posit_performance.hpp"
 
 int main(int argc, char** argv)
@@ -32,8 +28,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/perf/16b_posit.cpp
+++ b/perf/16b_posit.cpp
@@ -28,15 +28,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/perf/32b_posit.cpp
+++ b/perf/32b_posit.cpp
@@ -5,13 +5,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-// enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
-//#define POSIT_VERBOSE_OUTPUT
-#define POSIT_TRACE_DEBUG
-#define POSIT_TRACE_MUL
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "posit_performance.hpp"
 
 int main(int argc, char** argv)
@@ -32,8 +28,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/perf/32b_posit.cpp
+++ b/perf/32b_posit.cpp
@@ -28,15 +28,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/perf/4b_posit.cpp
+++ b/perf/4b_posit.cpp
@@ -5,11 +5,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-// enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
-//#define POSIT_VERBOSE_OUTPUT
-#define POSIT_TRACE_DEBUG
-#define POSIT_TRACE_MUL
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
 #include "posit_performance.hpp"
 
@@ -32,8 +29,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/perf/4b_posit.cpp
+++ b/perf/4b_posit.cpp
@@ -29,15 +29,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/perf/64b_posit.cpp
+++ b/perf/64b_posit.cpp
@@ -5,13 +5,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-// enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
-//#define POSIT_VERBOSE_OUTPUT
-#define POSIT_TRACE_DEBUG
-#define POSIT_TRACE_MUL
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "posit_performance.hpp"
 
 int main(int argc, char** argv)
@@ -32,8 +28,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/perf/64b_posit.cpp
+++ b/perf/64b_posit.cpp
@@ -28,15 +28,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/perf/8b_posit.cpp
+++ b/perf/8b_posit.cpp
@@ -29,15 +29,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/perf/8b_posit.cpp
+++ b/perf/8b_posit.cpp
@@ -5,13 +5,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-// enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
-//#define POSIT_VERBOSE_OUTPUT
-#define POSIT_TRACE_DEBUG
-#define POSIT_TRACE_MUL
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "posit_performance.hpp"
 
 int main(int argc, char** argv)
@@ -33,8 +29,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/posit/exceptions.hpp
+++ b/posit/exceptions.hpp
@@ -8,151 +8,137 @@
 #include <stdexcept>
 #include <string>
 
-// TODO: why does this work, but inside a namespace it can't be caught?
-struct integer_divide_by_zero : public std::runtime_error {
-	integer_divide_by_zero(const std::string& error = "integer divide by zero") : std::runtime_error(error) {}
+// TODO: why can't I namespace exceptions?
+//namespace sw {
+//	namespace unum {
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// POSIT ARITHMETIC EXCEPTIONS
+
+// base class for bitblock arithmetic exceptions
+struct bitblock_arithmetic_exception
+	: public std::runtime_error
+{
+	bitblock_arithmetic_exception(const std::string& error) : std::runtime_error(std::string("bitblock arithmetic exception: ") + error) {};
 };
 
-// TODO: why can't I namespace exceptions?
-namespace sw {
-	namespace unum {
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// specialized exceptions to aid application level exception handling
 
-		///////////////////////////////////////////////////////////////////////////////////////////////////
-		/// POSIT ARITHMETIC EXCEPTIONS
+// is thrown when denominator is 0 in a division operator
+struct integer_divide_by_zero
+	: public bitblock_arithmetic_exception
+{
+	integer_divide_by_zero(const std::string& error = "integer divide by zero") : bitblock_arithmetic_exception(error) {}
+};
 
-		// base class for bitblock arithmetic exceptions
-		struct bitblock_arithmetic_exception
-			: public std::runtime_error
-		{
-			std::string tag = "bitblock arithmetic exception: ";
-			bitblock_arithmetic_exception(const std::string& error) : std::runtime_error(tag + error) {};
-		};
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// POSIT ARITHMETIC EXCEPTIONS
 
-		//////////////////////////////////////////////////////////////////////////////////////////////////
-		/// specialized exceptions to aid application level exception handling
+// base class for posit arithmetic exceptions
+struct posit_arithmetic_exception
+	: public std::runtime_error
+{			
+	posit_arithmetic_exception(const std::string& error) : std::runtime_error(std::string("posit arithmetic exception: ") + error) {};
+};
 
-		// is thrown when denominator is 0 in a division operator
-		struct integer_divide_by_zero_
-			: public bitblock_arithmetic_exception
-		{
-			integer_divide_by_zero_(const std::string& error = "integer divide by zero") : bitblock_arithmetic_exception(error) {}
-		};
+//////////////////////////////////////////////////////////////////////////////////////////////////
+/// specialized exceptions to aid application level exception handling
 
-		///////////////////////////////////////////////////////////////////////////////////////////////////
-		/// POSIT ARITHMETIC EXCEPTIONS
+// not_a_real is thrown when a rvar is NaR
+struct not_a_real
+	: posit_arithmetic_exception
+{
+	not_a_real(const std::string& error = "nar (not a real)") : posit_arithmetic_exception(error) {}
+};
 
-		// base class for posit arithmetic exceptions
-		struct posit_arithmetic_exception
-			: public std::runtime_error
-		{
-			std::string tag = "posit arithmetic exception: ";
-			posit_arithmetic_exception(const std::string& error) : std::runtime_error(tag + error) {};
-		};
+// divide_by_zero is thrown when the denominator in a division operator is 0
+struct divide_by_zero 
+	: posit_arithmetic_exception
+{
+	divide_by_zero(const std::string& error = "divide by zero") : posit_arithmetic_exception(error) {}
+};
 
-		//////////////////////////////////////////////////////////////////////////////////////////////////
-		/// specialized exceptions to aid application level exception handling
+// divide_by_nar is thrown when the denominator in a division operator is NaR
+struct divide_by_nar
+	: posit_arithmetic_exception
+{
+	divide_by_nar(const std::string& error = "divide by nar") : posit_arithmetic_exception(error) {}
+};
 
-		// not_a_real is thrown when a rvar is NaR
-		struct not_a_real
-			: posit_arithmetic_exception
-		{
-			not_a_real(const std::string& error = "nar (not a real)") : posit_arithmetic_exception(error) {}
-		};
+// numerator_is_nar is thrown when the numerator in a division operator is NaR
+struct numerator_is_nar
+	: posit_arithmetic_exception
+{
+	numerator_is_nar(const std::string& error = "numerator is nar") : posit_arithmetic_exception(error) {}
+};
 
-		// divide_by_zero is thrown when the denominator in a division operator is 0
-		struct divide_by_zero 
-		  : posit_arithmetic_exception
-		{
-			divide_by_zero(const std::string& error = "divide by zero") : posit_arithmetic_exception(error) {}
-		};
+// operand_is_nar is thrown when an rvar in a binary operator is NaR
+struct operand_is_nar
+	: public posit_arithmetic_exception
+{
+	operand_is_nar(const std::string& error = "operand is nar") : posit_arithmetic_exception(error) {}
+};
 
-		// divide_by_nar is thrown when the denominator in a division operator is NaR
-		struct divide_by_nar
-			: posit_arithmetic_exception
-		{
-			divide_by_nar(const std::string& error = "divide by nar") : posit_arithmetic_exception(error) {}
-		};
+// thrown when division yields no signficant fraction bits
+struct division_result_is_zero
+	: posit_arithmetic_exception
+{
+	division_result_is_zero(const std::string& error = "division yielded no significant bits") : posit_arithmetic_exception(error) {}
+};
 
-		// numerator_is_nar is thrown when the numerator in a division operator is NaR
-		struct numerator_is_nar
-			: posit_arithmetic_exception
-		{
-			numerator_is_nar(const std::string& error = "numerator is nar") : posit_arithmetic_exception(error) {}
-		};
+// thrown when division yields NaR
+struct division_result_is_infinite
+	: posit_arithmetic_exception
+{
+	division_result_is_infinite(const std::string& error = "division yielded infinite") : posit_arithmetic_exception(error) {}
+};
 
-		// operand_is_nar is thrown when an rvar in a binary operator is NaR
-		struct operand_is_nar
-			: public posit_arithmetic_exception
-		{
-			operand_is_nar(const std::string& error = "operand is nar") : posit_arithmetic_exception(error) {}
-		};
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// POSIT INTERNAL OPERATION EXCEPTIONS
 
-		// thrown when division yields no signficant fraction bits
-		struct division_result_is_zero
-			: posit_arithmetic_exception
-		{
-			division_result_is_zero(const std::string& error = "division yielded no significant bits") : posit_arithmetic_exception(error) {}
-		};
+struct posit_internal_exception
+	: public std::runtime_error
+{		
+	posit_internal_exception(const std::string& error) : std::runtime_error(std::string("posit internal exception") + error) {};
 
-		// thrown when division yields NaR
-		struct division_result_is_infinite
-			: posit_arithmetic_exception
-		{
-			division_result_is_infinite(const std::string& error = "division yielded infinite") : posit_arithmetic_exception(error) {}
-		};
+};
 
-		///////////////////////////////////////////////////////////////////////////////////////////////////
-		/// POSIT INTERNAL OPERATION EXCEPTIONS
+struct shift_too_large
+	: posit_internal_exception
+{
+	shift_too_large(const std::string& error = "shift value too large for given posit") : posit_internal_exception(error) {}
+};
 
-		struct posit_internal_exception
-			: public std::runtime_error
-		{
-			std::string tag = "posit internal exception";
-			posit_internal_exception(const std::string& error) : std::runtime_error(tag + error) {};
+struct hpos_too_large
+	: posit_internal_exception
+{
+	hpos_too_large(const std::string& error = "position of hidden bit too large for given posit") : posit_internal_exception(error) {}
+};
 
-		};
+struct rbits_too_large
+	: posit_internal_exception
+{
+	rbits_too_large(const std::string& error = "number of remaining bits too large for this fraction") :posit_internal_exception(error) {}
+};
 
-		struct shift_too_large
-		  : posit_internal_exception
-		{
-			shift_too_large(const std::string& error = "shift value too large for given posit") : posit_internal_exception(error) {}
-		};
+struct cut_off_leading_bit
+	: posit_internal_exception
+{
+	cut_off_leading_bit(const std::string& error = "leading significant bit is cut off") : posit_internal_exception(error) {}
+};
 
-		struct hpos_too_large
-		  : posit_internal_exception
-		{
-			hpos_too_large(const std::string& error = "position of hidden bit too large for given posit") : posit_internal_exception(error) {}
-		};
+struct iteration_bound_too_large
+	: posit_internal_exception
+{
+	iteration_bound_too_large(const std::string& error = "iteration bound is too large") : posit_internal_exception(error) {}
+};
 
-		struct rbits_too_large
-		  : posit_internal_exception
-		{
-			rbits_too_large(const std::string& error = "number of remaining bits too large for this fraction") :posit_internal_exception(error) {}
-		};
-
-		struct cut_off_leading_bit
-		  : posit_internal_exception
-		{
-			cut_off_leading_bit(const std::string& error = "leading significant bit is cut off") : posit_internal_exception(error) {}
-		};
-
-		struct iteration_bound_too_large
-		  : posit_internal_exception
-		{
-			iteration_bound_too_large(const std::string& error = "iteration bound is too large") : posit_internal_exception(error) {}
-		};
-
-		struct round_off_all
-		  : posit_internal_exception
-		{
-			round_off_all(const std::string& error = "cannot round off all bits") : posit_internal_exception(error) {}
-		};
-
-
-
-
-	} // namespace unum
-} // namespace sw
+struct round_off_all
+	: posit_internal_exception
+{
+	round_off_all(const std::string& error = "cannot round off all bits") : posit_internal_exception(error) {}
+};
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -162,8 +148,7 @@ namespace sw {
 struct quire_exception
 	: public std::runtime_error
 {
-	std::string tag = "posit arithmetic exception: ";
-	quire_exception(const std::string& error) : std::runtime_error(tag + error) {};
+	quire_exception(const std::string& error) : std::runtime_error(std::string("quire exception: ") + error) {};
 };
 
 struct operand_too_large_for_quire

--- a/posit/exceptions.hpp
+++ b/posit/exceptions.hpp
@@ -1,105 +1,180 @@
 #pragma once
 // exceptions.hpp: exceptions for problems in posit calculations
 //
-// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include <stdexcept>
 #include <string>
 
-struct not_a_real
-	: std::runtime_error
-{
-	not_a_real(const std::string& error = "nar (not a real)") : std::runtime_error(error) {}
-};
-
-struct divide_by_zero 
-  : std::runtime_error
-{
-	divide_by_zero(const std::string& error = "divide by zero") : std::runtime_error(error) {}
-};
-
-struct divide_by_nar
-	: std::runtime_error
-{
-	divide_by_nar(const std::string& error = "divide by nar") : std::runtime_error(error) {}
-};
-
-struct numerator_is_nar
-	: std::runtime_error
-{
-	numerator_is_nar(const std::string& error = "numerator is nar") : std::runtime_error(error) {}
-};
-
-struct operand_is_nar
-	: std::runtime_error
-{
-	operand_is_nar(const std::string& error = "operand is nar") : std::runtime_error(error) {}
-};
-
-struct integer_divide_by_zero 
-  : std::runtime_error
-{
+// TODO: why does this work, but inside a namespace it can't be caught?
+struct integer_divide_by_zero : public std::runtime_error {
 	integer_divide_by_zero(const std::string& error = "integer divide by zero") : std::runtime_error(error) {}
 };
 
-struct shift_too_large
-  : std::runtime_error
-{
-    shift_too_large(const std::string& error = "shift value too large for given posit") : std::runtime_error(error) {}
-};
+// TODO: why can't I namespace exceptions?
+namespace sw {
+	namespace unum {
 
-struct hpos_too_large
-  : std::runtime_error
-{
-    hpos_too_large(const std::string& error = "position of hidden bit too large for given posit") : std::runtime_error(error) {}
-};
+		///////////////////////////////////////////////////////////////////////////////////////////////////
+		/// POSIT ARITHMETIC EXCEPTIONS
 
-struct rbits_too_large
-  : std::runtime_error
-{
-    rbits_too_large(const std::string& error = "number of remaining bits too large for this fraction") : std::runtime_error(error) {}
-};
+		// base class for bitblock arithmetic exceptions
+		struct bitblock_arithmetic_exception
+			: public std::runtime_error
+		{
+			std::string tag = "bitblock arithmetic exception: ";
+			bitblock_arithmetic_exception(const std::string& error) : std::runtime_error(tag + error) {};
+		};
 
-struct cut_off_leading_bit
-  : std::runtime_error
-{
-    cut_off_leading_bit(const std::string& error = "leading significant bit is cut off") : std::runtime_error(error) {}
-};
+		//////////////////////////////////////////////////////////////////////////////////////////////////
+		/// specialized exceptions to aid application level exception handling
 
-struct iteration_bound_too_large
-  : std::runtime_error
-{
-    iteration_bound_too_large(const std::string& error = "iteration bound is too large") : std::runtime_error(error) {}
-};
+		// is thrown when denominator is 0 in a division operator
+		struct integer_divide_by_zero_
+			: public bitblock_arithmetic_exception
+		{
+			integer_divide_by_zero_(const std::string& error = "integer divide by zero") : bitblock_arithmetic_exception(error) {}
+		};
 
-struct round_off_all
-  : std::runtime_error
-{
-    round_off_all(const std::string& error = "cannot round off all bits") : std::runtime_error(error) {}
-};
+		///////////////////////////////////////////////////////////////////////////////////////////////////
+		/// POSIT ARITHMETIC EXCEPTIONS
 
-struct division_result_is_zero
-	: std::runtime_error
-{
-	division_result_is_zero(const std::string& error = "division yielded no significant bits") : std::runtime_error(error) {}
-};
+		// base class for posit arithmetic exceptions
+		struct posit_arithmetic_exception
+			: public std::runtime_error
+		{
+			std::string tag = "posit arithmetic exception: ";
+			posit_arithmetic_exception(const std::string& error) : std::runtime_error(tag + error) {};
+		};
 
-struct division_result_is_infinite
-	: std::runtime_error
+		//////////////////////////////////////////////////////////////////////////////////////////////////
+		/// specialized exceptions to aid application level exception handling
+
+		// not_a_real is thrown when a rvar is NaR
+		struct not_a_real
+			: posit_arithmetic_exception
+		{
+			not_a_real(const std::string& error = "nar (not a real)") : posit_arithmetic_exception(error) {}
+		};
+
+		// divide_by_zero is thrown when the denominator in a division operator is 0
+		struct divide_by_zero 
+		  : posit_arithmetic_exception
+		{
+			divide_by_zero(const std::string& error = "divide by zero") : posit_arithmetic_exception(error) {}
+		};
+
+		// divide_by_nar is thrown when the denominator in a division operator is NaR
+		struct divide_by_nar
+			: posit_arithmetic_exception
+		{
+			divide_by_nar(const std::string& error = "divide by nar") : posit_arithmetic_exception(error) {}
+		};
+
+		// numerator_is_nar is thrown when the numerator in a division operator is NaR
+		struct numerator_is_nar
+			: posit_arithmetic_exception
+		{
+			numerator_is_nar(const std::string& error = "numerator is nar") : posit_arithmetic_exception(error) {}
+		};
+
+		// operand_is_nar is thrown when an rvar in a binary operator is NaR
+		struct operand_is_nar
+			: public posit_arithmetic_exception
+		{
+			operand_is_nar(const std::string& error = "operand is nar") : posit_arithmetic_exception(error) {}
+		};
+
+		// thrown when division yields no signficant fraction bits
+		struct division_result_is_zero
+			: posit_arithmetic_exception
+		{
+			division_result_is_zero(const std::string& error = "division yielded no significant bits") : posit_arithmetic_exception(error) {}
+		};
+
+		// thrown when division yields NaR
+		struct division_result_is_infinite
+			: posit_arithmetic_exception
+		{
+			division_result_is_infinite(const std::string& error = "division yielded infinite") : posit_arithmetic_exception(error) {}
+		};
+
+		///////////////////////////////////////////////////////////////////////////////////////////////////
+		/// POSIT INTERNAL OPERATION EXCEPTIONS
+
+		struct posit_internal_exception
+			: public std::runtime_error
+		{
+			std::string tag = "posit internal exception";
+			posit_internal_exception(const std::string& error) : std::runtime_error(tag + error) {};
+
+		};
+
+		struct shift_too_large
+		  : posit_internal_exception
+		{
+			shift_too_large(const std::string& error = "shift value too large for given posit") : posit_internal_exception(error) {}
+		};
+
+		struct hpos_too_large
+		  : posit_internal_exception
+		{
+			hpos_too_large(const std::string& error = "position of hidden bit too large for given posit") : posit_internal_exception(error) {}
+		};
+
+		struct rbits_too_large
+		  : posit_internal_exception
+		{
+			rbits_too_large(const std::string& error = "number of remaining bits too large for this fraction") :posit_internal_exception(error) {}
+		};
+
+		struct cut_off_leading_bit
+		  : posit_internal_exception
+		{
+			cut_off_leading_bit(const std::string& error = "leading significant bit is cut off") : posit_internal_exception(error) {}
+		};
+
+		struct iteration_bound_too_large
+		  : posit_internal_exception
+		{
+			iteration_bound_too_large(const std::string& error = "iteration bound is too large") : posit_internal_exception(error) {}
+		};
+
+		struct round_off_all
+		  : posit_internal_exception
+		{
+			round_off_all(const std::string& error = "cannot round off all bits") : posit_internal_exception(error) {}
+		};
+
+
+
+
+	} // namespace unum
+} // namespace sw
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+/// QUIRE ARITHMETIC EXCEPTIONS
+
+// base class for quire exceptions
+struct quire_exception
+	: public std::runtime_error
 {
-	division_result_is_infinite(const std::string& error = "division yielded infinite") : std::runtime_error(error) {}
+	std::string tag = "posit arithmetic exception: ";
+	quire_exception(const std::string& error) : std::runtime_error(tag + error) {};
 };
 
 struct operand_too_large_for_quire
-	: std::runtime_error
+	: public quire_exception
 {
-	operand_too_large_for_quire(const std::string& error = "operand value too large for quire") : std::runtime_error(error) {}
+	operand_too_large_for_quire(const std::string& error = "operand value too large for quire") : quire_exception(error) {}
 };
 
 struct operand_too_small_for_quire
-	: std::runtime_error
+	: public quire_exception
 {
-	operand_too_small_for_quire(const std::string& error = "operand value too small for quire") : std::runtime_error(error) {}
+	operand_too_small_for_quire(const std::string& error = "operand value too small for quire") : quire_exception(error) {}
 };
+

--- a/tests/bitblock/arithmetic.cpp
+++ b/tests/bitblock/arithmetic.cpp
@@ -207,12 +207,6 @@ try {
 	catch (const integer_divide_by_zero& e) {
 		cout << "Properly caught exception: " << e.what() << endl;
 	}
-	catch (const sw::unum::bitblock_arithmetic_exception& e) {
-		cout << "Properly caught exception: " << e.what() << endl;
-	}
-	catch (const std::runtime_error& e) {
-		cout << "Properly caught exception: " << e.what() << endl;
-	}
 	catch (...) {
 		cout << "Why can't I catch this specific exception type?" << endl;
 	}

--- a/tests/bitblock/arithmetic.cpp
+++ b/tests/bitblock/arithmetic.cpp
@@ -3,25 +3,19 @@
 // Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-
-#include "stdafx.h"
-#include <sstream>
-
-#include "../../posit/exceptions.hpp"
+#include "common.hpp"
+#include "../../posit/exceptions.hpp"	// TODO: remove namespace polution
 #include "../../bitblock/bitblock.hpp"
 #include "../tests/test_helpers.hpp"
 #include "../bitblock_test_helpers.hpp"
 
-using namespace std;
-using namespace sw::unum;
-
-
 int Conversions() {
+	using namespace sw::unum;
 	const size_t nbits = 33;
 	int nrOfFailedTestCases = 0;
 	bitblock<nbits> a, b, ref, sum;
 
-	cout << "Binary conversions" << endl;
+	std::cout << "Binary conversions" << std::endl;
 
 	ref = convert_to_bitblock<nbits, uint64_t>(uint64_t(0x155555555));
 	a = flip_sign_bit(convert_to_bitblock<nbits,uint64_t>(uint64_t(0x55555555)));
@@ -29,31 +23,31 @@ int Conversions() {
 
 	b = convert_to_bitblock<nbits,uint64_t>(uint64_t(0x5));
 
-	cout << "1's complement of a = " << to_binary(ones_complement(a)) << endl;
+	std::cout << "1's complement of a = " << to_binary(ones_complement(a)) << std::endl;
 	ref = convert_to_bitblock<nbits, uint64_t>(uint64_t(0xAAAAAAAA));
 	nrOfFailedTestCases += (ones_complement(a) != ref ? 1 : 0);
-	cout << "1's complement of b = " << to_binary(ones_complement(b)) << endl;
+	std::cout << "1's complement of b = " << to_binary(ones_complement(b)) << std::endl;
 	ref = convert_to_bitblock<nbits, uint64_t>(uint64_t(0x1FFFFFFFA));
 	nrOfFailedTestCases += (ones_complement(b) != ref ? 1 : 0);
 
 	const size_t nnbits = 9;
 	bitblock<nnbits> c, ref2;
 	c = convert_to_bitblock<9,int8_t>(int8_t(-128));  // this looks like -1 for a 9bit posit
-	cout << "c                   = " << to_binary(c) << endl;
+	std::cout << "c                   = " << to_binary(c) << std::endl;
 	ref2 = convert_to_bitblock<nnbits, uint64_t>(uint64_t(0x180));
 	nrOfFailedTestCases += (c != ref2 ? 1 : 0);
 
 	c = twos_complement(c);							// this looks like  1 for a 9bit posit
-	cout << "2's Complement      = " << to_binary(c) << endl;
+	std::cout << "2's Complement      = " << to_binary(c) << std::endl;
 	ref2 = convert_to_bitblock<nnbits, uint64_t>(uint64_t(0x080));
 	nrOfFailedTestCases += (c != ref2 ? 1 : 0);
 
 	bitblock<9> d;
 	d = convert_to_bitblock<9,int64_t>(int64_t(int8_t(-128)));
-	cout << "d                   = " << to_binary(d) << endl;
+	std::cout << "d                   = " << to_binary(d) << std::endl;
 	d = twos_complement(d);
-	cout << "2's complement      = " << to_binary(d) << endl;
-	cout << endl;
+	std::cout << "2's complement      = " << to_binary(d) << std::endl;
+	std::cout << std::endl;
 	nrOfFailedTestCases += (c != d ? 1 : 0);
 
 	return nrOfFailedTestCases;
@@ -66,17 +60,17 @@ int IncrementRightAdjustedBitset()
 	const size_t nbits = 5;
 	int nrOfFailedTestCases = 0;
 
-	bitblock<nbits> r1, ref;
+	sw::unum::bitblock<nbits> r1, ref;
 	bool carry;
 
-	cout << "Increments" << endl;
+	std::cout << "Increments" << std::endl;
 	for (std::size_t i = 0; i < nbits; i++) {
 		r1.reset();
 		r1.set(nbits - 1 - i, true);
 		carry = false;
-		cout << "carry " << (carry ? "1" : "0") << " r1 " << r1 << " <-- input" << endl;
-		carry = increment_unsigned(r1, int(i));
-		cout << "carry " << (carry ? "1" : "0") << " r1 " << r1 << " <-- result" << endl;
+		std::cout << "carry " << (carry ? "1" : "0") << " r1 " << r1 << " <-- input" << std::endl;
+		carry = sw::unum::increment_unsigned(r1, int(i));
+		std::cout << "carry " << (carry ? "1" : "0") << " r1 " << r1 << " <-- result" << std::endl;
 	}
 
 	return nrOfFailedTestCases;
@@ -86,9 +80,9 @@ template<size_t src_size, size_t tgt_size>
 int VerifyCopyInto(bool bReportIndividualTestCases = false) {
 	int nrOfFailedTestCases = 0;
 
-	bitblock<src_size> operand;
-	bitblock<tgt_size> addend;
-	bitblock<tgt_size> reference;
+	sw::unum::bitblock<src_size> operand;
+	sw::unum::bitblock<tgt_size> addend;
+	sw::unum::bitblock<tgt_size> reference;
 	
 	// use a programmatic pattern of alternating bits
 	// so it is easy to spot any differences
@@ -98,14 +92,14 @@ int VerifyCopyInto(bool bReportIndividualTestCases = false) {
 	}
 
 	for (size_t i = 0; i < tgt_size - src_size; i++) {
-		copy_into<src_size, tgt_size>(operand, i, addend);
+		sw::unum::copy_into<src_size, tgt_size>(operand, i, addend);
 
 		if (reference != addend) {
 			nrOfFailedTestCases++;
-			if (bReportIndividualTestCases) cout << "FAIL operand : " << operand << " at i=" << i << " result   : " << addend << " reference: " << reference << endl;
+			if (bReportIndividualTestCases) std::cout << "FAIL operand : " << operand << " at i=" << i << " result   : " << addend << " reference: " << reference << std::endl;
 		}
 		else {
-			if (bReportIndividualTestCases) cout << "PASS operand : " << operand << " at i=" << i << " result   : " << addend << " reference: " << reference << endl;
+			if (bReportIndividualTestCases) std::cout << "PASS operand : " << operand << " at i=" << i << " result   : " << addend << " reference: " << reference << std::endl;
 		}
 
 
@@ -120,6 +114,9 @@ int VerifyCopyInto(bool bReportIndividualTestCases = false) {
 
 int main(int argc, char** argv)
 try {
+	using namespace std;
+	using namespace sw::unum;
+
 	bool bReportIndividualTestCases = false;
 	int nrOfFailedTestCases = 0;
 
@@ -207,8 +204,17 @@ try {
 	try {
 		integer_divide_unsigned(a, b, c); // divide by zero
 	}
-	catch (runtime_error& e) {
+	catch (const integer_divide_by_zero& e) {
 		cout << "Properly caught exception: " << e.what() << endl;
+	}
+	catch (const sw::unum::bitblock_arithmetic_exception& e) {
+		cout << "Properly caught exception: " << e.what() << endl;
+	}
+	catch (const std::runtime_error& e) {
+		cout << "Properly caught exception: " << e.what() << endl;
+	}
+	catch (...) {
+		cout << "Why can't I catch this specific exception type?" << endl;
 	}
 
 	nrOfFailedTestCases += ReportTestResult(ValidateBitsetDivision<3>(bReportIndividualTestCases), "bitblock<3>", "/");
@@ -232,10 +238,14 @@ try {
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	cerr << msg << endl;
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {
-	cerr << "Caught unknown exception" << endl;
+	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/bitblock/common.hpp
+++ b/tests/bitblock/common.hpp
@@ -1,0 +1,35 @@
+// common.hpp : include file for common system include files,
+// or project specific include files that are used frequently, but
+// are changed infrequently
+//
+
+#pragma once
+
+#ifdef WINDOWS
+// Including SDKDDKVer.h defines the highest available Windows platform.
+
+// If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
+// set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
+
+#include <SDKDDKVer.h>
+#endif // WINDOWS
+
+#include <cassert>
+#include <stdio.h>
+//#include <tchar.h>
+#include <cstdint>	// uint8_t, etc.
+#include <cmath>	// for frexp/frexpf and std::fma
+#include <cfenv>	// feclearexcept/fetestexcept
+
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+
+#if defined(__GNUC__)
+#if __GNUC__ < 5
+#define hexfloat     scientific
+#define defaultfloat scientific
+#endif
+#endif
+

--- a/tests/bitblock/logic.cpp
+++ b/tests/bitblock/logic.cpp
@@ -4,27 +4,22 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
-#include "stdafx.h"
-
+#include "common.hpp"
 #include "../tests/test_helpers.hpp"
 #include "../../posit/exceptions.hpp"
 #include "../../bitblock/bitblock.hpp"
-
-
-using namespace std;
-using namespace sw::unum;
 
 template<size_t nbits>
 int ValidateBitsetLogicLessThan() {
 	const size_t NR_TEST_CASES = (unsigned(1) << nbits);
 	int nrOfFailedTestCases = 0;
-	bitblock<nbits> a, b;
+	sw::unum::bitblock<nbits> a, b;
 	bool ref, bref;
 
 	for (unsigned i = 0; i < NR_TEST_CASES; i++) {
-		a = convert_to_bitblock<nbits, unsigned>(i);
+		a = sw::unum::convert_to_bitblock<nbits, unsigned>(i);
 		for (unsigned j = 0; j < NR_TEST_CASES; j++) {
-			b = convert_to_bitblock<nbits, unsigned>(j);
+			b = sw::unum::convert_to_bitblock<nbits, unsigned>(j);
 			ref = i < j;
 			bref = a < b;
 			if (ref != bref) {
@@ -40,13 +35,13 @@ template<size_t nbits>
 int ValidateBitsetLogicGreaterThan() {
 	const size_t NR_TEST_CASES = (unsigned(1) << nbits);
 	int nrOfFailedTestCases = 0;
-	bitblock<nbits> a, b;
+	sw::unum::bitblock<nbits> a, b;
 	bool ref, bref;
 
 	for (unsigned i = 0; i < NR_TEST_CASES; i++) {
-		a = convert_to_bitblock<nbits, unsigned>(i);
+		a = sw::unum::convert_to_bitblock<nbits, unsigned>(i);
 		for (unsigned j = 0; j < NR_TEST_CASES; j++) {
-			b = convert_to_bitblock<nbits, unsigned>(j);
+			b = sw::unum::convert_to_bitblock<nbits, unsigned>(j);
 			ref = i > j;
 			bref = a > b;
 			if (ref != bref) {
@@ -62,13 +57,13 @@ template<size_t nbits>
 int ValidateBitsetLogicEqual() {
 	const size_t NR_TEST_CASES = (unsigned(1) << nbits);
 	int nrOfFailedTestCases = 0;
-	bitblock<nbits> a, b;
+	sw::unum::bitblock<nbits> a, b;
 	bool ref, bref;
 
 	for (unsigned i = 0; i < NR_TEST_CASES; i++) {
-		a = convert_to_bitblock<nbits, unsigned>(i);
+		a = sw::unum::convert_to_bitblock<nbits, unsigned>(i);
 		for (unsigned j = 0; j < NR_TEST_CASES; j++) {
-			b = convert_to_bitblock<nbits, unsigned>(j);
+			b = sw::unum::convert_to_bitblock<nbits, unsigned>(j);
 			ref = i == j;
 			bref = a == b;
 			if (ref != bref) {
@@ -84,13 +79,13 @@ template<size_t nbits>
 int ValidateBitsetLogicNotEqual() {
 	const size_t NR_TEST_CASES = (unsigned(1) << nbits);
 	int nrOfFailedTestCases = 0;
-	bitblock<nbits> a, b;
+	sw::unum::bitblock<nbits> a, b;
 	bool ref, bref;
 
 	for (unsigned i = 0; i < NR_TEST_CASES; i++) {
-		a = convert_to_bitblock<nbits, unsigned>(i);
+		a = sw::unum::convert_to_bitblock<nbits, unsigned>(i);
 		for (unsigned j = 0; j < NR_TEST_CASES; j++) {
-			b = convert_to_bitblock<nbits, unsigned>(j);
+			b = sw::unum::convert_to_bitblock<nbits, unsigned>(j);
 			ref = i != j;
 			bref = a != b;
 			if (ref != bref) {
@@ -106,13 +101,13 @@ template<size_t nbits>
 int ValidateBitsetLogicLessOrEqualThan() {
 	const size_t NR_TEST_CASES = (unsigned(1) << nbits);
 	int nrOfFailedTestCases = 0;
-	bitblock<nbits> a, b;
+	sw::unum::bitblock<nbits> a, b;
 	bool ref, bref;
 
 	for (unsigned i = 0; i < NR_TEST_CASES; i++) {
-		a = convert_to_bitblock<nbits, unsigned>(i);
+		a = sw::unum::convert_to_bitblock<nbits, unsigned>(i);
 		for (unsigned j = 0; j < NR_TEST_CASES; j++) {
-			b = convert_to_bitblock<nbits, unsigned>(j);
+			b = sw::unum::convert_to_bitblock<nbits, unsigned>(j);
 			ref = i <= j;
 			bref = a <= b;
 			if (ref != bref) {
@@ -128,13 +123,13 @@ template<size_t nbits>
 int ValidateBitsetLogicGreaterOrEqualThan() {
 	const size_t NR_TEST_CASES = (unsigned(1) << nbits);
 	int nrOfFailedTestCases = 0;
-	bitblock<nbits> a, b;
+	sw::unum::bitblock<nbits> a, b;
 	bool ref, bref;
 
 	for (unsigned i = 0; i < NR_TEST_CASES; i++) {
-		a = convert_to_bitblock<nbits, unsigned>(i);
+		a = sw::unum::convert_to_bitblock<nbits, unsigned>(i);
 		for (unsigned j = 0; j < NR_TEST_CASES; j++) {
-			b = convert_to_bitblock<nbits, unsigned>(j);
+			b = sw::unum::convert_to_bitblock<nbits, unsigned>(j);
 			ref = i >= j;
 			bref = a >= b;
 			if (ref != bref) {
@@ -151,6 +146,9 @@ int ValidateBitsetLogicGreaterOrEqualThan() {
 
 int main()
 try {
+	using namespace std;
+	using namespace sw::unum;
+
 	//bool bReportIndividualTestCases = false;
 	int nrOfFailedTestCases = 0;
 
@@ -230,11 +228,11 @@ try {
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	cerr << msg << endl;
+	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {
-	cerr << "Caught unknown exception" << endl;
+	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }
 

--- a/tests/float/quires.cpp
+++ b/tests/float/quires.cpp
@@ -8,7 +8,8 @@
 
 // till we figure out how to derive sizes from types
 #define TEMPLATIZED_TYPE 0
-
+// enable/disable quire exceptions
+#define QUIRE_THROW_EXCEPTION 0
 #include "../../posit/exceptions.hpp"
 #include "../../bitblock/bitblock.hpp"
 #include "../../posit/bit_functions.hpp"
@@ -188,6 +189,14 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/float/quires.cpp
+++ b/tests/float/quires.cpp
@@ -191,7 +191,7 @@ catch (char const* msg) {
 	std::cerr << msg << '\n';
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/128bit_posit.cpp
+++ b/tests/posit/128bit_posit.cpp
@@ -6,9 +6,8 @@
 
 #include "common.hpp"
 // enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
 
@@ -48,8 +47,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_SUCCESS; //as we manually throwing the not supported yet it should not fall through the cracks     EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/128bit_posit.cpp
+++ b/tests/posit/128bit_posit.cpp
@@ -6,7 +6,7 @@
 
 #include "common.hpp"
 // enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
@@ -47,15 +47,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_SUCCESS; //as we manually throwing the not supported yet it should not fall through the cracks     EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/16bit_posit.cpp
+++ b/tests/posit/16bit_posit.cpp
@@ -6,7 +6,7 @@
 
 #include "common.hpp"
 // enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
@@ -46,15 +46,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/16bit_posit.cpp
+++ b/tests/posit/16bit_posit.cpp
@@ -5,10 +5,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-
-#include <vector>
+// enable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
 
@@ -47,8 +46,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/32bit_posit.cpp
+++ b/tests/posit/32bit_posit.cpp
@@ -6,7 +6,7 @@
 
 #include "common.hpp"
 // enable/disable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
@@ -46,15 +46,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/32bit_posit.cpp
+++ b/tests/posit/32bit_posit.cpp
@@ -5,10 +5,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include "common.hpp"
-// enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
 
@@ -47,8 +46,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/48bit_posit.cpp
+++ b/tests/posit/48bit_posit.cpp
@@ -6,7 +6,7 @@
 
 #include "common.hpp"
 // enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
@@ -46,15 +46,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/48bit_posit.cpp
+++ b/tests/posit/48bit_posit.cpp
@@ -6,9 +6,8 @@
 
 #include "common.hpp"
 // enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
 
@@ -47,8 +46,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/64bit_posit.cpp
+++ b/tests/posit/64bit_posit.cpp
@@ -8,7 +8,6 @@
 // enable posit arithmetic exceptions
 #define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
-
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
 
@@ -47,15 +46,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/64bit_posit.cpp
+++ b/tests/posit/64bit_posit.cpp
@@ -47,8 +47,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/8bit_posit.cpp
+++ b/tests/posit/8bit_posit.cpp
@@ -6,9 +6,8 @@
 
 #include "common.hpp"
 // enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include <posit>
-
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
 
@@ -48,8 +47,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (const std::runtime_error& err) {
-	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/8bit_posit.cpp
+++ b/tests/posit/8bit_posit.cpp
@@ -6,7 +6,7 @@
 
 #include "common.hpp"
 // enable posit arithmetic exceptions
-#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 #include <posit>
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
@@ -47,15 +47,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_add.cpp
+++ b/tests/posit/arithmetic_add.cpp
@@ -9,13 +9,13 @@
 // when you define POSIT_VERBOSE_OUTPUT executing an ADD the code will print intermediate results
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_ADD
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
-
 
 // generate specific test case that you can trace with the trace conditions in posit.h
 // for most bugs they are traceable with _trace_conversion and _trace_add
@@ -124,6 +124,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_add.cpp
+++ b/tests/posit/arithmetic_add.cpp
@@ -126,15 +126,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_divide.cpp
+++ b/tests/posit/arithmetic_divide.cpp
@@ -9,8 +9,9 @@
 // when you define POSIT_VERBOSE_OUTPUT executing an DIV the code will print intermediate results
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_DIV
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"
 #include "../tests/test_helpers.hpp"
@@ -257,6 +258,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_divide.cpp
+++ b/tests/posit/arithmetic_divide.cpp
@@ -260,15 +260,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_fma.cpp
+++ b/tests/posit/arithmetic_fma.cpp
@@ -81,15 +81,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_fma.cpp
+++ b/tests/posit/arithmetic_fma.cpp
@@ -8,13 +8,13 @@
 // when you define POSIT_VERBOSE_OUTPUT executing an SUB the code will print intermediate results
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_SUB
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"
 #include "../tests/test_helpers.hpp"
 #include "../tests/posit_test_helpers.hpp"
-
 
 // generate specific test case that you can trace with the trace conditions in posit.h
 // for most bugs they are traceable with _trace_conversion and _trace_sub
@@ -79,6 +79,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_literals.cpp
+++ b/tests/posit/arithmetic_literals.cpp
@@ -9,8 +9,9 @@
 // when you define POSIT_VERBOSE_OUTPUT executing an ADD the code will print intermediate results
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_ADD
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 // enable/disable the ability to use literals in binary logic and arithmetic operators
 #define POSIT_ENABLE_LITERALS 1
 #include "../../posit/posit.hpp"
@@ -232,6 +233,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_literals.cpp
+++ b/tests/posit/arithmetic_literals.cpp
@@ -235,15 +235,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_multiply.cpp
+++ b/tests/posit/arithmetic_multiply.cpp
@@ -9,8 +9,9 @@
 // when you define POSIT_VERBOSE_OUTPUT executing an MUL the code will print intermediate results
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_MUL
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"
 #include "../tests/test_helpers.hpp"
@@ -211,6 +212,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_multiply.cpp
+++ b/tests/posit/arithmetic_multiply.cpp
@@ -214,15 +214,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_negate.cpp
+++ b/tests/posit/arithmetic_negate.cpp
@@ -101,15 +101,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_negate.cpp
+++ b/tests/posit/arithmetic_negate.cpp
@@ -6,10 +6,12 @@
 
 #include "common.hpp"
 
+// when you define POSIT_VERBOSE_OUTPUT the code will print intermediate results for CONVERSIONs
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_CONVERSION
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"
 #include "../tests/test_helpers.hpp"
@@ -97,6 +99,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_reciprocate.cpp
+++ b/tests/posit/arithmetic_reciprocate.cpp
@@ -127,15 +127,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_reciprocate.cpp
+++ b/tests/posit/arithmetic_reciprocate.cpp
@@ -10,8 +10,9 @@
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_RECIPROCATE
 #define POSIT_TRACE_CONVERSION
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_decoded.hpp"		// old reference design for validation/debug
 #include "../../posit/posit_manipulators.hpp"
@@ -124,6 +125,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_sqrt.cpp
+++ b/tests/posit/arithmetic_sqrt.cpp
@@ -183,15 +183,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_sqrt.cpp
+++ b/tests/posit/arithmetic_sqrt.cpp
@@ -9,8 +9,9 @@
 // when you define POSIT_VERBOSE_OUTPUT the code will print intermediate results for selected arithmetic operations
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_SQRT
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"
 #include "../../posit/math_sqrt.hpp"
@@ -180,6 +181,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/arithmetic_subtract.cpp
+++ b/tests/posit/arithmetic_subtract.cpp
@@ -135,15 +135,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/arithmetic_subtract.cpp
+++ b/tests/posit/arithmetic_subtract.cpp
@@ -8,8 +8,9 @@
 // when you define POSIT_VERBOSE_OUTPUT executing an SUB the code will print intermediate results
 //#define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_SUB
-
 // minimum set of include files to reflect source code dependencies
+// enable/disable posit arithmetic exceptions
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_manipulators.hpp"
 #include "../tests/test_helpers.hpp"
@@ -132,6 +133,22 @@ try {
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/assignment.cpp
+++ b/tests/posit/assignment.cpp
@@ -98,15 +98,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/assignment.cpp
+++ b/tests/posit/assignment.cpp
@@ -98,6 +98,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/conversion.cpp
+++ b/tests/posit/conversion.cpp
@@ -296,6 +296,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/conversion.cpp
+++ b/tests/posit/conversion.cpp
@@ -296,15 +296,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/conversion_functions.cpp
+++ b/tests/posit/conversion_functions.cpp
@@ -676,15 +676,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/conversion_functions.cpp
+++ b/tests/posit/conversion_functions.cpp
@@ -676,6 +676,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/decode.cpp
+++ b/tests/posit/decode.cpp
@@ -61,8 +61,20 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (std::runtime_error& e) {
-	std::cerr << e.what() << std::endl;
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/tests/posit/decode.cpp
+++ b/tests/posit/decode.cpp
@@ -61,15 +61,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/decrement.cpp
+++ b/tests/posit/decrement.cpp
@@ -111,6 +111,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/decrement.cpp
+++ b/tests/posit/decrement.cpp
@@ -111,15 +111,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/increment.cpp
+++ b/tests/posit/increment.cpp
@@ -111,6 +111,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/increment.cpp
+++ b/tests/posit/increment.cpp
@@ -111,15 +111,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/logic.cpp
+++ b/tests/posit/logic.cpp
@@ -566,6 +566,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/logic.cpp
+++ b/tests/posit/logic.cpp
@@ -566,15 +566,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/math_exponent.cpp
+++ b/tests/posit/math_exponent.cpp
@@ -152,15 +152,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/math_exponent.cpp
+++ b/tests/posit/math_exponent.cpp
@@ -152,6 +152,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/math_hyperbolic.cpp
+++ b/tests/posit/math_hyperbolic.cpp
@@ -231,15 +231,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/math_hyperbolic.cpp
+++ b/tests/posit/math_hyperbolic.cpp
@@ -231,6 +231,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/math_logarithm.cpp
+++ b/tests/posit/math_logarithm.cpp
@@ -163,15 +163,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/math_logarithm.cpp
+++ b/tests/posit/math_logarithm.cpp
@@ -163,6 +163,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/math_pow.cpp
+++ b/tests/posit/math_pow.cpp
@@ -157,15 +157,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/math_pow.cpp
+++ b/tests/posit/math_pow.cpp
@@ -157,6 +157,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/math_trigonometric.cpp
+++ b/tests/posit/math_trigonometric.cpp
@@ -149,6 +149,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/math_trigonometric.cpp
+++ b/tests/posit/math_trigonometric.cpp
@@ -149,15 +149,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/postfix.cpp
+++ b/tests/posit/postfix.cpp
@@ -32,6 +32,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/postfix.cpp
+++ b/tests/posit/postfix.cpp
@@ -32,15 +32,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/prefix.cpp
+++ b/tests/posit/prefix.cpp
@@ -32,6 +32,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/prefix.cpp
+++ b/tests/posit/prefix.cpp
@@ -32,15 +32,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/quire_accumulation.cpp
+++ b/tests/posit/quire_accumulation.cpp
@@ -323,15 +323,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit/quire_accumulation.cpp
+++ b/tests/posit/quire_accumulation.cpp
@@ -323,6 +323,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/reciprocal_tables.cpp
+++ b/tests/posit/reciprocal_tables.cpp
@@ -47,6 +47,22 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
+catch (const sw::unum::posit_arithmetic_exception& err) {
+	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::quire_exception& err) {
+	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::unum::posit_internal_exception& err) {
+	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
 catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;

--- a/tests/posit/reciprocal_tables.cpp
+++ b/tests/posit/reciprocal_tables.cpp
@@ -47,15 +47,15 @@ catch (char const* msg) {
 	std::cerr << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_arithmetic_exception& err) {
+catch (const posit_arithmetic_exception& err) {
 	std::cerr << "Uncaught posit arithmetic exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::quire_exception& err) {
+catch (const quire_exception& err) {
 	std::cerr << "Uncaught quire exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::unum::posit_internal_exception& err) {
+catch (const posit_internal_exception& err) {
 	std::cerr << "Uncaught posit internal exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }

--- a/tests/posit_test_helpers.hpp
+++ b/tests/posit_test_helpers.hpp
@@ -464,6 +464,7 @@ namespace sw {
 							throw err;
 						}
 					}
+
 #else
 					psum = pa + pb;
 #endif

--- a/tests/quire_test_helpers.hpp
+++ b/tests/quire_test_helpers.hpp
@@ -124,8 +124,11 @@ namespace sw {
 						std::cerr << "quire value conversion failed: " << components(v) << " != " << components(r) << std::endl;
 					}
 				}
-				catch (const std::runtime_error& err) {
+				catch (const quire_exception& err) {
 					std::cerr << "Caught the exception: " << err.what() << ". RHS was " << v << " " << components(v) << std::endl;
+				}
+				catch (...) {
+					std::cerr << "Why can't I catch quire_exception type?\n";
 				}
 			}
 		}

--- a/tests/quire_test_helpers.hpp
+++ b/tests/quire_test_helpers.hpp
@@ -15,7 +15,6 @@
 namespace sw {
 	namespace unum {
 
-
 		int TestQuireAccumulationResult(int nrOfFailedTests, std::string descriptor)
 		{
 			if (nrOfFailedTests > 0) {


### PR DESCRIPTION
Adding three classifications of exceptions:
posit_arithmetic_exception
posit_internal_exception
quire_exception

to streamline the application level exception handling. The application doesn't need to 'know' the exact cause, and simply record the exception message to discover what was the cause. 

For the internal handling of specific exceptions in the verification we do need the exact exception to figure out if the exception is expected and thus can be consumed by the verification middleware. 