### PR TITLE
Iso constants precision experiments

### DIFF
--- a/applications/science/physics_constants.cpp
+++ b/applications/science/physics_constants.cpp
@@ -104,13 +104,17 @@ std::string report_compiler_version() {
 }
 
 template<typename Scalar>
-void Represent(std::ostream& ostr, Scalar s, std::streamsize precision = 17) {
+void Represent(std::ostream& ostr, Scalar s, std::streamsize precision = 17, bool hexFormat = false) {
 	using namespace std;
 	// preserve the existing ostream precision
 	auto old_precision = cout.precision();
 	ostr << setprecision(precision);
 
-	ostr << s << endl;
+	ostr << setw(15) << s;
+	if (hexFormat) {
+		ostr << " : " << setw(70) << color_print(s) << " : " << hex_format(s);
+	}
+	ostr << endl;
 
 	// restore the previous ostream precision
 	ostr << setprecision(old_precision);
@@ -121,11 +125,12 @@ void Sample(std::ostream& ostr, long double constant) {
 	Represent(ostr << minmax_range< long double  >() << " : ", constant, 23);
 	Represent(ostr << minmax_range< double       >() << " : ", double(constant), 15);
 	Represent(ostr << minmax_range< float        >() << " : ", float(constant), 6);
-	Represent(ostr << minmax_range< posit<32, 2> >() << " : ", posit<32, 2>(constant));
-	Represent(ostr << minmax_range< posit<32, 3> >() << " : ", posit<32, 3>(constant));
-	Represent(ostr << minmax_range< posit<40, 3> >() << " : ", posit<40, 3>(constant));
-	Represent(ostr << minmax_range< posit<48, 3> >() << " : ", posit<48, 3>(constant));
-	Represent(ostr << minmax_range< posit<64, 3> >() << " : ", posit<64, 3>(constant));
+	Represent(ostr << minmax_range< posit<32, 2> >() << " : ", posit<32, 2>(constant), 4, true);
+	Represent(ostr << minmax_range< posit<32, 3> >() << " : ", posit<32, 3>(constant), 6, true);
+	Represent(ostr << minmax_range< posit<40, 3> >() << " : ", posit<40, 3>(constant), 8, true);
+	Represent(ostr << minmax_range< posit<48, 3> >() << " : ", posit<48, 3>(constant), 10, true);
+	Represent(ostr << minmax_range< posit<56, 3> >() << " : ", posit<56, 3>(constant), 12, true);
+	Represent(ostr << minmax_range< posit<64, 3> >() << " : ", posit<64, 3>(constant), 15, true);
 }
 
 void CompareIEEEValues(std::ostream& ostr, long double constant) {

--- a/include/universal/blas/vector.hpp
+++ b/include/universal/blas/vector.hpp
@@ -6,6 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <iostream>
 #include <iomanip>
+#include <sstream>
 #include <vector>
 #include <initializer_list>
 #include <cmath>  // for std::sqrt

--- a/include/universal/native/ieee-754.hpp
+++ b/include/universal/native/ieee-754.hpp
@@ -483,6 +483,7 @@ inline std::string to_triple(const long double& number) {
 	ss << scale << ',';
 
 	// print fraction bits
+	ss << (decoder.parts.bit63 ? '1' : '0');
 	uint64_t mask = (uint64_t(1) << 62);
 	for (int i = 62; i >= 0; --i) {
 		ss << ((decoder.parts.fraction & mask) ? '1' : '0');
@@ -490,6 +491,48 @@ inline std::string to_triple(const long double& number) {
 	}
 
 	ss << ')';
+	return ss.str();
+}
+
+// generate a color coded binary string for a native double precision IEEE floating point
+inline std::string color_print(const long double& number) {
+	std::stringstream ss;
+	long_double_decoder decoder;
+	decoder.ld = number;
+
+	Color red(ColorCode::FG_RED);
+	Color yellow(ColorCode::FG_YELLOW);
+	Color blue(ColorCode::FG_BLUE);
+	Color magenta(ColorCode::FG_MAGENTA);
+	Color cyan(ColorCode::FG_CYAN);
+	Color white(ColorCode::FG_WHITE);
+	Color def(ColorCode::FG_DEFAULT);
+
+	// print sign bit
+	ss << red << (decoder.parts.sign ? '1' : '0') << '.';
+
+	// print exponent bits
+	{
+		uint64_t mask = 0x8000;
+		for (int i = 15; i >= 0; --i) {
+			ss << cyan << ((decoder.parts.exponent & mask) ? '1' : '0');
+			if (i > 0 && i % 4 == 0) ss << cyan << '\'';
+			mask >>= 1;
+		}
+	}
+
+	ss << '.';
+
+	// print fraction bits
+	ss << magenta << (decoder.parts.bit63 ? '1' : '0');
+	uint64_t mask = (uint64_t(1) << 62);
+	for (int i = 62; i >= 0; --i) {
+		ss << magenta << ((decoder.parts.fraction & mask) ? '1' : '0');
+		if (i > 0 && i % 4 == 0) ss << magenta << '\'';
+		mask >>= 1;
+	}
+
+	ss << def;
 	return ss.str();
 }
 
@@ -635,8 +678,8 @@ inline std::string to_triple(const long double& number) {
 	ss << scale << ',';
 
 	// print fraction bits
-	uint64_t mask = (uint64_t(1) << 62);
 	ss << (decoder.parts.bit63 ? '1' : '0');
+	uint64_t mask = (uint64_t(1) << 62);
 	for (int i = 62; i >= 0; --i) {
 		ss << ((decoder.parts.fraction & mask) ? '1' : '0');
 		mask >>= 1;
@@ -676,8 +719,8 @@ inline std::string color_print(const long double& number) {
 	ss << '.';
 
 	// print fraction bits
-	uint64_t mask = 0x8000'0000'0000'0000;
 	ss << magenta << (decoder.parts.bit63 ? '1' : '0');
+	uint64_t mask = (uint64_t(1) << 62);
 	for (int i = 62; i >= 0; --i) {
 		ss << magenta << ((decoder.parts.fraction & mask) ? '1' : '0');
 		if (i > 0 && i % 4 == 0) ss << magenta << '\'';

--- a/tests/native/fractionviz.cpp
+++ b/tests/native/fractionviz.cpp
@@ -1,0 +1,47 @@
+//  fractionviz.cpp : fraction bits visualization of real types
+//
+// Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <iostream>
+#include <string>
+#include <universal/posit/posit>
+//#include <universal/native/ieee754.h>
+
+// conditional compile flags
+#define MANUAL_TESTING 1
+#define STRESS_TESTING 0
+
+int main()
+try {
+	using namespace std;
+	using namespace sw::unum;
+
+	// compare bits of different real number representations
+	
+	float f         = 1.0e10;
+	double d        = 1.0e10;
+	long double ld  = 1.0e10;
+	posit<32,2> p32 = 1.0e10;
+	posit<64,2> p64 = 1.0e10;
+
+	cout << color_print(f) << endl;
+	cout << color_print(d) << endl;
+	cout << color_print(ld) << endl;
+	cout << color_print(p32) << endl;
+	cout << color_print(p64) << endl;
+
+	return EXIT_SUCCESS;
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << '\n';
+	return EXIT_FAILURE;
+}

--- a/tests/utils/posit_test_randoms.hpp
+++ b/tests/utils/posit_test_randoms.hpp
@@ -425,11 +425,11 @@ namespace sw { namespace unum {
 			// generate random value
 			unsigned long long value = distr(eng);
 			pref.set_raw_bits(value);   // assign to a posit<nbits+1,es> to generate the reference we know how to perturb
-			long double da = (long double)(pref);
 
-			//std::cout << std::hex << "0x" << value << std::endl;
-			//std::cout << std::dec << da << std::endl;
 /*
+			long double da = (long double)(pref);
+			std::cout << std::hex << "0x" << value << std::endl;
+			std::cout << std::dec << da << std::endl;
 			long double eps;
 			if (value == 0) {
 				eps = minpos / 2.0;
@@ -437,7 +437,7 @@ namespace sw { namespace unum {
 			else {
 				eps = da > 0 ? da * 1.0e-6 : da * -1.0e-6;
 			}
-			*/
+*/
 
 			pprev = pnext = pref;
 			--pprev;


### PR DESCRIPTION
Due to the scale of the ISO constants, we are observing that posits with a higher es value are offering more accurate representation then the standard posit<32,2> and posit<64,2>.

This PR adds tooling and a test suite to measure these differences.