### PR TITLE
C api add posit256

### DIFF
--- a/c_api/test/posit/posit256.c
+++ b/c_api/test/posit/posit256.c
@@ -6,37 +6,37 @@
 
 #include <posit_c_api.h>
 
-int main(int argc, char* argv[]) 
+int main(int argc, char* argv[])
 {
 	const int maxNr = 196;
 	posit256_t pa, pb, pc;
-	char str[POSIT_FORMAT256_SIZE];
+	char str[posit256_str_SIZE];
 	bool failures = false;
 	bool bReportIndividualTestCases = false;
 
 	// special case values
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_add256(pa, pb);
-	posit_format256(pc, str);
+	pc = posit_add(pa, pb);
+	posit_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_sub256(pa, pb);
-	posit_format256(pc, str);
+	pc = posit_sub(pa, pb);
+	posit_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_mul256(pa, pb);
-	posit_format256(pc, str);
+	pc = posit_mul(pa, pb);
+	posit_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_div256(pa, pb);
-	posit_format256(pc, str);
+	pc = posit_div(pa, pb);
+	posit_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	bool noReference = true;
@@ -45,23 +45,23 @@ int main(int argc, char* argv[])
 	// partial state space
 	int fails = 0;
 	for (int a = 0; a < maxNr; ++a) {
-		pa = posit_assign256(a, 0, 0, 0);
+		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
-			pb = posit_assign256(b, 0, 0, 0);
-			pc = posit_add256(pa, pb);
+			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
+			pc = posit_add(pa, pb);
 
 			long double da, db, dref;
-			da = posit_value256(pa);
-			db = posit_value256(pb);
+			da = posit_told(pa);
+			db = posit_told(pb);
 			dref = da + db;
 
-			posit256_t pref = posit_assign256f(dref);
-			if (posit_equal256(pref, pc)) {
-				char sa[POSIT_FORMAT256_SIZE], sb[POSIT_FORMAT256_SIZE], sc[POSIT_FORMAT256_SIZE], sref[POSIT_FORMAT256_SIZE];
-				posit_format256(pa, sa);
-				posit_format256(pb, sb);
-				posit_format256(pc, sc);
-				posit_format256(pref, sref);
+			posit256_t pref = posit256(dref);
+			if (posit_cmp(pref, pc)) {
+				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
+				posit_str(sa, pa);
+				posit_str(sb, pb);
+				posit_str(sc, pc);
+				posit_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s + %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}
@@ -83,23 +83,23 @@ int main(int argc, char* argv[])
 	// partial state space
 	fails = 0;
 	for (int a = 0; a < maxNr; ++a) {
-		pa = posit_assign256(a, 0, 0, 0);
+		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
-			pb = posit_assign256(b, 0, 0, 0);
-			pc = posit_sub256(pa, pb);
+			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
+			pc = posit_sub(pa, pb);
 
 			long double da, db, dref;
-			da = posit_value256(pa);
-			db = posit_value256(pb);
+			da = posit_told(pa);
+			db = posit_told(pb);
 			dref = da - db;
 
-			posit256_t pref = posit_assign256f(dref);
-			if (posit_equal256(pref, pc)) {
-				char sa[POSIT_FORMAT256_SIZE], sb[POSIT_FORMAT256_SIZE], sc[POSIT_FORMAT256_SIZE], sref[POSIT_FORMAT256_SIZE];
-				posit_format256(pa, sa);
-				posit_format256(pb, sb);
-				posit_format256(pc, sc);
-				posit_format256(pref, sref);
+			posit256_t pref = posit256(dref);
+			if (posit_cmp(pref, pc)) {
+				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
+				posit_str(sa, pa);
+				posit_str(sb, pb);
+				posit_str(sc, pc);
+				posit_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s - %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}
@@ -121,23 +121,23 @@ int main(int argc, char* argv[])
 	// partial state space
 	fails = 0;
 	for (int a = 0; a < maxNr; ++a) {
-		pa = posit_assign256(a, 0, 0, 0);
+		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
-			pb = posit_assign256(b, 0, 0, 0);
-			pc = posit_mul256(pa, pb);
+			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
+			pc = posit_mul(pa, pb);
 
 			long double da, db, dref;
-			da = posit_value256(pa);
-			db = posit_value256(pb);
+			da = posit_told(pa);
+			db = posit_told(pb);
 			dref = da * db;
 
-			posit256_t pref = posit_assign256f(dref);
-			if (posit_equal256(pref, pc)) {
-				char sa[POSIT_FORMAT256_SIZE], sb[POSIT_FORMAT256_SIZE], sc[POSIT_FORMAT256_SIZE], sref[POSIT_FORMAT256_SIZE];
-				posit_format256(pa, sa);
-				posit_format256(pb, sb);
-				posit_format256(pc, sc);
-				posit_format256(pref, sref);
+			posit256_t pref = posit256(dref);
+			if (posit_cmp(pref, pc)) {
+				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
+				posit_str(sa, pa);
+				posit_str(sb, pb);
+				posit_str(sc, pc);
+				posit_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s * %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}
@@ -159,23 +159,23 @@ int main(int argc, char* argv[])
 	// partial state space
 	fails = 0;
 	for (int a = 0; a < maxNr; ++a) {
-		pa = posit_assign256(a, 0, 0, 0);
+		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
-			pb = posit_assign256(b, 0, 0, 0);
-			pc = posit_div256(pa, pb);
+			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
+			pc = posit_div(pa, pb);
 
 			long double da, db, dref;
-			da = posit_value256(pa);
-			db = posit_value256(pb);
+			da = posit_told(pa);
+			db = posit_told(pb);
 			dref = da / db;
 
-			posit256_t pref = posit_assign256f(dref);
-			if (posit_equal256(pref, pc)) {
-				char sa[POSIT_FORMAT256_SIZE], sb[POSIT_FORMAT256_SIZE], sc[POSIT_FORMAT256_SIZE], sref[POSIT_FORMAT256_SIZE];
-				posit_format256(pa, sa);
-				posit_format256(pb, sb);
-				posit_format256(pc, sc);
-				posit_format256(pref, sref);
+			posit256_t pref = posit256(dref);
+			if (posit_cmp(pref, pc)) {
+				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
+				posit_str(sa, pa);
+				posit_str(sb, pb);
+				posit_str(sc, pc);
+				posit_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s / %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}

--- a/posit/posit_c_api.h
+++ b/posit/posit_c_api.h
@@ -16,19 +16,19 @@ extern "C" {
 
 	//////////////////////////////////////////////////////////////////////
 	/// Standard posit configuration per the POSIT standard
-	typedef union posit8_u   { 
+	typedef union posit8_u   {
 		uint8_t x[1];
 		uint8_t v;
 	}											posit8_t;	// posit<8,0>
-	typedef union posit16_u  { 
+	typedef union posit16_u  {
 		uint8_t x[2];
 		uint16_t v;
 	}											posit16_t;	// posit<16,1>
-	typedef struct posit32_s { 
+	typedef struct posit32_s {
 		uint8_t x[4];
 		uint32_t v;
 	}											posit32_t;	// posit<32,2>
-	typedef struct posit64_s { 
+	typedef struct posit64_s {
 		uint8_t x[8];
 		uint64_t v;
 	}											posit64_t;	// posit<64,3>
@@ -116,8 +116,8 @@ extern "C" {
 	static const posit8_t  NAR8  = { 0x80 };
 	static const posit16_t NAR16 = { 0x00, 0x80 };
 	static const posit32_t NAR32 = { 0x00, 0x00, 0x00, 0x80 };
-	static const posit64_t NAR64 = { 
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 
+	static const posit64_t NAR64 = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
 	};
 	static const posit128_t NAR128 = {{   // we a storing this in little endian
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -156,8 +156,12 @@ enum {
 	#define posit64_str_SIZE posit64_str_SIZE
 
 	/// report posit format for posit128_t. str must be at least 40 characters in size:  128.4x12345678123456781234567812345678p + /0 is 40 chars
-	posit128_str_SIZE = 40
+	posit128_str_SIZE = 40,
 	#define posit128_str_SIZE posit128_str_SIZE
+
+	/// TODO: I don't know the max size of a printed posit256 but it should be less than 80
+	posit256_str_SIZE = 80
+	#define posit256_str_SIZE posit256_str_SIZE
 };
 
 // reinterpret bits from an insigned integer type to a posit
@@ -217,6 +221,10 @@ static inline uint64_t  posit64_bits(posit64_t p) { return p.v; }
 #include "posit_c_macros.h"
 #undef POSIT_NBITS
 
+#define POSIT_NBITS 256
+#include "posit_c_macros.h"
+#undef POSIT_NBITS
+
 #if __STDC_VERSION__ >= 201112L && !defined(POSIT_NO_GENERICS)
 
 #define POSIT_FROM(nbits, x) (_Generic((x), \
@@ -233,13 +241,15 @@ static inline uint64_t  posit64_bits(posit64_t p) { return p.v; }
 	posit16_t: 			POSIT_GLUE4(posit,nbits,_from,p16), \
 	posit32_t: 			POSIT_GLUE4(posit,nbits,_from,p32), \
 	posit64_t: 			POSIT_GLUE4(posit,nbits,_from,p64), \
-	posit128_t: 		POSIT_GLUE4(posit,nbits,_from,p128) \
+	posit128_t: 		POSIT_GLUE4(posit,nbits,_from,p128), \
+	posit256_t: 		POSIT_GLUE4(posit,nbits,_from,p256) \
 )(x))
 #define posit8(x)       POSIT_FROM(8, (x))
 #define posit16(x)      POSIT_FROM(16, (x))
 #define posit32(x)      POSIT_FROM(32, (x))
 #define posit64(x)      POSIT_FROM(64, (x))
 #define posit128(x)     POSIT_FROM(128, (x))
+#define posit256(x)     POSIT_FROM(256, (x))
 
 #define POSIT_OP2(nbits, op, y) _Generic((y), \
 	long double: 		POSIT_GLUE5(posit,nbits,_,op,ld), \
@@ -255,7 +265,8 @@ static inline uint64_t  posit64_bits(posit64_t p) { return p.v; }
 	posit16_t: 			POSIT_GLUE5(posit,nbits,_,op,p16), \
 	posit32_t: 			POSIT_GLUE5(posit,nbits,_,op,p32), \
 	posit64_t: 			POSIT_GLUE5(posit,nbits,_,op,p64), \
-	posit128_t: 		POSIT_GLUE5(posit,nbits,_,op,p128) \
+	posit128_t: 		POSIT_GLUE5(posit,nbits,_,op,p128), \
+	posit256_t: 		POSIT_GLUE5(posit,nbits,_,op,p256) \
 )
 #define POSIT_OP2X(nbits, op, x) _Generic((x), \
 	long double: 		POSIT_GLUE5(posit,nbits,_,ld,op), \
@@ -271,7 +282,8 @@ static inline uint64_t  posit64_bits(posit64_t p) { return p.v; }
 	posit16_t: 			POSIT_GLUE5(posit,nbits,_,p16,op), \
 	posit32_t: 			POSIT_GLUE5(posit,nbits,_,p32,op), \
 	posit64_t: 			POSIT_GLUE5(posit,nbits,_,p64,op), \
-	posit128_t: 		POSIT_GLUE5(posit,nbits,_,p128,op) \
+	posit128_t: 		POSIT_GLUE5(posit,nbits,_,p128,op), \
+	posit256_t: 		POSIT_GLUE5(posit,nbits,_,p256,op) \
 )
 
 #define POSIT_GENERIC_OP(p,x,op) (_Generic((p), \
@@ -280,12 +292,14 @@ static inline uint64_t  posit64_bits(posit64_t p) { return p.v; }
 	posit32_t:          POSIT_OP2(32, op, (x)), \
 	posit64_t:          POSIT_OP2(64, op, (x)), \
 	posit128_t:         POSIT_OP2(128, op, (x)), \
+    posit256_t:         POSIT_OP2(256, op, (x)), \
 	default: _Generic((x), \
 		posit8_t:       POSIT_OP2X(8, op, (p)), \
 		posit16_t:      POSIT_OP2X(16, op, (p)), \
 		posit32_t:      POSIT_OP2X(32, op, (p)), \
 		posit64_t:      POSIT_OP2X(64, op, (p)), \
-		posit128_t:     POSIT_OP2X(128, op, (p)) \
+		posit128_t:     POSIT_OP2X(128, op, (p)), \
+        posit256_t:     POSIT_OP2X(256, op, (p)) \
 	) \
 )((p),(x)))
 #define posit_add(p, x) POSIT_GENERIC_OP(p,x,add)
@@ -299,7 +313,8 @@ static inline uint64_t  posit64_bits(posit64_t p) { return p.v; }
 	posit16_t: POSIT_GLUE(posit16_,op), \
 	posit32_t: POSIT_GLUE(posit32_,op), \
 	posit64_t: POSIT_GLUE(posit64_,op), \
-	posit128_t: POSIT_GLUE(posit128_,op) \
+	posit128_t: POSIT_GLUE(posit128_,op), \
+    posit256_t: POSIT_GLUE(posit256_,op) \
 )
 #define posit_str(buf, p)   POSIT_GENETIC1(p, str)((buf), (p))
 #define posit_sqrt(p)       POSIT_GENETIC1(p, sqrt)(p)

--- a/posit/posit_c_macros.h
+++ b/posit/posit_c_macros.h
@@ -113,6 +113,10 @@ POSIT_OPS(p64, posit64_t)
 POSIT_T POSIT_MKNAME(fromp128)(posit128_t p) POSIT_IMPL({ return POSIT_API::fromp<capi128>(p); })
 POSIT_OPS(p128, posit128_t)
 #endif
+#if POSIT_NBITS != 256
+POSIT_T POSIT_MKNAME(fromp256)(posit256_t p) POSIT_IMPL({ return POSIT_API::fromp<capi256>(p); })
+POSIT_OPS(p256, posit256_t)
+#endif
 
 POSIT_FUNCS(ld, long double)
 POSIT_FUNCS(d, double)


### PR DESCRIPTION
I noticed you added a test for posit256 type, this adds posit256 and makes the test build properly. It should be a good reference for adding types in the future since it shows what needs to be changed in the macro rat's nest.