### PR TITLE
bug fix: integer conversion was 2's complementing twice

### DIFF
--- a/posit/posit
+++ b/posit/posit
@@ -9,12 +9,18 @@
 // enable/disable the ability to use literals in binary logic and arithmetic operators
 #define POSIT_ENABLE_LITERALS 1
 // enable throwing specific exceptions for posit arithmetic errors
-// left to application to enable/disable
+// left to application to enable
+#if !defined(POSIT_THROW_ARITHMETIC_EXCEPTION)
+// default is to use NaR as a signalling error
+#define POSIT_THROW_ARITHMETIC_EXCEPTION 0
 //#define POSIT_THROW_ARITHMETIC_EXCEPTION 1
+#endif
 
 #include "posit.hpp"
 #include "posit_decoded.hpp"
+#ifdef POSIT_FAST_SPECIALIZATION
 #include "specialized/posit_4_0.hpp"
+#endif
 #include "posit_manipulators.hpp"
 #include "posit_functions.hpp"
 #include "quire.hpp"

--- a/posit/posit.hpp
+++ b/posit/posit.hpp
@@ -489,10 +489,6 @@ namespace sw {
 					setToZero();
 					return *this;
 				}
-				else if (v.isNegative()) {
-					convert(v, *this);
-					_raw_bits = twos_complement(_raw_bits);
-				}
 				else {
 					convert(v, *this);
 				}
@@ -503,10 +499,6 @@ namespace sw {
 				if (v.isZero()) {
 					setToZero();
 					return *this;
-				}
-				else if (v.isNegative()) {
-					convert(v, *this);
-					_raw_bits = twos_complement(_raw_bits);
 				}
 				else {
 					convert(v, *this);
@@ -519,10 +511,6 @@ namespace sw {
 					setToZero();
 					return *this;
 				}
-				else if (v.isNegative()) {
-					convert(v, *this);
-					_raw_bits = twos_complement(_raw_bits);
-				}
 				else {
 					convert(v, *this);
 				}
@@ -533,10 +521,6 @@ namespace sw {
 				if (v.isZero()) {
 					setToZero();
 					return *this;
-				}
-				else if (v.isNegative()) {
-					convert(v, *this);
-					_raw_bits = twos_complement(_raw_bits);
 				}
 				else {
 					convert(v, *this);
@@ -549,10 +533,6 @@ namespace sw {
 					setToZero();
 					return *this;
 				}
-				else if (v.isNegative()) {
-					convert(v, *this);
-					_raw_bits = twos_complement(_raw_bits);
-				}
 				else {
 					convert(v, *this);
 				}
@@ -563,10 +543,6 @@ namespace sw {
 				if (v.isZero()) {
 					setToZero();
 					return *this;
-				}
-				else if (v.isNegative()) {
-					convert(v, *this);
-					_raw_bits = twos_complement(_raw_bits);
 				}
 				else {
 					convert(v, *this);
@@ -579,10 +555,6 @@ namespace sw {
 					setToZero();
 					return *this;
 				}
-				// else if (v.isNegative()) {
-				// 	convert(v);
-				// 	take_2s_complement();
-				// }
 				else {
 					convert(v, *this);
 				}
@@ -594,10 +566,6 @@ namespace sw {
 					setToZero();
 					return *this;
 				}
-				// else if (v.isNegative()) {
-				// 	convert(v);
-				// 	take_2s_complement();
-				// }
 				else {
 					convert(v, *this);
 				}
@@ -612,7 +580,6 @@ namespace sw {
 				else {
 					convert(v, *this);
 				}
-				// convert(v);
 				return *this;
 			}
 			posit& operator=(const unsigned long long rhs) {
@@ -624,7 +591,6 @@ namespace sw {
 				else {
 					convert(v, *this);
 				}
-				// convert(v);
 				return *this;
 			}
 			posit& operator=(const float rhs) {
@@ -1065,7 +1031,6 @@ namespace sw {
 				decrement_bitset(_raw_bits);
 			}
 	
-
 
 		private:
 			bitblock<nbits>      _raw_bits;	// raw bit representation

--- a/posit/posit_manipulators.hpp
+++ b/posit/posit_manipulators.hpp
@@ -117,7 +117,7 @@ namespace sw {
 		}
 
 		template<size_t nbits, size_t es>
-		std::string info_print(const posit<nbits, es>& p, int printPrecision) {
+		std::string info_print(const posit<nbits, es>& p, int printPrecision = 17) {
 			std::stringstream ss;
 			constexpr size_t fbits = p.fbits;
 			bool		     	 _sign;

--- a/tests/posit/32bit_posit.cpp
+++ b/tests/posit/32bit_posit.cpp
@@ -3,7 +3,6 @@
 // Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-
 #include "common.hpp"
 // enable/disable posit arithmetic exceptions
 #define POSIT_THROW_ARITHMETIC_EXCEPTION 1

--- a/tests/posit/conversion.cpp
+++ b/tests/posit/conversion.cpp
@@ -9,7 +9,8 @@
 // if you want to trace the posit intermediate results
 // #define POSIT_VERBOSE_OUTPUT
 #define POSIT_TRACE_CONVERT
-
+// enable the ability to use literals in binary logic and arithmetic operators
+#define POSIT_ENABLE_LITERALS 1
 // minimum set of include files to reflect source code dependencies
 #include "../../posit/posit.hpp"
 #include "../../posit/posit_decoded.hpp"
@@ -191,7 +192,7 @@ try {
 	bool bReportIndividualTestCases = false;
 	int nrOfFailedTestCases = 0;
 
-	std::string tag = "Conversion failed";
+	std::string tag = "Conversion test";
 
 #if MANUAL_TESTING
 	// generate individual testcases to hand trace/debug
@@ -213,29 +214,42 @@ try {
 	cout << "----------------\n";
 #endif
 
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<3, 0>(tag, true), "posit<3,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<4, 0>(tag, true), "posit<4,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<5, 0>(tag, true), "posit<5,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<6, 0>(tag, true), "posit<6,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<7, 0>(tag, true), "posit<7,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<8, 0>(tag, true), "posit<8,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<9, 0>(tag, true), "posit<9,0>", "conversion");
+
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<3, 0>(tag, true), "posit<3,0>", "conversion");
-	return 0;
 
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<4, 1>(tag, true), "posit<4,1>", "conversion");
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<5, 2>(tag, true), "posit<5,2>", "conversion");
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<6, 3>(tag, true), "posit<6,3>", "conversion");
-	return 0;
 
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<4, 0>(tag, true), "posit<4,0>", "conversion");
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<4, 1>(tag, true), "posit<4,1>", "conversion"); 
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<5, 0>(tag, true), "posit<5,0>", "conversion");
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<5, 1>(tag, true), "posit<5,1>", "conversion");
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion<5, 2>(tag, true), "posit<5,2>", "conversion");
-	return 0;
+
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<6, 0>("Posit<6,0> addition failed: ", bReportIndividualTestCases), "posit<6,0>", "addition");
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<6, 1>("Posit<6,1> addition failed: ", bReportIndividualTestCases), "posit<6,1>", "addition");
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<6, 2>("Posit<6,2> addition failed: ", bReportIndividualTestCases), "posit<6,2>", "addition");
 	nrOfFailedTestCases += ReportTestResult(ValidateAddition<6, 3>("Posit<6,3> addition failed: ", bReportIndividualTestCases), "posit<6,3>", "addition");
