### PR TITLE
C api no generics in tests

### DIFF
--- a/c_api/test/posit/posit128.c
+++ b/c_api/test/posit/posit128.c
@@ -4,6 +4,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#define POSIT_NO_GENERICS // MSVC doesn't support _Generic so we'll leave it out from these tests
 #include <posit_c_api.h>
 
 int main(int argc, char* argv[])
@@ -17,26 +18,26 @@ int main(int argc, char* argv[])
 	// special case values
 	pa = NAR128;
 	pb = ZERO128;
-	pc = posit_add(pa, pb);
-	posit_str(str, pc);
+	pc = posit128_add(pa, pb);
+	posit128_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR128;
 	pb = ZERO128;
-	pc = posit_sub(pa, pb);
-	posit_str(str, pc);
+	pc = posit128_sub(pa, pb);
+	posit128_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR128;
 	pb = ZERO128;
-	pc = posit_mul(pa, pb);
-	posit_str(str, pc);
+	pc = posit128_mul(pa, pb);
+	posit128_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR128;
 	pb = ZERO128;
-	pc = posit_div(pa, pb);
-	posit_str(str, pc);
+	pc = posit128_div(pa, pb);
+	posit128_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	bool noReference = true;
@@ -48,20 +49,20 @@ int main(int argc, char* argv[])
 		pa = posit128_reinterpret( (uint64_t[]){ a, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit128_reinterpret( (uint64_t[]){ b, 0 } );
-			pc = posit_add(pa, pb);
+			pc = posit128_add(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit128_told(pa);
+			db = posit128_told(pb);
 			dref = da + db;
 
 			posit128_t pref = posit128_fromld(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit128_cmp(pref, pc)) {
 				char sa[40], sb[40], sc[40], sref[40];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit128_str(sa, pa);
+				posit128_str(sb, pb);
+				posit128_str(sc, pc);
+				posit128_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s + %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
@@ -87,20 +88,20 @@ int main(int argc, char* argv[])
 		pa = posit128_reinterpret( (uint64_t[]){ a, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit128_reinterpret( (uint64_t[]){ b, 0 } );
-			pc = posit_sub(pa, pb);
+			pc = posit128_sub(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit128_told(pa);
+			db = posit128_told(pb);
 			dref = da - db;
 
 			posit128_t pref = posit128_fromld(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit128_cmp(pref, pc)) {
 				char sa[40], sb[40], sc[40], sref[40];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit128_str(sa, pa);
+				posit128_str(sb, pb);
+				posit128_str(sc, pc);
+				posit128_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s - %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
@@ -126,20 +127,20 @@ int main(int argc, char* argv[])
 		pa = posit128_reinterpret( (uint64_t[]){ a, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit128_reinterpret( (uint64_t[]){ b, 0 } );
-			pc = posit_mul(pa, pb);
+			pc = posit128_mul(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit128_told(pa);
+			db = posit128_told(pb);
 			dref = da * db;
 
 			posit128_t pref = posit128_fromld(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit128_cmp(pref, pc)) {
 				char sa[40], sb[40], sc[40], sref[40];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit128_str(sa, pa);
+				posit128_str(sb, pb);
+				posit128_str(sc, pc);
+				posit128_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s * %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
@@ -165,20 +166,20 @@ int main(int argc, char* argv[])
 		pa = posit128_reinterpret( (uint64_t[]){ a, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit128_reinterpret( (uint64_t[]){ b, 0 } );
-			pc = posit_div(pa, pb);
+			pc = posit128_div(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit128_told(pa);
+			db = posit128_told(pb);
 			dref = da / db;
 
 			posit128_t pref = posit128_fromld(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit128_cmp(pref, pc)) {
 				char sa[40], sb[40], sc[40], sref[40];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit128_str(sa, pa);
+				posit128_str(sb, pb);
+				posit128_str(sc, pc);
+				posit128_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s / %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;

--- a/c_api/test/posit/posit16.c
+++ b/c_api/test/posit/posit16.c
@@ -4,6 +4,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#define POSIT_NO_GENERICS // MSVC doesn't support _Generic so we'll leave it out from these tests
 #include <posit_c_api.h>
 
 int main(int argc, char* argv[])
@@ -14,32 +15,32 @@ int main(int argc, char* argv[])
 
 	// special case values
 	pa = NAR16;
-	pb = posit16(0);
-	pc = posit_add(pa, pb);
-	posit_str(str, pc);
+	pb = ZERO16;
+	pc = posit16_add(pa, pb);
+	posit16_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 16.1x%04xp\n", posit_bits(pc));
+	printf("posit value = 16.1x%04xp\n", posit16_bits(pc));
 
 	pa = NAR16;
-	pb = posit16(0);
-	pc = posit_sub(pa, pb);
-	posit_str(str, pc);
+	pb = ZERO16;
+	pc = posit16_sub(pa, pb);
+	posit16_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 16.1x%04xp\n", posit_bits(pc));
+	printf("posit value = 16.1x%04xp\n", posit16_bits(pc));
 
 	pa = NAR16;
-	pb = posit16(0);
-	pc = posit_mul(pa, pb);
-	posit_str(str, pc);
+	pb = ZERO16;
+	pc = posit16_mul(pa, pb);
+	posit16_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 16.1x%04xp\n", posit_bits(pc));
+	printf("posit value = 16.1x%04xp\n", posit16_bits(pc));
 
 	pa = NAR16;
-	pb = posit16(0);
-	pc = posit_div(pa, pb);
-	posit_str(str, pc);
+	pb = ZERO16;
+	pc = posit16_div(pa, pb);
+	posit16_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 16.1x%04xp\n", posit_bits(pc));
+	printf("posit value = 16.1x%04xp\n", posit16_bits(pc));
 
 
 	// partial state space
@@ -48,15 +49,15 @@ int main(int argc, char* argv[])
 		pa = posit16_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit16_reinterpret(b);
-			pc = posit_add(pa, pb);
+			pc = posit16_add(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit16_tof(pa);
+			db = posit16_tof(pb);
 			dref = da + db;
 			posit16_t pref = posit16_fromf(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit16_cmp(pref, pc)) {
 				printf("FAIL: 16.1x%04xp + 16.1x%04xp produced 16.1x%04xp instead of 16.1x%04xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit16_bits(pa), posit16_bits(pb), posit16_bits(pc), posit16_bits(pref));
 				++fails;
 			}
 		}
@@ -75,15 +76,15 @@ int main(int argc, char* argv[])
 		pa = posit16_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit16_reinterpret(b);
-			pc = posit_sub(pa, pb);
+			pc = posit16_sub(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit16_tof(pa);
+			db = posit16_tof(pb);
 			dref = da - db;
 			posit16_t pref = posit16_fromf(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit16_cmp(pref, pc)) {
 				printf("FAIL: 16.1x%04xp - 16.1x%04xp produced 16.1x%04xp instead of 16.1x%04xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit16_bits(pa), posit16_bits(pb), posit16_bits(pc), posit16_bits(pref));
 				++fails;
 			}
 		}
@@ -102,15 +103,15 @@ int main(int argc, char* argv[])
 		pa = posit16_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit16_reinterpret(b);
-			pc = posit_mul(pa, pb);
+			pc = posit16_mul(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit16_tof(pa);
+			db = posit16_tof(pb);
 			dref = da * db;
 			posit16_t pref = posit16_fromf(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit16_cmp(pref, pc)) {
 				printf("FAIL: 16.1x%04xp * 16.1x%04xp produced 16.1x%04xp instead of 16.1x%04xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit16_bits(pa), posit16_bits(pb), posit16_bits(pc), posit16_bits(pref));
 				++fails;
 			}
 		}
@@ -129,15 +130,15 @@ int main(int argc, char* argv[])
 		pa = posit16_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit16_reinterpret(b);
-			pc = posit_div(pa, pb);
+			pc = posit16_div(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit16_tof(pa);
+			db = posit16_tof(pb);
 			dref = da / db;
 			posit16_t pref = posit16_fromf(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit16_cmp(pref, pc)) {
 				printf("FAIL: 16.1x%04xp / 16.1x%04xp produced 16.1x%04xp instead of 16.1x%04xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit16_bits(pa), posit16_bits(pb), posit16_bits(pc), posit16_bits(pref));
 				++fails;
 			}
 		}

--- a/c_api/test/posit/posit256.c
+++ b/c_api/test/posit/posit256.c
@@ -4,6 +4,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#define POSIT_NO_GENERICS // MSVC doesn't support _Generic so we'll leave it out from these tests
 #include <posit_c_api.h>
 
 int main(int argc, char* argv[])
@@ -17,26 +18,26 @@ int main(int argc, char* argv[])
 	// special case values
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_add(pa, pb);
-	posit_str(str, pc);
+	pc = posit256_add(pa, pb);
+	posit256_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_sub(pa, pb);
-	posit_str(str, pc);
+	pc = posit256_sub(pa, pb);
+	posit256_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_mul(pa, pb);
-	posit_str(str, pc);
+	pc = posit256_mul(pa, pb);
+	posit256_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	pa = NAR256;
 	pb = ZERO256;
-	pc = posit_div(pa, pb);
-	posit_str(str, pc);
+	pc = posit256_div(pa, pb);
+	posit256_str(str, pc);
 	printf("posit value = %s\n", str);
 
 	bool noReference = true;
@@ -48,21 +49,21 @@ int main(int argc, char* argv[])
 		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
-			pc = posit_add(pa, pb);
+			pc = posit256_add(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit256_told(pa);
+			db = posit256_told(pb);
 			dref = da + db;
 
-			posit256_t pref = posit256(dref);
+			posit256_t pref = posit256_fromld(dref);
 
-			if (posit_cmp(pref, pc)) {
+			if (posit256_cmp(pref, pc)) {
 				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit256_str(sa, pa);
+				posit256_str(sb, pb);
+				posit256_str(sc, pc);
+				posit256_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s + %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
@@ -88,20 +89,20 @@ int main(int argc, char* argv[])
 		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
-			pc = posit_sub(pa, pb);
+			pc = posit256_sub(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit256_told(pa);
+			db = posit256_told(pb);
 			dref = da - db;
 
-			posit256_t pref = posit256(dref);
-			if (posit_cmp(pref, pc)) {
+			posit256_t pref = posit256_fromld(dref);
+			if (posit256_cmp(pref, pc)) {
 				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit256_str(sa, pa);
+				posit256_str(sb, pb);
+				posit256_str(sc, pc);
+				posit256_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s - %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
@@ -127,21 +128,21 @@ int main(int argc, char* argv[])
 		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
-			pc = posit_mul(pa, pb);
+			pc = posit256_mul(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit256_told(pa);
+			db = posit256_told(pb);
 			dref = da * db;
 
-			posit256_t pref = posit256(dref);
+			posit256_t pref = posit256_fromld(dref);
 
-			if (posit_cmp(pref, pc)) {
+			if (posit256_cmp(pref, pc)) {
 				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit256_str(sa, pa);
+				posit256_str(sb, pb);
+				posit256_str(sc, pc);
+				posit256_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s * %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
@@ -167,21 +168,21 @@ int main(int argc, char* argv[])
 		pa = posit256_reinterpret( (uint64_t[]){ a, 0, 0, 0 } );
 		for (int b = 0; b < maxNr; ++b) {
 			pb = posit256_reinterpret( (uint64_t[]){ b, 0, 0, 0 } );
-			pc = posit_div(pa, pb);
+			pc = posit256_div(pa, pb);
 
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit256_told(pa);
+			db = posit256_told(pb);
 			dref = da / db;
 
-			posit256_t pref = posit256(dref);
+			posit256_t pref = posit256_fromld(dref);
 
-			if (posit_cmp(pref, pc)) {
+			if (posit256_cmp(pref, pc)) {
 				char sa[posit256_str_SIZE], sb[posit256_str_SIZE], sc[posit256_str_SIZE], sref[posit256_str_SIZE];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit256_str(sa, pa);
+				posit256_str(sb, pb);
+				posit256_str(sc, pc);
+				posit256_str(sref, pref);
 
 				if (bReportIndividualTestCases) printf("FAIL: %s / %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;

--- a/c_api/test/posit/posit32.c
+++ b/c_api/test/posit/posit32.c
@@ -4,6 +4,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#define POSIT_NO_GENERICS // MSVC doesn't support _Generic so we'll leave it out from these tests
 #include <posit_c_api.h>
 
 int main(int argc, char* argv[])
@@ -15,31 +16,31 @@ int main(int argc, char* argv[])
 	// special case values
 	pa = NAR32;
 	pb = ZERO32;
-	pc = posit_add(pa, pb);
-	posit_str(str, pc);
+	pc = posit32_add(pa, pb);
+	posit32_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 32.2x%08xp\n", posit_bits(pc));
+	printf("posit value = 32.2x%08xp\n", posit32_bits(pc));
 
 	pa = NAR32;
 	pb = ZERO32;
-	pc = posit_sub(pa, pb);
-	posit_str(str, pc);
+	pc = posit32_sub(pa, pb);
+	posit32_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 32.2x%08xp\n", posit_bits(pc));
+	printf("posit value = 32.2x%08xp\n", posit32_bits(pc));
 
 	pa = NAR32;
 	pb = ZERO32;
-	pc = posit_mul(pa, pb);
-	posit_str(str, pc);
+	pc = posit32_mul(pa, pb);
+	posit32_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 32.2x%08xp\n", posit_bits(pc));
+	printf("posit value = 32.2x%08xp\n", posit32_bits(pc));
 
 	pa = NAR32;
 	pb = ZERO32;
-	pc = posit_div(pa, pb);
-	posit_str(str, pc);
+	pc = posit32_div(pa, pb);
+	posit32_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 32.2x%08xp\n", posit_bits(pc));
+	printf("posit value = 32.2x%08xp\n", posit32_bits(pc));
 
 	// partial state space
 	int fails = 0;
@@ -47,15 +48,15 @@ int main(int argc, char* argv[])
 		pa = posit32_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit32_reinterpret(b);
-			pc = posit_add(pa, pb);
+			pc = posit32_add(pa, pb);
 			double da, db, dref;
 			da = posit32_tod(pa);
 			db = posit32_tod(pb);
 			dref = da + db;
 			posit32_t pref = posit32_fromf(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit32_cmp(pref, pc)) {
 				printf("FAIL: 32.2x%08xp + 32.2x%08xp produced 32.2x%08xp instead of 32.2x%08xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit32_bits(pa), posit32_bits(pb), posit32_bits(pc), posit32_bits(pref));
 				++fails;
 				break;
 			}
@@ -76,7 +77,7 @@ int main(int argc, char* argv[])
 		pa = posit32_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit32_reinterpret(b);
-			pc = posit_sub(pa, pb);
+			pc = posit32_sub(pa, pb);
 			double da, db, dref;
 			da = posit32_tod(pa);
 			db = posit32_tod(pb);
@@ -84,7 +85,7 @@ int main(int argc, char* argv[])
 			posit32_t pref = posit32_fromf(dref);
 			if (pref.v != pc.v) {
 				printf("FAIL: 32.2x%08xp - 32.2x%08xp produced 32.2x%08xp instead of 32.2x%08xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit32_bits(pa), posit32_bits(pb), posit32_bits(pc), posit32_bits(pref));
 				++fails;
 			}
 		}
@@ -103,15 +104,15 @@ int main(int argc, char* argv[])
 		pa = posit32_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit32_reinterpret(b);
-			pc = posit_mul(pa, pb);
+			pc = posit32_mul(pa, pb);
 			double da, db, dref;
 			da = posit32_tod(pa);
 			db = posit32_tod(pb);
 			dref = da * db;
-			posit32_t pref = posit32(dref);
-			if (posit_cmp(pref, pc) != 0) {
+			posit32_t pref = posit32_fromd(dref);
+			if (posit32_cmp(pref, pc) != 0) {
 				printf("FAIL: 32.2x%08xp * 32.2x%08xp produced 32.2x%08xp instead of 32.2x%08xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit32_bits(pa), posit32_bits(pb), posit32_bits(pc), posit32_bits(pref));
 				++fails;
 			}
 		}
@@ -130,15 +131,15 @@ int main(int argc, char* argv[])
 		pa = posit32_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit32_reinterpret(b);
-			pc = posit_div(pa, pb);
+			pc = posit32_div(pa, pb);
 			double da, db, dref;
-			da = posit_tod(pa);
-			db = posit_tod(pb);
+			da = posit32_tod(pa);
+			db = posit32_tod(pb);
 			dref = da / db;
-			posit32_t pref = posit32(dref);
-			if (posit_cmp(pref, pc) != 0) {
+			posit32_t pref = posit32_fromd(dref);
+			if (posit32_cmp(pref, pc) != 0) {
 				printf("FAIL: 32.2x%08xp / 32.2x%08xp produced 32.2x%08xp instead of 32.2x%08xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit32_bits(pa), posit32_bits(pb), posit32_bits(pc), posit32_bits(pref));
 				++fails;
 			}
 		}

--- a/c_api/test/posit/posit64.c
+++ b/c_api/test/posit/posit64.c
@@ -4,11 +4,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#define POSIT_NO_GENERICS // MSVC doesn't support _Generic so we'll leave it out from these tests
 #include <posit_c_api.h>
-
-#ifdef __cplusplus
-#error "wtf"
-#endif
 
 int main(int argc, char* argv[])
 {
@@ -20,26 +17,26 @@ int main(int argc, char* argv[])
 	// special case tolds
 	pa = NAR64;
 	pb = ZERO64;
-	pc = posit_add(pa, pb);
+	pc = posit64_add(pa, pb);
 	posit64_str(str, pc);
 	printf("posit told = %s\n", str);
 
 	pa = NAR64;
 	pb = ZERO64;
-	pc = posit_sub(pa, pb);
-	posit_str(str, pc);
+	pc = posit64_sub(pa, pb);
+	posit64_str(str, pc);
 	printf("posit told = %s\n", str);
 
 	pa = NAR64;
 	pb = ZERO64;
-	pc = posit_mul(pa, pb);
-	posit_str(str, pc);
+	pc = posit64_mul(pa, pb);
+	posit64_str(str, pc);
 	printf("posit told = %s\n", str);
 
 	pa = NAR64;
 	pb = ZERO64;
-	pc = posit_div(pa, pb);
-	posit_str(str, pc);
+	pc = posit64_div(pa, pb);
+	posit64_str(str, pc);
 	printf("posit told = %s\n", str);
 
 	// partial state space
@@ -48,18 +45,18 @@ int main(int argc, char* argv[])
 		pa = posit64_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit64_reinterpret(b);
-			pc = posit_add(pa, pb);
+			pc = posit64_add(pa, pb);
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit64_told(pa);
+			db = posit64_told(pb);
 			dref = da + db;
 			posit64_t pref = posit64_fromd(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit64_cmp(pref, pc)) {
 				char sa[32], sb[32], sc[32], sref[32];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit64_str(sa, pa);
+				posit64_str(sb, pb);
+				posit64_str(sc, pc);
+				posit64_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s + %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}
@@ -79,18 +76,18 @@ int main(int argc, char* argv[])
 		pa = posit64_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit64_reinterpret(b);
-			pc = posit_sub(pa, pb);
+			pc = posit64_sub(pa, pb);
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit64_told(pa);
+			db = posit64_told(pb);
 			dref = da - db;
 			posit64_t pref = posit64_fromd(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit64_cmp(pref, pc)) {
 				char sa[32], sb[32], sc[32], sref[32];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit64_str(sa, pa);
+				posit64_str(sb, pb);
+				posit64_str(sc, pc);
+				posit64_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s - %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}
@@ -110,18 +107,18 @@ int main(int argc, char* argv[])
 		pa = posit64_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit64_reinterpret(b);
-			pc = posit_mul(pa, pb);
+			pc = posit64_mul(pa, pb);
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit64_told(pa);
+			db = posit64_told(pb);
 			dref = da * db;
 			posit64_t pref = posit64_fromd(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit64_cmp(pref, pc)) {
 				char sa[32], sb[32], sc[32], sref[32];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit64_str(sa, pa);
+				posit64_str(sb, pb);
+				posit64_str(sc, pc);
+				posit64_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s * %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}
@@ -144,18 +141,18 @@ int main(int argc, char* argv[])
 		pa = posit64_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit64_reinterpret(b);
-			pc = posit_div(pa, pb);
+			pc = posit64_div(pa, pb);
 			long double da, db, dref;
-			da = posit_told(pa);
-			db = posit_told(pb);
+			da = posit64_told(pa);
+			db = posit64_told(pb);
 			dref = da / db;
 			posit64_t pref = posit64_fromd(dref);
-			if (posit_cmp(pref, pc)) {
+			if (posit64_cmp(pref, pc)) {
 				char sa[32], sb[32], sc[32], sref[32];
-				posit_str(sa, pa);
-				posit_str(sb, pb);
-				posit_str(sc, pc);
-				posit_str(sref, pref);
+				posit64_str(sa, pa);
+				posit64_str(sb, pb);
+				posit64_str(sc, pc);
+				posit64_str(sref, pref);
 				if (bReportIndividualTestCases) printf("FAIL: %s / %s produced %s instead of %s\n", sa, sb, sc, sref);
 				++fails;
 			}

--- a/c_api/test/posit/posit8.c
+++ b/c_api/test/posit/posit8.c
@@ -4,6 +4,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#define POSIT_NO_GENERICS // MSVC doesn't support _Generic so we'll leave it out from these tests
 #include <posit_c_api.h>
 #include <math.h> // sqrt()
 
@@ -16,31 +17,31 @@ int main(int argc, char* argv[])
 	// special case values
 	pa = NAR8;
 	pb = ZERO8;
-	pc = posit_add(pa, pb);
-	posit_str(str, pc);
+	pc = posit8_add(pa, pb);
+	posit8_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 8.0x%02xp\n", posit_bits(pc));
+	printf("posit value = 8.0x%02xp\n", posit8_bits(pc));
 
 	pa = NAR8;
 	pb = ZERO8;
-	pc = posit_sub(pa, pb);
-	posit_str(str, pc);
+	pc = posit8_sub(pa, pb);
+	posit8_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 8.0x%02xp\n", posit_bits(pc));
+	printf("posit value = 8.0x%02xp\n", posit8_bits(pc));
 
 	pa = NAR8;
 	pb = ZERO8;
-	pc = posit_mul(pa, pb);
-	posit_str(str, pc);
+	pc = posit8_mul(pa, pb);
+	posit8_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 8.0x%02xp\n", posit_bits(pc));
+	printf("posit value = 8.0x%02xp\n", posit8_bits(pc));
 
 	pa = NAR8;
 	pb = ZERO8;
-	pc = posit_div(pa, pb);
-	posit_str(str, pc);
+	pc = posit8_div(pa, pb);
+	posit8_str(str, pc);
 	printf("posit value = %s\n", str);
-	printf("posit value = 8.0x%02xp\n", posit_bits(pc));
+	printf("posit value = 8.0x%02xp\n", posit8_bits(pc));
 
 
 	// full state space
@@ -49,15 +50,15 @@ int main(int argc, char* argv[])
 		pa = posit8_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit8_reinterpret(b);
-			pc = posit_add(pa, pb);
+			pc = posit8_add(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit8_tof(pa);
+			db = posit8_tof(pb);
 			dref = da + db;
-			posit8_t pref = posit8(dref);
-			if (posit_cmp(pref, pc)) {
+			posit8_t pref = posit8_fromf(dref);
+			if (posit8_cmp(pref, pc)) {
 				printf("FAIL: 8.0x%02xp + 8.0x%02xp produced 8.0x%02xp instead of 8.0x%02xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit8_bits(pa), posit8_bits(pb), posit8_bits(pc), posit8_bits(pref));
 				++fails;
 			}
 		}
@@ -76,15 +77,15 @@ int main(int argc, char* argv[])
 		pa = posit8_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit8_reinterpret(b);
-			pc = posit_sub(pa, pb);
+			pc = posit8_sub(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit8_tof(pa);
+			db = posit8_tof(pb);
 			dref = da - db;
-			posit8_t pref = posit8(dref);
-			if (posit_cmp(pref, pc)) {
+			posit8_t pref = posit8_fromf(dref);
+			if (posit8_cmp(pref, pc)) {
 				printf("FAIL: 8.0x%02xp - 8.0x%02xp produced 8.0x%02xp instead of 8.0x%02xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit8_bits(pa), posit8_bits(pb), posit8_bits(pc), posit8_bits(pref));
 				++fails;
 			}
 		}
@@ -103,15 +104,15 @@ int main(int argc, char* argv[])
 		pa = posit8_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit8_reinterpret(b);
-			pc = posit_mul(pa, pb);
+			pc = posit8_mul(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit8_tof(pa);
+			db = posit8_tof(pb);
 			dref = da * db;
-			posit8_t pref = posit8(dref);
-			if (posit_cmp(pref, pc)) {
+			posit8_t pref = posit8_fromf(dref);
+			if (posit8_cmp(pref, pc)) {
 				printf("FAIL: 8.0x%02xp * 8.0x%02xp produced 8.0x%02xp instead of 8.0x%02xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit8_bits(pa), posit8_bits(pb), posit8_bits(pc), posit8_bits(pref));
 				++fails;
 			}
 		}
@@ -130,15 +131,15 @@ int main(int argc, char* argv[])
 		pa = posit8_reinterpret(a);
 		for (int b = 0; b < 256; ++b) {
 			pb = posit8_reinterpret(b);
-			pc = posit_div(pa, pb);
+			pc = posit8_div(pa, pb);
 			float da, db, dref;
-			da = posit_tof(pa);
-			db = posit_tof(pb);
+			da = posit8_tof(pa);
+			db = posit8_tof(pb);
 			dref = da / db;
-			posit8_t pref = posit8(dref);
-			if (posit_cmp(pref, pc)) {
+			posit8_t pref = posit8_fromf(dref);
+			if (posit8_cmp(pref, pc)) {
 				printf("FAIL: 8.0x%02xp / 8.0x%02xp produced 8.0x%02xp instead of 8.0x%02xp\n",
-                    posit_bits(pa), posit_bits(pb), posit_bits(pc), posit_bits(pref));
+                    posit8_bits(pa), posit8_bits(pb), posit8_bits(pc), posit8_bits(pref));
 				++fails;
 			}
 		}
@@ -155,14 +156,14 @@ int main(int argc, char* argv[])
 	fails = 0;
 	for (int a = 0; a < 256*256; ++a) {
 		pa = posit8_reinterpret(a);
-		pc = posit_sqrt(pa);
+		pc = posit8_sqrt(pa);
 		float da, dref;
-		da = posit_tof(pa);
+		da = posit8_tof(pa);
 		dref = sqrt(da);
-		posit8_t pref = posit8(dref);
-		if (posit_cmp(pref, pc)) {
+		posit8_t pref = posit8_fromf(dref);
+		if (posit8_cmp(pref, pc)) {
 			printf("FAIL: sqrt(8.0x%02xp) produced 8.0x%02xp instead of 8.0x%02xp\n",
-	    posit_bits(pa), posit_bits(pc), posit_bits(pref));
+	    posit8_bits(pa), posit8_bits(pc), posit8_bits(pref));
 			++fails;
 		}
 	}

--- a/posit/posit_c_macros.h
+++ b/posit/posit_c_macros.h
@@ -57,6 +57,9 @@
     }) \
     POSIT_INLINE(__rett__ POSIT_GLUE3(POSIT_MKNAME(p), POSIT_NBITS, __op__)(POSIT_T x, POSIT_T y) { \
         return POSIT_GLUE3(POSIT_MKNAME(__op__), p, POSIT_NBITS)(x, y); \
+    }) \
+    POSIT_INLINE(__rett__ POSIT_MKNAME(__op__)(POSIT_T x, POSIT_T y) { \
+        return POSIT_GLUE3(POSIT_MKNAME(__op__), p, POSIT_NBITS)(x, y); \
     })
 
 // single argument operation
@@ -103,6 +106,9 @@ int POSIT_GLUE3(POSIT_MKNAME(cmp),p,POSIT_NBITS)(POSIT_T x, POSIT_T y) POSIT_IMP
     return POSIT_API::cmp(x, y);
 })
 POSIT_INLINE(int POSIT_GLUE3(POSIT_MKNAME(p), POSIT_NBITS, cmp)(POSIT_T x, POSIT_T y) {
+    return POSIT_GLUE3(POSIT_MKNAME(cmp), p, POSIT_NBITS)(x, y);
+})
+POSIT_INLINE(int POSIT_MKNAME(cmp)(POSIT_T x, POSIT_T y) {
     return POSIT_GLUE3(POSIT_MKNAME(cmp), p, POSIT_NBITS)(x, y);
 })
 


### PR DESCRIPTION
Remove use of generics in tests because they're not supported by MSVC++

Also added `posit<n>_add()` which defers to `posit<n>_addp<n>` the form used in the macros.