### PR TITLE
Constexpr of posit and its specialized implementations

### DIFF
--- a/include/universal/posit/math/classify.hpp
+++ b/include/universal/posit/math/classify.hpp
@@ -1,51 +1,50 @@
 #pragma once
 // math_classify.hpp: classification functions for posits
 //
-// Copyright (C) 2017-2018 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 
 namespace sw {
-	namespace unum {
+namespace unum {
 
-		// the current shims are NON-COMPLIANT with the posit standard, which says that every function must be
-		// correctly rounded for every input value. Anything less sacrifices bitwise reproducibility of results.
+	// the current shims are NON-COMPLIANT with the posit standard, which says that every function must be
+	// correctly rounded for every input value. Anything less sacrifices bitwise reproducibility of results.
 
-		// STD LIB function for IEEE floats: Categorizes floating point value arg into the following categories: zero, subnormal, normal, infinite, NAN, or implementation-defined category.
-		template<size_t nbits, size_t es>
-		int fpclassify(const posit<nbits,es>& p) {
-			return std::fpclassify((long double)(p));
-		}
+	// STD LIB function for IEEE floats: Categorizes floating point value arg into the following categories: zero, subnormal, normal, infinite, NAN, or implementation-defined category.
+	template<size_t nbits, size_t es>
+	int fpclassify(const posit<nbits,es>& p) {
+		return std::fpclassify((long double)(p));
+	}
 		
-		// STD LIB function for IEEE floats: Determines if the given floating point number arg has finite value i.e. it is normal, subnormal or zero, but not infinite or NaN.
-		// specialized for posits
-		template<size_t nbits, size_t es>
-		inline bool isfinite(const posit<nbits,es>& p) {
-			return !p.isnar();
-		}
+	// STD LIB function for IEEE floats: Determines if the given floating point number arg has finite value i.e. it is normal, subnormal or zero, but not infinite or NaN.
+	// specialized for posits
+	template<size_t nbits, size_t es>
+	inline bool isfinite(const posit<nbits,es>& p) {
+		return !p.isnar();
+	}
 
-		// STD LIB function for IEEE floats: Determines if the given floating point number arg is a positive or negative infinity.
-		// specialized for posits
-		template<size_t nbits, size_t es>
-		inline bool isinf(const posit<nbits, es>& p) {
-			return p.isnar();
-		}
+	// STD LIB function for IEEE floats: Determines if the given floating point number arg is a positive or negative infinity.
+	// specialized for posits
+	template<size_t nbits, size_t es>
+	inline bool isinf(const posit<nbits, es>& p) {
+		return p.isnar();
+	}
 
-		// STD LIB function for IEEE floats: Determines if the given floating point number arg is a not-a-number (NaN) value.
-		// specialized for posits
-		template<size_t nbits, size_t es>
-		inline bool isnan(const posit<nbits, es>& p) {
-			return p.isnar();
-		}
+	// STD LIB function for IEEE floats: Determines if the given floating point number arg is a not-a-number (NaN) value.
+	// specialized for posits
+	template<size_t nbits, size_t es>
+	inline bool isnan(const posit<nbits, es>& p) {
+		return p.isnar();
+	}
 
-		// STD LIB function for IEEE floats: Determines if the given floating point number arg is normal, i.e. is neither zero, subnormal, infinite, nor NaN.
-		// specialized for posits
-		template<size_t nbits, size_t es>
-		inline bool isnormal(const posit<nbits, es>& p) {
-			return std::isnormal((long double)(p));
-		}
+	// STD LIB function for IEEE floats: Determines if the given floating point number arg is normal, i.e. is neither zero, subnormal, infinite, nor NaN.
+	// specialized for posits
+	template<size_t nbits, size_t es>
+	inline bool isnormal(const posit<nbits, es>& p) {
+		return std::isnormal((long double)(p));
+	}
 
-	}  // namespace unum
-
+}  // namespace unum
 }  // namespace sw

--- a/include/universal/posit/posit.hpp
+++ b/include/universal/posit/posit.hpp
@@ -565,22 +565,22 @@ public:
 	}
 
 	// initializers for native types
-	constexpr posit(const signed char initial_value)        { *this = initial_value; }
-	constexpr posit(const short initial_value)              { *this = initial_value; }
-	constexpr posit(const int initial_value)                { *this = initial_value; }
-	constexpr posit(const long initial_value)               { *this = initial_value; }
-	constexpr posit(const long long initial_value)          { *this = initial_value; }
-	constexpr posit(const char initial_value)               { *this = initial_value; }
-	constexpr posit(const unsigned short initial_value)     { *this = initial_value; }
-	constexpr posit(const unsigned int initial_value)       { *this = initial_value; }
-	constexpr posit(const unsigned long initial_value)      { *this = initial_value; }
-	constexpr posit(const unsigned long long initial_value) { *this = initial_value; }
-	constexpr posit(const float initial_value)              { *this = initial_value; }
-	          posit(const double initial_value)             { *this = initial_value; }
-	constexpr posit(const long double initial_value)        { *this = initial_value; }
+	constexpr explicit posit(const signed char initial_value)        { *this = initial_value; }
+	constexpr explicit posit(const short initial_value)              { *this = initial_value; }
+	constexpr explicit posit(const int initial_value)                { *this = initial_value; }
+	constexpr explicit posit(const long initial_value)               { *this = initial_value; }
+	constexpr explicit posit(const long long initial_value)          { *this = initial_value; }
+	constexpr explicit posit(const char initial_value)               { *this = initial_value; }
+	constexpr explicit posit(const unsigned short initial_value)     { *this = initial_value; }
+	constexpr explicit posit(const unsigned int initial_value)       { *this = initial_value; }
+	constexpr explicit posit(const unsigned long initial_value)      { *this = initial_value; }
+	constexpr explicit posit(const unsigned long long initial_value) { *this = initial_value; }
+	constexpr explicit posit(const float initial_value)              { *this = initial_value; }
+	constexpr          posit(const double initial_value)             { *this = initial_value; }
+	constexpr explicit posit(const long double initial_value)        { *this = initial_value; }
 
 	// assignment operators for native types