-	return 0;
 
 #else
 
 	cout << "Posit conversion validation" << endl;
+
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<5, 0>(tag, bReportIndividualTestCases), "posit<5,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<6, 0>(tag, bReportIndividualTestCases), "posit<6,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<7, 0>(tag, bReportIndividualTestCases), "posit<7,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<8, 0>(tag, bReportIndividualTestCases), "posit<8,0>", "conversion");
+	nrOfFailedTestCases += ReportTestResult(ValidateIntegerConversion<9, 0>(tag, bReportIndividualTestCases), "posit<9,0>", "conversion");
 
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion< 3, 0>(tag, bReportIndividualTestCases), "posit<3,0>", "conversion");
 	nrOfFailedTestCases += ReportTestResult(ValidateConversion< 4, 0>(tag, bReportIndividualTestCases), "posit<4,0>", "conversion");

--- a/tests/posit/logic.cpp
+++ b/tests/posit/logic.cpp
@@ -3,13 +3,12 @@
 // Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-
 #include "common.hpp"
-
 // minimum set of include files to reflect source code dependencies
 #define POSIT_ENABLE_LITERALS 1
 #include "../../posit/posit.hpp"
 #include "../tests/test_helpers.hpp"
+#include "../../posit/posit_manipulators.hpp"
 
 // Posit equal diverges from IEEE float in dealing with INFINITY/NAN
 // Posit NaR can be checked for equality/inequality
@@ -239,7 +238,7 @@ int ValidatePositLogicGreaterOrEqualThan() {
 	return nrOfFailedTestCases;
 }
 
-#define MANUAL_TESTING 0
+#define MANUAL_TESTING 1
 #define STRESS_TESTING 0
 
 int main()
