### PR TITLE
C api static array index

### DIFF
--- a/posit/posit_c_api.h
+++ b/posit/posit_c_api.h
@@ -16,19 +16,19 @@ extern "C" {
 
 	//////////////////////////////////////////////////////////////////////
 	/// Standard posit configuration per the POSIT standard
-	typedef union posit8_u   { 
+	typedef union posit8_u   {
 		uint8_t x[1];
 		uint8_t v;
 	}											posit8_t;	// posit<8,0>
-	typedef union posit16_u  { 
+	typedef union posit16_u  {
 		uint8_t x[2];
 		uint16_t v;
 	}											posit16_t;	// posit<16,1>
-	typedef struct posit32_s { 
+	typedef struct posit32_s {
 		uint8_t x[4];
 		uint32_t v;
 	}											posit32_t;	// posit<32,2>
-	typedef struct posit64_s { 
+	typedef struct posit64_s {
 		uint8_t x[8];
 		uint64_t v;
 	}											posit64_t;	// posit<64,3>
@@ -116,8 +116,8 @@ extern "C" {
 	static const posit8_t  NAR8  = { 0x80 };
 	static const posit16_t NAR16 = { 0x00, 0x80 };
 	static const posit32_t NAR32 = { 0x00, 0x00, 0x00, 0x80 };
-	static const posit64_t NAR64 = { 
-		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 
+	static const posit64_t NAR64 = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
 	};
 	static const posit128_t NAR128 = {{   // we a storing this in little endian
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -165,7 +165,7 @@ static inline posit8_t   posit8_reinterpret(uint8_t n)   { posit8_t  x; x.v = n;
 static inline posit16_t  posit16_reinterpret(uint16_t n) { posit16_t x; x.v = n; return x; }
 static inline posit32_t  posit32_reinterpret(uint32_t n) { posit32_t x; x.v = n; return x; }
 static inline posit64_t  posit64_reinterpret(uint64_t n) { posit64_t x; x.v = n; return x; }
-#ifdef __cplusplus
+#if defined(__cplusplus) || defined(_MSC_VER)
 static inline posit128_t posit128_reinterpret(uint64_t* n) {
     posit128_t out;
     out.longs[0] = n[0];
@@ -182,10 +182,10 @@ static inline posit256_t posit256_reinterpret(uint64_t* n) {
 }
 #else
 // static array parameters are illegal in C++ but they provide valuable verification in C
-static inline posit128_t posit128_reinterpret(uint64_t n[2]) {
+static inline posit128_t posit128_reinterpret(uint64_t n[static 2]) {
     return (posit128_t){ .longs = { n[0], n[1] } };
 }
-static inline posit256_t posit256_reinterpret(uint64_t n[4]) {
+static inline posit256_t posit256_reinterpret(uint64_t n[static 4]) {
     return (posit256_t){ .longs = { n[0], n[1], n[2], n[3] } };
 }
 #endif

--- a/posit/posit_c_macros.h
+++ b/posit/posit_c_macros.h
@@ -68,13 +68,12 @@
 // We're done defining stuff, now we make functions
 /////
 
-#ifdef __cplusplus
+#if defined(__cplusplus) || defined(_MSC_VER)
 void POSIT_MKNAME(str)(char* out, POSIT_T p) POSIT_IMPL({ POSIT_API::format(p, out); })
 #else
 // Feature of C which is not preasent in C++
 // https://hamberg.no/erlend/posts/2013-02-18-static-array-indices.html
-//void POSIT_MKNAME(str)(char out[static POSIT_MKNAME(str_SIZE)], POSIT_T p);  // error in MSVC
-void POSIT_MKNAME(str)(char out[POSIT_MKNAME(str_SIZE)], POSIT_T p);
+void POSIT_MKNAME(str)(char out[static POSIT_MKNAME(str_SIZE)], POSIT_T p);
 #endif
 
 POSIT_BASE_OP(add)


### PR DESCRIPTION
This builds on top of #78 but the main thing here is to add back static array indexes because they provide a valuable type checking in C, for example doing:
```c
char buf[3];
posit256_str(buf, p);
```
will be a compiler error because the compiler knows that buf is not big enough. It's in the C spec but MSVC++ doesn't support it because MSVC++ doesn't support the C spec, it's really only a C++ compiler. So I just proposed to detect it and fallback on the less safe C++ APIs.