### PR TITLE
Remove dependency on long double in sqrt.hpp

### DIFF
--- a/include/universal/posit/math/sqrt.hpp
+++ b/include/universal/posit/math/sqrt.hpp
@@ -180,7 +180,7 @@ namespace sw {
 #else
 		template<size_t nbits, size_t es>
 		inline posit<nbits, es> sqrt(const posit<nbits, es>& a) {
-			return posit<nbits, es>(std::sqrt((long double)a));
+			return posit<nbits, es>(std::sqrt((double)a));
 		}
 #endif
 


### PR DESCRIPTION
Fixing https://github.com/stillwater-sc/universal/issues/144, Sqrt was not working when building TVM on a 32-bit i386 machine.

This change keeps the posit math functions consistent as well,
since sqrt is the only one that casts to `long double` while other math functions cast to `double`.

cc: @Ravenwater 