### PR TITLE
adding a unary operator+() to get std::complex to work for posits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ cmake_minimum_required(VERSION 3.5)
 
 ####
 # Set project variables
-project (universal VERSION 1.0.0 LANGUAGES C CXX)
+project (universal VERSION 2.0.0 LANGUAGES C CXX)
 
 ####
 ## Enable project() command to manage VERSION variables

--- a/posit/posit.hpp
+++ b/posit/posit.hpp
@@ -733,6 +733,9 @@ public:
 		// TODO: how to get rid of this decode step?
 		return negated;
 	}
+	posit operator+() const {
+		return *this;
+	}
 
 	// we model a hw pipeline with register assignments, functional block, and conversion
 	posit& operator+=(const posit& rhs) {


### PR DESCRIPTION
progressing on the DSP library FFT and iFFT functionality discovered that std::complex<> uses an unary operator+(). 

Added.