### PR TITLE
Fix Lowest Posit Function

### DIFF
--- a/include/universal/posit/numeric_limits.hpp
+++ b/include/universal/posit/numeric_limits.hpp
@@ -140,8 +140,8 @@ namespace std {
 			return sw::unum::maxpos<nbits, es>(pmaxpos);
 		} 
 		static constexpr Posit lowest() { // return most negative value
-			Posit pmaxneg;
-			return sw::unum::maxneg<nbits, es>(pmaxneg);
+			Posit pminneg;
+			return sw::unum::minneg<nbits, es>(pminneg);
 		} 
 		static constexpr Posit epsilon() { // return smallest effective increment from 1.0
 			Posit one{ 1 }, incr{ 1 };


### PR DESCRIPTION
IIUC, maxneg returns the maximum negative value,
while minneg returns the min negative value, which is what the lowest posit value is

@Ravenwater there should also be a regression test for this, I poked around a bit but wasn't sure where a good place for the test to live would be