-	posit& operator=(const signed char rhs) {
+	posit& operator=(signed char rhs) {
 		value<8*sizeof(signed char)-1> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -591,7 +591,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const short rhs) {
+	posit& operator=(short rhs) {
 		value<8*sizeof(short)-1> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -602,7 +602,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const int rhs) {
+	posit& operator=(int rhs) {
 		value<8*sizeof(int)-1> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -613,7 +613,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const long rhs) {
+	posit& operator=(long rhs) {
 		value<8*sizeof(long)> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -624,7 +624,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const long long rhs) {
+	posit& operator=(long long rhs) {
 		value<8*sizeof(long long)-1> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -635,7 +635,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const char rhs) {
+	posit& operator=(char rhs) {
 		value<8*sizeof(char)> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -646,7 +646,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const unsigned short rhs) {
+	posit& operator=(unsigned short rhs) {
 		value<8*sizeof(unsigned short)> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -657,7 +657,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const unsigned int rhs) {
+	posit& operator=(unsigned int rhs) {
 		value<8*sizeof(unsigned int)> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -668,7 +668,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const unsigned long rhs) {
+	posit& operator=(unsigned long rhs) {
 		value<8*sizeof(unsigned long)> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -679,7 +679,7 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const unsigned long long rhs) {
+	posit& operator=(unsigned long long rhs) {
 		value<8*sizeof(unsigned long long)> v(rhs);
 		if (v.iszero()) {
 			setzero();
@@ -690,14 +690,14 @@ public:
 		}
 		return *this;
 	}
-	posit& operator=(const float rhs) {
+	posit& operator=(float rhs) {
 		return float_assign(rhs);
 	}
-	constexpr posit& operator=(const double rhs) & {
+	constexpr posit& operator=(double rhs) & {
             float_assign(rhs);
             return *this; 
 	}
-	posit& operator=(const long double rhs) {
+	posit& operator=(long double rhs) {
        	return float_assign(rhs);
 	}
 

--- a/include/universal/posit/specialized/posit_128_4.hpp
+++ b/include/universal/posit/specialized/posit_128_4.hpp
@@ -1,733 +1,733 @@
 #pragma once
 // posit_128_4.hpp: specialized 128-bit posit using fast compute specialized for posit<128,4>
 //
-// Copyright (C) 2017-2019 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 namespace sw {
-	namespace unum {
+namespace unum {
 
-		// set the fast specialization variable to indicate that we are running a special template specialization
+	// set the fast specialization variable to indicate that we are running a special template specialization
 #if POSIT_FAST_POSIT_128_4
 #pragma message("Fast specialization of posit<128,4>")
 
-	// fast specialized posit<128,4>
-	template<>
-	class posit<NBITS_IS_128, ES_IS_4> {
-	public:
-		static constexpr size_t nbits = NBITS_IS_128;
-		static constexpr size_t es = ES_IS_4;
-		static constexpr size_t sbits = 1;
-		static constexpr size_t rbits = nbits - sbits;
-		static constexpr size_t ebits = es;
-		static constexpr size_t fbits = nbits - 3 - es;
-		static constexpr size_t fhbits = fbits + 1;
-		static constexpr uint64_t sign_mask = 0x8000000000000000ull;  // 0x8000'0000'0000'0000ull;
+// fast specialized posit<128,4>
+template<>
+class posit<NBITS_IS_128, ES_IS_4> {
+public:
+	static constexpr size_t nbits = NBITS_IS_128;
+	static constexpr size_t es = ES_IS_4;
+	static constexpr size_t sbits = 1;
+	static constexpr size_t rbits = nbits - sbits;
+	static constexpr size_t ebits = es;
+	static constexpr size_t fbits = nbits - 3 - es;
+	static constexpr size_t fhbits = fbits + 1;
+	static constexpr uint64_t sign_mask = 0x8000000000000000ull;  // 0x8000'0000'0000'0000ull;
 
-		posit() { _bits = 0; }
-		posit(const posit&) = default;
-		posit(posit&&) = default;
-		posit& operator=(const posit&) = default;
-		posit& operator=(posit&&) = default;
+	posit() { _bits = 0; }
+	posit(const posit&) = default;
+	posit(posit&&) = default;
+	posit& operator=(const posit&) = default;
+	posit& operator=(posit&&) = default;
 
-		// initializers for native types
-		explicit posit(const signed char initial_value)        { *this = initial_value; }
-		explicit posit(const short initial_value)              { *this = initial_value; }
-		explicit posit(const int initial_value)                { *this = initial_value; }
-		explicit posit(const long initial_value)               { *this = initial_value; }
-		explicit posit(const long long initial_value)          { *this = initial_value; }
-		explicit posit(const char initial_value)               { *this = initial_value; }
-		explicit posit(const unsigned short initial_value)     { *this = initial_value; }
-		explicit posit(const unsigned int initial_value)       { *this = initial_value; }
-		explicit posit(const unsigned long initial_value)      { *this = initial_value; }
-		explicit posit(const unsigned long long initial_value) { *this = initial_value; }
-		explicit posit(const float initial_value)              { *this = initial_value; }
-		explicit posit(const double initial_value)             { *this = initial_value; }
-		explicit posit(const long double initial_value)        { *this = initial_value; }
+	// initializers for native types
+	constexpr explicit posit(signed char initial_value)        { *this = initial_value; }
+	constexpr explicit posit(short initial_value)              { *this = initial_value; }
+	constexpr explicit posit(int initial_value)                { *this = initial_value; }
+	constexpr explicit posit(long initial_value)               { *this = initial_value; }
+	constexpr explicit posit(long long initial_value)          { *this = initial_value; }
+	constexpr explicit posit(char initial_value)               { *this = initial_value; }
+	constexpr explicit posit(unsigned short initial_value)     { *this = initial_value; }
+	constexpr explicit posit(unsigned int initial_value)       { *this = initial_value; }
+	constexpr explicit posit(unsigned long initial_value)      { *this = initial_value; }
+	constexpr explicit posit(unsigned long long initial_value) { *this = initial_value; }
+	constexpr explicit posit(float initial_value)              { *this = initial_value; }
+	constexpr explicit posit(double initial_value)             { *this = initial_value; }
+	          explicit posit(long double initial_value)        { *this = initial_value; }
 
-		// assignment operators for native types
-		posit& operator=(const signed char rhs)       { 
-			// special case for speed as this is a common initialization
-			if (rhs == 0) {
-				_bits = 0x00;
-				return *this;
-			}
-
-			bool sign = bool(rhs & 0x80);
-			int8_t v = sign ? -rhs : rhs; // project to positve side of the projective reals
-			uint8_t raw;
-			if (v > 48 || v == -128) { // +-maxpos, 0x80 is special in int8 arithmetic as it is its own negation
-				raw = 0x7F;
-			}
-			else {
-				uint8_t mask = 0x40;
-				int8_t k = 6;
-				uint8_t fraction_bits = v;
-				while (!(fraction_bits & mask)) {
-					k--;
-					fraction_bits <<= 1;
-				}
-				fraction_bits = (fraction_bits ^ mask);
-				raw = (0x7F ^ (0x3F >> k)) | (fraction_bits >> (k + 1));
-
-				mask = 0x1 << k; //bitNPlusOne
-				if (mask & fraction_bits) {
-					if (((mask - 1) & fraction_bits) | ((mask << 1) & fraction_bits)) raw++;
-				}
-			}
-			_bits = sign ? -raw : raw;
+	// assignment operators for native types
+	posit& operator=(signed char rhs)       { 
+		// special case for speed as this is a common initialization
+		if (rhs == 0) {
+			_bits = 0x00;
 			return *this;
 		}
-		posit& operator=(const short rhs)             { return operator=((signed char)(rhs)); }
-		posit& operator=(const int rhs)               { return operator=((signed char)(rhs)); }
-		posit& operator=(const long rhs)              { return operator=((signed char)(rhs)); }
-		posit& operator=(const long long rhs)         { return operator=((signed char)(rhs)); }
-		posit& operator=(const char rhs)              { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned short rhs)    { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned int rhs)      { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned long rhs)     { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned long long rhs){ return operator=((signed char)(rhs)); }
-		posit& operator=(const float rhs)             { return float_assign(rhs); }
-		posit& operator=(const double rhs)            { return float_assign(rhs); }
-		posit& operator=(const long double rhs)       { return float_assign(rhs); }
 
-		explicit operator long double() const { return to_long_double(); }
-		explicit operator double() const { return to_double(); }
-		explicit operator float() const { return to_float(); }
-		explicit operator long long() const { return to_long_long(); }
-		explicit operator long() const { return to_long(); }
-		explicit operator int() const { return to_int(); }
-		explicit operator unsigned long long() const { return to_long_long(); }
-		explicit operator unsigned long() const { return to_long(); }
-		explicit operator unsigned int() const { return to_int(); }
+		bool sign = bool(rhs & 0x80);
+		int8_t v = sign ? -rhs : rhs; // project to positve side of the projective reals
+		uint8_t raw;
+		if (v > 48 || v == -128) { // +-maxpos, 0x80 is special in int8 arithmetic as it is its own negation
+			raw = 0x7F;
+		}
+		else {
+			uint8_t mask = 0x40;
+			int8_t k = 6;
+			uint8_t fraction_bits = v;
+			while (!(fraction_bits & mask)) {
+				k--;
+				fraction_bits <<= 1;
+			}
+			fraction_bits = (fraction_bits ^ mask);
+			raw = (0x7F ^ (0x3F >> k)) | (fraction_bits >> (k + 1));
 
-		posit& set(sw::unum::bitblock<NBITS_IS_128>& raw) {
-			_bits = uint8_t(raw.to_ulong());
+			mask = 0x1 << k; //bitNPlusOne
+			if (mask & fraction_bits) {
+				if (((mask - 1) & fraction_bits) | ((mask << 1) & fraction_bits)) raw++;
+			}
+		}
+		_bits = sign ? -raw : raw;
+		return *this;
+	}
+	posit& operator=(short rhs)					{ return operator=((signed char)(rhs)); }
+	posit& operator=(int rhs)					{ return operator=((signed char)(rhs)); }
+	posit& operator=(long rhs)					{ return operator=((signed char)(rhs)); }
+	posit& operator=(long long rhs)				{ return operator=((signed char)(rhs)); }
+	posit& operator=(char rhs)					{ return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned short rhs)		{ return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned int rhs)			{ return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned long rhs)			{ return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned long long rhs)	{ return operator=((signed char)(rhs)); }
+	posit& operator=(float rhs)					{ return float_assign(rhs); }
+	posit& operator=(double rhs)				{ return float_assign(rhs); }
+	constexpr posit& operator=(long double rhs) { return float_assign(rhs); }
+
+	explicit operator long double() const { return to_long_double(); }
+	explicit operator double() const { return to_double(); }
+	explicit operator float() const { return to_float(); }
+	explicit operator long long() const { return to_long_long(); }
+	explicit operator long() const { return to_long(); }
+	explicit operator int() const { return to_int(); }
+	explicit operator unsigned long long() const { return to_long_long(); }
+	explicit operator unsigned long() const { return to_long(); }
+	explicit operator unsigned int() const { return to_int(); }
+
+	posit& set(sw::unum::bitblock<NBITS_IS_128>& raw) {
+		_bits = uint8_t(raw.to_ulong());
+		return *this;
+	}
+	posit& set_raw_bits(uint64_t value) {
+		_bits = uint8_t(value & 0xff);
+		return *this;
+	}
+	posit operator-() const {
+		if (iszero()) {
 			return *this;
 		}
-		posit& set_raw_bits(uint64_t value) {
-			_bits = uint8_t(value & 0xff);
+		if (isnar()) {
 			return *this;
 		}
-		posit operator-() const {
-			if (iszero()) {
-				return *this;
-			}
-			if (isnar()) {
-				return *this;
-			}
-			posit p;
-			return p.set_raw_bits((~_bits) + 1);
+		posit p;
+		return p.set_raw_bits((~_bits) + 1);
+	}
+	posit& operator+=(const posit& b) { // derived from SoftPosit
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {  // infinity
+			_bits = 0x80;
+			return *this;
 		}
-		posit& operator+=(const posit& b) { // derived from SoftPosit
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {  // infinity
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) { // zero
-				_bits = lhs | rhs;
-				return *this;
-			}
-			bool sign = bool(_bits & 0x80);
-			if (sign) {
-				lhs = -lhs & 0xFF;
-				rhs = -rhs & 0xFF;
-			}
-			if (lhs < rhs) std::swap(lhs, rhs);
+		if (iszero() || b.iszero()) { // zero
+			_bits = lhs | rhs;
+			return *this;
+		}
+		bool sign = bool(_bits & 0x80);
+		if (sign) {
+			lhs = -lhs & 0xFF;
+			rhs = -rhs & 0xFF;
+		}
+		if (lhs < rhs) std::swap(lhs, rhs);
 			
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t frac16A = (0x80 | remaining) << 7;
-			int8_t shiftRight = m;
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint16_t frac16B = (0x80 | remaining) << 7;
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t frac16A = (0x80 | remaining) << 7;
+		int8_t shiftRight = m;
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint16_t frac16B = (0x80 | remaining) << 7;
 
-			// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
-			(shiftRight>7) ? (frac16B = 0) : (frac16B >>= shiftRight); 
+		// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
+		(shiftRight>7) ? (frac16B = 0) : (frac16B >>= shiftRight); 
 
-			frac16A += frac16B;
+		frac16A += frac16B;
 
-			bool rcarry = bool(0x8000 & frac16A); // is MSB set
-			if (rcarry) {
-				m++;
-				frac16A >>= 1;
-			}
+		bool rcarry = bool(0x8000 & frac16A); // is MSB set
+		if (rcarry) {
+			m++;
+			frac16A >>= 1;
+		}
 
-			_bits = round(m, frac16A);
-			if (sign) _bits = -_bits & 0xFF;
+		_bits = round(m, frac16A);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator-=(const posit& b) {  // derived from SoftPosit
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {
+			_bits = 0x80;
 			return *this;
 		}
-		posit& operator-=(const posit& b) {  // derived from SoftPosit
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) {
-				_bits = lhs | rhs;
-				return *this;
-			}
-			// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
-			bool sign = bool(lhs & 0x80);
-			(sign) ? (lhs = (-lhs & 0xFF)) : (rhs = (-rhs & 0xFF));
-
-			if (lhs == rhs) {
-				_bits = 0x00;
-				return *this;
-			}
-			if (lhs < rhs) {
-				std::swap(lhs, rhs);
-				sign = !sign;
-			}
-
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t frac16A = (0x80 | remaining) << 7;
-			int8_t shiftRight = m;
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint16_t frac16B = (0x80 | remaining) << 7;
-
-			// do the subtraction of the fractions
-			if (shiftRight >= 14) {
-				_bits = lhs;
-				if (sign) _bits = -_bits & 0xFFFF;
-				return *this;
-			}
-			else {
-				frac16B >>= shiftRight;
-			}
-			frac16A -= frac16B;
-
-			while ((frac16A >> 14) == 0) {
-				m--;
-				frac16A <<= 1;
-			}
-			bool ecarry = bool (0x4000 & frac16A);
-			if (!ecarry) {
-				m--;
-				frac16A <<= 1;
-			}
-
-			_bits = round(m, frac16A);
-			if (sign) _bits = -_bits & 0xFF;
+		if (iszero() || b.iszero()) {
+			_bits = lhs | rhs;
 			return *this;
 		}
-		posit& operator*=(const posit& b) {
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) {
-				_bits = 0x00;
-				return *this;
-			}
+		// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
+		bool sign = bool(lhs & 0x80);
+		(sign) ? (lhs = (-lhs & 0xFF)) : (rhs = (-rhs & 0xFF));
 
-			// calculate the sign of the result
-			bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
-			lhs = lhs & 0x80 ? -lhs : lhs;
-			rhs = rhs & 0x80 ? -rhs : rhs;
-
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint8_t lhs_fraction = (0x80 | remaining);
-			// adjust shift and extract fraction bits of rhs
-			extractMultiplicand(rhs, m, remaining);
-			uint8_t rhs_fraction = (0x80 | remaining);
-			uint16_t result_fraction = uint16_t(lhs_fraction) * uint16_t(rhs_fraction);
-
-			bool rcarry = bool(result_fraction & 0x8000);
-			if (rcarry) {
-				m++;
-				result_fraction >>= 1;
-			}
-
-			// round
-			_bits = round(m, result_fraction);
-			if (sign) _bits = -_bits & 0xFF;
+		if (lhs == rhs) {
+			_bits = 0x00;
 			return *this;
 		}
-		posit& operator/=(const posit& b) {
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar() || b.iszero()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero()) {
-				_bits = 0x00;
-				return *this;
-			}
+		if (lhs < rhs) {
+			std::swap(lhs, rhs);
+			sign = !sign;
+		}
 
-			// calculate the sign of the result
-			bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
-			lhs = lhs & 0x80 ? -lhs : lhs;
-			rhs = rhs & 0x80 ? -rhs : rhs;
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t frac16A = (0x80 | remaining) << 7;
+		int8_t shiftRight = m;
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint16_t frac16B = (0x80 | remaining) << 7;
 
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t lhs_fraction = (0x80 | remaining) << 7;
-			// adjust shift and extract fraction bits of rhs
-			extractDividand(rhs, m, remaining);
-			uint8_t rhs_fraction = (0x80 | remaining);
-			div_t result = div(lhs_fraction, uint16_t(rhs_fraction));
-			uint16_t result_fraction = result.quot;
-			uint16_t remainder = result.rem;
-
-			if (result_fraction != 0) {
-				bool rcarry = result_fraction >> 7; // this is the hidden bit (7th bit) , extreme right bit is bit 0
-				if (!rcarry) {
-					--m;
-					result_fraction <<= 1;
-				}
-			}
-
-			// round
-			_bits = adjustAndRound(m, result_fraction, remainder != 0);
-			if (sign) _bits = -_bits & 0xFF;
-
+		// do the subtraction of the fractions
+		if (shiftRight >= 14) {
+			_bits = lhs;
+			if (sign) _bits = -_bits & 0xFFFF;
 			return *this;
 		}
-		posit& operator++() {
-			++_bits;
+		else {
+			frac16B >>= shiftRight;
+		}
+		frac16A -= frac16B;
+
+		while ((frac16A >> 14) == 0) {
+			m--;
+			frac16A <<= 1;
+		}
+		bool ecarry = bool (0x4000 & frac16A);
+		if (!ecarry) {
+			m--;
+			frac16A <<= 1;
+		}
+
+		_bits = round(m, frac16A);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator*=(const posit& b) {
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {
+			_bits = 0x80;
 			return *this;
 		}
-		posit operator++(int) {
-			posit tmp(*this);
-			operator++();
-			return tmp;
-		}
-		posit& operator--() {
-			--_bits;
-			return *this;
-		}
-		posit operator--(int) {
-			posit tmp(*this);
-			operator--();
-			return tmp;
-		}
-		posit reciprocate() const {
-			posit p = 1.0 / *this;
-			return p;
-		}
-		// SELECTORS
-		inline bool isnar() const      { return (_bits == 0x80); }
-		inline bool iszero() const     { return (_bits == 0x00); }
-		inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
-		inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
-		inline bool isneg() const      { return (_bits & 0x80); }
-		inline bool ispos() const      { return !isneg(); }
-		inline bool ispowerof2() const { return !(_bits & 0x1); }
-
-		inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
-
-		bitblock<NBITS_IS_128> get() const { bitblock<NBITS_IS_128> bb; bb = int(_bits); return bb; }
-		unsigned long long encoding() const { return (unsigned long long)(_bits); }
-
-		inline void clear() { _bits = 0; }
-		inline void setzero() { clear(); }
-		inline void setnar() { _bits = 0x80; }
-		inline posit twosComplement() const {
-			posit<NBITS_IS_128, ES_IS_4> p;
-			int8_t v = -*(int8_t*)&_bits;
-			p.set_raw_bits(v);
-			return p;
-		}
-	private:
-		uint8_t _bits;
-
-		// Conversion functions
-#if POSIT_THROW_ARITHMETIC_EXCEPTION
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_long_double());
-		}
-#else
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar())  return int(INFINITY);
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return long(INFINITY);
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return (long long)(INFINITY);
-			return long(to_long_double());
-		}
-#endif
-		float       to_float() const {
-			return (float)to_double();
-		}
-		double      to_double() const {
-			if (iszero())	return 0.0;
-			if (isnar())	return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			double s = (_sign ? -1.0 : 1.0);
-			double r = _regime.value();
-			double e = _exponent.value();
-			double f = (1.0 + _fraction.value());
-			return s * r * e * f;
-		}
-		long double to_long_double() const {
-			if (iszero())  return 0.0;
-			if (isnar())   return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			long double s = (_sign ? -1.0 : 1.0);
-			long double r = _regime.value();
-			long double e = _exponent.value();
-			long double f = (1.0 + _fraction.value());
-			return s * r * e * f;
-		}
-
-		template <typename T>
-		posit& float_assign(const T& rhs) {
-			constexpr int dfbits = std::numeric_limits<T>::digits - 1;
-			value<dfbits> v((T)rhs);
-
-			// special case processing
-			if (v.iszero()) {
-				setzero();
-				return *this;
-			}
-			if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
-				setnar();
-				return *this;
-			}
-
-			bitblock<NBITS_IS_128> ptt;
-			convert_to_bb<NBITS_IS_128, ES_IS_4, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
-			_bits = uint8_t(ptt.to_ulong());
+		if (iszero() || b.iszero()) {
+			_bits = 0x00;
 			return *this;
 		}
 
-		// helper method
-		// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
-		inline void decode_regime(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				m = -1;
-				while (!(remaining >> 7)) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
+		// calculate the sign of the result
+		bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
+		lhs = lhs & 0x80 ? -lhs : lhs;
+		rhs = rhs & 0x80 ? -rhs : rhs;
+
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint8_t lhs_fraction = (0x80 | remaining);
+		// adjust shift and extract fraction bits of rhs
+		extractMultiplicand(rhs, m, remaining);
+		uint8_t rhs_fraction = (0x80 | remaining);
+		uint16_t result_fraction = uint16_t(lhs_fraction) * uint16_t(rhs_fraction);
+
+		bool rcarry = bool(result_fraction & 0x8000);
+		if (rcarry) {
+			m++;
+			result_fraction >>= 1;
 		}
-		inline void extractAddand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				++m;
-				while (!(remaining >> 7)) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
+
+		// round
+		_bits = round(m, result_fraction);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator/=(const posit& b) {
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar() || b.iszero()) {
+			_bits = 0x80;
+			return *this;
 		}
-		inline void extractMultiplicand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
+		if (iszero()) {
+			_bits = 0x00;
+			return *this;
+		}
+
+		// calculate the sign of the result
+		bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
+		lhs = lhs & 0x80 ? -lhs : lhs;
+		rhs = rhs & 0x80 ? -rhs : rhs;
+
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t lhs_fraction = (0x80 | remaining) << 7;
+		// adjust shift and extract fraction bits of rhs
+		extractDividand(rhs, m, remaining);
+		uint8_t rhs_fraction = (0x80 | remaining);
+		div_t result = div(lhs_fraction, uint16_t(rhs_fraction));
+		uint16_t result_fraction = result.quot;
+		uint16_t remainder = result.rem;
+
+		if (result_fraction != 0) {
+			bool rcarry = result_fraction >> 7; // this is the hidden bit (7th bit) , extreme right bit is bit 0
+			if (!rcarry) {
 				--m;
-				while (!(remaining >> 7)) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
+				result_fraction <<= 1;
 			}
 		}
-		inline void extractDividand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				++m;
-				while (!(remaining >> 7)) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
-		}
-		inline uint8_t round(const int8_t m, uint16_t fraction) const {
-			uint8_t scale, regime, bits;
-			if (m < 0) {
-				scale = (-m & 0xFF);
-				regime = 0x40 >> scale;
-			}
-			else {
-				scale = m + 1;
-				regime = 0x7F - (0x7F >> scale);
-			}
 
-			if (scale > 6) {
-				bits = m<0 ? 0x1 : 0x7F;  // minpos and maxpos
-			}
-			else {
-				fraction = (fraction & 0x3FFF) >> scale;
-				uint8_t final_fbits = uint8_t(fraction >> 8);
-				bool bitNPlusOne = bool(0x80 & fraction);
-				bits = uint8_t(regime) + uint8_t(final_fbits);
-				// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
-				if (bitNPlusOne) {
-					uint8_t moreBits = (0x7F & fraction) ? 0x01 : 0x00;
-					bits += (bits & 0x01) | moreBits;
-				}
-			}
-			return bits;
-		}
-		inline uint8_t adjustAndRound(const int8_t k, uint16_t fraction, bool nonZeroRemainder) const {
-			uint8_t scale, regime, bits;
-			if (k < 0) {
-				scale = (-k & 0xFF);
-				regime = 0x40 >> scale;
-			}
-			else {
-				scale = k + 1;
-				regime = 0x7F - (0x7F >> scale);
-			}
+		// round
+		_bits = adjustAndRound(m, result_fraction, remainder != 0);
+		if (sign) _bits = -_bits & 0xFF;
 
-			if (scale > 6) {
-				bits = k<0 ? 0x1 : 0x7F;  // minpos and maxpos
-			}
-			else {
-				//remove carry and rcarry bits and shift to correct position
-				fraction &= 0x7F;
-				uint8_t final_fbits = (uint_fast16_t)fraction >> (scale + 1);
-				bool bitNPlusOne = (0x1 & (fraction >> scale));
-				bits = uint8_t(regime) + uint8_t(final_fbits);
-#ifdef NOW
-				std::cout << std::hex;
-				std::cout << "fraction raw   = " << int(fraction) << std::endl;
-				std::cout << "fraction final = " << int(final_fbits) << std::endl;
-				std::cout << "posit bits     = " << int(bits) << std::endl;
-				std::cout << std::dec;
-#endif
-				if (bitNPlusOne) {
-					uint8_t moreBits = (((1 << scale) - 1) & fraction) ? 0x01 : 0x00;
-					if (nonZeroRemainder) moreBits = 0x01;
-					//std::cout << "bitsMore = " << (moreBits ? "true" : "false") << std::endl;
-					// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
-					bits += (bits & 0x01) | moreBits;
-				}
-			}
-			return bits;
-		}
-		// I/O operators
-		friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_128, ES_IS_4>& p);
-		friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_128, ES_IS_4>& p);
+		return *this;
+	}
+	posit& operator++() {
+		++_bits;
+		return *this;
+	}
+	posit operator++(int) {
+		posit tmp(*this);
+		operator++();
+		return tmp;
+	}
+	posit& operator--() {
+		--_bits;
+		return *this;
+	}
+	posit operator--(int) {
+		posit tmp(*this);
+		operator--();
+		return tmp;
+	}
+	posit reciprocate() const {
+		posit p = 1.0 / *this;
+		return p;
+	}
+	// SELECTORS
+	inline bool isnar() const      { return (_bits == 0x80); }
+	inline bool iszero() const     { return (_bits == 0x00); }
+	inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
+	inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
+	inline bool isneg() const      { return (_bits & 0x80); }
+	inline bool ispos() const      { return !isneg(); }
+	inline bool ispowerof2() const { return !(_bits & 0x1); }
 
-		// posit - posit logic functions
-		friend bool operator==(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
-		friend bool operator!=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
-		friend bool operator< (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
-		friend bool operator> (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
-		friend bool operator<=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
-		friend bool operator>=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
+	inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
 
-	};
+	bitblock<NBITS_IS_128> get() const { bitblock<NBITS_IS_128> bb; bb = int(_bits); return bb; }
+	unsigned long long encoding() const { return (unsigned long long)(_bits); }
 
-	// posit I/O operators
-	// generate a posit format ASCII format nbits.esxNN...NNp
-	inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_128, ES_IS_4>& p) {
-		// to make certain that setw and left/right operators work properly
-		// we need to transform the posit into a string
-		std::stringstream ss;
-#if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
-		ss << NBITS_IS_128 << '.' << ES_IS_4 << 'x' << to_hex(p.get()) << 'p';
+	inline void clear() { _bits = 0; }
+	inline void setzero() { clear(); }
+	inline void setnar() { _bits = 0x80; }
+	inline posit twosComplement() const {
+		posit<NBITS_IS_128, ES_IS_4> p;
+		int8_t v = -*(int8_t*)&_bits;
+		p.set_raw_bits(v);
+		return p;
+	}
+private:
+	uint8_t _bits;
+
+	// Conversion functions
+#if POSIT_THROW_ARITHMETIC_EXCEPTION
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_long_double());
+	}
 #else
-		std::streamsize prec = ostr.precision();
-		std::streamsize width = ostr.width();
-		std::ios_base::fmtflags ff;
-		ff = ostr.flags();
-		ss.flags(ff);
-		ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar())  return int(INFINITY);
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return long(INFINITY);
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return (long long)(INFINITY);
+		return long(to_long_double());
+	}
 #endif
-		return ostr << ss.str();
+	float       to_float() const {
+		return (float)to_double();
 	}
-
-	// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
-	inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_128, ES_IS_4>& p) {
-		std::string txt;
-		istr >> txt;
-		if (!parse(txt, p)) {
-			std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+	double      to_double() const {
+		if (iszero())	return 0.0;
+		if (isnar())	return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		return istr;
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		double s = (_sign ? -1.0 : 1.0);
+		double r = _regime.value();
+		double e = _exponent.value();
+		double f = (1.0 + _fraction.value());
+		return s * r * e * f;
 	}
-
-	// convert a posit value to a string using "nar" as designation of NaR
-	std::string to_string(const posit<NBITS_IS_128, ES_IS_4>& p, std::streamsize precision) {
-		if (p.isnar()) {
-			return std::string("nar");
+	long double to_long_double() const {
+		if (iszero())  return 0.0;
+		if (isnar())   return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		std::stringstream ss;
-		ss << std::setprecision(precision) << float(p);
-		return ss.str();
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		long double s = (_sign ? -1.0 : 1.0);
+		long double r = _regime.value();
+		long double e = _exponent.value();
+		long double f = (1.0 + _fraction.value());
+		return s * r * e * f;
 	}
 
-	// posit - posit binary logic operators
-	inline bool operator==(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return lhs._bits == rhs._bits;
-	}
-	inline bool operator!=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return !operator==(lhs, rhs);
-	}
-	inline bool operator< (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return *(signed char*)(&lhs._bits) < *(signed char*)(&rhs._bits);
-	}
-	inline bool operator> (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return operator< (rhs, lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return operator< (lhs, rhs) || operator==(lhs, rhs);
-	}
-	inline bool operator>=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return !operator< (lhs, rhs);
+	template <typename T>
+	posit& float_assign(const T& rhs) {
+		constexpr int dfbits = std::numeric_limits<T>::digits - 1;
+		value<dfbits> v((T)rhs);
+
+		// special case processing
+		if (v.iszero()) {
+			setzero();
+			return *this;
+		}
+		if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
+			setnar();
+			return *this;
+		}
+
+		bitblock<NBITS_IS_128> ptt;
+		convert_to_bb<NBITS_IS_128, ES_IS_4, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
+		_bits = uint8_t(ptt.to_ulong());
+		return *this;
 	}
 
-	inline posit<NBITS_IS_128, ES_IS_4> operator+(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		posit<NBITS_IS_128, ES_IS_4> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result += rhs;
-		} 
+	// helper method
+	// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
+	inline void decode_regime(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			m = -1;
+			while (!(remaining >> 7)) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractAddand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 7)) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractMultiplicand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			--m;
+			while (!(remaining >> 7)) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractDividand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 7)) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline uint8_t round(const int8_t m, uint16_t fraction) const {
+		uint8_t scale, regime, bits;
+		if (m < 0) {
+			scale = (-m & 0xFF);
+			regime = 0x40 >> scale;
+		}
 		else {
-			result -= rhs;
+			scale = m + 1;
+			regime = 0x7F - (0x7F >> scale);
 		}
-		return result;
-	}
-	inline posit<NBITS_IS_128, ES_IS_4> operator-(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		posit<NBITS_IS_128, ES_IS_4> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result -= rhs.twosComplement();
+
+		if (scale > 6) {
+			bits = m<0 ? 0x1 : 0x7F;  // minpos and maxpos
 		}
 		else {
-			result += rhs.twosComplement();
+			fraction = (fraction & 0x3FFF) >> scale;
+			uint8_t final_fbits = uint8_t(fraction >> 8);
+			bool bitNPlusOne = bool(0x80 & fraction);
+			bits = uint8_t(regime) + uint8_t(final_fbits);
+			// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
+			if (bitNPlusOne) {
+				uint8_t moreBits = (0x7F & fraction) ? 0x01 : 0x00;
+				bits += (bits & 0x01) | moreBits;
+			}
 		}
-		return result;
-
+		return bits;
 	}
-	// binary operator*() is provided by generic class
+	inline uint8_t adjustAndRound(const int8_t k, uint16_t fraction, bool nonZeroRemainder) const {
+		uint8_t scale, regime, bits;
+		if (k < 0) {
+			scale = (-k & 0xFF);
+			regime = 0x40 >> scale;
+		}
+		else {
+			scale = k + 1;
+			regime = 0x7F - (0x7F >> scale);
+		}
+
+		if (scale > 6) {
+			bits = k<0 ? 0x1 : 0x7F;  // minpos and maxpos
+		}
+		else {
+			//remove carry and rcarry bits and shift to correct position
+			fraction &= 0x7F;
+			uint8_t final_fbits = (uint_fast16_t)fraction >> (scale + 1);
+			bool bitNPlusOne = (0x1 & (fraction >> scale));
+			bits = uint8_t(regime) + uint8_t(final_fbits);
+#ifdef NOW
+			std::cout << std::hex;
+			std::cout << "fraction raw   = " << int(fraction) << std::endl;
+			std::cout << "fraction final = " << int(final_fbits) << std::endl;
+			std::cout << "posit bits     = " << int(bits) << std::endl;
+			std::cout << std::dec;
+#endif
+			if (bitNPlusOne) {
+				uint8_t moreBits = (((1 << scale) - 1) & fraction) ? 0x01 : 0x00;
+				if (nonZeroRemainder) moreBits = 0x01;
+				//std::cout << "bitsMore = " << (moreBits ? "true" : "false") << std::endl;
+				// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
+				bits += (bits & 0x01) | moreBits;
+			}
+		}
+		return bits;
+	}
+	// I/O operators
+	friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_128, ES_IS_4>& p);
+	friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_128, ES_IS_4>& p);
+
+	// posit - posit logic functions
+	friend bool operator==(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
+	friend bool operator!=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
+	friend bool operator< (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
+	friend bool operator> (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
+	friend bool operator<=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
+	friend bool operator>=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs);
+
+};
+
+// posit I/O operators
+// generate a posit format ASCII format nbits.esxNN...NNp
+inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_128, ES_IS_4>& p) {
+	// to make certain that setw and left/right operators work properly
+	// we need to transform the posit into a string
+	std::stringstream ss;
+#if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
+	ss << NBITS_IS_128 << '.' << ES_IS_4 << 'x' << to_hex(p.get()) << 'p';
+#else
+	std::streamsize prec = ostr.precision();
+	std::streamsize width = ostr.width();
+	std::ios_base::fmtflags ff;
+	ff = ostr.flags();
+	ss.flags(ff);
+	ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+#endif
+	return ostr << ss.str();
+}
+
+// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
+inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_128, ES_IS_4>& p) {
+	std::string txt;
+	istr >> txt;
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+	}
+	return istr;
+}
+
+// convert a posit value to a string using "nar" as designation of NaR
+std::string to_string(const posit<NBITS_IS_128, ES_IS_4>& p, std::streamsize precision) {
+	if (p.isnar()) {
+		return std::string("nar");
+	}
+	std::stringstream ss;
+	ss << std::setprecision(precision) << float(p);
+	return ss.str();
+}
+
+// posit - posit binary logic operators
+inline bool operator==(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return lhs._bits == rhs._bits;
+}
+inline bool operator!=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return !operator==(lhs, rhs);
+}
+inline bool operator< (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return *(signed char*)(&lhs._bits) < *(signed char*)(&rhs._bits);
+}
+inline bool operator> (const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return operator< (rhs, lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return operator< (lhs, rhs) || operator==(lhs, rhs);
+}
+inline bool operator>=(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return !operator< (lhs, rhs);
+}
+
+inline posit<NBITS_IS_128, ES_IS_4> operator+(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	posit<NBITS_IS_128, ES_IS_4> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result += rhs;
+	} 
+	else {
+		result -= rhs;
+	}
+	return result;
+}
+inline posit<NBITS_IS_128, ES_IS_4> operator-(const posit<NBITS_IS_128, ES_IS_4>& lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	posit<NBITS_IS_128, ES_IS_4> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result -= rhs.twosComplement();
+	}
+	else {
+		result += rhs.twosComplement();
+	}
+	return result;
+
+}
+// binary operator*() is provided by generic class
 
 #if POSIT_ENABLE_LITERALS
-	// posit - literal logic functions
+// posit - literal logic functions
 
-	// posit - int logic operators
-	inline bool operator==(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
-		return operator==(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
-	}
-	inline bool operator!=(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
-		return !operator==(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
-	}
-	inline bool operator< (const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
-		return operator<(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
-	}
-	inline bool operator> (const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
-		return operator< (posit<NBITS_IS_128, ES_IS_4>(rhs), lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
-		return operator< (lhs, posit<NBITS_IS_128, ES_IS_4>(rhs)) || operator==(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
-	}
-	inline bool operator>=(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
-		return !operator<(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
-	}
+// posit - int logic operators
+inline bool operator==(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
+	return operator==(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
+}
+inline bool operator!=(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
+	return !operator==(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
+}
+inline bool operator< (const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
+	return operator<(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
+}
+inline bool operator> (const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
+	return operator< (posit<NBITS_IS_128, ES_IS_4>(rhs), lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
+	return operator< (lhs, posit<NBITS_IS_128, ES_IS_4>(rhs)) || operator==(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
+}
+inline bool operator>=(const posit<NBITS_IS_128, ES_IS_4>& lhs, int rhs) {
+	return !operator<(lhs, posit<NBITS_IS_128, ES_IS_4>(rhs));
+}
 
-	// int - posit logic operators
-	inline bool operator==(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return posit<NBITS_IS_128, ES_IS_4>(lhs) == rhs;
-	}
-	inline bool operator!=(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return !operator==(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
-	}
-	inline bool operator< (int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return operator<(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
-	}
-	inline bool operator> (int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return operator< (posit<NBITS_IS_128, ES_IS_4>(rhs), lhs);
-	}
-	inline bool operator<=(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return operator< (posit<NBITS_IS_128, ES_IS_4>(lhs), rhs) || operator==(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
-	}
-	inline bool operator>=(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
-		return !operator<(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
-	}
+// int - posit logic operators
+inline bool operator==(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return posit<NBITS_IS_128, ES_IS_4>(lhs) == rhs;
+}
+inline bool operator!=(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return !operator==(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
+}
+inline bool operator< (int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return operator<(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
+}
+inline bool operator> (int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return operator< (posit<NBITS_IS_128, ES_IS_4>(rhs), lhs);
+}
+inline bool operator<=(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return operator< (posit<NBITS_IS_128, ES_IS_4>(lhs), rhs) || operator==(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
+}
+inline bool operator>=(int lhs, const posit<NBITS_IS_128, ES_IS_4>& rhs) {
+	return !operator<(posit<NBITS_IS_128, ES_IS_4>(lhs), rhs);
+}
 
 #endif // POSIT_ENABLE_LITERALS
 
@@ -736,5 +736,5 @@ namespace sw {
 #	define POSIT_FAST_POSIT_128_4 0
 #endif // POSIT_FAST_POSIT_128_4
 
-  }
+}
 }

--- a/include/universal/posit/specialized/posit_16_1.hpp
+++ b/include/universal/posit/specialized/posit_16_1.hpp
@@ -32,19 +32,19 @@ namespace sw {
 		posit& operator=(posit&&) = default;
 
 		// initializers for native types
-		constexpr explicit posit(signed char initial_value) : _bits(0)        { *this = initial_value; }
-		constexpr explicit posit(short initial_value) : _bits(0)              { *this = initial_value; }
-		constexpr explicit posit(int initial_value) : _bits(0)                { *this = initial_value; }
-		constexpr explicit posit(long initial_value) : _bits(0)               { *this = initial_value; }
-		constexpr explicit posit(long long initial_value) : _bits(0)          { *this = initial_value; }
-		constexpr explicit posit(char initial_value) : _bits(0)               { *this = initial_value; }
-		constexpr explicit posit(unsigned short initial_value) : _bits(0)     { *this = initial_value; }
-		constexpr explicit posit(unsigned int initial_value) : _bits(0)       { *this = initial_value; }
-		constexpr explicit posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
-		constexpr explicit posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
-		constexpr explicit posit(float initial_value) : _bits(0)              { *this = initial_value; }
-		constexpr          posit(double initial_value) : _bits(0)             { *this = initial_value; }
-		constexpr explicit posit(long double initial_value) : _bits(0)        { *this = initial_value; }
+		explicit constexpr posit(signed char initial_value) : _bits(0)        { *this = initial_value; }
+		explicit constexpr posit(short initial_value) : _bits(0)              { *this = initial_value; }
+		explicit constexpr posit(int initial_value) : _bits(0)                { *this = initial_value; }
+		explicit constexpr posit(long initial_value) : _bits(0)               { *this = initial_value; }
+		explicit constexpr posit(long long initial_value) : _bits(0)          { *this = initial_value; }
+		explicit constexpr posit(char initial_value) : _bits(0)               { *this = initial_value; }
+		explicit constexpr posit(unsigned short initial_value) : _bits(0)     { *this = initial_value; }
+		explicit constexpr posit(unsigned int initial_value) : _bits(0)       { *this = initial_value; }
+		explicit constexpr posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
+		explicit constexpr posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
+		explicit constexpr posit(float initial_value) : _bits(0)              { *this = initial_value; }
+		         constexpr posit(double initial_value) : _bits(0)             { *this = initial_value; }
+	    explicit constexpr posit(long double initial_value) : _bits(0)        { *this = initial_value; }
 
 		// assignment operators for native types
 		constexpr posit& operator=(signed char rhs)       { return integer_assign((long)rhs); }
@@ -526,8 +526,6 @@ namespace sw {
 			_bits = uint16_t(ptt.to_ulong());
 			return *this;
 		}
-
-
 
 		// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
 		inline void decode_regime(const uint16_t bits, int8_t& m, uint16_t& remaining) const {

--- a/include/universal/posit/specialized/posit_16_1.hpp
+++ b/include/universal/posit/specialized/posit_16_1.hpp
@@ -58,7 +58,7 @@ namespace sw {
 		constexpr posit& operator=(unsigned long rhs)     { return integer_assign((long)rhs); }
 		constexpr posit& operator=(unsigned long long rhs){ return integer_assign((long)rhs); }
 		constexpr posit& operator=(float rhs)             { return float_assign(double(rhs)); }
-		constexpr posit& operator=(double rhs)  { return float_assign(rhs); }
+		constexpr posit& operator=(double rhs)            { return float_assign(rhs); }
 		constexpr posit& operator=(long double rhs)       { return float_assign(double(rhs)); }
 
 		explicit operator long double() const { return to_long_double(); }
@@ -509,13 +509,13 @@ namespace sw {
 		// enough bits to correctly round mul/div and elementary function results. That is, if you use a single precision
 		// float, you will inject errors in the validation suites.
 		constexpr posit& float_assign(double rhs) {
+			constexpr int dfbits = std::numeric_limits<double>::digits - 1;
+			value<dfbits> v(rhs);
 			// special case processing
-			if (0.0 == rhs) {
+			if (v.iszero()) {
 				setzero();
 				return *this;
 			}
-			constexpr int dfbits = std::numeric_limits<double>::digits - 1;
-			value<dfbits> v((double)rhs);
 			if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
 				setnar();
 				return *this;

--- a/include/universal/posit/specialized/posit_16_1.hpp
+++ b/include/universal/posit/specialized/posit_16_1.hpp
@@ -42,9 +42,9 @@ namespace sw {
 		explicit constexpr posit(unsigned int initial_value) : _bits(0)       { *this = initial_value; }
 		explicit constexpr posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
 		explicit constexpr posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
-		explicit constexpr posit(float initial_value) : _bits(0)              { *this = initial_value; }
-		         constexpr posit(double initial_value) : _bits(0)             { *this = initial_value; }
-	    explicit constexpr posit(long double initial_value) : _bits(0)        { *this = initial_value; }
+		explicit           posit(float initial_value) : _bits(0)              { *this = initial_value; }
+		                   posit(double initial_value) : _bits(0)             { *this = initial_value; }
+	        explicit           posit(long double initial_value) : _bits(0)        { *this = initial_value; }
 
 		// assignment operators for native types
 		constexpr posit& operator=(signed char rhs)       { return integer_assign((long)rhs); }
@@ -57,9 +57,9 @@ namespace sw {
 		constexpr posit& operator=(unsigned int rhs)      { return integer_assign((long)rhs); }
 		constexpr posit& operator=(unsigned long rhs)     { return integer_assign((long)rhs); }
 		constexpr posit& operator=(unsigned long long rhs){ return integer_assign((long)rhs); }
-		constexpr posit& operator=(float rhs)             { return float_assign(double(rhs)); }
-		constexpr posit& operator=(double rhs)            { return float_assign(rhs); }
-		constexpr posit& operator=(long double rhs)       { return float_assign(double(rhs)); }
+		          posit& operator=(float rhs)             { return float_assign(double(rhs)); }
+		          posit& operator=(double rhs)            { return float_assign(rhs); }
+		          posit& operator=(long double rhs)       { return float_assign(double(rhs)); }
 
 		explicit operator long double() const { return to_long_double(); }
 		explicit operator double() const { return to_double(); }
@@ -508,7 +508,7 @@ namespace sw {
 		// convert a double precision IEEE floating point to a posit<16,1>. You need to use at least doubles to capture
 		// enough bits to correctly round mul/div and elementary function results. That is, if you use a single precision
 		// float, you will inject errors in the validation suites.
-		constexpr posit& float_assign(double rhs) {
+		posit& float_assign(double rhs) {
 			constexpr int dfbits = std::numeric_limits<double>::digits - 1;
 			value<dfbits> v(rhs);
 			// special case processing

--- a/include/universal/posit/specialized/posit_16_1.hpp
+++ b/include/universal/posit/specialized/posit_16_1.hpp
@@ -25,41 +25,41 @@ namespace sw {
 		static constexpr size_t fhbits = fbits + 1;
 		static constexpr uint16_t sign_mask = 0x8000u;
 
-		posit() { _bits = 0; }
+		constexpr posit() : _bits(0) {}
 		posit(const posit&) = default;
 		posit(posit&&) = default;
 		posit& operator=(const posit&) = default;
 		posit& operator=(posit&&) = default;
 
 		// initializers for native types
-		explicit posit(signed char initial_value)        { *this = initial_value; }
-		explicit posit(short initial_value)              { *this = initial_value; }
-		explicit posit(int initial_value)                { *this = initial_value; }
-		explicit posit(long initial_value)               { *this = initial_value; }
-		explicit posit(long long initial_value)          { *this = initial_value; }
-		explicit posit(char initial_value)               { *this = initial_value; }
-		explicit posit(unsigned short initial_value)     { *this = initial_value; }
-		explicit posit(unsigned int initial_value)       { *this = initial_value; }
-		explicit posit(unsigned long initial_value)      { *this = initial_value; }
-		explicit posit(unsigned long long initial_value) { *this = initial_value; }
-		explicit posit(float initial_value)              { *this = initial_value; }
-		explicit posit(double initial_value)             { *this = initial_value; }
-		explicit posit(long double initial_value)        { *this = initial_value; }
+		constexpr explicit posit(signed char initial_value) : _bits(0)        { *this = initial_value; }
+		constexpr explicit posit(short initial_value) : _bits(0)              { *this = initial_value; }
+		constexpr explicit posit(int initial_value) : _bits(0)                { *this = initial_value; }
+		constexpr explicit posit(long initial_value) : _bits(0)               { *this = initial_value; }
+		constexpr explicit posit(long long initial_value) : _bits(0)          { *this = initial_value; }
+		constexpr explicit posit(char initial_value) : _bits(0)               { *this = initial_value; }
+		constexpr explicit posit(unsigned short initial_value) : _bits(0)     { *this = initial_value; }
+		constexpr explicit posit(unsigned int initial_value) : _bits(0)       { *this = initial_value; }
+		constexpr explicit posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
+		constexpr explicit posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
+		constexpr explicit posit(float initial_value) : _bits(0)              { *this = initial_value; }
+		constexpr          posit(double initial_value) : _bits(0)             { *this = initial_value; }
+		constexpr explicit posit(long double initial_value) : _bits(0)        { *this = initial_value; }
 
 		// assignment operators for native types
-		posit& operator=(signed char rhs)       { return integer_assign((long)rhs); }
-		posit& operator=(short rhs)             { return integer_assign((long)rhs); }
-		posit& operator=(int rhs)               { return integer_assign((long)rhs); }
-		posit& operator=(long rhs)              { return integer_assign(rhs); }
-		posit& operator=(long long rhs)         { return integer_assign((long)rhs);	}
-		posit& operator=(char rhs)              { return integer_assign((long)rhs); }
-		posit& operator=(unsigned short rhs)    { return integer_assign((long)rhs); }
-		posit& operator=(unsigned int rhs)      { return integer_assign((long)rhs); }
-		posit& operator=(unsigned long rhs)     { return integer_assign((long)rhs); }
-		posit& operator=(unsigned long long rhs){ return integer_assign((long)rhs); }
-		posit& operator=(float rhs)             { return float_assign(double(rhs)); }
-		posit& operator=(double rhs)            { return float_assign(rhs); }
-		posit& operator=(long double rhs)       { return float_assign(double(rhs)); }
+		constexpr posit& operator=(signed char rhs)       { return integer_assign((long)rhs); }
+		constexpr posit& operator=(short rhs)             { return integer_assign((long)rhs); }
+		constexpr posit& operator=(int rhs)               { return integer_assign((long)rhs); }
+		constexpr posit& operator=(long rhs)              { return integer_assign(rhs); }
+		constexpr posit& operator=(long long rhs)         { return integer_assign((long)rhs);	}
+		constexpr posit& operator=(char rhs)              { return integer_assign((long)rhs); }
+		constexpr posit& operator=(unsigned short rhs)    { return integer_assign((long)rhs); }
+		constexpr posit& operator=(unsigned int rhs)      { return integer_assign((long)rhs); }
+		constexpr posit& operator=(unsigned long rhs)     { return integer_assign((long)rhs); }
+		constexpr posit& operator=(unsigned long long rhs){ return integer_assign((long)rhs); }
+		constexpr posit& operator=(float rhs)             { return float_assign(double(rhs)); }
+		constexpr posit& operator=(double rhs)  { return float_assign(rhs); }
+		constexpr posit& operator=(long double rhs)       { return float_assign(double(rhs)); }
 
 		explicit operator long double() const { return to_long_double(); }
 		explicit operator double() const { return to_double(); }
@@ -354,6 +354,7 @@ namespace sw {
 			posit p = 1.0 / *this;
 			return p;
 		}
+		
 		// SELECTORS
 		inline bool isnar() const      { return (_bits == sign_mask); }
 		inline bool iszero() const     { return (_bits == 0x0); }
@@ -463,7 +464,7 @@ namespace sw {
 
 
 		// helper methods
-		posit& integer_assign(long rhs) {
+		constexpr posit& integer_assign(long rhs) {
 			// special case for speed as this is a common initialization
 			if (rhs == 0) {
 				_bits = 0x0;
@@ -507,17 +508,14 @@ namespace sw {
 		// convert a double precision IEEE floating point to a posit<16,1>. You need to use at least doubles to capture
 		// enough bits to correctly round mul/div and elementary function results. That is, if you use a single precision
 		// float, you will inject errors in the validation suites.
-		posit& float_assign(double rhs) {
-			//posit16_t p = posit16_fromf(rhs);
-			//_bits = p.v;
-			constexpr int dfbits = std::numeric_limits<double>::digits - 1;
-			value<dfbits> v((double)rhs);
-
+		constexpr posit& float_assign(double rhs) {
 			// special case processing
-			if (v.iszero()) {
+			if (0.0 == rhs) {
 				setzero();
 				return *this;
 			}
+			constexpr int dfbits = std::numeric_limits<double>::digits - 1;
+			value<dfbits> v((double)rhs);
 			if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
 				setnar();
 				return *this;

--- a/include/universal/posit/specialized/posit_256_5.hpp
+++ b/include/universal/posit/specialized/posit_256_5.hpp
@@ -1,733 +1,733 @@
 #pragma once
 // posit_256_5.hpp: specialized 256-bit posit using fast compute specialized for posit<256,5>
 //
-// Copyright (C) 2017-2019 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 namespace sw {
-	namespace unum {
+namespace unum {
 
-		// set the fast specialization variable to indicate that we are running a special template specialization
+	// set the fast specialization variable to indicate that we are running a special template specialization
 #if POSIT_FAST_POSIT_256_5
 #pragma message("Fast specialization of posit<256,5>")
 
-	// fast specialized posit<256,5>
-	template<>
-	class posit<NBITS_IS_256, ES_IS_5> {
-	public:
-		static constexpr size_t nbits = NBITS_IS_256;
-		static constexpr size_t es = ES_IS_5;
-		static constexpr size_t sbits = 1;
-		static constexpr size_t rbits = nbits - sbits;
-		static constexpr size_t ebits = es;
-		static constexpr size_t fbits = nbits - 3 - es;
-		static constexpr size_t fhbits = fbits + 1;
-		static constexpr uint64_t sign_mask = 0x8000000000000000ull;  // 0x8000'0000'0000'0000ull;
+// fast specialized posit<256,5>
+template<>
+class posit<NBITS_IS_256, ES_IS_5> {
+public:
+	static constexpr size_t nbits = NBITS_IS_256;
+	static constexpr size_t es = ES_IS_5;
+	static constexpr size_t sbits = 1;
+	static constexpr size_t rbits = nbits - sbits;
+	static constexpr size_t ebits = es;
+	static constexpr size_t fbits = nbits - 3 - es;
+	static constexpr size_t fhbits = fbits + 1;
+	static constexpr uint64_t sign_mask = 0x8000000000000000ull;  // 0x8000'0000'0000'0000ull;
 
-		posit() { _bits = 0; }
-		posit(const posit&) = default;
-		posit(posit&&) = default;
-		posit& operator=(const posit&) = default;
-		posit& operator=(posit&&) = default;
+	posit() { _bits = 0; }
+	posit(const posit&) = default;
+	posit(posit&&) = default;
+	posit& operator=(const posit&) = default;
+	posit& operator=(posit&&) = default;
 
-		// initializers for native types
-		explicit posit(const signed char initial_value)        { *this = initial_value; }
-		explicit posit(const short initial_value)              { *this = initial_value; }
-		explicit posit(const int initial_value)                { *this = initial_value; }
-		explicit posit(const long initial_value)               { *this = initial_value; }
-		explicit posit(const long long initial_value)          { *this = initial_value; }
-		explicit posit(const char initial_value)               { *this = initial_value; }
-		explicit posit(const unsigned short initial_value)     { *this = initial_value; }
-		explicit posit(const unsigned int initial_value)       { *this = initial_value; }
-		explicit posit(const unsigned long initial_value)      { *this = initial_value; }
-		explicit posit(const unsigned long long initial_value) { *this = initial_value; }
-		explicit posit(const float initial_value)              { *this = initial_value; }
-		explicit posit(const double initial_value)             { *this = initial_value; }
-		explicit posit(const long double initial_value)        { *this = initial_value; }
+	// initializers for native types
+	constexpr explicit posit(signed char initial_value)        { *this = initial_value; }
+	constexpr explicit posit(short initial_value)              { *this = initial_value; }
+	constexpr explicit posit(int initial_value)                { *this = initial_value; }
+	constexpr explicit posit(long initial_value)               { *this = initial_value; }
+	constexpr explicit posit(long long initial_value)          { *this = initial_value; }
+	constexpr explicit posit(char initial_value)               { *this = initial_value; }
+	constexpr explicit posit(unsigned short initial_value)     { *this = initial_value; }
+	constexpr explicit posit(unsigned int initial_value)       { *this = initial_value; }
+	constexpr explicit posit(unsigned long initial_value)      { *this = initial_value; }
+	constexpr explicit posit(unsigned long long initial_value) { *this = initial_value; }
+	constexpr explicit posit(float initial_value)              { *this = initial_value; }
+	constexpr explicit posit(double initial_value)             { *this = initial_value; }
+	constexpr          posit(long double initial_value)        { *this = initial_value; }
 
-		// assignment operators for native types
-		posit& operator=(const signed char rhs)       { 
-			// special case for speed as this is a common initialization
-			if (rhs == 0) {
-				_bits = 0x00;
-				return *this;
-			}
-
-			bool sign = bool(rhs & 0x80);
-			int8_t v = sign ? -rhs : rhs; // project to positve side of the projective reals
-			uint8_t raw;
-			if (v > 48 || v == -128) { // +-maxpos, 0x80 is special in int8 arithmetic as it is its own negation
-				raw = 0x7F;
-			}
-			else {
-				uint8_t mask = 0x40;
-				int8_t k = 6;
-				uint8_t fraction_bits = v;
-				while (!(fraction_bits & mask)) {
-					k--;
-					fraction_bits <<= 1;
-				}
-				fraction_bits = (fraction_bits ^ mask);
-				raw = (0x7F ^ (0x3F >> k)) | (fraction_bits >> (k + 1));
-
-				mask = 0x1 << k; //bitNPlusOne
-				if (mask & fraction_bits) {
-					if (((mask - 1) & fraction_bits) | ((mask << 1) & fraction_bits)) raw++;
-				}
-			}
-			_bits = sign ? -raw : raw;
+	// assignment operators for native types
+	posit& operator=(signed char rhs)       { 
+		// special case for speed as this is a common initialization
+		if (rhs == 0) {
+			_bits = 0x00;
 			return *this;
 		}
-		posit& operator=(const short rhs)             { return operator=((signed char)(rhs)); }
-		posit& operator=(const int rhs)               { return operator=((signed char)(rhs)); }
-		posit& operator=(const long rhs)              { return operator=((signed char)(rhs)); }
-		posit& operator=(const long long rhs)         { return operator=((signed char)(rhs)); }
-		posit& operator=(const char rhs)              { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned short rhs)    { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned int rhs)      { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned long rhs)     { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned long long rhs){ return operator=((signed char)(rhs)); }
-		posit& operator=(const float rhs)             { return float_assign(rhs); }
-		posit& operator=(const double rhs)            { return float_assign(rhs); }
-		posit& operator=(const long double rhs)       { return float_assign(rhs); }
 
-		explicit operator long double() const { return to_long_double(); }
-		explicit operator double() const { return to_double(); }
-		explicit operator float() const { return to_float(); }
-		explicit operator long long() const { return to_long_long(); }
-		explicit operator long() const { return to_long(); }
-		explicit operator int() const { return to_int(); }
-		explicit operator unsigned long long() const { return to_long_long(); }
-		explicit operator unsigned long() const { return to_long(); }
-		explicit operator unsigned int() const { return to_int(); }
+		bool sign = bool(rhs & 0x80);
+		int8_t v = sign ? -rhs : rhs; // project to positve side of the projective reals
+		uint8_t raw;
+		if (v > 48 || v == -128) { // +-maxpos, 0x80 is special in int8 arithmetic as it is its own negation
+			raw = 0x7F;
+		}
+		else {
+			uint8_t mask = 0x40;
+			int8_t k = 6;
+			uint8_t fraction_bits = v;
+			while (!(fraction_bits & mask)) {
+				k--;
+				fraction_bits <<= 1;
+			}
+			fraction_bits = (fraction_bits ^ mask);
+			raw = (0x7F ^ (0x3F >> k)) | (fraction_bits >> (k + 1));
 
-		posit& set(sw::unum::bitblock<NBITS_IS_256>& raw) {
-			_bits = uint8_t(raw.to_ulong());
+			mask = 0x1 << k; //bitNPlusOne
+			if (mask & fraction_bits) {
+				if (((mask - 1) & fraction_bits) | ((mask << 1) & fraction_bits)) raw++;
+			}
+		}
+		_bits = sign ? -raw : raw;
+		return *this;
+	}
+	posit& operator=(short rhs)             { return operator=((signed char)(rhs)); }
+	posit& operator=(int rhs)               { return operator=((signed char)(rhs)); }
+	posit& operator=(long rhs)              { return operator=((signed char)(rhs)); }
+	posit& operator=(long long rhs)         { return operator=((signed char)(rhs)); }
+	posit& operator=(char rhs)              { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned short rhs)    { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned int rhs)      { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned long rhs)     { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned long long rhs){ return operator=((signed char)(rhs)); }
+	posit& operator=(float rhs)             { return float_assign(rhs); }
+	posit& operator=(double rhs)            { return float_assign(rhs); }
+	constexpr posit& operator=(long double rhs)       { return float_assign(rhs); }
+
+	explicit operator long double() const { return to_long_double(); }
+	explicit operator double() const { return to_double(); }
+	explicit operator float() const { return to_float(); }
+	explicit operator long long() const { return to_long_long(); }
+	explicit operator long() const { return to_long(); }
+	explicit operator int() const { return to_int(); }
+	explicit operator unsigned long long() const { return to_long_long(); }
+	explicit operator unsigned long() const { return to_long(); }
+	explicit operator unsigned int() const { return to_int(); }
+
+	posit& set(sw::unum::bitblock<NBITS_IS_256>& raw) {
+		_bits = uint8_t(raw.to_ulong());
+		return *this;
+	}
+	posit& set_raw_bits(uint64_t value) {
+		_bits = uint8_t(value & 0xff);
+		return *this;
+	}
+	posit operator-() const {
+		if (iszero()) {
 			return *this;
 		}
-		posit& set_raw_bits(uint64_t value) {
-			_bits = uint8_t(value & 0xff);
+		if (isnar()) {
 			return *this;
 		}
-		posit operator-() const {
-			if (iszero()) {
-				return *this;
-			}
-			if (isnar()) {
-				return *this;
-			}
-			posit p;
-			return p.set_raw_bits((~_bits) + 1);
+		posit p;
+		return p.set_raw_bits((~_bits) + 1);
+	}
+	posit& operator+=(const posit& b) { // derived from SoftPosit
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {  // infinity
+			_bits = 0x80;
+			return *this;
 		}
-		posit& operator+=(const posit& b) { // derived from SoftPosit
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {  // infinity
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) { // zero
-				_bits = lhs | rhs;
-				return *this;
-			}
-			bool sign = bool(_bits & 0x80);
-			if (sign) {
-				lhs = -lhs & 0xFF;
-				rhs = -rhs & 0xFF;
-			}
-			if (lhs < rhs) std::swap(lhs, rhs);
+		if (iszero() || b.iszero()) { // zero
+			_bits = lhs | rhs;
+			return *this;
+		}
+		bool sign = bool(_bits & 0x80);
+		if (sign) {
+			lhs = -lhs & 0xFF;
+			rhs = -rhs & 0xFF;
+		}
+		if (lhs < rhs) std::swap(lhs, rhs);
 			
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t frac16A = (0x80 | remaining) << 7;
-			int8_t shiftRight = m;
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint16_t frac16B = (0x80 | remaining) << 7;
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t frac16A = (0x80 | remaining) << 7;
+		int8_t shiftRight = m;
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint16_t frac16B = (0x80 | remaining) << 7;
 
-			// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
-			(shiftRight>7) ? (frac16B = 0) : (frac16B >>= shiftRight); 
+		// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
+		(shiftRight>7) ? (frac16B = 0) : (frac16B >>= shiftRight); 
 
-			frac16A += frac16B;
+		frac16A += frac16B;
 
-			bool rcarry = bool(0x8000 & frac16A); // is MSB set
-			if (rcarry) {
-				m++;
-				frac16A >>= 1;
-			}
+		bool rcarry = bool(0x8000 & frac16A); // is MSB set
+		if (rcarry) {
+			m++;
+			frac16A >>= 1;
+		}
 
-			_bits = round(m, frac16A);
-			if (sign) _bits = -_bits & 0xFF;
+		_bits = round(m, frac16A);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator-=(const posit& b) {  // derived from SoftPosit
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {
+			_bits = 0x80;
 			return *this;
 		}
-		posit& operator-=(const posit& b) {  // derived from SoftPosit
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) {
-				_bits = lhs | rhs;
-				return *this;
-			}
-			// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
-			bool sign = bool(lhs & 0x80);
-			(sign) ? (lhs = (-lhs & 0xFF)) : (rhs = (-rhs & 0xFF));
-
-			if (lhs == rhs) {
-				_bits = 0x00;
-				return *this;
-			}
-			if (lhs < rhs) {
-				std::swap(lhs, rhs);
-				sign = !sign;
-			}
-
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t frac16A = (0x80 | remaining) << 7;
-			int8_t shiftRight = m;
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint16_t frac16B = (0x80 | remaining) << 7;
-
-			// do the subtraction of the fractions
-			if (shiftRight >= 14) {
-				_bits = lhs;
-				if (sign) _bits = -_bits & 0xFFFF;
-				return *this;
-			}
-			else {
-				frac16B >>= shiftRight;
-			}
-			frac16A -= frac16B;
-
-			while ((frac16A >> 14) == 0) {
-				m--;
-				frac16A <<= 1;
-			}
-			bool ecarry = bool (0x4000 & frac16A);
-			if (!ecarry) {
-				m--;
-				frac16A <<= 1;
-			}
-
-			_bits = round(m, frac16A);
-			if (sign) _bits = -_bits & 0xFF;
+		if (iszero() || b.iszero()) {
+			_bits = lhs | rhs;
 			return *this;
 		}
-		posit& operator*=(const posit& b) {
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) {
-				_bits = 0x00;
-				return *this;
-			}
+		// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
+		bool sign = bool(lhs & 0x80);
+		(sign) ? (lhs = (-lhs & 0xFF)) : (rhs = (-rhs & 0xFF));
 
-			// calculate the sign of the result
-			bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
-			lhs = lhs & 0x80 ? -lhs : lhs;
-			rhs = rhs & 0x80 ? -rhs : rhs;
-
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint8_t lhs_fraction = (0x80 | remaining);
-			// adjust shift and extract fraction bits of rhs
-			extractMultiplicand(rhs, m, remaining);
-			uint8_t rhs_fraction = (0x80 | remaining);
-			uint16_t result_fraction = uint16_t(lhs_fraction) * uint16_t(rhs_fraction);
-
-			bool rcarry = bool(result_fraction & 0x8000);
-			if (rcarry) {
-				m++;
-				result_fraction >>= 1;
-			}
-
-			// round
-			_bits = round(m, result_fraction);
-			if (sign) _bits = -_bits & 0xFF;
+		if (lhs == rhs) {
+			_bits = 0x00;
 			return *this;
 		}
-		posit& operator/=(const posit& b) {
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar() || b.iszero()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero()) {
-				_bits = 0x00;
-				return *this;
-			}
+		if (lhs < rhs) {
+			std::swap(lhs, rhs);
+			sign = !sign;
+		}
 
-			// calculate the sign of the result
-			bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
-			lhs = (lhs & 0x80) ? -lhs : lhs;
-			rhs = (rhs & 0x80) ? -rhs : rhs;
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t frac16A = (0x80 | remaining) << 7;
+		int8_t shiftRight = m;
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint16_t frac16B = (0x80 | remaining) << 7;
 
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t lhs_fraction = (0x80 | remaining) << 7;
-			// adjust shift and extract fraction bits of rhs
-			extractDividand(rhs, m, remaining);
-			uint8_t rhs_fraction = (0x80 | remaining);
-			div_t result = div(lhs_fraction, uint16_t(rhs_fraction));
-			uint16_t result_fraction = result.quot;
-			uint16_t remainder = result.rem;
-
-			if (result_fraction != 0) {
-				bool rcarry = result_fraction >> 7; // this is the hidden bit (7th bit) , extreme right bit is bit 0
-				if (!rcarry) {
-					--m;
-					result_fraction <<= 1;
-				}
-			}
-
-			// round
-			_bits = adjustAndRound(m, result_fraction, remainder != 0);
-			if (sign) _bits = -_bits & 0xFF;
-
+		// do the subtraction of the fractions
+		if (shiftRight >= 14) {
+			_bits = lhs;
+			if (sign) _bits = -_bits & 0xFFFF;
 			return *this;
 		}
-		posit& operator++() {
-			++_bits;
+		else {
+			frac16B >>= shiftRight;
+		}
+		frac16A -= frac16B;
+
+		while ((frac16A >> 14) == 0) {
+			m--;
+			frac16A <<= 1;
+		}
+		bool ecarry = bool (0x4000 & frac16A);
+		if (!ecarry) {
+			m--;
+			frac16A <<= 1;
+		}
+
+		_bits = round(m, frac16A);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator*=(const posit& b) {
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {
+			_bits = 0x80;
 			return *this;
 		}
-		posit operator++(int) {
-			posit tmp(*this);
-			operator++();
-			return tmp;
-		}
-		posit& operator--() {
-			--_bits;
-			return *this;
-		}
-		posit operator--(int) {
-			posit tmp(*this);
-			operator--();
-			return tmp;
-		}
-		posit reciprocate() const {
-			posit p = 1.0 / *this;
-			return p;
-		}
-		// SELECTORS
-		inline bool isnar() const      { return (_bits == 0x80); }
-		inline bool iszero() const     { return (_bits == 0x00); }
-		inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
-		inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
-		inline bool isneg() const      { return (_bits & 0x80); }
-		inline bool ispos() const      { return !isneg(); }
-		inline bool ispowerof2() const { return !(_bits & 0x1); }
-
-		inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
-
-		bitblock<NBITS_IS_256> get() const { bitblock<NBITS_IS_256> bb; bb = int(_bits); return bb; }
-		unsigned long long encoding() const { return (unsigned long long)(_bits); }
-
-		inline void clear() { _bits = 0; }
-		inline void setzero() { clear(); }
-		inline void setnar() { _bits = 0x80; }
-		inline posit twosComplement() const {
-			posit<NBITS_IS_256, ES_IS_5> p;
-			int8_t v = -*(int8_t*)&_bits;
-			p.set_raw_bits(v);
-			return p;
-		}
-	private:
-		uint8_t _bits;
-
-		// Conversion functions
-#if POSIT_THROW_ARITHMETIC_EXCEPTION
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_long_double());
-		}
-#else
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar())  return int(INFINITY);
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return long(INFINITY);
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return (long long)(INFINITY);
-			return long(to_long_double());
-		}
-#endif
-		float       to_float() const {
-			return (float)to_double();
-		}
-		double      to_double() const {
-			if (iszero())	return 0.0;
-			if (isnar())	return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			double s = (_sign ? -1.0 : 1.0);
-			double r = _regime.value();
-			double e = _exponent.value();
-			double f = (1.0 + _fraction.value());
-			return s * r * e * f;
-		}
-		long double to_long_double() const {
-			if (iszero())  return 0.0;
-			if (isnar())   return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			long double s = (_sign ? -1.0 : 1.0);
-			long double r = _regime.value();
-			long double e = _exponent.value();
-			long double f = (1.0 + _fraction.value());
-			return s * r * e * f;
-		}
-
-		template <typename T>
-		posit& float_assign(const T& rhs) {
-			constexpr int dfbits = std::numeric_limits<T>::digits - 1;
-			value<dfbits> v((T)rhs);
-
-			// special case processing
-			if (v.iszero()) {
-				setzero();
-				return *this;
-			}
-			if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
-				setnar();
-				return *this;
-			}
-
-			bitblock<NBITS_IS_256> ptt;
-			convert_to_bb<NBITS_IS_256, ES_IS_5, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
-			_bits = uint8_t(ptt.to_ulong());
+		if (iszero() || b.iszero()) {
+			_bits = 0x00;
 			return *this;
 		}
 
-		// helper method
-		// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
-		inline void decode_regime(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				m = -1;
-				while (!(remaining >> 7)) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
+		// calculate the sign of the result
+		bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
+		lhs = lhs & 0x80 ? -lhs : lhs;
+		rhs = rhs & 0x80 ? -rhs : rhs;
+
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint8_t lhs_fraction = (0x80 | remaining);
+		// adjust shift and extract fraction bits of rhs
+		extractMultiplicand(rhs, m, remaining);
+		uint8_t rhs_fraction = (0x80 | remaining);
+		uint16_t result_fraction = uint16_t(lhs_fraction) * uint16_t(rhs_fraction);
+
+		bool rcarry = bool(result_fraction & 0x8000);
+		if (rcarry) {
+			m++;
+			result_fraction >>= 1;
 		}
-		inline void extractAddand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				++m;
-				while (!(remaining >> 7)) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
+
+		// round
+		_bits = round(m, result_fraction);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator/=(const posit& b) {
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar() || b.iszero()) {
+			_bits = 0x80;
+			return *this;
 		}
-		inline void extractMultiplicand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
+		if (iszero()) {
+			_bits = 0x00;
+			return *this;
+		}
+
+		// calculate the sign of the result
+		bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
+		lhs = (lhs & 0x80) ? -lhs : lhs;
+		rhs = (rhs & 0x80) ? -rhs : rhs;
+
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t lhs_fraction = (0x80 | remaining) << 7;
+		// adjust shift and extract fraction bits of rhs
+		extractDividand(rhs, m, remaining);
+		uint8_t rhs_fraction = (0x80 | remaining);
+		div_t result = div(lhs_fraction, uint16_t(rhs_fraction));
+		uint16_t result_fraction = result.quot;
+		uint16_t remainder = result.rem;
+
+		if (result_fraction != 0) {
+			bool rcarry = result_fraction >> 7; // this is the hidden bit (7th bit) , extreme right bit is bit 0
+			if (!rcarry) {
 				--m;
-				while (!(remaining >> 7)) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
+				result_fraction <<= 1;
 			}
 		}
-		inline void extractDividand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				++m;
-				while (!(remaining >> 7)) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
-		}
-		inline uint8_t round(const int8_t m, uint16_t fraction) const {
-			uint8_t scale, regime, bits;
-			if (m < 0) {
-				scale = (-m & 0xFF);
-				regime = 0x40 >> scale;
-			}
-			else {
-				scale = m + 1;
-				regime = 0x7F - (0x7F >> scale);
-			}
 
-			if (scale > 6) {
-				bits = m<0 ? 0x1 : 0x7F;  // minpos and maxpos
-			}
-			else {
-				fraction = (fraction & 0x3FFF) >> scale;
-				uint8_t final_fbits = uint8_t(fraction >> 8);
-				bool bitNPlusOne = bool(0x80 & fraction);
-				bits = uint8_t(regime) + uint8_t(final_fbits);
-				// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
-				if (bitNPlusOne) {
-					uint8_t moreBits = (0x7F & fraction) ? 0x01 : 0x00;
-					bits += (bits & 0x01) | moreBits;
-				}
-			}
-			return bits;
-		}
-		inline uint8_t adjustAndRound(const int8_t k, uint16_t fraction, bool nonZeroRemainder) const {
-			uint8_t scale, regime, bits;
-			if (k < 0) {
-				scale = (-k & 0xFF);
-				regime = 0x40 >> scale;
-			}
-			else {
-				scale = k + 1;
-				regime = 0x7F - (0x7F >> scale);
-			}
+		// round
+		_bits = adjustAndRound(m, result_fraction, remainder != 0);
+		if (sign) _bits = -_bits & 0xFF;
 
-			if (scale > 6) {
-				bits = k<0 ? 0x1 : 0x7F;  // minpos and maxpos
-			}
-			else {
-				//remove carry and rcarry bits and shift to correct position
-				fraction &= 0x7F;
-				uint8_t final_fbits = (uint_fast16_t)fraction >> (scale + 1);
-				bool bitNPlusOne = (0x1 & (fraction >> scale));
-				bits = uint8_t(regime) + uint8_t(final_fbits);
-#ifdef NOW
-				std::cout << std::hex;
-				std::cout << "fraction raw   = " << int(fraction) << std::endl;
-				std::cout << "fraction final = " << int(final_fbits) << std::endl;
-				std::cout << "posit bits     = " << int(bits) << std::endl;
-				std::cout << std::dec;
-#endif
-				if (bitNPlusOne) {
-					uint8_t moreBits = (((1 << scale) - 1) & fraction) ? 0x01 : 0x00;
-					if (nonZeroRemainder) moreBits = 0x01;
-					//std::cout << "bitsMore = " << (moreBits ? "true" : "false") << std::endl;
-					// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
-					bits += (bits & 0x01) | moreBits;
-				}
-			}
-			return bits;
-		}
-		// I/O operators
-		friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_256, ES_IS_5>& p);
-		friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_256, ES_IS_5>& p);
+		return *this;
+	}
+	posit& operator++() {
+		++_bits;
+		return *this;
+	}
+	posit operator++(int) {
+		posit tmp(*this);
+		operator++();
+		return tmp;
+	}
+	posit& operator--() {
+		--_bits;
+		return *this;
+	}
+	posit operator--(int) {
+		posit tmp(*this);
+		operator--();
+		return tmp;
+	}
+	posit reciprocate() const {
+		posit p = 1.0 / *this;
+		return p;
+	}
+	// SELECTORS
+	inline bool isnar() const      { return (_bits == 0x80); }
+	inline bool iszero() const     { return (_bits == 0x00); }
+	inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
+	inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
+	inline bool isneg() const      { return (_bits & 0x80); }
+	inline bool ispos() const      { return !isneg(); }
+	inline bool ispowerof2() const { return !(_bits & 0x1); }
 
-		// posit - posit logic functions
-		friend bool operator==(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
-		friend bool operator!=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
-		friend bool operator< (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
-		friend bool operator> (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
-		friend bool operator<=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
-		friend bool operator>=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
+	inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
 
-	};
+	bitblock<NBITS_IS_256> get() const { bitblock<NBITS_IS_256> bb; bb = int(_bits); return bb; }
+	unsigned long long encoding() const { return (unsigned long long)(_bits); }
 
-	// posit I/O operators
-	// generate a posit format ASCII format nbits.esxNN...NNp
-	inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_256, ES_IS_5>& p) {
-		// to make certain that setw and left/right operators work properly
-		// we need to transform the posit into a string
-		std::stringstream ss;
-#if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
-		ss << NBITS_IS_256 << '.' << ES_IS_5 << 'x' << to_hex(p.get()) << 'p';
+	inline void clear() { _bits = 0; }
+	inline void setzero() { clear(); }
+	inline void setnar() { _bits = 0x80; }
+	inline posit twosComplement() const {
+		posit<NBITS_IS_256, ES_IS_5> p;
+		int8_t v = -*(int8_t*)&_bits;
+		p.set_raw_bits(v);
+		return p;
+	}
+private:
+	uint8_t _bits;
+
+	// Conversion functions
+#if POSIT_THROW_ARITHMETIC_EXCEPTION
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_long_double());
+	}
 #else
-		std::streamsize prec = ostr.precision();
-		std::streamsize width = ostr.width();
-		std::ios_base::fmtflags ff;
-		ff = ostr.flags();
-		ss.flags(ff);
-		ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar())  return int(INFINITY);
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return long(INFINITY);
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return (long long)(INFINITY);
+		return long(to_long_double());
+	}
 #endif
-		return ostr << ss.str();
+	float       to_float() const {
+		return (float)to_double();
 	}
-
-	// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
-	inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_256, ES_IS_5>& p) {
-		std::string txt;
-		istr >> txt;
-		if (!parse(txt, p)) {
-			std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+	double      to_double() const {
+		if (iszero())	return 0.0;
+		if (isnar())	return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		return istr;
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		double s = (_sign ? -1.0 : 1.0);
+		double r = _regime.value();
+		double e = _exponent.value();
+		double f = (1.0 + _fraction.value());
+		return s * r * e * f;
 	}
-
-	// convert a posit value to a string using "nar" as designation of NaR
-	std::string to_string(const posit<NBITS_IS_256, ES_IS_5>& p, std::streamsize precision) {
-		if (p.isnar()) {
-			return std::string("nar");
+	long double to_long_double() const {
+		if (iszero())  return 0.0;
+		if (isnar())   return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		std::stringstream ss;
-		ss << std::setprecision(precision) << float(p);
-		return ss.str();
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		long double s = (_sign ? -1.0 : 1.0);
+		long double r = _regime.value();
+		long double e = _exponent.value();
+		long double f = (1.0 + _fraction.value());
+		return s * r * e * f;
 	}
 
-	// posit - posit binary logic operators
-	inline bool operator==(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return lhs._bits == rhs._bits;
-	}
-	inline bool operator!=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return !operator==(lhs, rhs);
-	}
-	inline bool operator< (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return *(signed char*)(&lhs._bits) < *(signed char*)(&rhs._bits);
-	}
-	inline bool operator> (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return operator< (rhs, lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return operator< (lhs, rhs) || operator==(lhs, rhs);
-	}
-	inline bool operator>=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return !operator< (lhs, rhs);
+	template <typename T>
+	posit& float_assign(const T& rhs) {
+		constexpr int dfbits = std::numeric_limits<T>::digits - 1;
+		value<dfbits> v((T)rhs);
+
+		// special case processing
+		if (v.iszero()) {
+			setzero();
+			return *this;
+		}
+		if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
+			setnar();
+			return *this;
+		}
+
+		bitblock<NBITS_IS_256> ptt;
+		convert_to_bb<NBITS_IS_256, ES_IS_5, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
+		_bits = uint8_t(ptt.to_ulong());
+		return *this;
 	}
 
-	inline posit<NBITS_IS_256, ES_IS_5> operator+(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		posit<NBITS_IS_256, ES_IS_5> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result += rhs;
-		} 
+	// helper method
+	// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
+	inline void decode_regime(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			m = -1;
+			while (!(remaining >> 7)) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractAddand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 7)) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractMultiplicand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			--m;
+			while (!(remaining >> 7)) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractDividand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 7)) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline uint8_t round(const int8_t m, uint16_t fraction) const {
+		uint8_t scale, regime, bits;
+		if (m < 0) {
+			scale = (-m & 0xFF);
+			regime = 0x40 >> scale;
+		}
 		else {
-			result -= rhs;
+			scale = m + 1;
+			regime = 0x7F - (0x7F >> scale);
 		}
-		return result;
-	}
-	inline posit<NBITS_IS_256, ES_IS_5> operator-(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		posit<NBITS_IS_256, ES_IS_5> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result -= rhs.twosComplement();
+
+		if (scale > 6) {
+			bits = m<0 ? 0x1 : 0x7F;  // minpos and maxpos
 		}
 		else {
-			result += rhs.twosComplement();
+			fraction = (fraction & 0x3FFF) >> scale;
+			uint8_t final_fbits = uint8_t(fraction >> 8);
+			bool bitNPlusOne = bool(0x80 & fraction);
+			bits = uint8_t(regime) + uint8_t(final_fbits);
+			// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
+			if (bitNPlusOne) {
+				uint8_t moreBits = (0x7F & fraction) ? 0x01 : 0x00;
+				bits += (bits & 0x01) | moreBits;
+			}
 		}
-		return result;
-
+		return bits;
 	}
-	// binary operator*() is provided by generic class
+	inline uint8_t adjustAndRound(const int8_t k, uint16_t fraction, bool nonZeroRemainder) const {
+		uint8_t scale, regime, bits;
+		if (k < 0) {
+			scale = (-k & 0xFF);
+			regime = 0x40 >> scale;
+		}
+		else {
+			scale = k + 1;
+			regime = 0x7F - (0x7F >> scale);
+		}
+
+		if (scale > 6) {
+			bits = k<0 ? 0x1 : 0x7F;  // minpos and maxpos
+		}
+		else {
+			//remove carry and rcarry bits and shift to correct position
+			fraction &= 0x7F;
+			uint8_t final_fbits = (uint_fast16_t)fraction >> (scale + 1);
+			bool bitNPlusOne = (0x1 & (fraction >> scale));
+			bits = uint8_t(regime) + uint8_t(final_fbits);
+#ifdef NOW
+			std::cout << std::hex;
+			std::cout << "fraction raw   = " << int(fraction) << std::endl;
+			std::cout << "fraction final = " << int(final_fbits) << std::endl;
+			std::cout << "posit bits     = " << int(bits) << std::endl;
+			std::cout << std::dec;
+#endif
+			if (bitNPlusOne) {
+				uint8_t moreBits = (((1 << scale) - 1) & fraction) ? 0x01 : 0x00;
+				if (nonZeroRemainder) moreBits = 0x01;
+				//std::cout << "bitsMore = " << (moreBits ? "true" : "false") << std::endl;
+				// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
+				bits += (bits & 0x01) | moreBits;
+			}
+		}
+		return bits;
+	}
+	// I/O operators
+	friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_256, ES_IS_5>& p);
+	friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_256, ES_IS_5>& p);
+
+	// posit - posit logic functions
+	friend bool operator==(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
+	friend bool operator!=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
+	friend bool operator< (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
+	friend bool operator> (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
+	friend bool operator<=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
+	friend bool operator>=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs);
+
+};
+
+// posit I/O operators
+// generate a posit format ASCII format nbits.esxNN...NNp
+inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_256, ES_IS_5>& p) {
+	// to make certain that setw and left/right operators work properly
+	// we need to transform the posit into a string
+	std::stringstream ss;
+#if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
+	ss << NBITS_IS_256 << '.' << ES_IS_5 << 'x' << to_hex(p.get()) << 'p';
+#else
+	std::streamsize prec = ostr.precision();
+	std::streamsize width = ostr.width();
+	std::ios_base::fmtflags ff;
+	ff = ostr.flags();
+	ss.flags(ff);
+	ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+#endif
+	return ostr << ss.str();
+}
+
+// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
+inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_256, ES_IS_5>& p) {
+	std::string txt;
+	istr >> txt;
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+	}
+	return istr;
+}
+
+// convert a posit value to a string using "nar" as designation of NaR
+std::string to_string(const posit<NBITS_IS_256, ES_IS_5>& p, std::streamsize precision) {
+	if (p.isnar()) {
+		return std::string("nar");
+	}
+	std::stringstream ss;
+	ss << std::setprecision(precision) << float(p);
+	return ss.str();
+}
+
+// posit - posit binary logic operators
+inline bool operator==(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return lhs._bits == rhs._bits;
+}
+inline bool operator!=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return !operator==(lhs, rhs);
+}
+inline bool operator< (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return *(signed char*)(&lhs._bits) < *(signed char*)(&rhs._bits);
+}
+inline bool operator> (const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return operator< (rhs, lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return operator< (lhs, rhs) || operator==(lhs, rhs);
+}
+inline bool operator>=(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return !operator< (lhs, rhs);
+}
+
+inline posit<NBITS_IS_256, ES_IS_5> operator+(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	posit<NBITS_IS_256, ES_IS_5> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result += rhs;
+	} 
+	else {
+		result -= rhs;
+	}
+	return result;
+}
+inline posit<NBITS_IS_256, ES_IS_5> operator-(const posit<NBITS_IS_256, ES_IS_5>& lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	posit<NBITS_IS_256, ES_IS_5> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result -= rhs.twosComplement();
+	}
+	else {
+		result += rhs.twosComplement();
+	}
+	return result;
+
+}
+// binary operator*() is provided by generic class
 
 #if POSIT_ENABLE_LITERALS
-	// posit - literal logic functions
+// posit - literal logic functions
 
-	// posit - int logic operators
-	inline bool operator==(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
-		return operator==(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
-	}
-	inline bool operator!=(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
-		return !operator==(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
-	}
-	inline bool operator< (const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
-		return operator<(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
-	}
-	inline bool operator> (const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
-		return operator< (posit<NBITS_IS_256, ES_IS_5>(rhs), lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
-		return operator< (lhs, posit<NBITS_IS_256, ES_IS_5>(rhs)) || operator==(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
-	}
-	inline bool operator>=(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
-		return !operator<(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
-	}
+// posit - int logic operators
+inline bool operator==(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
+	return operator==(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
+}
+inline bool operator!=(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
+	return !operator==(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
+}
+inline bool operator< (const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
+	return operator<(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
+}
+inline bool operator> (const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
+	return operator< (posit<NBITS_IS_256, ES_IS_5>(rhs), lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
+	return operator< (lhs, posit<NBITS_IS_256, ES_IS_5>(rhs)) || operator==(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
+}
+inline bool operator>=(const posit<NBITS_IS_256, ES_IS_5>& lhs, int rhs) {
+	return !operator<(lhs, posit<NBITS_IS_256, ES_IS_5>(rhs));
+}
 
-	// int - posit logic operators
-	inline bool operator==(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return posit<NBITS_IS_256, ES_IS_5>(lhs) == rhs;
-	}
-	inline bool operator!=(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return !operator==(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
-	}
-	inline bool operator< (int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return operator<(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
-	}
-	inline bool operator> (int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return operator< (posit<NBITS_IS_256, ES_IS_5>(rhs), lhs);
-	}
-	inline bool operator<=(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return operator< (posit<NBITS_IS_256, ES_IS_5>(lhs), rhs) || operator==(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
-	}
-	inline bool operator>=(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
-		return !operator<(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
-	}
+// int - posit logic operators
+inline bool operator==(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return posit<NBITS_IS_256, ES_IS_5>(lhs) == rhs;
+}
+inline bool operator!=(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return !operator==(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
+}
+inline bool operator< (int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return operator<(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
+}
+inline bool operator> (int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return operator< (posit<NBITS_IS_256, ES_IS_5>(rhs), lhs);
+}
+inline bool operator<=(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return operator< (posit<NBITS_IS_256, ES_IS_5>(lhs), rhs) || operator==(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
+}
+inline bool operator>=(int lhs, const posit<NBITS_IS_256, ES_IS_5>& rhs) {
+	return !operator<(posit<NBITS_IS_256, ES_IS_5>(lhs), rhs);
+}
 
 #endif // POSIT_ENABLE_LITERALS
 
@@ -736,5 +736,5 @@ namespace sw {
 #	define POSIT_FAST_POSIT_256_5 0
 #endif // POSIT_FAST_POSIT_256_5
 
-  }
+}
 }

--- a/include/universal/posit/specialized/posit_32_2.hpp
+++ b/include/universal/posit/specialized/posit_32_2.hpp
@@ -36,30 +36,30 @@ public:
 	explicit constexpr posit(short initial_value) : _bits(0)              { *this = initial_value; }
 	explicit constexpr posit(int initial_value) : _bits(0)                { *this = initial_value; }
 	explicit constexpr posit(long initial_value) : _bits(0)               { *this = initial_value; }
-	explicit constexpr posit(long long initial_value) : _bits(0)          { *this = initial_value; }
+	explicit           posit(long long initial_value) : _bits(0)          { *this = initial_value; }
 	explicit constexpr posit(char initial_value) : _bits(0)               { *this = initial_value; }
 	explicit constexpr posit(unsigned short initial_value) : _bits(0)     { *this = initial_value; }
 	explicit constexpr posit(unsigned int initial_value) : _bits(0)       { *this = initial_value; }
-	explicit constexpr posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
-	explicit constexpr posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
-	explicit constexpr posit(float initial_value) : _bits(0)              { *this = initial_value; }
-	         constexpr posit(double initial_value) : _bits(0)             { *this = initial_value; }
-	explicit constexpr posit(long double initial_value) : _bits(0)        { *this = initial_value; }
+	explicit           posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
+	explicit           posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
+	explicit           posit(float initial_value) : _bits(0)              { *this = initial_value; }
+	explicit           posit(double initial_value) : _bits(0)             { *this = initial_value; }
+	                   posit(long double initial_value) : _bits(0)        { *this = initial_value; }
 
 	// assignment operators for native types
 	constexpr posit& operator=(signed char rhs)       { return integer_assign((long)(rhs)); }
 	constexpr posit& operator=(short rhs)             { return integer_assign((long)(rhs)); }
 	constexpr posit& operator=(int rhs)               { return integer_assign((long)(rhs)); }
 	constexpr posit& operator=(long rhs)              { return integer_assign(rhs); }
-	constexpr posit& operator=(long long rhs)         { return float_assign((long double)(rhs)); }
+	          posit& operator=(long long rhs)         { return float_assign((long double)(rhs)); }
 	constexpr posit& operator=(char rhs)              { return integer_assign((long)(rhs)); }
 	constexpr posit& operator=(unsigned short rhs)    { return integer_assign((long)(rhs)); }
 	constexpr posit& operator=(unsigned int rhs)      { return integer_assign((long)(rhs)); }
-	constexpr posit& operator=(unsigned long rhs)     { return float_assign((long double)(rhs)); }
-	constexpr posit& operator=(unsigned long long rhs){ return float_assign((long double)(rhs)); }
-	constexpr posit& operator=(float rhs)             { return float_assign((long double)rhs); }
-	constexpr posit& operator=(double rhs)            { return float_assign((long double)rhs); }
-	constexpr posit& operator=(long double rhs)       { return float_assign(rhs); }
+	          posit& operator=(unsigned long rhs)     { return float_assign((long double)(rhs)); }
+	          posit& operator=(unsigned long long rhs){ return float_assign((long double)(rhs)); }
+	          posit& operator=(float rhs)             { return float_assign((long double)rhs); }
+	          posit& operator=(double rhs)            { return float_assign((long double)rhs); }
+	          posit& operator=(long double rhs)       { return float_assign(rhs); }
 
 	explicit operator long double() const { return to_long_double(); }
 	explicit operator double() const { return to_double(); }
@@ -553,7 +553,7 @@ private:
 		_bits = sign ? -raw : raw;
 		return *this;
 	}
-	constexpr posit& float_assign(long double rhs) {
+	posit& float_assign(long double rhs) {
 		constexpr int dfbits = std::numeric_limits<long double>::digits - 1;
 		value<dfbits> v(rhs);
 		// special case processing

--- a/include/universal/posit/specialized/posit_32_2.hpp
+++ b/include/universal/posit/specialized/posit_32_2.hpp
@@ -1,948 +1,947 @@
 #pragma once
 // posit_32_2.hpp: specialized 32-bit posit using fast compute specialized for posit<32,2>
 //
-// Copyright (C) 2017-2019 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 namespace sw {
-	namespace unum {
+namespace unum {
 
 // set the fast specialization variable to indicate that we are running a special template specialization
 #if POSIT_FAST_POSIT_32_2
 #pragma message("Fast specialization of posit<32,2>")
 
-	// fast specialized posit<32,2>
-	template<>
-	class posit<NBITS_IS_32, ES_IS_2> {
-	public:
-		static constexpr size_t nbits = NBITS_IS_32;
-		static constexpr size_t es = ES_IS_2;
-		static constexpr size_t sbits = 1;
-		static constexpr size_t rbits = nbits - sbits;
-		static constexpr size_t ebits = es;
-		static constexpr size_t fbits = nbits - 3 - es;
-		static constexpr size_t fhbits = fbits + 1;
-		static constexpr uint32_t sign_mask = 0x80000000ul;  // 0x8000'0000ul;
+// fast specialized posit<32,2>
+template<>
+class posit<NBITS_IS_32, ES_IS_2> {
+public:
+	static constexpr size_t nbits = NBITS_IS_32;
+	static constexpr size_t es = ES_IS_2;
+	static constexpr size_t sbits = 1;
+	static constexpr size_t rbits = nbits - sbits;
+	static constexpr size_t ebits = es;
+	static constexpr size_t fbits = nbits - 3 - es;
+	static constexpr size_t fhbits = fbits + 1;
+	static constexpr uint32_t sign_mask = 0x80000000ul;  // 0x8000'0000ul;
 
-		posit() { _bits = 0; }
-		posit(const posit&) = default;
-		posit(posit&&) = default;
-		posit& operator=(const posit&) = default;
-		posit& operator=(posit&&) = default;
+	posit() : _bits(0) {}
+	posit(const posit&) = default;
+	posit(posit&&) = default;
+	posit& operator=(const posit&) = default;
+	posit& operator=(posit&&) = default;
 
-		// initializers for native types
-		explicit posit(signed char initial_value)        { *this = initial_value; }
-		explicit posit(short initial_value)              { *this = initial_value; }
-		explicit posit(int initial_value)                { *this = initial_value; }
-		explicit posit(long initial_value)               { *this = initial_value; }
-		explicit posit(long long initial_value)          { *this = initial_value; }
-		explicit posit(char initial_value)               { *this = initial_value; }
-		explicit posit(unsigned short initial_value)     { *this = initial_value; }
-		explicit posit(unsigned int initial_value)       { *this = initial_value; }
-		explicit posit(unsigned long initial_value)      { *this = initial_value; }
-		explicit posit(unsigned long long initial_value) { *this = initial_value; }
-		explicit posit(float initial_value)              { *this = initial_value; }
-		explicit posit(double initial_value)             { *this = initial_value; }
-		explicit posit(long double initial_value)        { *this = initial_value; }
+	// initializers for native types
+	explicit constexpr posit(signed char initial_value) : _bits(0)        { *this = initial_value; }
+	explicit constexpr posit(short initial_value) : _bits(0)              { *this = initial_value; }
+	explicit constexpr posit(int initial_value) : _bits(0)                { *this = initial_value; }
+	explicit constexpr posit(long initial_value) : _bits(0)               { *this = initial_value; }
+	explicit constexpr posit(long long initial_value) : _bits(0)          { *this = initial_value; }
+	explicit constexpr posit(char initial_value) : _bits(0)               { *this = initial_value; }
+	explicit constexpr posit(unsigned short initial_value) : _bits(0)     { *this = initial_value; }
+	explicit constexpr posit(unsigned int initial_value) : _bits(0)       { *this = initial_value; }
+	explicit constexpr posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
+	explicit constexpr posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
+	 explicit posit(float initial_value) : _bits(0) { *this = initial_value; }
+	          posit(double initial_value) : _bits(0) { *this = initial_value; }
+	 explicit posit(long double initial_value) : _bits(0) { *this = initial_value; }
 
-		// assignment operators for native types
-		posit& operator=(signed char rhs)       { return integer_assign((long)(rhs)); }
-		posit& operator=(short rhs)             { return integer_assign((long)(rhs)); }
-		posit& operator=(int rhs)               { return integer_assign((long)(rhs)); }
-		posit& operator=(long rhs)              { return integer_assign(rhs); }
-		posit& operator=(long long rhs)         { return float_assign((long double)(rhs)); }
-		posit& operator=(char rhs)              { return integer_assign((long)(rhs)); }
-		posit& operator=(unsigned short rhs)    { return integer_assign((long)(rhs)); }
-		posit& operator=(unsigned int rhs)      { return integer_assign((long)(rhs)); }
-		posit& operator=(unsigned long rhs)     { return float_assign((long double)(rhs)); }
-		posit& operator=(unsigned long long rhs){ return float_assign((long double)(rhs)); }
-		posit& operator=(float rhs)             { return float_assign((long double)rhs); }
-		posit& operator=(double rhs)            { return float_assign((long double)rhs); }
-		posit& operator=(long double rhs)       { return float_assign(rhs); }
+	// assignment operators for native types
+	constexpr posit& operator=(signed char rhs)       { return integer_assign((long)(rhs)); }
+	constexpr posit& operator=(short rhs)             { return integer_assign((long)(rhs)); }
+	constexpr posit& operator=(int rhs)               { return integer_assign((long)(rhs)); }
+	constexpr posit& operator=(long rhs)              { return integer_assign(rhs); }
+	constexpr posit& operator=(long long rhs)         { return float_assign((long double)(rhs)); }
+	constexpr posit& operator=(char rhs)              { return integer_assign((long)(rhs)); }
+	constexpr posit& operator=(unsigned short rhs)    { return integer_assign((long)(rhs)); }
+	constexpr posit& operator=(unsigned int rhs)      { return integer_assign((long)(rhs)); }
+	constexpr posit& operator=(unsigned long rhs)     { return float_assign((long double)(rhs)); }
+	constexpr posit& operator=(unsigned long long rhs){ return float_assign((long double)(rhs)); }
+	constexpr posit& operator=(float rhs)             { return float_assign((long double)rhs); }
+	constexpr posit& operator=(double rhs)            { return float_assign((long double)rhs); }
+	constexpr posit& operator=(long double rhs)       { return float_assign(rhs); }
 
-		explicit operator long double() const { return to_long_double(); }
-		explicit operator double() const { return to_double(); }
-		explicit operator float() const { return to_float(); }
-		explicit operator long long() const { return to_long_long(); }
-		explicit operator long() const { return to_long(); }
-		explicit operator int() const { return to_int(); }
-		explicit operator unsigned long long() const { return to_long_long(); }
-		explicit operator unsigned long() const { return to_long(); }
-		explicit operator unsigned int() const { return to_int(); }
+	explicit operator long double() const { return to_long_double(); }
+	explicit operator double() const { return to_double(); }
+	explicit operator float() const { return to_float(); }
+	explicit operator long long() const { return to_long_long(); }
+	explicit operator long() const { return to_long(); }
+	explicit operator int() const { return to_int(); }
+	explicit operator unsigned long long() const { return to_long_long(); }
+	explicit operator unsigned long() const { return to_long(); }
+	explicit operator unsigned int() const { return to_int(); }
 
-		posit& set(sw::unum::bitblock<NBITS_IS_32>& raw) {
-			_bits = uint32_t(raw.to_ulong());
+	posit& set(sw::unum::bitblock<NBITS_IS_32>& raw) {
+		_bits = uint32_t(raw.to_ulong());
+		return *this;
+	}
+	posit& set_raw_bits(uint64_t value) {
+		_bits = uint32_t(value & 0xFFFFFFFF);
+		return *this;
+	}
+	posit operator-() const {
+		if (iszero()) {
 			return *this;
 		}
-		posit& set_raw_bits(uint64_t value) {
-			_bits = uint32_t(value & 0xFFFFFFFF);
+		if (isnar()) {
 			return *this;
 		}
-		posit operator-() const {
-			if (iszero()) {
-				return *this;
-			}
-			if (isnar()) {
-				return *this;
-			}
-			posit p;
-			return p.set_raw_bits((~_bits) + 1);
-		}
-		posit& operator+=(const posit& b) { // derived from SoftPosit
-			// special case handling of the inputs
+		posit p;
+		return p.set_raw_bits((~_bits) + 1);
+	}
+	posit& operator+=(const posit& b) { // derived from SoftPosit
+		// special case handling of the inputs
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
-			if (isnar() || b.isnar()) {
-				throw operand_is_nar{};
-			}
+		if (isnar() || b.isnar()) {
+			throw operand_is_nar{};
+		}
 #else
-			if (isnar() || b.isnar()) {
-				setnar();
-				return *this;
-			}
+		if (isnar() || b.isnar()) {
+			setnar();
+			return *this;
+		}
 #endif
-			uint32_t lhs = _bits;
-			uint32_t rhs = b._bits;
-			if (iszero() || b.iszero()) { // zero
-				_bits = lhs | rhs;
-				return *this;
-			}
-			bool sign = bool(_bits & sign_mask);
-			if (sign) {
-				lhs = -int32_t(lhs) & 0xFFFFFFFF;
-				rhs = -int32_t(rhs) & 0xFFFFFFFF;
-			}
-			if (lhs < rhs) std::swap(lhs, rhs);
+		uint32_t lhs = _bits;
+		uint32_t rhs = b._bits;
+		if (iszero() || b.iszero()) { // zero
+			_bits = lhs | rhs;
+			return *this;
+		}
+		bool sign = bool(_bits & sign_mask);
+		if (sign) {
+			lhs = -int32_t(lhs) & 0xFFFFFFFF;
+			rhs = -int32_t(rhs) & 0xFFFFFFFF;
+		}
+		if (lhs < rhs) std::swap(lhs, rhs);
 			
-			// decode the regime of lhs
-			int32_t m = 0; // pattern length
-			uint32_t remaining = 0;
-			decode_regime(lhs, m, remaining);
+		// decode the regime of lhs
+		int32_t m = 0; // pattern length
+		uint32_t remaining = 0;
+		decode_regime(lhs, m, remaining);
 
-			// extract the exponent
-			uint32_t exp = remaining >> 29;
+		// extract the exponent
+		uint32_t exp = remaining >> 29;
 
-			// extract the remaining fraction
-			uint64_t frac64A = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32;  // ((0x4000'0000ull | remaining << 1) & 0x7FFF'FFFFull) << 32;
-			int32_t shiftRight = m;
+		// extract the remaining fraction
+		uint64_t frac64A = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32;  // ((0x4000'0000ull | remaining << 1) & 0x7FFF'FFFFull) << 32;
+		int32_t shiftRight = m;
 
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint64_t frac64B = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32; // ((0x4000'0000ull | remaining << 1) & 0x7FFF'FFFFull) << 32;
-			// This is 4kZ + expZ; (where kZ=kA-kB and expZ=expA-expB)
-			shiftRight = (shiftRight << 2) + exp - (remaining >> 29);
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint64_t frac64B = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32; // ((0x4000'0000ull | remaining << 1) & 0x7FFF'FFFFull) << 32;
+		// This is 4kZ + expZ; (where kZ=kA-kB and expZ=expA-expB)
+		shiftRight = (shiftRight << 2) + exp - (remaining >> 29);
 
-			// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
-			frac64B = (shiftRight > 63) ? 0 : (frac64B >> shiftRight); 
+		// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
+		frac64B = (shiftRight > 63) ? 0 : (frac64B >> shiftRight); 
 
-			frac64A += frac64B; // add the now aligned fractions
+		frac64A += frac64B; // add the now aligned fractions
 
-			bool rcarry = bool(0x8000000000000000 & frac64A); // is MSB set   bool(0x8000'0000'0000'0000 & frac64A); 
-			if (rcarry) {
-				++exp;
-				if (exp > 3) {
-					++m;
-					exp &= 0x3;
-				}
-				frac64A >>= 1;
+		bool rcarry = bool(0x8000000000000000 & frac64A); // is MSB set   bool(0x8000'0000'0000'0000 & frac64A); 
+		if (rcarry) {
+			++exp;
+			if (exp > 3) {
+				++m;
+				exp &= 0x3;
 			}
+			frac64A >>= 1;
+		}
 
-			_bits = round(m, exp, frac64A);
+		_bits = round(m, exp, frac64A);
+		if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
+		return *this;
+	}
+	posit& operator+=(double rhs) {
+		return *this += posit<nbits, es>(rhs);
+	}
+	posit& operator-=(const posit& b) {  // derived from SoftPosit
+		// special case handling of the inputs
+#if POSIT_THROW_ARITHMETIC_EXCEPTION
+		if (isnar() || b.isnar()) {
+			throw operand_is_nar{};
+		}
+#else
+		if (isnar() || b.isnar()) {
+			setnar();
+			return *this;
+		}
+#endif
+		uint32_t lhs = _bits;
+		uint32_t rhs = b._bits;
+		if (iszero() || b.iszero()) {
+			_bits = lhs | rhs;
+			return *this;
+		}
+		// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
+		bool sign = bool(lhs & sign_mask);
+		(sign) ? (lhs = (-int32_t(lhs) & 0xFFFFFFFF)) : (rhs = (-int32_t(rhs) & 0xFFFFFFFF));
+
+		if (lhs == rhs) {
+			_bits = 0;
+			return *this;
+		}
+		if (lhs < rhs) {
+			std::swap(lhs, rhs);
+			sign = !sign;
+		}
+
+		// decode the regime of lhs
+		int32_t m = 0; // pattern length
+		uint32_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+
+		// extract the exponent
+		uint32_t exp = remaining >> 29;
+
+		// extract the remaining fraction
+		uint64_t frac64A = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32;
+		int32_t shiftRight = m;
+
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint64_t frac64B = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32;
+
+		// This is 4kZ + expZ; (where kZ=kA-kB and expZ=expA-expB)
+		shiftRight = (shiftRight << 2) + exp - (remaining >> 29);
+		if (shiftRight > 63) {  // catastrophic cancellation case
+			_bits = lhs;
 			if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
 			return *this;
 		}
-		posit& operator+=(double rhs) {
-			return *this += posit<nbits, es>(rhs);
+		else {
+			frac64B >>= shiftRight;  // adjust the rhs fraction
 		}
-		posit& operator-=(const posit& b) {  // derived from SoftPosit
-			// special case handling of the inputs
-#if POSIT_THROW_ARITHMETIC_EXCEPTION
-			if (isnar() || b.isnar()) {
-				throw operand_is_nar{};
-			}
-#else
-			if (isnar() || b.isnar()) {
-				setnar();
-				return *this;
-			}
-#endif
-			uint32_t lhs = _bits;
-			uint32_t rhs = b._bits;
-			if (iszero() || b.iszero()) {
-				_bits = lhs | rhs;
-				return *this;
-			}
-			// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
-			bool sign = bool(lhs & sign_mask);
-			(sign) ? (lhs = (-int32_t(lhs) & 0xFFFFFFFF)) : (rhs = (-int32_t(rhs) & 0xFFFFFFFF));
+		frac64A -= frac64B;			// subtract the aligned fractions
 
-			if (lhs == rhs) {
-				_bits = 0;
-				return *this;
-			}
-			if (lhs < rhs) {
-				std::swap(lhs, rhs);
-				sign = !sign;
-			}
-
-			// decode the regime of lhs
-			int32_t m = 0; // pattern length
-			uint32_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-
-			// extract the exponent
-			uint32_t exp = remaining >> 29;
-
-			// extract the remaining fraction
-			uint64_t frac64A = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32;
-			int32_t shiftRight = m;
-
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint64_t frac64B = ((0x40000000ull | remaining << 1) & 0x7FFFFFFFull) << 32;
-
-			// This is 4kZ + expZ; (where kZ=kA-kB and expZ=expA-expB)
-			shiftRight = (shiftRight << 2) + exp - (remaining >> 29);
-			if (shiftRight > 63) {  // catastrophic cancellation case
-				_bits = lhs;
-				if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
-				return *this;
+		// adjust the results
+		while ((frac64A >> 59) == 0) {
+			--m;
+			frac64A <<= 4;
+		}
+		bool ecarry = bool (0x4000000000000000 & frac64A);
+		//bool ecarry = bool(0x4000'0000'0000'0000 & frac64A);
+		while (!ecarry) {
+			if (exp == 0) {
+				--m;
+				exp = 0x3;
 			}
 			else {
-				frac64B >>= shiftRight;  // adjust the rhs fraction
+				exp--;
 			}
-			frac64A -= frac64B;			// subtract the aligned fractions
+			frac64A <<= 1;
+			ecarry = bool(0x4000000000000000 & frac64A);
+			//ecarry = bool(0x4000'0000'0000'0000 & frac64A);
+		}
 
-			// adjust the results
-			while ((frac64A >> 59) == 0) {
-				--m;
-				frac64A <<= 4;
+		_bits = round(m, exp, frac64A);
+		if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
+		return *this;
+	}
+	posit& operator-=(double rhs) {
+		return *this -= posit<nbits, es>(rhs);
+	}
+	posit& operator*=(const posit& b) {
+		// special case handling of the inputs
+#if POSIT_THROW_ARITHMETIC_EXCEPTION
+		if (isnar() || b.isnar()) {
+			throw operand_is_nar{};
+		}
+#else
+		if (isnar() || b.isnar()) {
+			setnar();
+			return *this;
+		}
+#endif // POSIT_THROW_ARITHMETIC_EXCEPTION
+
+		if (iszero() || b.iszero()) {
+			_bits = 0;
+			return *this;
+		}
+		uint32_t lhs = _bits;
+		uint32_t rhs = b._bits;
+		// calculate the sign of the result
+		bool sign = bool(lhs & sign_mask) ^ bool(rhs & sign_mask);
+		lhs = (lhs & sign_mask) ? -int32_t(lhs) : lhs;
+		rhs = (rhs & sign_mask) ? -int32_t(rhs) : rhs;
+
+		// decode the regime of lhs
+		int32_t m = 0;
+		uint32_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint32_t exp = remaining >> 29;  // lhs exponent
+		uint32_t lhs_fraction = ((remaining << 1) | 0x40000000) & 0x7FFFFFFF;;
+
+		// adjust shift and extract fraction bits of rhs
+		extractMultiplicand(rhs, m, remaining);
+		uint32_t rhs_fraction = (((remaining << 1) | 0x40000000) & 0x7FFFFFFF);
+		uint64_t result_fraction = uint64_t(lhs_fraction) * uint64_t(rhs_fraction);
+		exp += remaining >> 29;  // product exp is the sum of lhs exp and rhs exp
+
+		// adjust exponent if it has overflown
+		if (exp > 3) {
+			++m;
+			exp &= 0x3;
+		}
+
+		bool rcarry = bool(result_fraction >> 61); // the 3rd bit of the 64-bit result fraction
+		if (rcarry) {
+			++exp;
+			if (exp > 3) { // adjust again if we have overflown
+				++m;
+				exp &= 0x3;
 			}
-			bool ecarry = bool (0x4000000000000000 & frac64A);
-			//bool ecarry = bool(0x4000'0000'0000'0000 & frac64A);
-			while (!ecarry) {
+			result_fraction >>= 1;
+		}
+
+		// round
+		_bits = round_mul(m, exp, result_fraction);
+		if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
+		return *this;
+	}
+	posit& operator*=(double rhs) {
+		return *this *= posit<nbits, es>(rhs);
+	}
+	posit& operator/=(const posit& b) {
+		// since we are encoding error conditions as NaR (Not a Real), we need to process that condition first
+#if POSIT_THROW_ARITHMETIC_EXCEPTION
+		if (b.iszero()) {
+			throw divide_by_zero{};    // not throwing is a quiet signalling NaR
+		}
+		if (b.isnar()) {
+			throw divide_by_nar{};
+		}
+		if (isnar()) {
+			throw numerator_is_nar{};
+		}
+#else
+		if (isnar() || b.isnar() || b.iszero()) {
+			setnar();
+			return *this;
+		}
+#endif // POSIT_THROW_ARITHMETIC_EXCEPTION
+		if (iszero()) {
+			setzero();
+			return *this;
+		}
+
+		uint32_t lhs = _bits;
+		uint32_t rhs = b._bits;
+		// calculate the sign of the result
+		bool sign = bool(lhs & sign_mask) ^ bool(rhs & sign_mask);
+		lhs = (lhs & sign_mask) ? -int32_t(lhs) : lhs;
+		rhs = (rhs & sign_mask) ? -int32_t(rhs) : rhs;
+
+		// decode the regime of lhs
+		int32_t m = 0;
+		uint32_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+
+		// extract exponent
+		int32_t exp = remaining >> 29;
+
+		// extract the lhs fraction
+		uint32_t lhs_fraction = ((remaining << 1) | 0x40000000) & 0x7FFFFFFF;
+		uint64_t lhs64 = uint64_t(lhs_fraction) << 30;
+
+		// adjust shift and extract fraction bits of rhs
+		extractDividand(rhs, m, remaining);
+		// calculate exponent, exp = lhs_exp - rhs_exp
+		exp -= remaining >> 29;
+		uint32_t rhs_fraction = ((remaining << 1) | 0x40000000) & 0x7FFFFFFF;
+
+		// execute the integer division of fractions
+		lldiv_t result = lldiv(lhs64, uint64_t(rhs_fraction));
+		uint64_t result_fraction = result.quot;
+		uint64_t remainder = result.rem;
+
+		// adjust exponent if underflowed
+		if (exp < 0) {
+			exp += 4;
+			--m;
+		}
+
+		if (result_fraction != 0) {
+			bool rcarry = result_fraction >> 30; // this is the hidden bit (31th bit), extreme right bit is bit 0
+			if (!rcarry) {
 				if (exp == 0) {
 					--m;
 					exp = 0x3;
 				}
 				else {
-					exp--;
+					--exp;
 				}
-				frac64A <<= 1;
-				ecarry = bool(0x4000000000000000 & frac64A);
-				//ecarry = bool(0x4000'0000'0000'0000 & frac64A);
+				result_fraction <<= 1;
 			}
+		}
 
-			_bits = round(m, exp, frac64A);
-			if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
-			return *this;
-		}
-		posit& operator-=(double rhs) {
-			return *this -= posit<nbits, es>(rhs);
-		}
-		posit& operator*=(const posit& b) {
-			// special case handling of the inputs
+		// round
+		_bits = adjustAndRound(m, exp, result_fraction, remainder != 0);
+		if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
+		return *this;
+	}
+	posit& operator/=(double rhs) {
+		return *this /= posit<nbits, es>(rhs);
+	}
+
+	posit& operator++() {
+		++_bits;
+		return *this;
+	}
+	posit operator++(int) {
+		posit tmp(*this);
+		operator++();
+		return tmp;
+	}
+	posit& operator--() {
+		--_bits;
+		return *this;
+	}
+	posit operator--(int) {
+		posit tmp(*this);
+		operator--();
+		return tmp;
+	}
+	posit reciprocate() const {
+		posit p = 1.0 / *this;
+		return p;
+	}
+	// SELECTORS
+	inline bool isnar() const      { return (_bits == 0x80000000); }
+	inline bool iszero() const     { return (_bits == 0x0); }
+	inline bool isone() const      { return (_bits == 0x40000000); } // pattern 010000...
+	inline bool isminusone() const { return (_bits == 0xC0000000); } // pattern 110000...
+	inline bool isneg() const      { return (_bits & 0x80000000); }
+	inline bool ispos() const      { return !isneg(); }
+	inline bool ispowerof2() const { return !(_bits & 0x1); }
+
+	inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
+
+	bitblock<NBITS_IS_32> get() const { bitblock<NBITS_IS_32> bb; bb = long(_bits); return bb; }
+	unsigned long long encoding() const { return (unsigned long long)(_bits); }
+
+	inline void clear() { _bits = 0x0; }
+	inline void setzero() { clear(); }
+	inline void setnar() { _bits = 0x80000000; }
+	inline posit twosComplement() const {
+		posit<NBITS_IS_32, ES_IS_2> p;
+		int32_t v = -(int32_t)_bits;
+		p.set_raw_bits(v);
+		return p;
+	}
+private:
+	uint32_t _bits;
+
+	// Conversion functions
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
-			if (isnar() || b.isnar()) {
-				throw operand_is_nar{};
-			}
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_long_double());
+	}
 #else
-			if (isnar() || b.isnar()) {
-				setnar();
-				return *this;
-			}
-#endif // POSIT_THROW_ARITHMETIC_EXCEPTION
-
-			if (iszero() || b.iszero()) {
-				_bits = 0;
-				return *this;
-			}
-			uint32_t lhs = _bits;
-			uint32_t rhs = b._bits;
-			// calculate the sign of the result
-			bool sign = bool(lhs & sign_mask) ^ bool(rhs & sign_mask);
-			lhs = (lhs & sign_mask) ? -int32_t(lhs) : lhs;
-			rhs = (rhs & sign_mask) ? -int32_t(rhs) : rhs;
-
-			// decode the regime of lhs
-			int32_t m = 0;
-			uint32_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint32_t exp = remaining >> 29;  // lhs exponent
-			uint32_t lhs_fraction = ((remaining << 1) | 0x40000000) & 0x7FFFFFFF;;
-
-			// adjust shift and extract fraction bits of rhs
-			extractMultiplicand(rhs, m, remaining);
-			uint32_t rhs_fraction = (((remaining << 1) | 0x40000000) & 0x7FFFFFFF);
-			uint64_t result_fraction = uint64_t(lhs_fraction) * uint64_t(rhs_fraction);
-			exp += remaining >> 29;  // product exp is the sum of lhs exp and rhs exp
-
-			// adjust exponent if it has overflown
-			if (exp > 3) {
-				++m;
-				exp &= 0x3;
-			}
-
-			bool rcarry = bool(result_fraction >> 61); // the 3rd bit of the 64-bit result fraction
-			if (rcarry) {
-				++exp;
-				if (exp > 3) { // adjust again if we have overflown
-					++m;
-					exp &= 0x3;
-				}
-				result_fraction >>= 1;
-			}
-
-			// round
-			_bits = round_mul(m, exp, result_fraction);
-			if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
-			return *this;
-		}
-		posit& operator*=(double rhs) {
-			return *this *= posit<nbits, es>(rhs);
-		}
-		posit& operator/=(const posit& b) {
-			// since we are encoding error conditions as NaR (Not a Real), we need to process that condition first
-#if POSIT_THROW_ARITHMETIC_EXCEPTION
-			if (b.iszero()) {
-				throw divide_by_zero{};    // not throwing is a quiet signalling NaR
-			}
-			if (b.isnar()) {
-				throw divide_by_nar{};
-			}
-			if (isnar()) {
-				throw numerator_is_nar{};
-			}
-#else
-			if (isnar() || b.isnar() || b.iszero()) {
-				setnar();
-				return *this;
-			}
-#endif // POSIT_THROW_ARITHMETIC_EXCEPTION
-			if (iszero()) {
-				setzero();
-				return *this;
-			}
-
-			uint32_t lhs = _bits;
-			uint32_t rhs = b._bits;
-			// calculate the sign of the result
-			bool sign = bool(lhs & sign_mask) ^ bool(rhs & sign_mask);
-			lhs = (lhs & sign_mask) ? -int32_t(lhs) : lhs;
-			rhs = (rhs & sign_mask) ? -int32_t(rhs) : rhs;
-
-			// decode the regime of lhs
-			int32_t m = 0;
-			uint32_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-
-			// extract exponent
-			int32_t exp = remaining >> 29;
-
-			// extract the lhs fraction
-			uint32_t lhs_fraction = ((remaining << 1) | 0x40000000) & 0x7FFFFFFF;
-			uint64_t lhs64 = uint64_t(lhs_fraction) << 30;
-
-			// adjust shift and extract fraction bits of rhs
-			extractDividand(rhs, m, remaining);
-			// calculate exponent, exp = lhs_exp - rhs_exp
-			exp -= remaining >> 29;
-			uint32_t rhs_fraction = ((remaining << 1) | 0x40000000) & 0x7FFFFFFF;
-
-			// execute the integer division of fractions
-			lldiv_t result = lldiv(lhs64, uint64_t(rhs_fraction));
-			uint64_t result_fraction = result.quot;
-			uint64_t remainder = result.rem;
-
-			// adjust exponent if underflowed
-			if (exp < 0) {
-				exp += 4;
-				--m;
-			}
-
-			if (result_fraction != 0) {
-				bool rcarry = result_fraction >> 30; // this is the hidden bit (31th bit), extreme right bit is bit 0
-				if (!rcarry) {
-					if (exp == 0) {
-						--m;
-						exp = 0x3;
-					}
-					else {
-						--exp;
-					}
-					result_fraction <<= 1;
-				}
-			}
-
-			// round
-			_bits = adjustAndRound(m, exp, result_fraction, remainder != 0);
-			if (sign) _bits = -int32_t(_bits) & 0xFFFFFFFF;
-			return *this;
-		}
-		posit& operator/=(double rhs) {
-			return *this /= posit<nbits, es>(rhs);
-		}
-
-		posit& operator++() {
-			++_bits;
-			return *this;
-		}
-		posit operator++(int) {
-			posit tmp(*this);
-			operator++();
-			return tmp;
-		}
-		posit& operator--() {
-			--_bits;
-			return *this;
-		}
-		posit operator--(int) {
-			posit tmp(*this);
-			operator--();
-			return tmp;
-		}
-		posit reciprocate() const {
-			posit p = 1.0 / *this;
-			return p;
-		}
-		// SELECTORS
-		inline bool isnar() const      { return (_bits == 0x80000000); }
-		inline bool iszero() const     { return (_bits == 0x0); }
-		inline bool isone() const      { return (_bits == 0x40000000); } // pattern 010000...
-		inline bool isminusone() const { return (_bits == 0xC0000000); } // pattern 110000...
-		inline bool isneg() const      { return (_bits & 0x80000000); }
-		inline bool ispos() const      { return !isneg(); }
-		inline bool ispowerof2() const { return !(_bits & 0x1); }
-
-		inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
-
-		bitblock<NBITS_IS_32> get() const { bitblock<NBITS_IS_32> bb; bb = long(_bits); return bb; }
-		unsigned long long encoding() const { return (unsigned long long)(_bits); }
-
-		inline void clear() { _bits = 0x0; }
-		inline void setzero() { clear(); }
-		inline void setnar() { _bits = 0x80000000; }
-		inline posit twosComplement() const {
-			posit<NBITS_IS_32, ES_IS_2> p;
-			int32_t v = -(int32_t)_bits;
-			p.set_raw_bits(v);
-			return p;
-		}
-	private:
-		uint32_t _bits;
-
-		// Conversion functions
-#if POSIT_THROW_ARITHMETIC_EXCEPTION
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_long_double());
-		}
-#else
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar())  return int(INFINITY);
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return long(INFINITY);
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return (long long)(INFINITY);
-			return long(to_long_double());
-		}
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar())  return int(INFINITY);
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return long(INFINITY);
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return (long long)(INFINITY);
+		return long(to_long_double());
+	}
 #endif
-		float       to_float() const {
-			return (float)to_double();
+	float       to_float() const {
+		return (float)to_double();
+	}
+	double      to_double() const {
+		if (iszero())	return 0.0;
+		if (isnar())	return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		double      to_double() const {
-			if (iszero())	return 0.0;
-			if (isnar())	return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			double s = (_sign ? -1.0 : 1.0);
-			double r = _regime.value();
-			double e = _exponent.value();
-			double f = (1.0 + _fraction.value());
-			return s * r * e * f;
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		double s = (_sign ? -1.0 : 1.0);
+		double r = _regime.value();
+		double e = _exponent.value();
+		double f = (1.0 + _fraction.value());
+		return s * r * e * f;
+	}
+	long double to_long_double() const {
+		if (iszero())  return 0.0;
+		if (isnar())   return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		long double to_long_double() const {
-			if (iszero())  return 0.0;
-			if (isnar())   return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			long double s = (_sign ? -1.0 : 1.0);
-			long double r = _regime.value();
-			long double e = _exponent.value();
-			long double f = (1.0 + _fraction.value());
-			return s * r * e * f;
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		long double s = (_sign ? -1.0 : 1.0);
+		long double r = _regime.value();
+		long double e = _exponent.value();
+		long double f = (1.0 + _fraction.value());
+		return s * r * e * f;
+	}
+
+	// helper methods
+	constexpr posit& integer_assign(long rhs) {
+		// special case for speed as this is a common initialization
+		if (rhs == 0) {
+			_bits = 0x0;
+			return *this;
 		}
 
-		// helper methods
-		posit& integer_assign(long rhs) {
-			// special case for speed as this is a common initialization
-			if (rhs == 0) {
-				_bits = 0x0;
-				return *this;
-			}
-
-			bool sign = rhs < 0 ? true : false;
-			uint32_t v = sign ? -rhs : rhs; // project to positive side of the projective reals
-			int32_t raw;          // we can use signed integer representation as we are taking care of the sign bit
-			if (v == sign_mask) { // +-maxpos, 0x8000'0000 is special in int32 arithmetic as it is its own negation
-				raw = 0x7FB00000;     // -2147483648  0x7FB0'0000; 
-			}
+		bool sign = rhs < 0 ? true : false;
+		uint32_t v = sign ? -rhs : rhs; // project to positive side of the projective reals
+		int32_t raw = 0;          // we can use signed integer representation as we are taking care of the sign bit
+		if (v == sign_mask) { // +-maxpos, 0x8000'0000 is special in int32 arithmetic as it is its own negation
+			raw = 0x7FB00000;     // -2147483648  0x7FB0'0000; 
+		}
 //			else if (v > 0xFFFFFBFF) { //  4294966271        // this is for unsigned arguments
 //				raw = 0x7FC00000;     //  4294967296
 //			}
-			else if (v < 0x2) {        // 0 and 1
-				raw = (v << 30);
-			}
-			else {
-				int8_t m = 31;
-				uint32_t fraction_bits = v;
-				while (!(fraction_bits & sign_mask)) {
-					--m;
-					fraction_bits <<= 1;
-				}
-				int8_t k = (m >> 2);
-				uint32_t exponent_bits = (m & 0x3) << (27 - k);
-				fraction_bits = (fraction_bits ^ sign_mask);
-				raw = (0x7FFFFFFF ^ (0x3FFFFFFF >> k)) | exponent_bits | (fraction_bits >> (k + 4));
-
-				uint32_t fraction_bit_mask = 0x8 << k; //bitNPlusOne
-				if (fraction_bit_mask & fraction_bits) {
-					if (((fraction_bit_mask - 1) & fraction_bits) | ((fraction_bit_mask << 1) & fraction_bits)) raw++;
-				}
-			}
-			_bits = sign ? -raw : raw;
-			return *this;
+		else if (v < 0x2) {        // 0 and 1
+			raw = (v << 30);
 		}
-		posit& float_assign(long double rhs) {
-			constexpr int dfbits = std::numeric_limits<long double>::digits - 1;
-			value<dfbits> v((long double)rhs);
-
-			// special case processing
-			if (v.iszero()) {
-				setzero();
-				return *this;
-			}
-			if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
-				setnar();
-				return *this;
-			}
-
-			bitblock<NBITS_IS_32> ptt;
-			convert_to_bb<NBITS_IS_32, ES_IS_2, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
-			_bits = uint32_t(ptt.to_ulong());
-			return *this;
-		}
-
-		// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
-		inline void decode_regime(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
-			remaining = (bits << 2) & 0xFFFFFFFF;
-			if (bits & 0x40000000) {  // positive regimes
-				while (remaining >> 31) {
-					++m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-			}
-			else {              // negative regimes
-				m = -1;
-				while (!(remaining >> 31)) {
-					--m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-				remaining &= 0x7FFFFFFF;
-			}
-		}
-		inline void extractAddand(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
-			remaining = (bits << 2) & 0xFFFFFFFF;
-			if (bits & 0x40000000) {  // positive regimes
-				while (remaining >> 31) {
-					--m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-			}
-			else {              // negative regimes
-				++m;
-				while (!(remaining >> 31)) {
-					++m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-				remaining &= 0x7FFFFFFF;
-			}
-		}
-		inline void extractMultiplicand(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
-			remaining = (bits << 2) & 0xFFFFFFFF;
-			if (bits & 0x40000000) {  // positive regimes
-				while (remaining >> 31) {
-					++m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-			}
-			else {              // negative regimes
+		else {
+			int8_t m = 31;
+			uint32_t fraction_bits = v;
+			while (!(fraction_bits & sign_mask)) {
 				--m;
-				while (!(remaining >> 31)) {
-					--m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-				remaining &= 0x7FFFFFFF;
+				fraction_bits <<= 1;
+			}
+			int8_t k = (m >> 2);
+			uint32_t exponent_bits = (m & 0x3) << (27 - k);
+			fraction_bits = (fraction_bits ^ sign_mask);
+			raw = (0x7FFFFFFF ^ (0x3FFFFFFF >> k)) | exponent_bits | (fraction_bits >> (k + 4));
+
+			uint32_t fraction_bit_mask = 0x8 << k; //bitNPlusOne
+			if (fraction_bit_mask & fraction_bits) {
+				if (((fraction_bit_mask - 1) & fraction_bits) | ((fraction_bit_mask << 1) & fraction_bits)) raw++;
 			}
 		}
-		inline void extractDividand(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
-			remaining = (bits << 2) & 0xFFFFFFFF;
-			if (bits & 0x40000000) {  // positive regimes
-				while (remaining >> 31) {
-					--m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-			}
-			else {              // negative regimes
+		_bits = sign ? -raw : raw;
+		return *this;
+	}
+	constexpr posit& float_assign(long double rhs) {
+		// special case processing
+		if (rhs == 0.0l) {
+			setzero();
+			return *this;
+		}
+		constexpr int dfbits = std::numeric_limits<long double>::digits - 1;
+		value<dfbits> v((long double)rhs);
+		if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
+			setnar();
+			return *this;
+		}
+
+		bitblock<NBITS_IS_32> ptt;
+		convert_to_bb<NBITS_IS_32, ES_IS_2, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
+		_bits = uint32_t(ptt.to_ulong());
+		return *this;
+	}
+
+	// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
+	inline void decode_regime(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
+		remaining = (bits << 2) & 0xFFFFFFFF;
+		if (bits & 0x40000000) {  // positive regimes
+			while (remaining >> 31) {
 				++m;
-				while (!(remaining >> 31)) {
-					++m;
-					remaining = (remaining << 1) & 0xFFFFFFFF;
-				}
-				remaining &= 0x7FFFFFFF;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
 			}
 		}
-
-		inline uint32_t round(const int8_t m, uint32_t exp, uint64_t fraction) const {
-			uint32_t scale, regime, bits;
-			if (m < 0) {
-				scale = -m;
-				regime = 0x40000000 >> scale;
+		else {              // negative regimes
+			m = -1;
+			while (!(remaining >> 31)) {
+				--m;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
 			}
-			else {
-				scale = m + 1;
-				regime = 0x7FFFFFFF - (0x7FFFFFFF >> scale);
-			}
-
-			if (scale > 30) {
-				bits = m<0 ? 0x1 : 0x7FFFFFFF;  // minpos and maxpos
-			}
-			else {
-				fraction = (fraction & 0x3FFFFFFFFFFFFFFF) >> (scale + 2);
-				//fraction = (fraction & 0x3FFF'FFFF'FFFF'FFFF) >> (scale + 2);
-				uint32_t final_fbits = uint32_t(fraction >> 32);
-				bool bitNPlusOne = false;
-				if (scale <= 28) {
-					bitNPlusOne = bool(0x80000000 & fraction);
-					exp <<= (28 - scale);
-				}
-				else {
-					if (scale == 30) {
-						bitNPlusOne = bool(exp & 0x2);
-						exp = 0;
-					}
-					else if (scale == 29) {
-						bitNPlusOne = bool(exp & 0x1);
-						exp >>= 1;
-					}
-					if (final_fbits > 0) {
-						final_fbits = 0x0;
-					}
-				}
-				bits = uint32_t(regime) + uint32_t(exp) + uint32_t(final_fbits);
-				// n+1 frac bit is 1. Need to check if another bit is 1 too, if not round to even
-				if (bitNPlusOne) {
-					uint32_t moreBits = (0x7FFFFFFF & fraction) ? 0x1 : 0x0;
-					bits += (bits & 0x0000001) | moreBits;
-				}
-			}
-			return bits;
+			remaining &= 0x7FFFFFFF;
 		}
-		inline uint32_t round_mul(const int8_t m, uint32_t exp, uint64_t fraction) const {
-			uint32_t scale, regime, bits;
-			if (m < 0) {
-				scale = -m;
-				regime = 0x40000000 >> scale;
+	}
+	inline void extractAddand(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
+		remaining = (bits << 2) & 0xFFFFFFFF;
+		if (bits & 0x40000000) {  // positive regimes
+			while (remaining >> 31) {
+				--m;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
 			}
-			else {
-				scale = m + 1;
-				regime = 0x7FFFFFFF - (0x7FFFFFFF >> scale);
-			}
-
-			if (scale > 30) {
-				bits = m<0 ? 0x1 : 0x7FFFFFFF;  // minpos and maxpos
-			}
-			else {
-				//std::cout << "fracin = " << std::hex << fraction << std::dec << std::endl;
-				fraction = (fraction & 0x0FFFFFFFFFFFFFFF) >> scale;
-				//fraction = (fraction & 0x0FFF'FFFF'FFFF'FFFF) >> scale;
-				//std::cout << "fracsh = " << std::hex << fraction << std::dec << std::endl;
-
-				uint32_t final_fbits = uint32_t(fraction >> 32);
-				bool bitNPlusOne = false;
-				if (scale <= 28) {
-					bitNPlusOne = bool(0x0000000080000000 & fraction);
-					//bitNPlusOne = bool(0x0000'0000'8000'0000 & fraction);
-					exp <<= (28 - scale);
-				}
-				else {
-					if (scale == 30) {
-						bitNPlusOne = bool(exp & 0x2);
-						exp = 0;
-					}
-					else if (scale == 29) {
-						bitNPlusOne = bool(exp & 0x1);
-						exp >>= 1;
-					}
-					if (final_fbits > 0) {
-						final_fbits = 0;
-					}
-				}
-				// sign is set by the calling environment as +/- behaves differently compared to */div
-				bits = uint32_t(regime) + uint32_t(exp) + uint32_t(final_fbits);
-
-				//std::cout << "scale  = " << scale << std::endl;
-				//std::cout << "frac64 = " << std::hex << fraction << std::dec << std::endl;
-				//std::cout << std::hex ;
-				//std::cout << "regime = " << regime << std::endl;
-				//std::cout << "expone = " << exp << std::endl;
-				//std::cout << "fracti = " << final_fbits << std::endl;
-				//std::cout << std::dec ;
-
-				// n+1 frac bit is 1. Need to check if another bit is 1 too, if not round to even
-				if (bitNPlusOne) {
-					uint32_t moreBits = (0x7FFFFFFF & fraction) ? 0x1 : 0x0;
-					bits += (bits & 0x0000001) | moreBits;
-				}
-			}
-			return bits;
 		}
-		inline uint32_t adjustAndRound(const int8_t k, uint32_t exp, uint64_t frac64, bool nonZeroRemainder) const {
-			uint32_t scale, regime, bits;
-			if (k < 0) {
-				scale = -k;
-				regime = 0x40000000 >> scale;
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 31)) {
+				++m;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
+			}
+			remaining &= 0x7FFFFFFF;
+		}
+	}
+	inline void extractMultiplicand(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
+		remaining = (bits << 2) & 0xFFFFFFFF;
+		if (bits & 0x40000000) {  // positive regimes
+			while (remaining >> 31) {
+				++m;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
+			}
+		}
+		else {              // negative regimes
+			--m;
+			while (!(remaining >> 31)) {
+				--m;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
+			}
+			remaining &= 0x7FFFFFFF;
+		}
+	}
+	inline void extractDividand(const uint32_t bits, int32_t& m, uint32_t& remaining) const {
+		remaining = (bits << 2) & 0xFFFFFFFF;
+		if (bits & 0x40000000) {  // positive regimes
+			while (remaining >> 31) {
+				--m;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
+			}
+		}
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 31)) {
+				++m;
+				remaining = (remaining << 1) & 0xFFFFFFFF;
+			}
+			remaining &= 0x7FFFFFFF;
+		}
+	}
+
+	inline uint32_t round(const int8_t m, uint32_t exp, uint64_t fraction) const {
+		uint32_t scale, regime, bits;
+		if (m < 0) {
+			scale = -m;
+			regime = 0x40000000 >> scale;
+		}
+		else {
+			scale = m + 1;
+			regime = 0x7FFFFFFF - (0x7FFFFFFF >> scale);
+		}
+
+		if (scale > 30) {
+			bits = m<0 ? 0x1 : 0x7FFFFFFF;  // minpos and maxpos
+		}
+		else {
+			fraction = (fraction & 0x3FFFFFFFFFFFFFFF) >> (scale + 2);
+			//fraction = (fraction & 0x3FFF'FFFF'FFFF'FFFF) >> (scale + 2);
+			uint32_t final_fbits = uint32_t(fraction >> 32);
+			bool bitNPlusOne = false;
+			if (scale <= 28) {
+				bitNPlusOne = bool(0x80000000 & fraction);
+				exp <<= (28 - scale);
 			}
 			else {
-				scale = k + 1;
-				regime = 0x7FFFFFFF - (0x7FFFFFFF >> scale);
+				if (scale == 30) {
+					bitNPlusOne = bool(exp & 0x2);
+					exp = 0;
+				}
+				else if (scale == 29) {
+					bitNPlusOne = bool(exp & 0x1);
+					exp >>= 1;
+				}
+				if (final_fbits > 0) {
+					final_fbits = 0x0;
+				}
 			}
+			bits = uint32_t(regime) + uint32_t(exp) + uint32_t(final_fbits);
+			// n+1 frac bit is 1. Need to check if another bit is 1 too, if not round to even
+			if (bitNPlusOne) {
+				uint32_t moreBits = (0x7FFFFFFF & fraction) ? 0x1 : 0x0;
+				bits += (bits & 0x0000001) | moreBits;
+			}
+		}
+		return bits;
+	}
+	inline uint32_t round_mul(const int8_t m, uint32_t exp, uint64_t fraction) const {
+		uint32_t scale, regime, bits;
+		if (m < 0) {
+			scale = -m;
+			regime = 0x40000000 >> scale;
+		}
+		else {
+			scale = m + 1;
+			regime = 0x7FFFFFFF - (0x7FFFFFFF >> scale);
+		}
 
-			if (scale > 30) {
-				bits = k<0 ? 0x1 : 0x7FFFFFFF;  // minpos and maxpos
+		if (scale > 30) {
+			bits = m<0 ? 0x1 : 0x7FFFFFFF;  // minpos and maxpos
+		}
+		else {
+			//std::cout << "fracin = " << std::hex << fraction << std::dec << std::endl;
+			fraction = (fraction & 0x0FFFFFFFFFFFFFFF) >> scale;
+			//fraction = (fraction & 0x0FFF'FFFF'FFFF'FFFF) >> scale;
+			//std::cout << "fracsh = " << std::hex << fraction << std::dec << std::endl;
+
+			uint32_t final_fbits = uint32_t(fraction >> 32);
+			bool bitNPlusOne = false;
+			if (scale <= 28) {
+				bitNPlusOne = bool(0x0000000080000000 & fraction);
+				//bitNPlusOne = bool(0x0000'0000'8000'0000 & fraction);
+				exp <<= (28 - scale);
 			}
 			else {
-				//remove carry and rcarry bits and shift to correct position
-				frac64 &= 0x3FFFFFFF;
-				uint32_t fraction = uint32_t((frac64) >> (scale + 2));
+				if (scale == 30) {
+					bitNPlusOne = bool(exp & 0x2);
+					exp = 0;
+				}
+				else if (scale == 29) {
+					bitNPlusOne = bool(exp & 0x1);
+					exp >>= 1;
+				}
+				if (final_fbits > 0) {
+					final_fbits = 0;
+				}
+			}
+			// sign is set by the calling environment as +/- behaves differently compared to */div
+			bits = uint32_t(regime) + uint32_t(exp) + uint32_t(final_fbits);
 
-				bool bitNPlusOne = false;
-				uint32_t moreBits = false;
-				if (scale <= 28) {
-					bitNPlusOne = bool (frac64 >> ((scale + 1)) & 0x1);
-					exp <<= (28 - scale);
-					if (bitNPlusOne) moreBits = (((1 << (scale + 1)) - 1) & frac64) ? 0x1 : 0x0;
+			//std::cout << "scale  = " << scale << std::endl;
+			//std::cout << "frac64 = " << std::hex << fraction << std::dec << std::endl;
+			//std::cout << std::hex ;
+			//std::cout << "regime = " << regime << std::endl;
+			//std::cout << "expone = " << exp << std::endl;
+			//std::cout << "fracti = " << final_fbits << std::endl;
+			//std::cout << std::dec ;
+
+			// n+1 frac bit is 1. Need to check if another bit is 1 too, if not round to even
+			if (bitNPlusOne) {
+				uint32_t moreBits = (0x7FFFFFFF & fraction) ? 0x1 : 0x0;
+				bits += (bits & 0x0000001) | moreBits;
+			}
+		}
+		return bits;
+	}
+	inline uint32_t adjustAndRound(const int8_t k, uint32_t exp, uint64_t frac64, bool nonZeroRemainder) const {
+		uint32_t scale, regime, bits;
+		if (k < 0) {
+			scale = -k;
+			regime = 0x40000000 >> scale;
+		}
+		else {
+			scale = k + 1;
+			regime = 0x7FFFFFFF - (0x7FFFFFFF >> scale);
+		}
+
+		if (scale > 30) {
+			bits = k<0 ? 0x1 : 0x7FFFFFFF;  // minpos and maxpos
+		}
+		else {
+			//remove carry and rcarry bits and shift to correct position
+			frac64 &= 0x3FFFFFFF;
+			uint32_t fraction = uint32_t((frac64) >> (scale + 2));
+
+			bool bitNPlusOne = false;
+			uint32_t moreBits = false;
+			if (scale <= 28) {
+				bitNPlusOne = bool (frac64 >> ((scale + 1)) & 0x1);
+				exp <<= (28 - scale);
+				if (bitNPlusOne) moreBits = (((1 << (scale + 1)) - 1) & frac64) ? 0x1 : 0x0;
+			}
+			else {
+				if (scale == 30) {
+					bitNPlusOne = bool(exp & 0x2);
+					moreBits = exp & 0x1;
+					exp = 0;
 				}
-				else {
-					if (scale == 30) {
-						bitNPlusOne = bool(exp & 0x2);
-						moreBits = exp & 0x1;
-						exp = 0;
-					}
-					else if (scale == 29) {
-						bitNPlusOne = bool(exp & 0x1);
-						exp >>= 1;
-					}
-					if (frac64 > 0) {
-						fraction = 0;
-						moreBits = 0x1;
-					}
+				else if (scale == 29) {
+					bitNPlusOne = bool(exp & 0x1);
+					exp >>= 1;
 				}
-				if (nonZeroRemainder) moreBits = 0x1;
-				bits = uint32_t(regime) + uint32_t(exp) + uint32_t(fraction);
-				if (bitNPlusOne) bits += (bits & 0x1) | moreBits;
+				if (frac64 > 0) {
+					fraction = 0;
+					moreBits = 0x1;
+				}
+			}
+			if (nonZeroRemainder) moreBits = 0x1;
+			bits = uint32_t(regime) + uint32_t(exp) + uint32_t(fraction);
+			if (bitNPlusOne) bits += (bits & 0x1) | moreBits;
 #define TRACE_DIV_
 #ifdef TRACE_DIV
-				std::cout << "universal\n";
-				std::cout << "scale          = " << scale << std::endl;
-				std::cout << std::hex;
-				std::cout << "regime         = " << regime << std::endl;
-				std::cout << "exponent       = " << exp << std::endl;
-				std::cout << "fraction raw   = " << frac64 << std::endl;
-				std::cout << "fraction final = " << fraction << std::endl;
-				std::cout << "posit bits     = " << bits << std::endl;
-				std::cout << std::dec;
+			std::cout << "universal\n";
+			std::cout << "scale          = " << scale << std::endl;
+			std::cout << std::hex;
+			std::cout << "regime         = " << regime << std::endl;
+			std::cout << "exponent       = " << exp << std::endl;
+			std::cout << "fraction raw   = " << frac64 << std::endl;
+			std::cout << "fraction final = " << fraction << std::endl;
+			std::cout << "posit bits     = " << bits << std::endl;
+			std::cout << std::dec;
 #endif
-			}
-			return bits;
 		}
-		// I/O operators
-		friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_32, ES_IS_2>& p);
-		friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_32, ES_IS_2>& p);
+		return bits;
+	}
+	// I/O operators
+	friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_32, ES_IS_2>& p);
+	friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_32, ES_IS_2>& p);
 
-		// posit - posit logic functions
-		friend bool operator==(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
-		friend bool operator!=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
-		friend bool operator< (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
-		friend bool operator> (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
-		friend bool operator<=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
-		friend bool operator>=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
+	// posit - posit logic functions
+	friend bool operator==(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
+	friend bool operator!=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
+	friend bool operator< (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
+	friend bool operator> (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
+	friend bool operator<=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
+	friend bool operator>=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs);
 
-	};
+};
 
-	// posit I/O operators
-	// generate a posit format ASCII format nbits.esxNN...NNp
-	inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_32, ES_IS_2>& p) {
-		// to make certain that setw and left/right operators work properly
-		// we need to transform the posit into a string
-		std::stringstream ss;
+// posit I/O operators
+// generate a posit format ASCII format nbits.esxNN...NNp
+inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_32, ES_IS_2>& p) {
+	// to make certain that setw and left/right operators work properly
+	// we need to transform the posit into a string
+	std::stringstream ss;
 #if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
-		ss << NBITS_IS_32 << '.' << ES_IS_2 << 'x' << to_hex(p.get()) << 'p';
+	ss << NBITS_IS_32 << '.' << ES_IS_2 << 'x' << to_hex(p.get()) << 'p';
 #else
-		std::streamsize prec = ostr.precision();
-		std::streamsize width = ostr.width();
-		std::ios_base::fmtflags ff;
-		ff = ostr.flags();
-		ss.flags(ff);
-		ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+	std::streamsize prec = ostr.precision();
+	std::streamsize width = ostr.width();
+	std::ios_base::fmtflags ff;
+	ff = ostr.flags();
+	ss.flags(ff);
+	ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
 #endif
-		return ostr << ss.str();
-	}
+	return ostr << ss.str();
+}
 
-	// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
-	inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_32, ES_IS_2>& p) {
-		std::string txt;
-		istr >> txt;
-		if (!parse(txt, p)) {
-			std::cerr << "unable to parse -" << txt << "- into a posit value\n";
-		}
-		return istr;
+// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
+inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_32, ES_IS_2>& p) {
+	std::string txt;
+	istr >> txt;
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
 	}
+	return istr;
+}
 
-	// convert a posit value to a string using "nar" as designation of NaR
-	std::string to_string(const posit<NBITS_IS_32, ES_IS_2>& p, std::streamsize precision) {
-		if (p.isnar()) {
-			return std::string("nar");
-		}
-		std::stringstream ss;
-		ss << std::setprecision(precision) << float(p);
-		return ss.str();
+// convert a posit value to a string using "nar" as designation of NaR
+std::string to_string(const posit<NBITS_IS_32, ES_IS_2>& p, std::streamsize precision) {
+	if (p.isnar()) {
+		return std::string("nar");
 	}
+	std::stringstream ss;
+	ss << std::setprecision(precision) << float(p);
+	return ss.str();
+}
 
-	// posit - posit binary logic operators
-	inline bool operator==(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return lhs._bits == rhs._bits;
-	}
-	inline bool operator!=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return !operator==(lhs, rhs);
-	}
-	inline bool operator< (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return long(lhs._bits) < long(rhs._bits);
-	}
-	inline bool operator> (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return operator< (rhs, lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return operator< (lhs, rhs) || operator==(lhs, rhs);
-	}
-	inline bool operator>=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return !operator< (lhs, rhs);
-	}
+// posit - posit binary logic operators
+inline bool operator==(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return lhs._bits == rhs._bits;
+}
+inline bool operator!=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return !operator==(lhs, rhs);
+}
+inline bool operator< (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return long(lhs._bits) < long(rhs._bits);
+}
+inline bool operator> (const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return operator< (rhs, lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return operator< (lhs, rhs) || operator==(lhs, rhs);
+}
+inline bool operator>=(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return !operator< (lhs, rhs);
+}
 
-	inline posit<NBITS_IS_32, ES_IS_2> operator+(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		posit<NBITS_IS_32, ES_IS_2> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result += rhs;
-		} 
-		else {
-			result -= rhs;
-		}
-		return result;
+inline posit<NBITS_IS_32, ES_IS_2> operator+(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	posit<NBITS_IS_32, ES_IS_2> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result += rhs;
+	} 
+	else {
+		result -= rhs;
 	}
-	inline posit<NBITS_IS_32, ES_IS_2> operator-(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		posit<NBITS_IS_32, ES_IS_2> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result -= rhs.twosComplement();
-		}
-		else {
-			result += rhs.twosComplement();
-		}
-		return result;
+	return result;
+}
+inline posit<NBITS_IS_32, ES_IS_2> operator-(const posit<NBITS_IS_32, ES_IS_2>& lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	posit<NBITS_IS_32, ES_IS_2> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result -= rhs.twosComplement();
+	}
+	else {
+		result += rhs.twosComplement();
+	}
+	return result;
 
-	}
-	// binary operator*() is provided by generic class
-	// binary operator/() is provided by generic class
+}
+// binary operator*() is provided by generic class
+// binary operator/() is provided by generic class
 
 #if POSIT_ENABLE_LITERALS
-	// posit - literal logic functions
+// posit - literal logic functions
 
-	// posit - int logic operators
-	inline bool operator==(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
-		return operator==(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
-	}
-	inline bool operator!=(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
-		return !operator==(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
-	}
-	inline bool operator< (const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
-		return operator<(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
-	}
-	inline bool operator> (const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
-		return operator< (posit<NBITS_IS_32, ES_IS_2>(rhs), lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
-		return operator< (lhs, posit<NBITS_IS_32, ES_IS_2>(rhs)) || operator==(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
-	}
-	inline bool operator>=(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
-		return !operator<(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
-	}
+// posit - int logic operators
+inline bool operator==(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
+	return operator==(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
+}
+inline bool operator!=(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
+	return !operator==(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
+}
+inline bool operator< (const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
+	return operator<(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
+}
+inline bool operator> (const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
+	return operator< (posit<NBITS_IS_32, ES_IS_2>(rhs), lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
+	return operator< (lhs, posit<NBITS_IS_32, ES_IS_2>(rhs)) || operator==(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
+}
+inline bool operator>=(const posit<NBITS_IS_32, ES_IS_2>& lhs, int rhs) {
+	return !operator<(lhs, posit<NBITS_IS_32, ES_IS_2>(rhs));
+}
 
-	// int - posit logic operators
-	inline bool operator==(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return posit<NBITS_IS_32, ES_IS_2>(lhs) == rhs;
-	}
-	inline bool operator!=(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return !operator==(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
-	}
-	inline bool operator< (int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return operator<(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
-	}
-	inline bool operator> (int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return operator< (posit<NBITS_IS_32, ES_IS_2>(rhs), lhs);
-	}
-	inline bool operator<=(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return operator< (posit<NBITS_IS_32, ES_IS_2>(lhs), rhs) || operator==(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
-	}
-	inline bool operator>=(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
-		return !operator<(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
-	}
+// int - posit logic operators
+inline bool operator==(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return posit<NBITS_IS_32, ES_IS_2>(lhs) == rhs;
+}
+inline bool operator!=(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return !operator==(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
+}
+inline bool operator< (int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return operator<(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
+}
+inline bool operator> (int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return operator< (posit<NBITS_IS_32, ES_IS_2>(rhs), lhs);
+}
+inline bool operator<=(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return operator< (posit<NBITS_IS_32, ES_IS_2>(lhs), rhs) || operator==(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
+}
+inline bool operator>=(int lhs, const posit<NBITS_IS_32, ES_IS_2>& rhs) {
+	return !operator<(posit<NBITS_IS_32, ES_IS_2>(lhs), rhs);
+}
 
 #endif // POSIT_ENABLE_LITERALS
 
@@ -951,6 +950,5 @@ namespace sw {
 #	define POSIT_FAST_POSIT_32_2 0
 #endif // POSIT_FAST_POSIT_32_2
 
-  }
-
-}
+} // namespace unum
+} // namespace sw

--- a/include/universal/posit/specialized/posit_64_3.hpp
+++ b/include/universal/posit/specialized/posit_64_3.hpp
@@ -1,733 +1,733 @@
 #pragma once
 // posit_64_3.hpp: specialized 64-bit posit using fast compute specialized for posit<64,3>
 //
-// Copyright (C) 2017-2019 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 namespace sw {
-	namespace unum {
+namespace unum {
 
-		// set the fast specialization variable to indicate that we are running a special template specialization
+	// set the fast specialization variable to indicate that we are running a special template specialization
 #if POSIT_FAST_POSIT_64_3
 #pragma message("Fast specialization of posit<64,3>")
 
-	// fast specialized posit<64,3>
-	template<>
-	class posit<NBITS_IS_64, ES_IS_3> {
-	public:
-		static constexpr size_t nbits = NBITS_IS_64;
-		static constexpr size_t es = ES_IS_3;
-		static constexpr size_t sbits = 1;
-		static constexpr size_t rbits = nbits - sbits;
-		static constexpr size_t ebits = es;
-		static constexpr size_t fbits = nbits - 3 - es;
-		static constexpr size_t fhbits = fbits + 1;
-		static constexpr uint64_t sign_mask = 0x8000000000000000ull;  // 0x8000'0000'0000'0000ull;
+// fast specialized posit<64,3>
+template<>
+class posit<NBITS_IS_64, ES_IS_3> {
+public:
+	static constexpr size_t nbits = NBITS_IS_64;
+	static constexpr size_t es = ES_IS_3;
+	static constexpr size_t sbits = 1;
+	static constexpr size_t rbits = nbits - sbits;
+	static constexpr size_t ebits = es;
+	static constexpr size_t fbits = nbits - 3 - es;
+	static constexpr size_t fhbits = fbits + 1;
+	static constexpr uint64_t sign_mask = 0x8000000000000000ull;  // 0x8000'0000'0000'0000ull;
 
-		posit() { _bits = 0; }
-		posit(const posit&) = default;
-		posit(posit&&) = default;
-		posit& operator=(const posit&) = default;
-		posit& operator=(posit&&) = default;
+	posit() { _bits = 0; }
+	posit(const posit&) = default;
+	posit(posit&&) = default;
+	posit& operator=(const posit&) = default;
+	posit& operator=(posit&&) = default;
 
-		// initializers for native types
-		explicit posit(const signed char initial_value)        { *this = initial_value; }
-		explicit posit(const short initial_value)              { *this = initial_value; }
-		explicit posit(const int initial_value)                { *this = initial_value; }
-		explicit posit(const long initial_value)               { *this = initial_value; }
-		explicit posit(const long long initial_value)          { *this = initial_value; }
-		explicit posit(const char initial_value)               { *this = initial_value; }
-		explicit posit(const unsigned short initial_value)     { *this = initial_value; }
-		explicit posit(const unsigned int initial_value)       { *this = initial_value; }
-		explicit posit(const unsigned long initial_value)      { *this = initial_value; }
-		explicit posit(const unsigned long long initial_value) { *this = initial_value; }
-		explicit posit(const float initial_value)              { *this = initial_value; }
-		explicit posit(const double initial_value)             { *this = initial_value; }
-		explicit posit(const long double initial_value)        { *this = initial_value; }
+	// initializers for native types
+	constexpr explicit posit(signed char initial_value)        { *this = initial_value; }
+	constexpr explicit posit(short initial_value)              { *this = initial_value; }
+	constexpr explicit posit(int initial_value)                { *this = initial_value; }
+	constexpr explicit posit(long initial_value)               { *this = initial_value; }
+	constexpr explicit posit(long long initial_value)          { *this = initial_value; }
+	constexpr explicit posit(char initial_value)               { *this = initial_value; }
+	constexpr explicit posit(unsigned short initial_value)     { *this = initial_value; }
+	constexpr explicit posit(unsigned int initial_value)       { *this = initial_value; }
+	constexpr explicit posit(unsigned long initial_value)      { *this = initial_value; }
+	constexpr explicit posit(unsigned long long initial_value) { *this = initial_value; }
+	constexpr explicit posit(float initial_value)              { *this = initial_value; }
+	constexpr explicit posit(double initial_value)             { *this = initial_value; }
+	constexpr          posit(long double initial_value)        { *this = initial_value; }
 
-		// assignment operators for native types
-		posit& operator=(const signed char rhs)       { 
-			// special case for speed as this is a common initialization
-			if (rhs == 0) {
-				_bits = 0x00;
-				return *this;
-			}
-
-			bool sign = bool(rhs & 0x80);
-			int8_t v = sign ? -rhs : rhs; // project to positve side of the projective reals
-			uint8_t raw;
-			if (v > 48 || v == -128) { // +-maxpos, 0x80 is special in int8 arithmetic as it is its own negation
-				raw = 0x7F;
-			}
-			else {
-				uint8_t mask = 0x40;
-				int8_t k = 6;
-				uint8_t fraction_bits = v;
-				while (!(fraction_bits & mask)) {
-					k--;
-					fraction_bits <<= 1;
-				}
-				fraction_bits = (fraction_bits ^ mask);
-				raw = (0x7F ^ (0x3F >> k)) | (fraction_bits >> (k + 1));
-
-				mask = 0x1 << k; //bitNPlusOne
-				if (mask & fraction_bits) {
-					if (((mask - 1) & fraction_bits) | ((mask << 1) & fraction_bits)) raw++;
-				}
-			}
-			_bits = sign ? -raw : raw;
+	// assignment operators for native types
+	posit& operator=(const signed char rhs)       { 
+		// special case for speed as this is a common initialization
+		if (rhs == 0) {
+			_bits = 0x00;
 			return *this;
 		}
-		posit& operator=(const short rhs)             { return operator=((signed char)(rhs)); }
-		posit& operator=(const int rhs)               { return operator=((signed char)(rhs)); }
-		posit& operator=(const long rhs)              { return operator=((signed char)(rhs)); }
-		posit& operator=(const long long rhs)         { return operator=((signed char)(rhs)); }
-		posit& operator=(const char rhs)              { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned short rhs)    { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned int rhs)      { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned long rhs)     { return operator=((signed char)(rhs)); }
-		posit& operator=(const unsigned long long rhs){ return operator=((signed char)(rhs)); }
-		posit& operator=(const float rhs)             { return float_assign(rhs); }
-		posit& operator=(const double rhs)            { return float_assign(rhs); }
-		posit& operator=(const long double rhs)       { return float_assign(rhs); }
 
-		explicit operator long double() const { return to_long_double(); }
-		explicit operator double() const { return to_double(); }
-		explicit operator float() const { return to_float(); }
-		explicit operator long long() const { return to_long_long(); }
-		explicit operator long() const { return to_long(); }
-		explicit operator int() const { return to_int(); }
-		explicit operator unsigned long long() const { return to_long_long(); }
-		explicit operator unsigned long() const { return to_long(); }
-		explicit operator unsigned int() const { return to_int(); }
+		bool sign = bool(rhs & 0x80);
+		int8_t v = sign ? -rhs : rhs; // project to positve side of the projective reals
+		uint8_t raw;
+		if (v > 48 || v == -128) { // +-maxpos, 0x80 is special in int8 arithmetic as it is its own negation
+			raw = 0x7F;
+		}
+		else {
+			uint8_t mask = 0x40;
+			int8_t k = 6;
+			uint8_t fraction_bits = v;
+			while (!(fraction_bits & mask)) {
+				k--;
+				fraction_bits <<= 1;
+			}
+			fraction_bits = (fraction_bits ^ mask);
+			raw = (0x7F ^ (0x3F >> k)) | (fraction_bits >> (k + 1));
 
-		posit& set(sw::unum::bitblock<NBITS_IS_64>& raw) {
-			_bits = uint8_t(raw.to_ulong());
+			mask = 0x1 << k; //bitNPlusOne
+			if (mask & fraction_bits) {
+				if (((mask - 1) & fraction_bits) | ((mask << 1) & fraction_bits)) raw++;
+			}
+		}
+		_bits = sign ? -raw : raw;
+		return *this;
+	}
+	posit& operator=(short rhs)             { return operator=((signed char)(rhs)); }
+	posit& operator=(int rhs)               { return operator=((signed char)(rhs)); }
+	posit& operator=(long rhs)              { return operator=((signed char)(rhs)); }
+	posit& operator=(long long rhs)         { return operator=((signed char)(rhs)); }
+	posit& operator=(char rhs)              { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned short rhs)    { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned int rhs)      { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned long rhs)     { return operator=((signed char)(rhs)); }
+	posit& operator=(unsigned long long rhs){ return operator=((signed char)(rhs)); }
+	posit& operator=(float rhs)             { return float_assign(rhs); }
+	posit& operator=(double rhs)            { return float_assign(rhs); }
+	posit& operator=(long double rhs)       { return float_assign(rhs); }
+
+	explicit operator long double() const { return to_long_double(); }
+	explicit operator double() const { return to_double(); }
+	explicit operator float() const { return to_float(); }
+	explicit operator long long() const { return to_long_long(); }
+	explicit operator long() const { return to_long(); }
+	explicit operator int() const { return to_int(); }
+	explicit operator unsigned long long() const { return to_long_long(); }
+	explicit operator unsigned long() const { return to_long(); }
+	explicit operator unsigned int() const { return to_int(); }
+
+	posit& set(sw::unum::bitblock<NBITS_IS_64>& raw) {
+		_bits = uint8_t(raw.to_ulong());
+		return *this;
+	}
+	posit& set_raw_bits(uint64_t value) {
+		_bits = uint8_t(value & 0xff);
+		return *this;
+	}
+	posit operator-() const {
+		if (iszero()) {
 			return *this;
 		}
-		posit& set_raw_bits(uint64_t value) {
-			_bits = uint8_t(value & 0xff);
+		if (isnar()) {
 			return *this;
 		}
-		posit operator-() const {
-			if (iszero()) {
-				return *this;
-			}
-			if (isnar()) {
-				return *this;
-			}
-			posit p;
-			return p.set_raw_bits((~_bits) + 1);
+		posit p;
+		return p.set_raw_bits((~_bits) + 1);
+	}
+	posit& operator+=(const posit& b) { // derived from SoftPosit
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {  // infinity
+			_bits = 0x80;
+			return *this;
 		}
-		posit& operator+=(const posit& b) { // derived from SoftPosit
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {  // infinity
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) { // zero
-				_bits = lhs | rhs;
-				return *this;
-			}
-			bool sign = bool(_bits & 0x80);
-			if (sign) {
-				lhs = -lhs & 0xFF;
-				rhs = -rhs & 0xFF;
-			}
-			if (lhs < rhs) std::swap(lhs, rhs);
+		if (iszero() || b.iszero()) { // zero
+			_bits = lhs | rhs;
+			return *this;
+		}
+		bool sign = bool(_bits & 0x80);
+		if (sign) {
+			lhs = -lhs & 0xFF;
+			rhs = -rhs & 0xFF;
+		}
+		if (lhs < rhs) std::swap(lhs, rhs);
 			
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t frac16A = (0x80 | remaining) << 7;
-			int8_t shiftRight = m;
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint16_t frac16B = (0x80 | remaining) << 7;
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t frac16A = (0x80 | remaining) << 7;
+		int8_t shiftRight = m;
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint16_t frac16B = (0x80 | remaining) << 7;
 
-			// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
-			(shiftRight>7) ? (frac16B = 0) : (frac16B >>= shiftRight); 
+		// Work-around CLANG (LLVM) compiler when shifting right more than number of bits
+		(shiftRight>7) ? (frac16B = 0) : (frac16B >>= shiftRight); 
 
-			frac16A += frac16B;
+		frac16A += frac16B;
 
-			bool rcarry = bool(0x8000 & frac16A); // is MSB set
-			if (rcarry) {
-				m++;
-				frac16A >>= 1;
-			}
+		bool rcarry = bool(0x8000 & frac16A); // is MSB set
+		if (rcarry) {
+			m++;
+			frac16A >>= 1;
+		}
 
-			_bits = round(m, frac16A);
-			if (sign) _bits = -_bits & 0xFF;
+		_bits = round(m, frac16A);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator-=(const posit& b) {  // derived from SoftPosit
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {
+			_bits = 0x80;
 			return *this;
 		}
-		posit& operator-=(const posit& b) {  // derived from SoftPosit
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) {
-				_bits = lhs | rhs;
-				return *this;
-			}
-			// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
-			bool sign = bool(lhs & 0x80);
-			(sign) ? (lhs = (-lhs & 0xFF)) : (rhs = (-rhs & 0xFF));
-
-			if (lhs == rhs) {
-				_bits = 0x00;
-				return *this;
-			}
-			if (lhs < rhs) {
-				std::swap(lhs, rhs);
-				sign = !sign;
-			}
-
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t frac16A = (0x80 | remaining) << 7;
-			int8_t shiftRight = m;
-			// adjust shift and extract fraction bits of rhs
-			extractAddand(rhs, shiftRight, remaining);
-			uint16_t frac16B = (0x80 | remaining) << 7;
-
-			// do the subtraction of the fractions
-			if (shiftRight >= 14) {
-				_bits = lhs;
-				if (sign) _bits = -_bits & 0xFFFF;
-				return *this;
-			}
-			else {
-				frac16B >>= shiftRight;
-			}
-			frac16A -= frac16B;
-
-			while ((frac16A >> 14) == 0) {
-				m--;
-				frac16A <<= 1;
-			}
-			bool ecarry = bool (0x4000 & frac16A);
-			if (!ecarry) {
-				m--;
-				frac16A <<= 1;
-			}
-
-			_bits = round(m, frac16A);
-			if (sign) _bits = -_bits & 0xFF;
+		if (iszero() || b.iszero()) {
+			_bits = lhs | rhs;
 			return *this;
 		}
-		posit& operator*=(const posit& b) {
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero() || b.iszero()) {
-				_bits = 0x00;
-				return *this;
-			}
+		// Both operands are actually the same sign if rhs inherits sign of sub: Make both positive
+		bool sign = bool(lhs & 0x80);
+		(sign) ? (lhs = (-lhs & 0xFF)) : (rhs = (-rhs & 0xFF));
 
-			// calculate the sign of the result
-			bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
-			lhs = lhs & 0x80 ? -lhs : lhs;
-			rhs = rhs & 0x80 ? -rhs : rhs;
-
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint8_t lhs_fraction = (0x80 | remaining);
-			// adjust shift and extract fraction bits of rhs
-			extractMultiplicand(rhs, m, remaining);
-			uint8_t rhs_fraction = (0x80 | remaining);
-			uint16_t result_fraction = uint16_t(lhs_fraction) * uint16_t(rhs_fraction);
-
-			bool rcarry = bool(result_fraction & 0x8000);
-			if (rcarry) {
-				m++;
-				result_fraction >>= 1;
-			}
-
-			// round
-			_bits = round(m, result_fraction);
-			if (sign) _bits = -_bits & 0xFF;
+		if (lhs == rhs) {
+			_bits = 0x00;
 			return *this;
 		}
-		posit& operator/=(const posit& b) {
-			uint8_t lhs = _bits;
-			uint8_t rhs = b._bits;
-			// process special cases
-			if (isnar() || b.isnar() || b.iszero()) {
-				_bits = 0x80;
-				return *this;
-			}
-			if (iszero()) {
-				_bits = 0x00;
-				return *this;
-			}
+		if (lhs < rhs) {
+			std::swap(lhs, rhs);
+			sign = !sign;
+		}
 
-			// calculate the sign of the result
-			bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
-			lhs = (lhs & 0x80) ? -lhs : lhs;
-			rhs = (rhs & 0x80) ? -rhs : rhs;
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t frac16A = (0x80 | remaining) << 7;
+		int8_t shiftRight = m;
+		// adjust shift and extract fraction bits of rhs
+		extractAddand(rhs, shiftRight, remaining);
+		uint16_t frac16B = (0x80 | remaining) << 7;
 
-			// decode the regime of lhs
-			int8_t m = 0; // pattern length
-			uint8_t remaining = 0;
-			decode_regime(lhs, m, remaining);
-			uint16_t lhs_fraction = (0x80 | remaining) << 7;
-			// adjust shift and extract fraction bits of rhs
-			extractDividand(rhs, m, remaining);
-			uint8_t rhs_fraction = (0x80 | remaining);
-			div_t result = div(lhs_fraction, uint16_t(rhs_fraction));
-			uint16_t result_fraction = result.quot;
-			uint16_t remainder = result.rem;
-
-			if (result_fraction != 0) {
-				bool rcarry = result_fraction >> 7; // this is the hidden bit (7th bit) , extreme right bit is bit 0
-				if (!rcarry) {
-					--m;
-					result_fraction <<= 1;
-				}
-			}
-
-			// round
-			_bits = adjustAndRound(m, result_fraction, remainder != 0);
-			if (sign) _bits = -_bits & 0xFF;
-
+		// do the subtraction of the fractions
+		if (shiftRight >= 14) {
+			_bits = lhs;
+			if (sign) _bits = -_bits & 0xFFFF;
 			return *this;
 		}
-		posit& operator++() {
-			++_bits;
+		else {
+			frac16B >>= shiftRight;
+		}
+		frac16A -= frac16B;
+
+		while ((frac16A >> 14) == 0) {
+			m--;
+			frac16A <<= 1;
+		}
+		bool ecarry = bool (0x4000 & frac16A);
+		if (!ecarry) {
+			m--;
+			frac16A <<= 1;
+		}
+
+		_bits = round(m, frac16A);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator*=(const posit& b) {
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar()) {
+			_bits = 0x80;
 			return *this;
 		}
-		posit operator++(int) {
-			posit tmp(*this);
-			operator++();
-			return tmp;
-		}
-		posit& operator--() {
-			--_bits;
-			return *this;
-		}
-		posit operator--(int) {
-			posit tmp(*this);
-			operator--();
-			return tmp;
-		}
-		posit reciprocate() const {
-			posit p = 1.0 / *this;
-			return p;
-		}
-		// SELECTORS
-		inline bool isnar() const      { return (_bits == 0x80); }
-		inline bool iszero() const     { return (_bits == 0x00); }
-		inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
-		inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
-		inline bool isneg() const      { return (_bits & 0x80); }
-		inline bool ispos() const      { return !isneg(); }
-		inline bool ispowerof2() const { return !(_bits & 0x1); }
-
-		inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
-
-		bitblock<NBITS_IS_64> get() const { bitblock<NBITS_IS_64> bb; bb = int(_bits); return bb; }
-		unsigned long long encoding() const { return (unsigned long long)(_bits); }
-
-		inline void clear() { _bits = 0; }
-		inline void setzero() { clear(); }
-		inline void setnar() { _bits = 0x80; }
-		inline posit twosComplement() const {
-			posit<NBITS_IS_64, ES_IS_3> p;
-			int8_t v = -*(int8_t*)&_bits;
-			p.set_raw_bits(v);
-			return p;
-		}
-	private:
-		uint8_t _bits;
-
-		// Conversion functions
-#if POSIT_THROW_ARITHMETIC_EXCEPTION
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar()) throw not_a_real{};
-			return long(to_long_double());
-		}
-#else
-		int         to_int() const {
-			if (iszero()) return 0;
-			if (isnar())  return int(INFINITY);
-			return int(to_float());
-		}
-		long        to_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return long(INFINITY);
-			return long(to_double());
-		}
-		long long   to_long_long() const {
-			if (iszero()) return 0;
-			if (isnar())  return (long long)(INFINITY);
-			return long(to_long_double());
-		}
-#endif
-		float       to_float() const {
-			return (float)to_double();
-		}
-		double      to_double() const {
-			if (iszero())	return 0.0;
-			if (isnar())	return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			double s = (_sign ? -1.0 : 1.0);
-			double r = _regime.value();
-			double e = _exponent.value();
-			double f = (1.0 + _fraction.value());
-			return s * r * e * f;
-		}
-		long double to_long_double() const {
-			if (iszero())  return 0.0;
-			if (isnar())   return NAN;
-			bool		     	 _sign;
-			regime<nbits, es>    _regime;
-			exponent<nbits, es>  _exponent;
-			fraction<fbits>      _fraction;
-			bitblock<nbits>		 _raw_bits;
-			_raw_bits.reset();
-			uint64_t mask = 1;
-			for (size_t i = 0; i < nbits; i++) {
-				_raw_bits.set(i, (_bits & mask));
-				mask <<= 1;
-			}
-			decode(_raw_bits, _sign, _regime, _exponent, _fraction);
-			long double s = (_sign ? -1.0 : 1.0);
-			long double r = _regime.value();
-			long double e = _exponent.value();
-			long double f = (1.0 + _fraction.value());
-			return s * r * e * f;
-		}
-
-		template <typename T>
-		posit& float_assign(const T& rhs) {
-			constexpr int dfbits = std::numeric_limits<T>::digits - 1;
-			value<dfbits> v((T)rhs);
-
-			// special case processing
-			if (v.iszero()) {
-				setzero();
-				return *this;
-			}
-			if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
-				setnar();
-				return *this;
-			}
-
-			bitblock<NBITS_IS_64> ptt;
-			convert_to_bb<NBITS_IS_64, ES_IS_3, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
-			_bits = uint8_t(ptt.to_ulong());
+		if (iszero() || b.iszero()) {
+			_bits = 0x00;
 			return *this;
 		}
 
-		// helper method
-		// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
-		inline void decode_regime(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				m = -1;
-				while (!(remaining >> 7)) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
+		// calculate the sign of the result
+		bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
+		lhs = lhs & 0x80 ? -lhs : lhs;
+		rhs = rhs & 0x80 ? -rhs : rhs;
+
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint8_t lhs_fraction = (0x80 | remaining);
+		// adjust shift and extract fraction bits of rhs
+		extractMultiplicand(rhs, m, remaining);
+		uint8_t rhs_fraction = (0x80 | remaining);
+		uint16_t result_fraction = uint16_t(lhs_fraction) * uint16_t(rhs_fraction);
+
+		bool rcarry = bool(result_fraction & 0x8000);
+		if (rcarry) {
+			m++;
+			result_fraction >>= 1;
 		}
-		inline void extractAddand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				++m;
-				while (!(remaining >> 7)) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
+
+		// round
+		_bits = round(m, result_fraction);
+		if (sign) _bits = -_bits & 0xFF;
+		return *this;
+	}
+	posit& operator/=(const posit& b) {
+		uint8_t lhs = _bits;
+		uint8_t rhs = b._bits;
+		// process special cases
+		if (isnar() || b.isnar() || b.iszero()) {
+			_bits = 0x80;
+			return *this;
 		}
-		inline void extractMultiplicand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
+		if (iszero()) {
+			_bits = 0x00;
+			return *this;
+		}
+
+		// calculate the sign of the result
+		bool sign = bool(lhs & 0x80) ^ bool(rhs & 0x80);
+		lhs = (lhs & 0x80) ? -lhs : lhs;
+		rhs = (rhs & 0x80) ? -rhs : rhs;
+
+		// decode the regime of lhs
+		int8_t m = 0; // pattern length
+		uint8_t remaining = 0;
+		decode_regime(lhs, m, remaining);
+		uint16_t lhs_fraction = (0x80 | remaining) << 7;
+		// adjust shift and extract fraction bits of rhs
+		extractDividand(rhs, m, remaining);
+		uint8_t rhs_fraction = (0x80 | remaining);
+		div_t result = div(lhs_fraction, uint16_t(rhs_fraction));
+		uint16_t result_fraction = result.quot;
+		uint16_t remainder = result.rem;
+
+		if (result_fraction != 0) {
+			bool rcarry = result_fraction >> 7; // this is the hidden bit (7th bit) , extreme right bit is bit 0
+			if (!rcarry) {
 				--m;
-				while (!(remaining >> 7)) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
+				result_fraction <<= 1;
 			}
 		}
-		inline void extractDividand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
-			remaining = (bits << 2) & 0xFF;
-			if (bits & 0x40) {  // positive regimes
-				while (remaining >> 7) {
-					--m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-			}
-			else {              // negative regimes
-				++m;
-				while (!(remaining >> 7)) {
-					++m;
-					remaining = (remaining << 1) & 0xFF;
-				}
-				remaining &= 0x7F;
-			}
-		}
-		inline uint8_t round(const int8_t m, uint16_t fraction) const {
-			uint8_t scale, regime, bits;
-			if (m < 0) {
-				scale = (-m & 0xFF);
-				regime = 0x40 >> scale;
-			}
-			else {
-				scale = m + 1;
-				regime = 0x7F - (0x7F >> scale);
-			}
 
-			if (scale > 6) {
-				bits = m<0 ? 0x1 : 0x7F;  // minpos and maxpos
-			}
-			else {
-				fraction = (fraction & 0x3FFF) >> scale;
-				uint8_t final_fbits = uint8_t(fraction >> 8);
-				bool bitNPlusOne = bool(0x80 & fraction);
-				bits = uint8_t(regime) + uint8_t(final_fbits);
-				// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
-				if (bitNPlusOne) {
-					uint8_t moreBits = (0x7F & fraction) ? 0x01 : 0x00;
-					bits += (bits & 0x01) | moreBits;
-				}
-			}
-			return bits;
-		}
-		inline uint8_t adjustAndRound(const int8_t k, uint16_t fraction, bool nonZeroRemainder) const {
-			uint8_t scale, regime, bits;
-			if (k < 0) {
-				scale = (-k & 0xFF);
-				regime = 0x40 >> scale;
-			}
-			else {
-				scale = k + 1;
-				regime = 0x7F - (0x7F >> scale);
-			}
+		// round
+		_bits = adjustAndRound(m, result_fraction, remainder != 0);
+		if (sign) _bits = -_bits & 0xFF;
 
-			if (scale > 6) {
-				bits = k<0 ? 0x1 : 0x7F;  // minpos and maxpos
-			}
-			else {
-				//remove carry and rcarry bits and shift to correct position
-				fraction &= 0x7F;
-				uint8_t final_fbits = (uint_fast16_t)fraction >> (scale + 1);
-				bool bitNPlusOne = (0x1 & (fraction >> scale));
-				bits = uint8_t(regime) + uint8_t(final_fbits);
-#ifdef NOW
-				std::cout << std::hex;
-				std::cout << "fraction raw   = " << int(fraction) << std::endl;
-				std::cout << "fraction final = " << int(final_fbits) << std::endl;
-				std::cout << "posit bits     = " << int(bits) << std::endl;
-				std::cout << std::dec;
-#endif
-				if (bitNPlusOne) {
-					uint8_t moreBits = (((1 << scale) - 1) & fraction) ? 0x01 : 0x00;
-					if (nonZeroRemainder) moreBits = 0x01;
-					//std::cout << "bitsMore = " << (moreBits ? "true" : "false") << std::endl;
-					// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
-					bits += (bits & 0x01) | moreBits;
-				}
-			}
-			return bits;
-		}
-		// I/O operators
-		friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_64, ES_IS_3>& p);
-		friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_64, ES_IS_3>& p);
+		return *this;
+	}
+	posit& operator++() {
+		++_bits;
+		return *this;
+	}
+	posit operator++(int) {
+		posit tmp(*this);
+		operator++();
+		return tmp;
+	}
+	posit& operator--() {
+		--_bits;
+		return *this;
+	}
+	posit operator--(int) {
+		posit tmp(*this);
+		operator--();
+		return tmp;
+	}
+	posit reciprocate() const {
+		posit p = 1.0 / *this;
+		return p;
+	}
+	// SELECTORS
+	inline bool isnar() const      { return (_bits == 0x80); }
+	inline bool iszero() const     { return (_bits == 0x00); }
+	inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
+	inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
+	inline bool isneg() const      { return (_bits & 0x80); }
+	inline bool ispos() const      { return !isneg(); }
+	inline bool ispowerof2() const { return !(_bits & 0x1); }
 
-		// posit - posit logic functions
-		friend bool operator==(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
-		friend bool operator!=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
-		friend bool operator< (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
-		friend bool operator> (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
-		friend bool operator<=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
-		friend bool operator>=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
+	inline int sign_value() const  { return (_bits & 0x8 ? -1 : 1); }
 
-	};
+	bitblock<NBITS_IS_64> get() const { bitblock<NBITS_IS_64> bb; bb = int(_bits); return bb; }
+	unsigned long long encoding() const { return (unsigned long long)(_bits); }
 
-	// posit I/O operators
-	// generate a posit format ASCII format nbits.esxNN...NNp
-	inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_64, ES_IS_3>& p) {
-		// to make certain that setw and left/right operators work properly
-		// we need to transform the posit into a string
-		std::stringstream ss;
-#if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
-		ss << NBITS_IS_64 << '.' << ES_IS_3 << 'x' << to_hex(p.get()) << 'p';
+	inline void clear() { _bits = 0; }
+	inline void setzero() { clear(); }
+	inline void setnar() { _bits = 0x80; }
+	inline posit twosComplement() const {
+		posit<NBITS_IS_64, ES_IS_3> p;
+		int8_t v = -*(int8_t*)&_bits;
+		p.set_raw_bits(v);
+		return p;
+	}
+private:
+	uint8_t _bits;
+
+	// Conversion functions
+#if POSIT_THROW_ARITHMETIC_EXCEPTION
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar()) throw not_a_real{};
+		return long(to_long_double());
+	}
 #else
-		std::streamsize prec = ostr.precision();
-		std::streamsize width = ostr.width();
-		std::ios_base::fmtflags ff;
-		ff = ostr.flags();
-		ss.flags(ff);
-		ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+	int         to_int() const {
+		if (iszero()) return 0;
+		if (isnar())  return int(INFINITY);
+		return int(to_float());
+	}
+	long        to_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return long(INFINITY);
+		return long(to_double());
+	}
+	long long   to_long_long() const {
+		if (iszero()) return 0;
+		if (isnar())  return (long long)(INFINITY);
+		return long(to_long_double());
+	}
 #endif
-		return ostr << ss.str();
+	float       to_float() const {
+		return (float)to_double();
 	}
-
-	// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
-	inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_64, ES_IS_3>& p) {
-		std::string txt;
-		istr >> txt;
-		if (!parse(txt, p)) {
-			std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+	double      to_double() const {
+		if (iszero())	return 0.0;
+		if (isnar())	return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		return istr;
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		double s = (_sign ? -1.0 : 1.0);
+		double r = _regime.value();
+		double e = _exponent.value();
+		double f = (1.0 + _fraction.value());
+		return s * r * e * f;
 	}
-
-	// convert a posit value to a string using "nar" as designation of NaR
-	std::string to_string(const posit<NBITS_IS_64, ES_IS_3>& p, std::streamsize precision) {
-		if (p.isnar()) {
-			return std::string("nar");
+	long double to_long_double() const {
+		if (iszero())  return 0.0;
+		if (isnar())   return NAN;
+		bool		     	 _sign;
+		regime<nbits, es>    _regime;
+		exponent<nbits, es>  _exponent;
+		fraction<fbits>      _fraction;
+		bitblock<nbits>		 _raw_bits;
+		_raw_bits.reset();
+		uint64_t mask = 1;
+		for (size_t i = 0; i < nbits; i++) {
+			_raw_bits.set(i, (_bits & mask));
+			mask <<= 1;
 		}
-		std::stringstream ss;
-		ss << std::setprecision(precision) << float(p);
-		return ss.str();
+		decode(_raw_bits, _sign, _regime, _exponent, _fraction);
+		long double s = (_sign ? -1.0 : 1.0);
+		long double r = _regime.value();
+		long double e = _exponent.value();
+		long double f = (1.0 + _fraction.value());
+		return s * r * e * f;
 	}
 
-	// posit - posit binary logic operators
-	inline bool operator==(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return lhs._bits == rhs._bits;
-	}
-	inline bool operator!=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return !operator==(lhs, rhs);
-	}
-	inline bool operator< (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return *(signed char*)(&lhs._bits) < *(signed char*)(&rhs._bits);
-	}
-	inline bool operator> (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return operator< (rhs, lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return operator< (lhs, rhs) || operator==(lhs, rhs);
-	}
-	inline bool operator>=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return !operator< (lhs, rhs);
+	template <typename T>
+	posit& float_assign(const T& rhs) {
+		constexpr int dfbits = std::numeric_limits<T>::digits - 1;
+		value<dfbits> v((T)rhs);
+
+		// special case processing
+		if (v.iszero()) {
+			setzero();
+			return *this;
+		}
+		if (v.isinf() || v.isnan()) {  // posit encode for FP_INFINITE and NaN as NaR (Not a Real)
+			setnar();
+			return *this;
+		}
+
+		bitblock<NBITS_IS_64> ptt;
+		convert_to_bb<NBITS_IS_64, ES_IS_3, dfbits>(v.sign(), v.scale(), v.fraction(), ptt); // TODO: needs to be faster
+		_bits = uint8_t(ptt.to_ulong());
+		return *this;
 	}
 
-	inline posit<NBITS_IS_64, ES_IS_3> operator+(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		posit<NBITS_IS_64, ES_IS_3> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result += rhs;
-		} 
+	// helper method
+	// decode_regime takes the raw bits of the posit, and returns the regime run-length, m, and the remaining fraction bits in remainder
+	inline void decode_regime(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			m = -1;
+			while (!(remaining >> 7)) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractAddand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 7)) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractMultiplicand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			--m;
+			while (!(remaining >> 7)) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline void extractDividand(const uint8_t bits, int8_t& m, uint8_t& remaining) const {
+		remaining = (bits << 2) & 0xFF;
+		if (bits & 0x40) {  // positive regimes
+			while (remaining >> 7) {
+				--m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+		}
+		else {              // negative regimes
+			++m;
+			while (!(remaining >> 7)) {
+				++m;
+				remaining = (remaining << 1) & 0xFF;
+			}
+			remaining &= 0x7F;
+		}
+	}
+	inline uint8_t round(const int8_t m, uint16_t fraction) const {
+		uint8_t scale, regime, bits;
+		if (m < 0) {
+			scale = (-m & 0xFF);
+			regime = 0x40 >> scale;
+		}
 		else {
-			result -= rhs;
+			scale = m + 1;
+			regime = 0x7F - (0x7F >> scale);
 		}
-		return result;
-	}
-	inline posit<NBITS_IS_64, ES_IS_3> operator-(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		posit<NBITS_IS_64, ES_IS_3> result = lhs;
-		if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
-			result -= rhs.twosComplement();
+
+		if (scale > 6) {
+			bits = m<0 ? 0x1 : 0x7F;  // minpos and maxpos
 		}
 		else {
-			result += rhs.twosComplement();
+			fraction = (fraction & 0x3FFF) >> scale;
+			uint8_t final_fbits = uint8_t(fraction >> 8);
+			bool bitNPlusOne = bool(0x80 & fraction);
+			bits = uint8_t(regime) + uint8_t(final_fbits);
+			// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
+			if (bitNPlusOne) {
+				uint8_t moreBits = (0x7F & fraction) ? 0x01 : 0x00;
+				bits += (bits & 0x01) | moreBits;
+			}
 		}
-		return result;
-
+		return bits;
 	}
-	// binary operator*() is provided by generic class
+	inline uint8_t adjustAndRound(const int8_t k, uint16_t fraction, bool nonZeroRemainder) const {
+		uint8_t scale, regime, bits;
+		if (k < 0) {
+			scale = (-k & 0xFF);
+			regime = 0x40 >> scale;
+		}
+		else {
+			scale = k + 1;
+			regime = 0x7F - (0x7F >> scale);
+		}
+
+		if (scale > 6) {
+			bits = k<0 ? 0x1 : 0x7F;  // minpos and maxpos
+		}
+		else {
+			//remove carry and rcarry bits and shift to correct position
+			fraction &= 0x7F;
+			uint8_t final_fbits = (uint_fast16_t)fraction >> (scale + 1);
+			bool bitNPlusOne = (0x1 & (fraction >> scale));
+			bits = uint8_t(regime) + uint8_t(final_fbits);
+#ifdef NOW
+			std::cout << std::hex;
+			std::cout << "fraction raw   = " << int(fraction) << std::endl;
+			std::cout << "fraction final = " << int(final_fbits) << std::endl;
+			std::cout << "posit bits     = " << int(bits) << std::endl;
+			std::cout << std::dec;
+#endif
+			if (bitNPlusOne) {
+				uint8_t moreBits = (((1 << scale) - 1) & fraction) ? 0x01 : 0x00;
+				if (nonZeroRemainder) moreBits = 0x01;
+				//std::cout << "bitsMore = " << (moreBits ? "true" : "false") << std::endl;
+				// n+1 frac bit is 1. Need to check if another bit is 1 too if not round to even
+				bits += (bits & 0x01) | moreBits;
+			}
+		}
+		return bits;
+	}
+	// I/O operators
+	friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_64, ES_IS_3>& p);
+	friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_64, ES_IS_3>& p);
+
+	// posit - posit logic functions
+	friend bool operator==(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
+	friend bool operator!=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
+	friend bool operator< (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
+	friend bool operator> (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
+	friend bool operator<=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
+	friend bool operator>=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs);
+
+};
+
+// posit I/O operators
+// generate a posit format ASCII format nbits.esxNN...NNp
+inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_64, ES_IS_3>& p) {
+	// to make certain that setw and left/right operators work properly
+	// we need to transform the posit into a string
+	std::stringstream ss;
+#if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
+	ss << NBITS_IS_64 << '.' << ES_IS_3 << 'x' << to_hex(p.get()) << 'p';
+#else
+	std::streamsize prec = ostr.precision();
+	std::streamsize width = ostr.width();
+	std::ios_base::fmtflags ff;
+	ff = ostr.flags();
+	ss.flags(ff);
+	ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+#endif
+	return ostr << ss.str();
+}
+
+// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
+inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_64, ES_IS_3>& p) {
+	std::string txt;
+	istr >> txt;
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+	}
+	return istr;
+}
+
+// convert a posit value to a string using "nar" as designation of NaR
+std::string to_string(const posit<NBITS_IS_64, ES_IS_3>& p, std::streamsize precision) {
+	if (p.isnar()) {
+		return std::string("nar");
+	}
+	std::stringstream ss;
+	ss << std::setprecision(precision) << float(p);
+	return ss.str();
+}
+
+// posit - posit binary logic operators
+inline bool operator==(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return lhs._bits == rhs._bits;
+}
+inline bool operator!=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return !operator==(lhs, rhs);
+}
+inline bool operator< (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return *(signed char*)(&lhs._bits) < *(signed char*)(&rhs._bits);
+}
+inline bool operator> (const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return operator< (rhs, lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return operator< (lhs, rhs) || operator==(lhs, rhs);
+}
+inline bool operator>=(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return !operator< (lhs, rhs);
+}
+
+inline posit<NBITS_IS_64, ES_IS_3> operator+(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	posit<NBITS_IS_64, ES_IS_3> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result += rhs;
+	} 
+	else {
+		result -= rhs;
+	}
+	return result;
+}
+inline posit<NBITS_IS_64, ES_IS_3> operator-(const posit<NBITS_IS_64, ES_IS_3>& lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	posit<NBITS_IS_64, ES_IS_3> result = lhs;
+	if (lhs.isneg() == rhs.isneg()) {  // are the posits the same sign?
+		result -= rhs.twosComplement();
+	}
+	else {
+		result += rhs.twosComplement();
+	}
+	return result;
+
+}
+// binary operator*() is provided by generic class
 
 #if POSIT_ENABLE_LITERALS
-	// posit - literal logic functions
+// posit - literal logic functions
 
-	// posit - int logic operators
-	inline bool operator==(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
-		return operator==(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
-	}
-	inline bool operator!=(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
-		return !operator==(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
-	}
-	inline bool operator< (const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
-		return operator<(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
-	}
-	inline bool operator> (const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
-		return operator< (posit<NBITS_IS_64, ES_IS_3>(rhs), lhs);
-	}
-	inline bool operator<=(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
-		return operator< (lhs, posit<NBITS_IS_64, ES_IS_3>(rhs)) || operator==(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
-	}
-	inline bool operator>=(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
-		return !operator<(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
-	}
+// posit - int logic operators
+inline bool operator==(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
+	return operator==(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
+}
+inline bool operator!=(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
+	return !operator==(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
+}
+inline bool operator< (const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
+	return operator<(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
+}
+inline bool operator> (const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
+	return operator< (posit<NBITS_IS_64, ES_IS_3>(rhs), lhs);
+}
+inline bool operator<=(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
+	return operator< (lhs, posit<NBITS_IS_64, ES_IS_3>(rhs)) || operator==(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
+}
+inline bool operator>=(const posit<NBITS_IS_64, ES_IS_3>& lhs, int rhs) {
+	return !operator<(lhs, posit<NBITS_IS_64, ES_IS_3>(rhs));
+}
 
-	// int - posit logic operators
-	inline bool operator==(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return posit<NBITS_IS_64, ES_IS_3>(lhs) == rhs;
-	}
-	inline bool operator!=(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return !operator==(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
-	}
-	inline bool operator< (int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return operator<(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
-	}
-	inline bool operator> (int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return operator< (posit<NBITS_IS_64, ES_IS_3>(rhs), lhs);
-	}
-	inline bool operator<=(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return operator< (posit<NBITS_IS_64, ES_IS_3>(lhs), rhs) || operator==(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
-	}
-	inline bool operator>=(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
-		return !operator<(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
-	}
+// int - posit logic operators
+inline bool operator==(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return posit<NBITS_IS_64, ES_IS_3>(lhs) == rhs;
+}
+inline bool operator!=(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return !operator==(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
+}
+inline bool operator< (int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return operator<(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
+}
+inline bool operator> (int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return operator< (posit<NBITS_IS_64, ES_IS_3>(rhs), lhs);
+}
+inline bool operator<=(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return operator< (posit<NBITS_IS_64, ES_IS_3>(lhs), rhs) || operator==(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
+}
+inline bool operator>=(int lhs, const posit<NBITS_IS_64, ES_IS_3>& rhs) {
+	return !operator<(posit<NBITS_IS_64, ES_IS_3>(lhs), rhs);
+}
 
 #endif // POSIT_ENABLE_LITERALS
 
@@ -737,5 +737,5 @@ namespace sw {
 #	define POSIT_FAST_POSIT_64_3 0
 #endif // POSIT_FAST_POSIT_64_3
 
-  }
-}
+} // namespace unum
+} // namespace sw

--- a/include/universal/posit/specialized/posit_8_0.hpp
+++ b/include/universal/posit/specialized/posit_8_0.hpp
@@ -1,353 +1,466 @@
 #pragma once
 // posit_8_0.hpp: specialized 8-bit posit using fast compute specialized for posit<8,0>
 //
-// Copyright (C) 2017-2019 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 namespace sw {
-	namespace unum {
+namespace unum {
 
 // set the fast specialization variable to indicate that we are running a special template specialization
 #if POSIT_FAST_POSIT_8_0
 #pragma message("Fast specialization of posit<8,0>")
 
-		// injecting the C API into namespace sw::unum
+	// injecting the C API into namespace sw::unum
 #include "posit_8_0.h"
 
-		template<>
-		class posit<NBITS_IS_8, ES_IS_0> {
-		public:
-			static constexpr size_t nbits = NBITS_IS_8;
-			static constexpr size_t es = ES_IS_0;
-			static constexpr size_t sbits = 1;
-			static constexpr size_t rbits = nbits - sbits;
-			static constexpr size_t ebits = es;
-			static constexpr size_t fbits = nbits - 3 - es;
-			static constexpr size_t fhbits = fbits + 1;
-			static constexpr uint8_t sign_mask = 0x80;
+	template<>
+	class posit<NBITS_IS_8, ES_IS_0> {
+	public:
+		static constexpr size_t nbits = NBITS_IS_8;
+		static constexpr size_t es = ES_IS_0;
+		static constexpr size_t sbits = 1;
+		static constexpr size_t rbits = nbits - sbits;
+		static constexpr size_t ebits = es;
+		static constexpr size_t fbits = nbits - 3 - es;
+		static constexpr size_t fhbits = fbits + 1;
+		static constexpr uint8_t sign_mask = 0x80;
 
-			posit() { _bits = 0; }
-			posit(const posit&) = default;
-			posit(posit&&) = default;
-			posit& operator=(const posit&) = default;
-			posit& operator=(posit&&) = default;
+		constexpr posit() : _bits(0) {}
+		posit(const posit&) = default;
+		posit(posit&&) = default;
+		posit& operator=(const posit&) = default;
+		posit& operator=(posit&&) = default;
 
-			// initializers for native types
-			explicit posit(const signed char initial_value)        { *this = initial_value; }
-			explicit posit(const short initial_value)              { *this = initial_value; }
-			explicit posit(const int initial_value)                { *this = initial_value; }
-			explicit posit(const long initial_value)               { *this = initial_value; }
-			explicit posit(const long long initial_value)          { *this = initial_value; }
-			explicit posit(const char initial_value)               { *this = initial_value; }
-			explicit posit(const unsigned short initial_value)     { *this = initial_value; }
-			explicit posit(const unsigned int initial_value)       { *this = initial_value; }
-			explicit posit(const unsigned long initial_value)      { *this = initial_value; }
-			explicit posit(const unsigned long long initial_value) { *this = initial_value; }
-			explicit posit(const float initial_value)              { *this = initial_value; }
-			explicit posit(const double initial_value)             { *this = initial_value; }
-			explicit posit(const long double initial_value)        { *this = initial_value; }
+		// initializers for native types
+		constexpr explicit posit(signed char initial_value) : _bits(0)        { *this = initial_value; }
+		constexpr explicit posit(short initial_value) : _bits(0)              { *this = initial_value; }
+		constexpr explicit posit(int initial_value) : _bits(0)                { *this = initial_value; }
+		constexpr explicit posit(long initial_value) : _bits(0)               { *this = initial_value; }
+		constexpr explicit posit(long long initial_value) : _bits(0)          { *this = initial_value; }
+		constexpr explicit posit(char initial_value) : _bits(0)               { *this = initial_value; }
+		constexpr explicit posit(unsigned short initial_value) : _bits(0)     { *this = initial_value; }
+		constexpr explicit posit(unsigned int initial_value) : _bits(0)       { *this = initial_value; }
+		constexpr explicit posit(unsigned long initial_value) : _bits(0)      { *this = initial_value; }
+		constexpr explicit posit(unsigned long long initial_value) : _bits(0) { *this = initial_value; }
+		constexpr explicit posit(float initial_value) : _bits(0)              { *this = initial_value; }
+		constexpr          posit(double initial_value) : _bits(0)             { *this = initial_value; }
+		constexpr explicit posit(long double initial_value) : _bits(0)        { *this = initial_value; }
 
-			// assignment operators for native types
-			posit& operator=(signed char rhs)             { return operator=((int)(rhs)); }
-			posit& operator=(short rhs)                   { return operator=((int)(rhs)); }
-			posit& operator=(int rhs)                     { return integer_assign(rhs); }
-			posit& operator=(long rhs)                    { return operator=((int)(rhs)); }
-			posit& operator=(long long rhs)               { return operator=((int)(rhs)); }
-			posit& operator=(char rhs)                    { return operator=((int)(rhs)); }
-			posit& operator=(unsigned short rhs)          { return operator=((int)(rhs)); }
-			posit& operator=(unsigned int rhs)            { return operator=((int)(rhs)); }
-			posit& operator=(unsigned long rhs)           { return operator=((int)(rhs)); }
-			posit& operator=(unsigned long long rhs)      { return operator=((int)(rhs)); }
-			posit& operator=(float rhs)                   { return float_assign(rhs); }
-			posit& operator=(double rhs)                  { return operator=(float(rhs)); }
-			posit& operator=(long double rhs)             { return operator=(float(rhs)); }
+		// assignment operators for native types
+		constexpr posit& operator=(signed char rhs)             { return operator=((int)(rhs)); }
+		constexpr posit& operator=(short rhs)                   { return operator=((int)(rhs)); }
+		constexpr posit& operator=(int rhs)                     { return integer_assign(rhs); }
+		constexpr posit& operator=(long rhs)                    { return operator=((int)(rhs)); }
+		constexpr posit& operator=(long long rhs)               { return operator=((int)(rhs)); }
+		constexpr posit& operator=(char rhs)                    { return operator=((int)(rhs)); }
+		constexpr posit& operator=(unsigned short rhs)          { return operator=((int)(rhs)); }
+		constexpr posit& operator=(unsigned int rhs)            { return operator=((int)(rhs)); }
+		constexpr posit& operator=(unsigned long rhs)           { return operator=((int)(rhs)); }
+		constexpr posit& operator=(unsigned long long rhs)      { return operator=((int)(rhs)); }
+		constexpr posit& operator=(float rhs)                   { return float_assign(rhs); }
+		constexpr posit& operator=(double rhs)                  { return float_assign(float(rhs)); }
+		constexpr posit& operator=(long double rhs)             { return float_assign(float(rhs)); }
 
-			explicit operator long double() const { return to_long_double(); }
-			explicit operator double() const { return to_double(); }
-			explicit operator float() const { return to_float(); }
-			explicit operator long long() const { return to_long_long(); }
-			explicit operator long() const { return to_long(); }
-			explicit operator int() const { return to_int(); }
-			explicit operator unsigned long long() const { return to_long_long(); }
-			explicit operator unsigned long() const { return to_long(); }
-			explicit operator unsigned int() const { return to_int(); }
+		explicit operator long double() const { return to_long_double(); }
+		explicit operator double() const { return to_double(); }
+		explicit operator float() const { return to_float(); }
+		explicit operator long long() const { return to_long_long(); }
+		explicit operator long() const { return to_long(); }
+		explicit operator int() const { return to_int(); }
+		explicit operator unsigned long long() const { return to_long_long(); }
+		explicit operator unsigned long() const { return to_long(); }
+		explicit operator unsigned int() const { return to_int(); }
 
-			posit& set(sw::unum::bitblock<NBITS_IS_8>& raw) {
-				_bits = uint8_t(raw.to_ulong());
-				return *this;
-			}
-			posit& set_raw_bits(uint64_t value) {
-				_bits = uint8_t(value & 0xff);
-				return *this;
-			}
-			posit operator-() const {
-				posit negated;
-				posit8_t b = { { _bits } };
-				return negated.set_raw_bits(posit8_negate(b).v);
-			}
-			posit& operator+=(const posit& b) {
-				posit8_t lhs = { { _bits } };
-				posit8_t rhs = { { b._bits} };
-				posit8_t add = posit8_addp8(lhs, rhs);
-				_bits = add.v;
-				return *this;
-			}
-			posit& operator-=(const posit& b) {
-				posit8_t lhs = { { _bits } };
-				posit8_t rhs = { { b._bits } };
-				posit8_t sub = posit8_subp8(lhs, rhs);
-				_bits = sub.v;
-				return *this;
-			}
-			posit& operator*=(const posit& b) {
-				posit8_t lhs = { { _bits } };
-				posit8_t rhs = { { b._bits } };
-				posit8_t mul = posit8_mulp8(lhs, rhs);
-				_bits = mul.v;
-				return *this;
-			}
-			posit& operator/=(const posit& b) {
-				posit8_t lhs = { { _bits } };
-				posit8_t rhs = { { b._bits } };
-				posit8_t div = posit8_divp8(lhs, rhs);
-				_bits = div.v;
-				return *this;
-			}
-			posit& operator++() {
-				++_bits;
-				return *this;
-			}
-			posit operator++(int) {
-				posit tmp(*this);
-				operator++();
-				return tmp;
-			}
-			posit& operator--() {
-				--_bits;
-				return *this;
-			}
-			posit operator--(int) {
-				posit tmp(*this);
-				operator--();
-				return tmp;
-			}
-			posit reciprocate() const {
-				posit p = 1.0 / *this;
-				return p;
-			}
-			// SELECTORS
-			inline bool isnar() const      { return (_bits == sign_mask); }
-			inline bool iszero() const     { return (_bits == 0x00); }
-			inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
-			inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
-			inline bool isneg() const      { return (_bits & sign_mask); }
-			inline bool ispos() const      { return !isneg(); }
-			inline bool ispowerof2() const { return !(_bits & 0x1); }
+		posit& set(sw::unum::bitblock<NBITS_IS_8>& raw) {
+			_bits = uint8_t(raw.to_ulong());
+			return *this;
+		}
+		posit& set_raw_bits(uint64_t value) {
+			_bits = uint8_t(value & 0xff);
+			return *this;
+		}
+		posit operator-() const {
+			posit negated;
+			posit8_t b = { { _bits } };
+			return negated.set_raw_bits(posit8_negate(b).v);
+		}
+		posit& operator+=(const posit& b) {
+			posit8_t lhs = { { _bits } };
+			posit8_t rhs = { { b._bits} };
+			posit8_t add = posit8_addp8(lhs, rhs);
+			_bits = add.v;
+			return *this;
+		}
+		posit& operator-=(const posit& b) {
+			posit8_t lhs = { { _bits } };
+			posit8_t rhs = { { b._bits } };
+			posit8_t sub = posit8_subp8(lhs, rhs);
+			_bits = sub.v;
+			return *this;
+		}
+		posit& operator*=(const posit& b) {
+			posit8_t lhs = { { _bits } };
+			posit8_t rhs = { { b._bits } };
+			posit8_t mul = posit8_mulp8(lhs, rhs);
+			_bits = mul.v;
+			return *this;
+		}
+		posit& operator/=(const posit& b) {
+			posit8_t lhs = { { _bits } };
+			posit8_t rhs = { { b._bits } };
+			posit8_t div = posit8_divp8(lhs, rhs);
+			_bits = div.v;
+			return *this;
+		}
+		posit& operator++() {
+			++_bits;
+			return *this;
+		}
+		posit operator++(int) {
+			posit tmp(*this);
+			operator++();
+			return tmp;
+		}
+		posit& operator--() {
+			--_bits;
+			return *this;
+		}
+		posit operator--(int) {
+			posit tmp(*this);
+			operator--();
+			return tmp;
+		}
+		posit reciprocate() const {
+			posit p = 1.0 / *this;
+			return p;
+		}
+		// SELECTORS
+		inline bool isnar() const      { return (_bits == sign_mask); }
+		inline bool iszero() const     { return (_bits == 0x00); }
+		inline bool isone() const      { return (_bits == 0x40); } // pattern 010000...
+		inline bool isminusone() const { return (_bits == 0xC0); } // pattern 110000...
+		inline bool isneg() const      { return (_bits & sign_mask); }
+		inline bool ispos() const      { return !isneg(); }
+		inline bool ispowerof2() const { return !(_bits & 0x1); }
 
-			inline int sign_value() const  { return (_bits & 0x80 ? -1 : 1); }
+		inline int sign_value() const  { return (_bits & 0x80 ? -1 : 1); }
 
-			bitblock<NBITS_IS_8> get() const { bitblock<NBITS_IS_8> bb; bb = int(_bits); return bb; }
-			unsigned long long encoding() const { return (unsigned long long)(_bits); }
+		bitblock<NBITS_IS_8> get() const { bitblock<NBITS_IS_8> bb; bb = int(_bits); return bb; }
+		unsigned long long encoding() const { return (unsigned long long)(_bits); }
 
-			inline void clear() { _bits = 0; }
-			inline void setzero() { clear(); }
-			inline void setnar() { _bits = 0x80; }
-			inline posit twosComplement() const {
-				posit<NBITS_IS_8, ES_IS_0> p;
-				int8_t v = -*(int8_t*)&_bits;
-				p.set_raw_bits(v);
-				return p;
-			}
-		private:
-			uint8_t _bits;
+		inline void clear() { _bits = 0; }
+		inline void setzero() { clear(); }
+		inline void setnar() { _bits = 0x80; }
+		inline posit twosComplement() const {
+			posit<NBITS_IS_8, ES_IS_0> p;
+			int8_t v = -*(int8_t*)&_bits;
+			p.set_raw_bits(v);
+			return p;
+		}
+	private:
+		uint8_t _bits;
 
-			// Conversion functions
+		// Conversion functions
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
-			int         to_int() const {
-				if (iszero()) return 0;
-				if (isnar()) throw not_a_real{};
-				return int(to_float());
-			}
-			long        to_long() const {
-				if (iszero()) return 0;
-				if (isnar()) throw not_a_real{};
-				return long(to_double());
-			}
-			long long   to_long_long() const {
-				if (iszero()) return 0;
-				if (isnar()) throw not_a_real{};
-				return long(to_long_double());
-			}
+		int         to_int() const {
+			if (iszero()) return 0;
+			if (isnar()) throw not_a_real{};
+			return int(to_float());
+		}
+		long        to_long() const {
+			if (iszero()) return 0;
+			if (isnar()) throw not_a_real{};
+			return long(to_double());
+		}
+		long long   to_long_long() const {
+			if (iszero()) return 0;
+			if (isnar()) throw not_a_real{};
+			return long(to_long_double());
+		}
 #else
-			int         to_int() const {
-				if (iszero()) return 0;
-				if (isnar())  return int(INFINITY);
-				return int(to_float());
-			}
-			long        to_long() const {
-				if (iszero()) return 0;
-				if (isnar())  return long(INFINITY);
-				return long(to_double());
-			}
-			long long   to_long_long() const {
-				if (iszero()) return 0;
-				if (isnar())  return (long long)(INFINITY);
-				return long(to_long_double());
-			}
+		int         to_int() const {
+			if (iszero()) return 0;
+			if (isnar())  return int(INFINITY);
+			return int(to_float());
+		}
+		long        to_long() const {
+			if (iszero()) return 0;
+			if (isnar())  return long(INFINITY);
+			return long(to_double());
+		}
+		long long   to_long_long() const {
+			if (iszero()) return 0;
+			if (isnar())  return (long long)(INFINITY);
+			return long(to_long_double());
+		}
 #endif
-			float       to_float() const {
-				posit8_t p = { { _bits } };
-				return posit8_tof(p);
-			}
-			double      to_double() const {
-				return (double)to_float();
-			}
-			long double to_long_double() const {
-				return (long double)to_float();
-			}
+		float       to_float() const {
+			posit8_t p = { { _bits } };
+			return posit8_tof(p);
+		}
+		double      to_double() const {
+			return (double)to_float();
+		}
+		long double to_long_double() const {
+			return (long double)to_float();
+		}
 
 
-			// helper methods			
-			posit& integer_assign(int rhs) {
-				posit8_t p = posit8_fromsi(rhs);
-				_bits = p.v;
+		// helper methods			
+		constexpr posit& integer_assign(int rhs) {
+			// special case for speed as this is a common initialization
+			if (rhs == 0) {
+				_bits = 0x0;
 				return *this;
 			}
-			posit& float_assign(float rhs) {
-				posit8_t p = posit8_fromf(rhs);
-				_bits = p.v;
-				return *this;
+			bool sign = (rhs < 0) ? true : false;
+			int v = sign ? -rhs : rhs; // project to positive side of the projective reals
+			uint8_t raw = 0;
+			if (v > 48) { // +-maxpos
+				raw = 0x7F;
+			}
+			else if (v < 2) {
+				raw = (v << 6);
+			}
+			else {
+				uint8_t mask = 0x40;
+				int8_t k = 6;
+				uint8_t fraction_bits = (v & 0xff);
+				while (!(fraction_bits & mask)) {
+					k--;
+					fraction_bits <<= 1;
+				}
+				fraction_bits = (fraction_bits ^ mask);
+				raw = (0x7F ^ (0x3F >> k)) | (fraction_bits >> (k + 1));
+
+				mask = 0x1 << k; //bitNPlusOne
+				if (mask & fraction_bits) {
+					if (((mask - 1) & fraction_bits) | ((mask << 1) & fraction_bits)) raw++;
+				}
 			}
 
-			// I/O operators
-			friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_8, ES_IS_0>& p);
-			friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_8, ES_IS_0>& p);
+			_bits = sign ? -raw : raw;
+			return *this;
+		}
+		constexpr posit& float_assign(float rhs) {
+			bool sign = false;
+			bool bitNPlusOne = 0, bitsMore = 0;
+			constexpr float _minpos = 0.015625f;
+			constexpr float _maxpos = 64.0f;
 
-			// posit - posit logic functions
-			friend bool operator==(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
-			friend bool operator!=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
-			friend bool operator< (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
-			friend bool operator> (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
-			friend bool operator<=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
-			friend bool operator>=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
+			sign = (rhs < 0.0) ? true : false;
 
-		};
+			if (std::isinf(rhs) || std::isnan(rhs)) {
+				_bits = 0x80;
+			}
+			else if (rhs == 0) {
+				_bits = 0;
+			}
+			else if (rhs == 1.0f) {
+				_bits = 0x40;
+			}
+			else if (rhs == -1.0f) {
+				_bits = 0xC0;
+			}
+			else if (rhs >= _maxpos) {
+				_bits = 0x7F;
+			}
+			else if (rhs <= -_maxpos) {
+				_bits = 0x81;
+			}
+			else if (rhs <= _minpos && !sign) {
+				_bits = 0x01;
+			}
+			else if (rhs >= -_minpos && sign) {
+				_bits = 0xFF;
+			}
+			else if (rhs < -1 || rhs > 1) {
+				if (sign) {
+					rhs = -rhs; // project to positive reals to simplify computation
+				}
 
-		// posit I/O operators
-		// generate a posit format ASCII format nbits.esxNN...NNp
-		inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_8, ES_IS_0>& p) {
-			// to make certain that setw and left/right operators work properly
-			// we need to transform the posit into a string
-			std::stringstream ss;
+				if (rhs <= _minpos) {
+					_bits = 0x01;
+				}
+				else { // determine the regime	
+					unsigned k = 1; //because k = m-1, we need to add back 1
+					while (rhs >= 2) {
+						rhs *= 0.5;
+						k++;
+					}
+
+					// rounding off regime bits
+					if (k > 6) {
+						_bits = 0x7F;
+					}
+					else {
+						int8_t fracLength = 6 - k;
+						uint8_t frac = (uint8_t)posit8_convertFraction(rhs, fracLength, &bitNPlusOne, &bitsMore);
+						uint_fast8_t regime = 0x7F - (0x7F >> k);
+						_bits = (regime + frac);
+						if (bitNPlusOne) _bits += ((_bits & 0x01) | bitsMore);
+					}
+					_bits = sign ? -_bits : _bits;
+				}
+			}
+			else if (rhs > -1 && rhs < 1) {
+				if (sign) {
+					rhs = -rhs;
+				}
+				unsigned k = 0;
+				while (rhs < 1) {
+					rhs *= 2;
+					k++;
+				}
+				// rounding off regime bits
+				if (k > 6)
+					_bits = 0x1;
+				else {
+					int8_t fracLength = 6 - k;
+					uint8_t frac = (uint8_t)posit8_convertFraction(rhs, fracLength, &bitNPlusOne, &bitsMore);
+					uint8_t regime = 0x40 >> k;
+					_bits = (regime + frac);
+					if (bitNPlusOne) _bits += ((_bits & 0x01) | bitsMore);
+				}
+				_bits = sign ? -_bits : _bits;
+			}
+			else {
+				//NaR - for NaN, INF and all other combinations
+				_bits = 0x80;
+			}
+			return *this;
+		}
+
+		// I/O operators
+		friend std::ostream& operator<< (std::ostream& ostr, const posit<NBITS_IS_8, ES_IS_0>& p);
+		friend std::istream& operator>> (std::istream& istr, posit<NBITS_IS_8, ES_IS_0>& p);
+
+		// posit - posit logic functions
+		friend bool operator==(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
+		friend bool operator!=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
+		friend bool operator< (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
+		friend bool operator> (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
+		friend bool operator<=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
+		friend bool operator>=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs);
+
+	};
+
+	// posit I/O operators
+	// generate a posit format ASCII format nbits.esxNN...NNp
+	inline std::ostream& operator<<(std::ostream& ostr, const posit<NBITS_IS_8, ES_IS_0>& p) {
+		// to make certain that setw and left/right operators work properly
+		// we need to transform the posit into a string
+		std::stringstream ss;
 #if POSIT_ROUNDING_ERROR_FREE_IO_FORMAT
-			ss << NBITS_IS_8 << '.' << ES_IS_0 << 'x' << to_hex(p.get()) << 'p';
+		ss << NBITS_IS_8 << '.' << ES_IS_0 << 'x' << to_hex(p.get()) << 'p';
 #else
-			std::streamsize prec = ostr.precision();
-			std::streamsize width = ostr.width();
-			std::ios_base::fmtflags ff;
-			ff = ostr.flags();
-			ss.flags(ff);
-			ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
+		std::streamsize prec = ostr.precision();
+		std::streamsize width = ostr.width();
+		std::ios_base::fmtflags ff;
+		ff = ostr.flags();
+		ss.flags(ff);
+		ss << std::showpos << std::setw(width) << std::setprecision(prec) << (long double)p;
 #endif
-			return ostr << ss.str();
-		}
+		return ostr << ss.str();
+	}
 
-		// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
-		inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_8, ES_IS_0>& p) {
-			std::string txt;
-			istr >> txt;
-			if (!parse(txt, p)) {
-				std::cerr << "unable to parse -" << txt << "- into a posit value\n";
-			}
-			return istr;
+	// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
+	inline std::istream& operator>> (std::istream& istr, posit<NBITS_IS_8, ES_IS_0>& p) {
+		std::string txt;
+		istr >> txt;
+		if (!parse(txt, p)) {
+			std::cerr << "unable to parse -" << txt << "- into a posit value\n";
 		}
+		return istr;
+	}
 
-		// convert a posit value to a string using "nar" as designation of NaR
-		std::string to_string(const posit<NBITS_IS_8, ES_IS_0>& p, std::streamsize precision) {
-			if (p.isnar()) {
-				return std::string("nar");
-			}
-			std::stringstream ss;
-			ss << std::setprecision(precision) << float(p);
-			return ss.str();
+	// convert a posit value to a string using "nar" as designation of NaR
+	std::string to_string(const posit<NBITS_IS_8, ES_IS_0>& p, std::streamsize precision) {
+		if (p.isnar()) {
+			return std::string("nar");
 		}
+		std::stringstream ss;
+		ss << std::setprecision(precision) << float(p);
+		return ss.str();
+	}
 
-		// posit - posit binary logic operators
-		inline bool operator==(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return lhs._bits == rhs._bits;
-		}
-		inline bool operator!=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return !operator==(lhs, rhs);
-		}
-		inline bool operator< (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return (signed char)(lhs._bits) < (signed char)(rhs._bits);
-		}
-		inline bool operator> (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return operator< (rhs, lhs);
-		}
-		inline bool operator<=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return operator< (lhs, rhs) || operator==(lhs, rhs);
-		}
-		inline bool operator>=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return !operator< (lhs, rhs);
-		}
+	// posit - posit binary logic operators
+	inline bool operator==(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return lhs._bits == rhs._bits;
+	}
+	inline bool operator!=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return !operator==(lhs, rhs);
+	}
+	inline bool operator< (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return (signed char)(lhs._bits) < (signed char)(rhs._bits);
+	}
+	inline bool operator> (const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return operator< (rhs, lhs);
+	}
+	inline bool operator<=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return operator< (lhs, rhs) || operator==(lhs, rhs);
+	}
+	inline bool operator>=(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return !operator< (lhs, rhs);
+	}
 
-		/* base class has these operators: no need to specialize */
-		inline posit<NBITS_IS_8, ES_IS_0> operator+(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {				
-			posit<NBITS_IS_8, ES_IS_0> result = lhs;
-			return result += rhs;
-		}
-		inline posit<NBITS_IS_8, ES_IS_0> operator-(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			posit<NBITS_IS_8, ES_IS_0> result = lhs;
-			return result -= rhs;
+	/* base class has these operators: no need to specialize */
+	inline posit<NBITS_IS_8, ES_IS_0> operator+(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {				
+		posit<NBITS_IS_8, ES_IS_0> result = lhs;
+		return result += rhs;
+	}
+	inline posit<NBITS_IS_8, ES_IS_0> operator-(const posit<NBITS_IS_8, ES_IS_0>& lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		posit<NBITS_IS_8, ES_IS_0> result = lhs;
+		return result -= rhs;
 
-		}
+	}
 			
-		// binary operator*() is provided by generic class
+	// binary operator*() is provided by generic class
 
 #if POSIT_ENABLE_LITERALS
-		// posit - literal logic functions
+	// posit - literal logic functions
 
-		// posit - int logic operators
-		inline bool operator==(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
-			return operator==(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
-		}
-		inline bool operator!=(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
-			return !operator==(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
-		}
-		inline bool operator< (const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
-			return operator<(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
-		}
-		inline bool operator> (const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
-			return operator< (posit<NBITS_IS_8, ES_IS_0>(rhs), lhs);
-		}
-		inline bool operator<=(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
-			return operator< (lhs, posit<NBITS_IS_8, ES_IS_0>(rhs)) || operator==(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
-		}
-		inline bool operator>=(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
-			return !operator<(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
-		}
+	// posit - int logic operators
+	inline bool operator==(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
+		return operator==(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
+	}
+	inline bool operator!=(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
+		return !operator==(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
+	}
+	inline bool operator< (const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
+		return operator<(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
+	}
+	inline bool operator> (const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
+		return operator< (posit<NBITS_IS_8, ES_IS_0>(rhs), lhs);
+	}
+	inline bool operator<=(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
+		return operator< (lhs, posit<NBITS_IS_8, ES_IS_0>(rhs)) || operator==(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
+	}
+	inline bool operator>=(const posit<NBITS_IS_8, ES_IS_0>& lhs, int rhs) {
+		return !operator<(lhs, posit<NBITS_IS_8, ES_IS_0>(rhs));
+	}
 
-		// int - posit logic operators
-		inline bool operator==(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return posit<NBITS_IS_8, ES_IS_0>(lhs) == rhs;
-		}
-		inline bool operator!=(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return !operator==(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
-		}
-		inline bool operator< (int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return operator<(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
-		}
-		inline bool operator> (int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return operator< (posit<NBITS_IS_8, ES_IS_0>(rhs), lhs);
-		}
-		inline bool operator<=(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return operator< (posit<NBITS_IS_8, ES_IS_0>(lhs), rhs) || operator==(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
-		}
-		inline bool operator>=(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
-			return !operator<(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
-		}
+	// int - posit logic operators
+	inline bool operator==(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return posit<NBITS_IS_8, ES_IS_0>(lhs) == rhs;
+	}
+	inline bool operator!=(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return !operator==(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
+	}
+	inline bool operator< (int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return operator<(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
+	}
+	inline bool operator> (int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return operator< (posit<NBITS_IS_8, ES_IS_0>(rhs), lhs);
+	}
+	inline bool operator<=(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return operator< (posit<NBITS_IS_8, ES_IS_0>(lhs), rhs) || operator==(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
+	}
+	inline bool operator>=(int lhs, const posit<NBITS_IS_8, ES_IS_0>& rhs) {
+		return !operator<(posit<NBITS_IS_8, ES_IS_0>(lhs), rhs);
+	}
 
 #endif // POSIT_ENABLE_LITERALS
 
@@ -356,5 +469,5 @@ namespace sw {
 #	define POSIT_FAST_POSIT_8_0 0
 #endif // POSIT_FAST_POSIT_8_0
 
-	}
-}
+} // namespace unum
+} // namespace sw

--- a/include/universal/posit/specialized/posit_8_0.hpp
+++ b/include/universal/posit/specialized/posit_8_0.hpp
@@ -252,7 +252,9 @@ namespace unum {
 
 			sign = (rhs < 0.0) ? true : false;
 
-			if (std::isinf(rhs) || std::isnan(rhs)) {
+			constexpr int spfbits = std::numeric_limits<float>::digits - 1;
+			value<spfbits> v(rhs);
+			if (v.isinf() || v.isnan()) {
 				_bits = 0x80;
 			}
 			else if (rhs == 0) {

--- a/include/universal/posit/value.hpp
+++ b/include/universal/posit/value.hpp
@@ -37,19 +37,19 @@ public:
 	constexpr value(const value& rhs)                       { *this = rhs; }
 
 	// decorated constructors
-	explicit constexpr value(const signed char initial_value)        { *this = initial_value; }
-	explicit constexpr value(const short initial_value)              { *this = initial_value; }
-	explicit constexpr value(const int initial_value)                { *this = initial_value; }
-	explicit constexpr value(const long initial_value)               { *this = initial_value; }
-	explicit constexpr value(const long long initial_value)          { *this = initial_value; }
-	explicit constexpr value(const char initial_value)               { *this = initial_value; }
-	explicit constexpr value(const unsigned short initial_value)     { *this = initial_value; }
-	explicit constexpr value(const unsigned int initial_value)       { *this = initial_value; }
-	explicit constexpr value(const unsigned long initial_value)      { *this = initial_value; }
-	explicit constexpr value(const unsigned long long initial_value) { *this = initial_value; }
-	explicit constexpr value(const float initial_value)              { *this = initial_value; }
-	         constexpr value(const double initial_value) : value{}   { *this = initial_value; }
-	explicit constexpr value(const long double initial_value)        { *this = initial_value; }
+	explicit constexpr value(signed char initial_value)        { *this = initial_value; }
+	explicit constexpr value(short initial_value)              { *this = initial_value; }
+	explicit constexpr value(int initial_value)                { *this = initial_value; }
+	explicit constexpr value(long initial_value)               { *this = initial_value; }
+	explicit constexpr value(long long initial_value)          { *this = initial_value; }
+	explicit constexpr value(char initial_value)               { *this = initial_value; }
+	explicit constexpr value(unsigned short initial_value)     { *this = initial_value; }
+	explicit constexpr value(unsigned int initial_value)       { *this = initial_value; }
+	explicit constexpr value(unsigned long initial_value)      { *this = initial_value; }
+	explicit constexpr value(unsigned long long initial_value) { *this = initial_value; }
+	explicit constexpr value(float initial_value)              { *this = initial_value; }
+	         constexpr value(double initial_value) : value{}   { *this = initial_value; }
+	explicit constexpr value(long double initial_value)        { *this = initial_value; }
 
 	constexpr value& operator=(const value& rhs) {
 		_sign	  = rhs._sign;
@@ -61,23 +61,23 @@ public:
 		_nan      = rhs._nan;
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const signed char rhs) {
+	constexpr value<fbits>& operator=(signed char rhs) {
 		*this = static_cast<long long>(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const short rhs) {
+	constexpr value<fbits>& operator=(short rhs) {
 		*this = static_cast<long long>(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const int rhs) {
+	constexpr value<fbits>& operator=(int rhs) {
 		*this = static_cast<long long>(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const long rhs) {
+	constexpr value<fbits>& operator=(long rhs) {
 		*this = static_cast<long long>(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const long long rhs) {
+	constexpr value<fbits>& operator=(long long rhs) {
 		if (_trace_conversion) std::cout << "---------------------- CONVERT -------------------" << std::endl;
 		if (rhs == 0) {
 			setzero();
@@ -106,23 +106,23 @@ public:
 		}
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const char rhs) {
+	constexpr value<fbits>& operator=(char rhs) {
 		*this = (unsigned long long)(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const unsigned short rhs) {
+	constexpr value<fbits>& operator=(unsigned short rhs) {
 		*this = static_cast<long long>(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const unsigned int rhs) {
+	constexpr value<fbits>& operator=(unsigned int rhs) {
 		*this = static_cast<long long>(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const unsigned long rhs) {
+	constexpr value<fbits>& operator=(unsigned long rhs) {
 		*this = static_cast<long long>(rhs);
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const unsigned long long rhs) {
+	constexpr value<fbits>& operator=(unsigned long long rhs) {
 		if (_trace_conversion) std::cout << "---------------------- CONVERT -------------------" << std::endl;
 		if (rhs == 0) {
 			setzero();
@@ -137,7 +137,7 @@ public:
 		if (_trace_conversion) std::cout << "uint64 " << rhs << " sign " << _sign << " scale " << _scale << " fraction b" << _fraction << std::dec << std::endl;
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const float rhs) {
+	constexpr value<fbits>& operator=(float rhs) {
 		reset();
 		if (_trace_conversion) std::cout << "---------------------- CONVERT -------------------" << std::endl;
 
@@ -170,7 +170,7 @@ public:
 		}
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const double rhs) {
+	constexpr value<fbits>& operator=(double rhs) {
                 using std::get;
 		reset();
 		if (_trace_conversion) std::cout << "---------------------- CONVERT -------------------" << std::endl;
@@ -212,7 +212,7 @@ public:
 		}
 		return *this;
 	}
-	constexpr value<fbits>& operator=(const long double rhs) {
+	constexpr value<fbits>& operator=(long double rhs) {
 		reset();
 		if (_trace_conversion) std::cout << "---------------------- CONVERT -------------------" << std::endl;
 

--- a/include/universal/posit/value.hpp
+++ b/include/universal/posit/value.hpp
@@ -311,9 +311,9 @@ public:
 	inline void setExponent(int e) { _scale = e; }
 	inline bool isneg() const { return _sign; }
 	inline bool ispos() const { return !_sign; }
-	inline bool iszero() const { return _zero; }
-	inline bool isinf() const { return _inf; }
-	inline bool isnan() const { return _nan; }
+	inline constexpr bool iszero() const { return _zero; }
+	inline constexpr bool isinf() const { return _inf; }
+	inline constexpr bool isnan() const { return _nan; }
 	inline bool sign() const { return _sign; }
 	inline int scale() const { return _scale; }
 	bitblock<fbits> fraction() const { return _fraction; }

--- a/tests/fixpnt/complex.cpp
+++ b/tests/fixpnt/complex.cpp
@@ -50,6 +50,7 @@ try {
 
 #if MANUAL_TESTING
 
+#if defined(__GNUG__)
 	{
 		// reference using native double precision floating point type
 		using namespace std::complex_literals;
@@ -58,27 +59,23 @@ try {
 		std::complex<double> z1 = 1i * 1i;     // imaginary unit squared
 		std::cout << "i * i = " << z1 << '\n';
 
-#if defined(__GNUG__)
-		// the pow and exp functions don't match in g++
-		// no idea how to fix the code below to make it compile with g++
-#else
-		std::complex<double> z2 = std::pow(1.0i, 2.0); // imaginary unit squared
-		std::cout << "pow(i, 2) = " << z2 << '\n';
+//		std::complex<double> z2 = std::pow(1.0i, 2.0); // imaginary unit squared
+//		std::cout << "pow(i, 2) = " << z2 << '\n';
 
-		double PI = std::acos(-1);
-		std::complex<double> z3 = std::exp(1i * PI); // Euler's formula
-		std::cout << "exp(i * pi) = " << z3 << '\n';
-#endif
+//		double PI = std::acos(-1);
+//		std::complex<double> z3 = std::exp(1i * PI); // Euler's formula
+//		std::cout << "exp(i * pi) = " << z3 << '\n';
 
-		std::complex<double> z4 = 1. + 2i, z5 = 1. - 2i; // conjugates
+		std::complex<double> z4{1.0, +2.0}, z5{1.0, -2.0}; // conjugates
 		std::cout << "(1+2i)*(1-2i) = " << z4 * z5 << '\n';
 	}
 
-#if defined(__GNUG__)
+#undef GPP_FIX
+#ifdef GPP_FIX
 	// for some reason the g++ doesn't compile this section as it is casting the constants differently
 	// than other compilers.
-			// no idea how to fix the code below to make it compile with g++
-/*
+	// no idea how to fix the code below to make it compile with g++
+	{
 		using namespace sw::unum::complex_literals;
 		using Real = sw::unum::fixpnt<8, 4>;
 		std::cout << std::fixed << std::setprecision(1);
@@ -95,7 +92,9 @@ try {
 
 		std::complex<Real> z4 = 1.0 + 2i, z5 = 1.0 - 2i; // conjugates
 		std::cout << "(1+2i)*(1-2i) = " << z4 * z5 << '\n';
-
+	}
+#endif // GPP_FIX
+/*
 	error: conversion from '__complex__ int' to non - scalar type 'std::complex<sw::unum::fixpnt<8, 4> >' requested
 		std::complex<Real> z1 = 1i * 1i;     // imaginary unit squared
 		                        ~~~^~~~
@@ -108,7 +107,28 @@ try {
 */
     // furthermore, the pow and exp functions don't match the correct complex<double> arguments in g++
 
-#else
+#else  // not G++
+
+	{
+		// reference using native double precision floating point type
+		using namespace std::complex_literals;
+		std::cout << std::fixed << std::setprecision(1);
+
+		std::complex<double> z1 = 1i * 1i;     // imaginary unit squared
+		std::cout << "i * i = " << z1 << '\n';
+
+		// the pow and exp functions don't match in g++
+		// no idea how to fix the code below to make it compile with g++
+		std::complex<double> z2 = std::pow(1.0i, 2.0); // imaginary unit squared
+		std::cout << "pow(i, 2) = " << z2 << '\n';
+
+		double PI = std::acos(-1);
+		std::complex<double> z3 = std::exp(1i * PI); // Euler's formula
+		std::cout << "exp(i * pi) = " << z3 << '\n';
+
+		std::complex<double> z4 = 1. + 2i, z5 = 1. - 2i; // conjugates
+		std::cout << "(1+2i)*(1-2i) = " << z4 * z5 << '\n';
+	}
 
 	{
 		// all the literals are marshalled through the std library double native type for complex literals

--- a/tests/fixpnt/complex/mod_complex_mul.cpp
+++ b/tests/fixpnt/complex/mod_complex_mul.cpp
@@ -120,7 +120,7 @@ try {
 	using namespace std;
 	using namespace sw::unum;
 
-	bool bReportIndividualTestCases = true;
+	bool bReportIndividualTestCases = false;
 	int nrOfFailedTestCases = 0;
 
 	std::string tag = "complex modulo multiplication failed: ";
@@ -175,11 +175,11 @@ try {
 
 	cout << "Fixed-point complex modulo multiplication validation" << endl;
 
-	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 0, Modulo, uint8_t>("Manual Testing", true), "fixpnt<4,0,Modulo,uint8_t>", "multiplication");
-	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 1, Modulo, uint8_t>("Manual Testing", true), "fixpnt<4,1,Modulo,uint8_t>", "multiplication");
-	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 2, Modulo, uint8_t>("Manual Testing", true), "fixpnt<4,2,Modulo,uint8_t>", "multiplication");
-	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 3, Modulo, uint8_t>("Manual Testing", true), "fixpnt<4,3,Modulo,uint8_t>", "multiplication");
-	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 4, Modulo, uint8_t>("Manual Testing", true), "fixpnt<4,4,Modulo,uint8_t>", "multiplication");
+	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 0, Modulo, uint8_t>("Manual Testing", bReportIndividualTestCases), "fixpnt<4,0,Modulo,uint8_t>", "multiplication");
+	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 1, Modulo, uint8_t>("Manual Testing", bReportIndividualTestCases), "fixpnt<4,1,Modulo,uint8_t>", "multiplication");
+	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 2, Modulo, uint8_t>("Manual Testing", bReportIndividualTestCases), "fixpnt<4,2,Modulo,uint8_t>", "multiplication");
+	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 3, Modulo, uint8_t>("Manual Testing", bReportIndividualTestCases), "fixpnt<4,3,Modulo,uint8_t>", "multiplication");
+	nrOfFailedTestCases += ReportTestResult(VerifyComplexMultiplication<4, 4, Modulo, uint8_t>("Manual Testing", bReportIndividualTestCases), "fixpnt<4,4,Modulo,uint8_t>", "multiplication");
 
 #if STRESS_TESTING
 

--- a/tests/posit/complex_add.cpp
+++ b/tests/posit/complex_add.cpp
@@ -144,6 +144,8 @@ try {
    std::complex<Real> z4 = 1. + 2i, z5 = 1. - 2i; // conjugates
                                          ~~~^~~~
 */
+		std::complex<Real> z4{1.0, +2.0}, z5{1.0, -2.0}; // conjugates
+		cout << "(1+2i)*(1-2i) = " << z4 * z5 << '\n';
 #else
 		std::complex<Real> z4 = 1. + 2i, z5 = 1. - 2i; // conjugates
 		cout << "(1+2i)*(1-2i) = " << z4 * z5 << '\n';
@@ -155,6 +157,7 @@ try {
 		cout << z1 << endl;
 	}
 
+	nrOfFailedTestCases += ReportTestResult(ValidateComplexAddition<2, 0>(tag, bReportIndividualTestCases), "posit<2,0>", "addition");
 	// manual exhaustive test
 	nrOfFailedTestCases += ReportTestResult(ValidateComplexAddition<5, 0>("Manual Testing", true), "complex<posit<5,0>>", "addition");
 	nrOfFailedTestCases += ReportTestResult(ValidateComplexAddition<5, 1>("Manual Testing", true), "complex<posit<5,1>>", "addition");

--- a/tests/posit/specialized/posit_16_1.cpp
+++ b/tests/posit/specialized/posit_16_1.cpp
@@ -31,7 +31,7 @@ try {
 	constexpr size_t es = 1;
 
 	int nrOfFailedTestCases = 0;
-	bool bReportIndividualTestCases = false;
+	bool bReportIndividualTestCases = true;
 	std::string tag = " posit<16,1>";
 
 #if POSIT_FAST_POSIT_16_1

--- a/tests/posit/specialized/posit_16_1.cpp
+++ b/tests/posit/specialized/posit_16_1.cpp
@@ -44,12 +44,16 @@ try {
 	cout << dynamic_range(p) << endl << endl;
 
 	// special cases
+	cout << "Special case tests " << endl;
+	string test = "Initialize to zero: ";
 	p = 0;
-	if (!p.iszero()) ++nrOfFailedTestCases;
+	nrOfFailedTestCases += ReportCheck(tag, test, p.iszero());
+	test = "Initialize to NAN";
 	p = NAN;
-	if (!p.isnar()) ++nrOfFailedTestCases;
+	nrOfFailedTestCases += ReportCheck(tag, test, p.isnar());
+	test = "Initialize to INFINITY";
 	p = INFINITY;
-	if (!p.isnar()) ++nrOfFailedTestCases;
+	nrOfFailedTestCases += ReportCheck(tag, test, p.isnar());
 
 	// logic tests
 	cout << "Logic operator tests " << endl;

--- a/tests/posit/specialized/posit_32_2.cpp
+++ b/tests/posit/specialized/posit_32_2.cpp
@@ -77,12 +77,16 @@ try {
 	cout << dynamic_range(p) << endl << endl;
 
 	// special cases
+	cout << "Special case tests " << endl;
+	string test = "Initialize to zero: ";
 	p = 0;
-	if (!p.iszero()) ++nrOfFailedTestCases;
+	nrOfFailedTestCases += ReportCheck(tag, test, p.iszero());
+	test = "Initialize to NAN";
 	p = NAN;
-	if (!p.isnar()) ++nrOfFailedTestCases;
+	nrOfFailedTestCases += ReportCheck(tag, test, p.isnar());
+	test = "Initialize to INFINITY";
 	p = INFINITY;
-	if (!p.isnar()) ++nrOfFailedTestCases;
+	nrOfFailedTestCases += ReportCheck(tag, test, p.isnar());
 
 	// logic tests
 	cout << "Logic operator tests " << endl;

--- a/tests/utils/posit_test_helpers.hpp
+++ b/tests/utils/posit_test_helpers.hpp
@@ -630,7 +630,9 @@ namespace unum {
 			pref = std::sqrt(da);
 			if (psqrt != pref) {
 				nrOfFailedTests++;
+				std::cout << psqrt << " != " << pref << std::endl;
 				if (bReportIndividualTestCases)	ReportUnaryArithmeticError("FAIL", "sqrt", pa, pref, psqrt);
+				if (nrOfFailedTests > 24) return nrOfFailedTests;
 			}
 			else {
 				//if (bReportIndividualTestCases) ReportUnaryArithmeticSuccess("PASS", "sqrt", pa, pref, psqrt);

--- a/tests/utils/posit_test_randoms.hpp
+++ b/tests/utils/posit_test_randoms.hpp
@@ -257,7 +257,7 @@ namespace unum {
 				if (bReportIndividualTestCases) ReportBinaryArithmeticError("FAIL", operation_string, pa, pb, preference, presult);
 			}
 			else {
-				if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", operation_string, pa, pb, preference, presult);
+				//if (bReportIndividualTestCases) ReportBinaryArithmeticSuccess("PASS", operation_string, pa, pb, preference, presult);
 			}
 		}
 

--- a/tests/utils/test_helpers.hpp
+++ b/tests/utils/test_helpers.hpp
@@ -17,3 +17,17 @@ int ReportTestResult(int nrOfFailedTests, const std::string& description, const 
 	return nrOfFailedTests;
 }
 
+// simple checker
+int ReportCheck(const std::string& tag, const std::string& test, bool success) {
+	using namespace std;
+	constexpr int TEST_TAG_WIDTH = 27;
+	int nrOfFailedTestCases = 0;
+	if (success) {
+		cout << tag << " " << left << setw(TEST_TAG_WIDTH) << test << "PASS\n";
+	}
+	else {
+		++nrOfFailedTestCases;
+		cout << tag << " " << left << setw(TEST_TAG_WIDTH) << test << "FAIL\n";
+	}
+	return nrOfFailedTestCases;
+}

--- a/tests/utils/test_helpers.hpp
+++ b/tests/utils/test_helpers.hpp
@@ -1,18 +1,20 @@
+#pragma once
 //  test_helpers.cpp : functions to aid in testing and test reporting
 //
 // Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-
+#include <iostream>
+#include <iomanip>
 
 // test reporting helper
-int ReportTestResult(int nrOfFailedTests, const std::string& description, const std::string& test_operation)
-{
+int ReportTestResult(int nrOfFailedTests, const std::string& description, const std::string& test_operation) {
+	using namespace std;
 	if (nrOfFailedTests > 0) {
-		std::cout << description << " " << test_operation << " FAIL " << nrOfFailedTests << " failed test cases" << std::endl;
+		cout << description << " " << test_operation << " FAIL " << nrOfFailedTests << " failed test cases\n";
 	}
 	else {
-		std::cout << description << " " << test_operation << " PASS" << std::endl;
+		cout << description << " " << test_operation << " PASS\n";
 	}
 	return nrOfFailedTests;
 }


### PR DESCRIPTION
in the <complex> library, constexpr types are used in function evaluation. To use posit types in these contexts, we need to make the posit class constexpr valid.

This check-in is a first step towards that goal. The underlying bitset and the conversion functions are not yet constexpr valid, so we need to plan out how to make them.