### PR TITLE
Turning off appveyor Debug builds as they are overrunning the log

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ image:
 - Visual Studio 2017
 configuration:
 - Release
-- Debug
+#- Debug
 platform:
 - x64
 environment:


### PR DESCRIPTION
AppVeyor MSVC CI is failing due to Debug builds overrunning the log file. Warnings generated by code in the Microsoft runtime is too voluminous. 

Stop-gap measure until we figure out how to capture the log in its own artifact.