@@ -250,32 +249,52 @@ try {
 	int nrOfFailedTestCases = 0;
 
 #if MANUAL_TESTING
-	constexpr size_t nbits = 8;
-	constexpr size_t es    = 0;
 
-	double nan    = NAN;
-	double inf    = INFINITY;
-	double normal = 0;
-	posit<nbits, es> pa(nan), pb(inf), pc(normal);
-	std::cout << pa << " " << pb << " " << pc << std::endl;
+	posit<4, 0> pa(1.5), pb(-4);
+
+	pb = -4;
 	
-	// showcasing the differences between posit and IEEE float
-	std::cout << "NaN ==  NaN: IEEE=" << (nan == nan ? "true" : "false")    << "    Posit=" << (pa == pa ? "true" : "false") << std::endl;
-	std::cout << "NaN == real: IEEE=" << (nan == normal ? "true" : "false") << "    Posit=" << (pa == pc ? "true" : "false") << std::endl;
-	std::cout << "INF ==  INF: IEEE=" << (inf == inf ? "true" : "false")    << "    Posit=" << (pb == pb ? "true" : "false") << std::endl;
-	std::cout << "NaN !=  NaN: IEEE=" << (nan != nan ? "true" : "false")    << "   Posit=" << (pa != pb ? "true" : "false") << std::endl;
-	std::cout << "INF !=  INF: IEEE=" << (inf != inf ? "true" : "false")    << "   Posit=" << (pb != pb ? "true" : "false") << std::endl;
-	std::cout << "NaN <= real: IEEE=" << (nan <= normal ? "true" : "false") << "    Posit=" << (pa <= pc ? "true" : "false") << std::endl;
-	std::cout << "NaN >= real: IEEE=" << (nan >= normal ? "true" : "false") << "    Posit=" << (pa >= pc ? "true" : "false") << std::endl;
-	std::cout << "INF <  real: IEEE=" << (inf <  normal ? "true" : "false") << "   Posit=" << (pa <  pc ? "true" : "false") << std::endl;
-	std::cout << "INF >  real: IEEE=" << (inf  > normal ? "true" : "false") << "    Posit=" << (pa  > pc ? "true" : "false") << std::endl;
+	if (pa < pb) {
+		cout << "incorrect: " << endl;
+		cout << "pa = " << info_print(pa) << " " << float(pa) << endl;
+		cout << "pb = " << info_print(pb) << " " << float(pb) << endl;
+	}
 
+	GeneratePositTable<4, 0>(cout);
+	ReportTestResult(ValidatePositLogicLessThan<4, 0>(), "posit<4,0>", "<");
+
+	return 0;
+
+	{
+		constexpr size_t nbits = 8;
+		constexpr size_t es = 0;
+		double nan    = NAN;
+		double inf    = INFINITY;
+		double normal = 0;
+		posit<nbits, es> pa(nan), pb(inf), pc(normal);
+		std::cout << pa << " " << pb << " " << pc << std::endl;
+	
+		// showcasing the differences between posit and IEEE float
+		std::cout << "NaN ==  NaN: IEEE=" << (nan == nan ? "true" : "false")    << "    Posit=" << (pa == pa ? "true" : "false") << std::endl;
+		std::cout << "NaN == real: IEEE=" << (nan == normal ? "true" : "false") << "    Posit=" << (pa == pc ? "true" : "false") << std::endl;
+		std::cout << "INF ==  INF: IEEE=" << (inf == inf ? "true" : "false")    << "    Posit=" << (pb == pb ? "true" : "false") << std::endl;
+		std::cout << "NaN !=  NaN: IEEE=" << (nan != nan ? "true" : "false")    << "   Posit=" << (pa != pb ? "true" : "false") << std::endl;
+		std::cout << "INF !=  INF: IEEE=" << (inf != inf ? "true" : "false")    << "   Posit=" << (pb != pb ? "true" : "false") << std::endl;
+		std::cout << "NaN <= real: IEEE=" << (nan <= normal ? "true" : "false") << "    Posit=" << (pa <= pc ? "true" : "false") << std::endl;
+		std::cout << "NaN >= real: IEEE=" << (nan >= normal ? "true" : "false") << "    Posit=" << (pa >= pc ? "true" : "false") << std::endl;
+		std::cout << "INF <  real: IEEE=" << (inf <  normal ? "true" : "false") << "   Posit=" << (pa <  pc ? "true" : "false") << std::endl;
+		std::cout << "INF >  real: IEEE=" << (inf  > normal ? "true" : "false") << "    Posit=" << (pa  > pc ? "true" : "false") << std::endl;
+	}
+
+	{
 	nrOfFailedTestCases += ReportTestResult(ValidatePositLogicEqual<3, 0>(), "posit<3,0>", "==");
 	nrOfFailedTestCases += ReportTestResult(ValidatePositLogicNotEqual<3, 0>(), "posit<3,0>", "!=");
 	nrOfFailedTestCases += ReportTestResult(ValidatePositLogicLessThan<3, 0>(), "posit<3,0>", "<");
 	nrOfFailedTestCases += ReportTestResult(ValidatePositLogicGreaterThan<3, 0>(), "posit<3,0>", ">");
 	nrOfFailedTestCases += ReportTestResult(ValidatePositLogicLessOrEqualThan<3, 0>(), "posit<3,0>", "<=");
 	nrOfFailedTestCases += ReportTestResult(ValidatePositLogicGreaterOrEqualThan<3, 0>(), "posit<3,0>", ">=");
+	}
+
 
 #else
 	posit<16, 1> p;


### PR DESCRIPTION
The function convert() acts on the sign of the value that is being converted, which in our current implementation is configured as a conversion of a posit value, which is 2's complemented when the sign indicates a negative number. 

The integer conversion code path had not been modified to reflect this new behavior after the API redesign.

Because the conversion verification tests only used the floating point paths, this was not caught. To plug this test hole, I added a new integer conversion test suite and made it part of the regular regression testing.