### PR TITLE
Make cfloat a trivial type and add static_asserts

### DIFF
--- a/applications/roots/rpoly_ak1.cpp
+++ b/applications/roots/rpoly_ak1.cpp
@@ -663,7 +663,7 @@ void RealIT_ak1(int* iFlag, int* NZ, double* sss, int N, double p[MDP1], int NN,
 // iFlag - flag to indicate a pair of zeros near real axis
 
 int i, j = 0, nm1 = N - 1;
-double ee, kv, mp, ms, omp, pv, s, t = 0;
+double ee, kv, mp, ms, omp{}, pv, s, t = 0;
 
 *iFlag = *NZ = 0;
 s = *sss;

--- a/include/universal/number/cfloat/attributes.hpp
+++ b/include/universal/number/cfloat/attributes.hpp
@@ -38,7 +38,7 @@ void report_range(std::ostream& ostr) {
 	constexpr bool hasSupernormals = CfloatConfiguration::hasSupernormals;
 	constexpr bool isSaturating = CfloatConfiguration::isSaturating;
 	using Cfloat = cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating>;
-	Cfloat c;
+	Cfloat c{};
 	ostr << std::setw(40) << type_tag(c) << " : [ "
 		<< c.maxneg() << " ... "
 		<< c.minneg() << " "

--- a/include/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/universal/number/cfloat/cfloat_impl.hpp
@@ -352,13 +352,7 @@ public:
 	typedef bt BlockType;
 
 	// constructors
-	constexpr cfloat() noexcept : _block{ 0 } {};
-
-	constexpr cfloat(const cfloat&) noexcept = default;
-	constexpr cfloat(cfloat&&) noexcept = default;
-
-	constexpr cfloat& operator=(const cfloat&) noexcept = default;
-	constexpr cfloat& operator=(cfloat&&) noexcept = default;
+	constexpr cfloat() = default;
 
 	// decorated/converting constructors
 	constexpr cfloat(const std::string& stringRep) {
@@ -3716,5 +3710,11 @@ using dble    = cfloat< 64, 11, uint32_t, true, false, false>;
 using fp64    = dble;
 using quad    = cfloat<128, 15, uint32_t, true, false, false>;
 using fp128   = quad;
+
+static_assert( std:: is_trivial_v<fp8    > );
+static_assert( std:: is_trivial_v<fp16   > );
+static_assert( std:: is_trivial_v<fp32   > );
+static_assert( std:: is_trivial_v<fp64   > );
+static_assert( std:: is_trivial_v<fp128  > );
 
 }} // namespace sw::universal

--- a/include/universal/number/cfloat/numeric_limits.hpp
+++ b/include/universal/number/cfloat/numeric_limits.hpp
@@ -29,7 +29,7 @@ public:
 		return Cfloat(0.5f);
 	}
 	static constexpr Cfloat denorm_min() {  // return minimum denormalized value
-		Cfloat dmin;
+		Cfloat dmin{};
 		++dmin;
 		return dmin;
 	}

--- a/include/universal/number/cfloat/table.hpp
+++ b/include/universal/number/cfloat/table.hpp
@@ -26,7 +26,7 @@ void GenerateTable(std::ostream& ostr, bool csvFormat = false)	{
 	constexpr size_t fbits = TestType::fbits;
 	using bt = typename TestType::BlockType;
 	constexpr size_t NR_VALUES = (1 << nbits);
-	TestType v;
+	TestType v{};
 
 	if (csvFormat) {
 		ostr << "\"Generate Lookup table for a " << type_tag(v) << " in CSV format\"" << std::endl;

--- a/include/universal/verification/cfloat_test_suite.hpp
+++ b/include/universal/verification/cfloat_test_suite.hpp
@@ -79,7 +79,7 @@ namespace sw { namespace universal {
 	template<typename Cfloat, sw::universal::BlockTripleOperator op>
 	void GenerateConversionTest(int scale, uint64_t rawBits) {
 		using namespace sw::universal;
-		Cfloat nut, ref;
+		Cfloat nut{}, ref{};
 //		std::cout << type_tag(nut) << '\n';
 		constexpr size_t fbits = Cfloat::fbits;
 		using bt = typename Cfloat::BlockType;
@@ -217,14 +217,14 @@ namespace sw { namespace universal {
 
 		// execute the test
 		int nrOfFailedTests = 0;
-		RefType refminpos;
+		RefType refminpos{};
 		refminpos.minpos();
 		double dminpos = double(refminpos);
 
 		// NUT: number under test
-		TestType nut, golden;
+		TestType nut{}, golden{};
 		for (size_t i = 0; i < NR_TEST_CASES && i < max_tests; ++i) {
-			RefType ref, prev, next;
+			RefType ref{}, prev{}, next{};
 			SrcType testValue{ 0.0 };
 			ref.setbits(i);
 			SrcType da = SrcType(ref);
@@ -464,8 +464,9 @@ namespace sw { namespace universal {
 		using SrcType = float;
 
 //		cfloat<32, 8, uint32_t, true, false, false> ref; // this is an IEEE-754 float
-		cfloat<32, 8, uint32_t, true, true, false> ref; // this is a superset of an IEEE-754 float with gradual overflow
-		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut;
+		cfloat<32, 8, uint32_t, true, true, false> ref{};
+		                                                // this is a superset of an IEEE-754 float with gradual overflow
+		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut{};
 
 		if (reportTestCases) { std::cerr << type_tag(nut) << '\n'; }
 		// this is too verbose, so I turned it off
@@ -517,9 +518,9 @@ namespace sw { namespace universal {
 		constexpr bool hasSupernormals = TestType::hasSupernormals;
 		constexpr bool isSaturating = TestType::isSaturating;
  
-		cfloat<64, 11, uint64_t, true, false, false> ref;  // this is an IEEE-754 double
+		cfloat<64, 11, uint64_t, true, false, false> ref{};  // this is an IEEE-754 double
 //		cfloat<64, 11, uint64_t, true, false, false> ref;  // this is a superset of an IEEE-754 double with gradual overflow
-		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut;
+		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut{};
 
 		if (reportTestCases) { std::cerr << type_tag(nut) << '\n'; }
 		// this is too verbose, so I turned it off
@@ -571,7 +572,7 @@ namespace sw { namespace universal {
 		constexpr bool hasSubnormals = true;
 		constexpr bool hasSupernormals = true;
 		constexpr bool isSaturating = false;
-		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut, result;
+		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut{}, result{};
 		float f{ 0.0f };
 		int nrOfFailedTests{ 0 };
 
@@ -601,7 +602,7 @@ namespace sw { namespace universal {
 		constexpr bool hasSubnormals = true;
 		constexpr bool hasSupernormals = true;
 		constexpr bool isSaturating = false;
-		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut, result;
+		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut{}, result{};
 		double d{ 0.0f };
 		int nrOfFailedTests{ 0 };
 
@@ -632,7 +633,7 @@ namespace sw { namespace universal {
 		constexpr bool hasSubnormals = true;
 		constexpr bool hasSupernormals = true;
 		constexpr bool isSaturating = false;
-		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut, result;
+		cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating> nut{}, result{};
 		double d{ 0.0f };
 		int nrOfFailedTests{ 0 };
 
@@ -686,7 +687,7 @@ namespace sw { namespace universal {
 
 		int nrOfTestFailures{ 0 };
 
-		cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a, nut;
+		cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a{}, nut{};
 //		std::cout << dynamic_range(a) << '\n';
 		int minposScale = minpos_scale(a);
 		int maxposScale = maxpos_scale(a);
@@ -836,7 +837,7 @@ namespace sw { namespace universal {
 
 		int nrOfTestFailures{ 0 };
 
-		cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a, nut;
+		cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a{}, nut{};
 		//		std::cout << dynamic_range(a) << '\n';
 		int minposScale = minpos_scale(a);
 		int maxposScale = maxpos_scale(a);
@@ -890,7 +891,7 @@ namespace sw { namespace universal {
 
 		int nrOfTestFailures{ 0 };
 		constexpr size_t NR_VALUES = (1u << nbits);
-		cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a;
+		cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a{};
 
 		// ADD
 		if constexpr (op == BlockTripleOperator::ADD) {
@@ -995,7 +996,7 @@ namespace sw { namespace universal {
 		// 0.11.111   nan
 
 		std::vector< Cfloat > s(NR_OF_REALS);
-		Cfloat c; // == TestType but marshalled
+		Cfloat c{}; // == TestType but marshalled
 		constexpr size_t NEGATIVE_ZERO = (1ull << (nbits - 1)); // pattern 1.00.000
 		constexpr size_t MAX_POS = (~0ull >> (64 - nbits + 1)); // pattern 0.11.111
 		size_t i = 0;
@@ -1091,7 +1092,7 @@ namespace sw { namespace universal {
 
 		int nrOfFailedTestCases = 0;
 
-		Cfloat c, ref; // == TestType but marshalled
+		Cfloat c{}, ref{}; // == TestType but marshalled
 		// starting from SNaN iterating from -inf, -maxpos to maxpos, +inf, +nan
 		for (typename std::vector < Cfloat >::iterator it = set.begin(); it != set.end() - 1; ++it) {
 			c = *it;
@@ -1185,7 +1186,7 @@ namespace sw { namespace universal {
 
 		int nrOfFailedTestCases = 0;
 
-		Cfloat c, ref;
+		Cfloat c{}, ref{};
 		// starting from +nan, +inf, maxpos, ..., +0, -0, ..., maxneg, -inf, -nan
 		for (typename std::vector < Cfloat >::iterator it = set.end() - 1; it != set.begin(); --it) {
 			c = *it;
@@ -1226,7 +1227,7 @@ namespace sw { namespace universal {
 		// Cfloat maxpos(sw::universal::SpecificValue::maxpos), maxneg(sw::universal::SpecificValue::maxneg);
 
 		double da, db, ref;  // make certain that IEEE doubles are sufficient as reference
-		Cfloat a, b, nut, cref;
+		Cfloat a{}, b{}, nut{}, cref{};
 		for (size_t i = 0; i < NR_VALUES; ++i) {
 			a.setbits(i); // number system concept requires a member function setbits()
 			da = double(a);
@@ -1372,7 +1373,7 @@ namespace sw { namespace universal {
 		// Cfloat maxpos(sw::universal::SpecificValue::maxpos), maxneg(sw::universal::SpecificValue::maxneg);
 
 		double da, db, ref;  // make certain that IEEE doubles are sufficient as reference
-		Cfloat a, b, nut, cref;
+		Cfloat a{}, b{}, nut{}, cref{};
 		for (size_t i = 0; i < NR_VALUES; ++i) {
 			a.setbits(i); // number system concept requires a member function setbits()
 			da = double(a);
@@ -1519,7 +1520,7 @@ namespace sw { namespace universal {
 		// Cfloat maxpos(sw::universal::SpecificValue::maxpos), maxneg(sw::universal::SpecificValue::maxneg);
 
 		double da, db, ref;  // make certain that IEEE doubles are sufficient as reference
-		Cfloat a, b, nut, cref;
+		Cfloat a{}, b{}, nut{}, cref{};
 		for (size_t i = 0; i < NR_VALUES; ++i) {
 			a.setbits(i); // number system concept requires a member function setbits()
 			da = double(a);
@@ -1659,7 +1660,7 @@ namespace sw { namespace universal {
 		// Cfloat maxpos(sw::universal::SpecificValue::maxpos), maxneg(sw::universal::SpecificValue::maxneg);
 
 		double da, db, ref;  // make certain that IEEE doubles are sufficient as reference
-		Cfloat a, b, nut, cref;
+		Cfloat a{}, b{}, nut{}, cref{};
 		for (size_t i = 0; i < NR_VALUES; ++i) {
 			a.setbits(i); // number system concept requires a member function setbits()
 			da = double(a);

--- a/tests/cfloat/api/api.cpp
+++ b/tests/cfloat/api/api.cpp
@@ -83,7 +83,7 @@ try {
 
 		std::cout << "---\n";
 
-		quarter q;
+		quarter q; // uninitialized
 		q.setbits(0x01);  // smallest subnormal
 		std::cout << "minpos  cfloat<8,2> : " << to_binary(q) << " : " << q << '\n';
 		q.setbits(0x5f);  // max normal
@@ -91,7 +91,7 @@ try {
 		q.setbits(0x7d);  // max supernormal
 		std::cout << "maxpos  cfloat<8,2> : " << to_binary(q) << " : " << q << '\n';
 
-		half h;
+		half h; // uninitialized
 		h.setbits(0x0001); // smallest subnormal
 		std::cout << "minpos  cfloat<16,5>: " << to_binary(h) << " : " << h << '\n';
 		h.setbits(0x7bff);  // max normal
@@ -100,14 +100,14 @@ try {
 		std::cout << "maxpos  cfloat<16,5>: " << to_binary(h) << " : " << h << '\n';
 
 		using QuarterNormal = cfloat<  8, 2, uint8_t, false, false, false>; // no sub or supernormals
-		QuarterNormal qn;
+		QuarterNormal qn; // uninitialized
 		qn.minpos();
 		std::cout << "minpos quarterNormal: " << to_binary(qn) << " : " << qn << '\n';
 		qn.maxpos();
 		std::cout << "maxpos quarterNormal: " << to_binary(qn) << " : " << qn << '\n';
 
 		using halfNormal = cfloat< 16, 5, uint16_t, false, false, false>; // no sub or supernormals
-		halfNormal hn;
+		halfNormal hn; // uninitialized
 		hn.minpos();
 		std::cout << "minpos halfNormal   : " << to_binary(hn) << " : " << hn << '\n';
 		hn.maxpos();
@@ -123,7 +123,7 @@ try {
 		constexpr size_t es = 3;
 		using Real = cfloat<nbits, es>;  // bt = uint8_t, hasSubnormals = false, hasSupernormals = false, isSaturating = false
 
-		CONSTEXPRESSION Real a; // zero constexpr
+		CONSTEXPRESSION Real a{}; // zero constexpr
 		std::cout << type_tag(a) << '\n';
 
 		CONSTEXPRESSION Real b(1.0f);  // constexpr of a native type conversion
@@ -143,7 +143,7 @@ try {
 		constexpr size_t es = 5;
 		using Real = cfloat<nbits, es>;  // bt = uint8_t, hasSubnormals = false, hasSupernormals = false, isSaturating = false
 
-		Real a;
+		Real a; // uninitialized
 		std::cout << type_tag(a) << '\n';
 
 		a.setbits(0x0000);
@@ -161,7 +161,7 @@ try {
 
 	std::cout << "set specific values of interest\n";
 	{
-		cfloat<8, 2> a;
+		cfloat<8, 2> a; // uninitialized
 		std::cout << "maxpos : " << a.maxpos() << " : " << scale(a) << '\n';
 		std::cout << "minpos : " << a.minpos() << " : " << scale(a) << '\n';
 		std::cout << "zero   : " << a.zero() << " : " << scale(a) << '\n';
@@ -177,7 +177,7 @@ try {
 		using BlockType = uint32_t;
 		using Cfloat = cfloat<nbits, es, BlockType, true>;
 		constexpr size_t fbits = Cfloat::fbits;
-		Cfloat a, b;
+		Cfloat a, b; // uninitialized
 
 		// enumerate the subnormals
 		uint32_t pattern = 1ul;
@@ -206,7 +206,7 @@ try {
 		using BlockType = uint32_t;
 		float subnormal = std::nextafter(0.0f, 1.0f);
 		using Cfloat = cfloat<32, 8, BlockType, true>;
-		Cfloat a;
+		Cfloat a; // uninitialized
 		blockbinary<a.fhbits, BlockType> significant;
 
 		uint32_t pattern = 0x00000001ul;

--- a/tests/cfloat/api/dynamic_range.cpp
+++ b/tests/cfloat/api/dynamic_range.cpp
@@ -25,7 +25,7 @@ void GenerateSinglePrecisionSubnormals()
 	constexpr bool hasSubnormals = true;
     constexpr bool hasSupernormals = true;
 	constexpr bool isSaturating = true;
-	cfloat<nbits, es, bt, hasSubnormals, !hasSupernormals, !isSaturating> a;
+	cfloat<nbits, es, bt, hasSubnormals, !hasSupernormals, !isSaturating> a{};
 	++a;
 	float f = float(a);
 	std::cout << std::setprecision(16);

--- a/tests/cfloat/api/special_cases.cpp
+++ b/tests/cfloat/api/special_cases.cpp
@@ -24,7 +24,16 @@
 template<size_t nbits, size_t es, typename bt = uint8_t, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 inline int TestZero() {
 	int fails = 0;
-	sw::universal::cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> r;
+	using Cfloat = sw::universal::cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>;
+
+	unsigned char storage[]{"uninitialized storage with junk content"};
+	static_assert(sizeof storage > sizeof(Cfloat),"");
+	Cfloat* x = new (storage) Cfloat; // placement new over uninitialized storage
+	if (x->iszero()) ++fails;
+	x->~Cfloat();
+	Cfloat& r = *new (storage) Cfloat{}; // placement new, zero-initializing
+
+	//sw::universal::cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> r;
 	//std::cout << to_binary(r) << std::endl;
 	if (!r.iszero()) ++fails;
 	r = -r;
@@ -101,7 +110,7 @@ void TestIsZero(int& nrOfFailedTestCases) {
 template<size_t nbits, size_t es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 inline int TestInf() {
 	int fails = 0;
-	sw::universal::cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> r;
+	sw::universal::cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> r{};
 	r.setinf(); // default is to set -inf
 	//std::cout << to_binary(r) << std::endl;
 	if (!r.isinf()) ++fails;
@@ -183,7 +192,7 @@ void TestIsInf(int& nrOfFailedTestCases) {
 template<size_t nbits, size_t es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 inline int TestNaN() {
 	int fails = 0;
-	sw::universal::cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> r;
+	sw::universal::cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> r{};
 	r.setnan();
 	//std::cout << to_binary(r) << std::endl;
 	if (!r.isnan()) ++fails;
@@ -387,7 +396,7 @@ void TestScale(int& nrOfFailedTestCases) {
 
 	{
 		std::cout << "scale cfloat<4,1>               : ";
-		cfloat<4, 1, uint8_t, true, true, false> a;
+		cfloat<4, 1, uint8_t, true, true, false> a{};
 		a.setbits(5); if (a.scale() != 1) ++nrOfFailedTestCases;
 		a.setbits(11); if (a.scale() != 0) ++nrOfFailedTestCases;
 		std::cout << ((currentFails == nrOfFailedTestCases) ? "PASS\n" : "FAIL\n");
@@ -396,14 +405,14 @@ void TestScale(int& nrOfFailedTestCases) {
 
 	{
 		std::cout << "scale cfloat<5,1>               : ";
-		cfloat<5, 1, uint8_t, true, true, false> a;
+		cfloat<5, 1, uint8_t, true, true, false> a{};
 		a.setbits(12); if (a.scale() != 1) ++nrOfFailedTestCases;
 		a.setbits(20); if (a.scale() != 0) ++nrOfFailedTestCases;
 		std::cout << ((currentFails == nrOfFailedTestCases) ? "PASS\n" : "FAIL\n");
 	}
 	{
 		std::cout << "scale cfloat<5,2>               : ";
-		cfloat<5, 2> a;
+		cfloat<5, 2> a{};
 		// [1-11-11]
 		a.setbits(0x1F); if (a.scale() != 2) ++nrOfFailedTestCases;
 		// [1-10-11]
@@ -416,7 +425,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<6,1>               : ";
-		cfloat<6, 1, uint8_t, true, true, false> a;
+		cfloat<6, 1, uint8_t, true, true, false> a{};
 		// [1-1-1111]
 		a.setbits(0x3F); if (a.scale() != 1) ++nrOfFailedTestCases;
 		// [1-0-1111]
@@ -425,7 +434,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<7,1>               : ";
-		cfloat<7, 1, uint8_t, true, true, false> a;
+		cfloat<7, 1, uint8_t, true, true, false> a{};
 		// [1-1-1'1111]
 		a.setbits(0x7F); if (a.scale() != 1) ++nrOfFailedTestCases;
 		// [1-0-1'1111]
@@ -434,7 +443,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<8,1>               : ";
-		cfloat<8, 1, uint8_t, true, true, false> a;
+		cfloat<8, 1, uint8_t, true, true, false> a{};
 		// [1-1-11'1111]
 		a.setbits(0xFF); if (a.scale() != 1) ++nrOfFailedTestCases;
 		// [1-0-11'1111]
@@ -443,7 +452,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<8,2>               : ";
-		cfloat<8, 2> a;
+		cfloat<8, 2> a{};
 		// [1-11-1'1111]
 		a.setbits(0xFF); if (a.scale() != 2) ++nrOfFailedTestCases;
 		// [1-10-1'1111]
@@ -456,7 +465,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<8,3>               : ";
-		cfloat<8, 3> a;
+		cfloat<8, 3> a{};
 		// [1-111-'1111]
 		a.setbits(0xFF); if (a.scale() != 4) ++nrOfFailedTestCases;
 		// [1-110-'1111]
@@ -477,7 +486,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<8,4>               : ";
-		cfloat<8, 4> a;
+		cfloat<8, 4> a{};
 		// [1-111'1-111]
 		a.setbits(0xFF); if (a.scale() != 8) ++nrOfFailedTestCases;
 		// [1-111'0-111]
@@ -515,7 +524,7 @@ void TestScale(int& nrOfFailedTestCases) {
 
 	{
 		std::cout << "scale cfloat<8,5>               : ";
-		cfloat<8, 5> a;
+		cfloat<8, 5> a{};
 		// [1-111'11-11]
 		a.setbits(0xFF); if (a.scale() != 16) ++nrOfFailedTestCases;
 		// [1-111'10-11]
@@ -584,22 +593,22 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 #if 0
 	{
-		cfloat<9, 2> a; a.scale();
+		cfloat<9, 2> a{}; a.scale();
 	}
 	{
-		cfloat<9, 3> a; a.scale();
+		cfloat<9, 3> a{}; a.scale();
 	}
 	{
-		cfloat<10, 2> a; a.scale();
+		cfloat<10, 2> a{}; a.scale();
 	}
 	{
-		cfloat<10, 3> a; a.scale();
+		cfloat<10, 3> a{}; a.scale();
 	}
 #endif
 	std::cout << "\n\nStandard floating-point sizes\n";
 	{
 		std::cout << "scale cfloat<8,2,uint8_t>       : ";
-		cfloat<8, 2, uint8_t> a;
+		cfloat<8, 2, uint8_t> a{};
 		// [1-11-1'1111]
 		a.setbits(0xFF); if (a.scale() != 2) ++nrOfFailedTestCases;
 		// [1-10-1'1111]
@@ -612,7 +621,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<16,5,uint16_t>     : ";
-		cfloat<16, 5, uint16_t> a;
+		cfloat<16, 5, uint16_t> a{};
 		// [1-111'11-11'0000'0000]
 		a.setbits(0xFF00); if (a.scale() != 16) ++nrOfFailedTestCases;
 		// [1-111'10-11'0000'0000]
@@ -681,7 +690,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<32,8,uint32_t>     : ";
-		cfloat<32, 8, uint32_t> a;
+		cfloat<32, 8, uint32_t> a{};
 		// [1-111'1111'1-111'1111'1111'1111'1111'0000]
 		a.setbits(0xFFFF'FFF0); if (a.scale() != 128) ++nrOfFailedTestCases;
 		// [1-011'1111'1-111'1111'1111'1111'1111'0000]
@@ -692,7 +701,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<64,11,uint64_t>    : ";
-		cfloat<64, 11, uint64_t> a;
+		cfloat<64, 11, uint64_t> a{};
 		// [1-111'1111'1111-'1111'1111'1111'1111'0000]
 		a.setbits(0xFFFF'FFFF'FFFF'FFF0); if (a.scale() != 1024) ++nrOfFailedTestCases;
 		// [1-111'1111'1110-'1111'1111'1111'1111'0000]
@@ -706,7 +715,7 @@ void TestScale(int& nrOfFailedTestCases) {
 	}
 	{
 		std::cout << "scale cfloat<128,15,uint64_t>   : ";
-//		cfloat<128, 15, uint64_t> a;
+//		cfloat<128, 15, uint64_t> a{};
 		// [1-111'1111'1111'1111-'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'0000]
 //		a.assign("0xFFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFFF'FFF0"); if (a.scale() != 16*1024) ++nrOfFailedTestCases;
 		// [1-011'1111'1111'1111-'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'1111'0000]
@@ -751,7 +760,7 @@ try {
 	/// check if this is correct if es is > 2. In particular, cfloat<32,8> and cfloat<64,11> should write test suite for that
 
 	{
-		cfloat<8, 2> a;
+		cfloat<8, 2> a{};
 		std::cout << "maxpos : " << a.maxpos() << " : " << scale(a) << '\n';
 		std::cout << "minpos : " << a.minpos() << " : " << scale(a) << '\n';
 		std::cout << "zero   : " << a.zero() << " : " << scale(a) << '\n';

--- a/tests/cfloat/arithmetic/decrement.cpp
+++ b/tests/cfloat/arithmetic/decrement.cpp
@@ -40,7 +40,7 @@ try {
 
 	{
 		using Cfloat = cfloat<4, 1, uint8_t, true, true, false>;
-		Cfloat c;
+		Cfloat c; // uninitialized
 		c.setbits(0x00);
 		--c;
 		for (int i = 0; i < 5; ++i) {

--- a/tests/cfloat/arithmetic/increment.cpp
+++ b/tests/cfloat/arithmetic/increment.cpp
@@ -49,7 +49,7 @@ try {
 	}
 		{
 		using Cfloat = cfloat<17,2, uint8_t, hasSubnormals, hasSupernormals, !isSaturating>;
-		Cfloat c;
+		Cfloat c; // uninitialized
 		c.setbits(0x0FEFD);
 		for (int i = 0; i < 10; ++i) {
 			std::cout << to_binary(c) << " : " << c++ << '\n';

--- a/tests/cfloat/arithmetic/nonsaturating/normal/subtraction.cpp
+++ b/tests/cfloat/arithmetic/nonsaturating/normal/subtraction.cpp
@@ -79,7 +79,7 @@ try {
 		float fb = 0.5f;
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/nonsaturating/subnormal/subtraction.cpp
+++ b/tests/cfloat/arithmetic/nonsaturating/subnormal/subtraction.cpp
@@ -79,7 +79,7 @@ try {
 		float fb = 0.5f;
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/nonsaturating/subsuper/subtraction.cpp
+++ b/tests/cfloat/arithmetic/nonsaturating/subsuper/subtraction.cpp
@@ -79,7 +79,7 @@ try {
 		float fb = 0.5f;
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/nonsaturating/supernormal/subtraction.cpp
+++ b/tests/cfloat/arithmetic/nonsaturating/supernormal/subtraction.cpp
@@ -79,7 +79,7 @@ try {
 		float fb = 0.5f;
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/random_arithmetic.cpp
+++ b/tests/cfloat/arithmetic/random_arithmetic.cpp
@@ -63,7 +63,7 @@ try {
 		using Cfloat = cfloat<32, 8, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
 //		nrOfFailedTestCases += Randoms<Cfloat>(reportTestCases, test_tag, 1000);
 
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.assign("0b1.11100011.00100010101110100100101");
 		b.assign("0b1.11111111.01100000000011101110110");
 		c = a + b;
@@ -82,7 +82,7 @@ try {
 		using Cfloat = cfloat<40, 8, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
 //		nrOfFailedTestCases += Randoms<Cfloat>(reportTestCases, test_tag, 10);
 
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.assign("0b1.01111001.0101101001000110000101011011110");
 		b.assign("0b0.10100101.0111101101110011110011100111011");
 		c = a + b;

--- a/tests/cfloat/arithmetic/saturating/normal/addition.cpp
+++ b/tests/cfloat/arithmetic/saturating/normal/addition.cpp
@@ -66,7 +66,7 @@ try {
 		float fb = -0.5f;
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/saturating/subnormal/addition.cpp
+++ b/tests/cfloat/arithmetic/saturating/subnormal/addition.cpp
@@ -69,7 +69,7 @@ try {
 		float fb = -0.5f; // 7.625f; // 0.0625f; 3.9375f; 
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/saturating/subsuper/addition.cpp
+++ b/tests/cfloat/arithmetic/saturating/subsuper/addition.cpp
@@ -67,7 +67,7 @@ try {
 		float fb = -0.5f; // 7.625f; // 0.0625f; 3.9375f; 
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/saturating/subsuper/multiplication.cpp
+++ b/tests/cfloat/arithmetic/saturating/subsuper/multiplication.cpp
@@ -77,7 +77,7 @@ Generate table for a class sw::universal::cfloat<3,1,unsigned char,1,1,0> in TXT
 		constexpr bool hasSupernormal = true;
 		constexpr bool isSaturating = true;
 		using Cfloat = cfloat < nbits, es, uint8_t, hasSubnormal, hasSupernormal, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 //		GenerateTable<Cfloat>(cout);
 //		a.constexprClassParameters();
 		a = fa;

--- a/tests/cfloat/arithmetic/saturating/subsuper/subtraction.cpp
+++ b/tests/cfloat/arithmetic/saturating/subsuper/subtraction.cpp
@@ -66,7 +66,7 @@ try {
 //		float fa = std::numeric_limits<float>::infinity();
 		float fb = 0.5f; // 7.625f; // 0.0625f; 3.9375f; 
 
-		cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating > a, b, c;
+		cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating > a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/arithmetic/saturating/supernormal/addition.cpp
+++ b/tests/cfloat/arithmetic/saturating/supernormal/addition.cpp
@@ -67,7 +67,7 @@ try {
 		float fb = -0.5f;
 
 		using Cfloat = cfloat < 8, 4, uint8_t, hasSubnormals, hasSupernormals, isSaturating >;
-		Cfloat a, b, c;
+		Cfloat a, b, c; // uninitialized
 		a.constexprClassParameters();
 		a = fa;
 		b = fb;

--- a/tests/cfloat/conversion/double_conversion.cpp
+++ b/tests/cfloat/conversion/double_conversion.cpp
@@ -22,7 +22,7 @@
 void CompilerBug() {
 	using namespace sw::universal;
 	{
-		cfloat<5, 1, uint8_t, true, true, false> a;
+		cfloat<5, 1, uint8_t, true, true, false> a; // uninitialized
 		a.setbits(0x0);
 		std::cout << "cfloat<5,1> : " << to_binary(a) << " : " << a << '\n';
 		float f = float(a);
@@ -31,7 +31,7 @@ void CompilerBug() {
 		std::cout << "double     : " << d << '\n';
 	}
 	{
-		cfloat<5, 1, uint8_t, true, true, false> a;
+		cfloat<5, 1, uint8_t, true, true, false> a; // uninitialized
 		a.setbits(0x10);
 		std::cout << "cfloat<5,1> : " << to_binary(a) << " : " << a << '\n';
 		float f = float(a);
@@ -41,7 +41,7 @@ void CompilerBug() {
 	}
 
 	{
-		cfloat<6, 1, uint8_t, true, true, false> a;
+		cfloat<6, 1, uint8_t, true, true, false> a; // uninitialized
 		a.setbits(0x0);
 		std::cout << "cfloat<6,1> : " << to_binary(a) << " : " << a << '\n';
 		float f = float(a);
@@ -50,7 +50,7 @@ void CompilerBug() {
 		std::cout << "double     : " << d << '\n';
 	}
 	{
-		cfloat<6, 1, uint8_t, true, true, false> a;
+		cfloat<6, 1, uint8_t, true, true, false> a; // uninitialized
 		a.setbits(0x20);
 		std::cout << "cfloat<6,1> : " << to_binary(a) << " : " << a << '\n';
 		float f = float(a);
@@ -126,7 +126,7 @@ void GenerateDoublePrecisionSubnormals()
 	constexpr size_t es = 11;
 	using bt = uint64_t;
 	using namespace sw::universal;
-	cfloat<nbits, es, bt> a;
+	cfloat<nbits, es, bt> a{};
 	++a;
 	double d = double(a);
 	std::cout << std::setprecision(20);
@@ -193,7 +193,7 @@ try {
 		double testValue = double(ref);
 		std::cout << "ref : " << to_binary(ref) << " : " << ref << '\n';
 		std::cout << "test: " << to_binary(testValue) << " : " << testValue << '\n';
-		cfloat<64, 8, uint8_t> nut;
+		cfloat<64, 8, uint8_t> nut;  // uninitialized
 		//		a.constexprClassParameters();
 		nut = testValue;
 		double da = double(nut);

--- a/tests/cfloat/conversion/float_conversion.cpp
+++ b/tests/cfloat/conversion/float_conversion.cpp
@@ -27,7 +27,7 @@ void ToNativeBug() {  // now resolved... exponentiation was incorrect
 	constexpr bool hasSubnormals = true;
 	constexpr bool hasSupernormals = true;
 	constexpr bool isSaturating = false;
-	cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a, b;
+	cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a{}, b{};
 	// b1.00111111.00011001011010001001001 != b1.01111111.00011001011010001001001
 	a.assign("0b1.00111111.00011001011010001001001");
 	std::cout << "cfloat   : " << to_binary(a) << '\n';
@@ -94,7 +94,7 @@ void GenerateSinglePrecisionSubnormals()
 	constexpr bool hasSubnormals = true;
 	constexpr bool hasSupernormals = true;
 	constexpr bool isSaturating = false;
-	cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a;
+	cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> a{};
 	++a;
 	float f = float(a);
 	std::cout << std::setprecision(16);
@@ -114,7 +114,7 @@ void GenerateSinglePrecisionSubnormals()
 template<typename cfloatType>
 void Test1() 
 {
-	cfloatType a;
+	cfloatType a{};
 	a.constexprClassParameters();
 
 	float testValue = 8.0f;
@@ -128,7 +128,7 @@ void Test2()
 {
 	using namespace sw::universal;
 	
-	cfloat<8, 6, uint8_t, cfloatType::hasSubnormals, cfloatType::hasSupernormals, cfloatType::isSaturating> a;
+	cfloat<8, 6, uint8_t, cfloatType::hasSubnormals, cfloatType::hasSupernormals, cfloatType::isSaturating> a{};
 	float testValue = 14680063.0f;
 	a = testValue;
 	float f = float(a);
@@ -144,7 +144,7 @@ void Test2()
 
 template<size_t nbits, size_t es, typename bt>
 void testConversion(float f) {
-	sw::universal::cfloat<nbits, es, bt> a;
+	sw::universal::cfloat<nbits, es, bt> a{};
 	a.convert_ieee754(f);
 }
 
@@ -207,19 +207,19 @@ try {
 		Cfloat a("0b0.01110000100.11110101000111000011111000000000000000000000000000000000000000000000");
 		std::cout << to_binary(a) << " : " << a << '\n';
 
-		cfloat<32, 8, uint32_t, hasSubnormals, hasSupernormals, isSaturating> ref; // this is a superset of IEEE-754 float with supernormals
+		cfloat<32, 8, uint32_t, hasSubnormals, hasSupernormals, isSaturating> ref{}; // this is a superset of IEEE-754 float with supernormals
 		ref.setbits(0x027a8e1f);
 		float refValue = float(ref);
 		std::cout << to_binary(refValue) << " : " << refValue << '\n';
 		{
-			cfloat<80, 11, uint8_t, hasSubnormals, hasSupernormals, isSaturating> nut;
+			cfloat<80, 11, uint8_t, hasSubnormals, hasSupernormals, isSaturating> nut{};
 			nut = refValue;
 			float testValue = float(nut);
 			std::cout << to_binary(testValue) << " : " << testValue << '\n';
 			std::cout << to_binary(nut) << " : " << nut << '\n';
 		}
 		{
-			cfloat<80, 11, uint16_t, hasSubnormals, hasSupernormals, isSaturating> nut;
+			cfloat<80, 11, uint16_t, hasSubnormals, hasSupernormals, isSaturating> nut{};
 			nut = refValue;
 			float testValue = float(nut);
 			std::cout << to_binary(testValue) << " : " << testValue << '\n';
@@ -231,7 +231,7 @@ try {
 		f = 0.125f; // - std::pow(2.0f, -20.0f);
 		std::cout << to_binary(f) << " : " << f << std::endl;
 
-		cfloat<6, 1, uint8_t, hasSubnormals, hasSupernormals, isSaturating> a;
+		cfloat<6, 1, uint8_t, hasSubnormals, hasSupernormals, isSaturating> a{};
 		a.convert_ieee754(f);
 		std::cout << to_binary(a, true) << " : " << a << '\n';
 	}

--- a/tests/cfloat/conversion/ieee754_subnormals.cpp
+++ b/tests/cfloat/conversion/ieee754_subnormals.cpp
@@ -50,11 +50,11 @@ try {
 		using bt = uint32_t;
 		using Cfloat = cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>;
 		constexpr size_t fbits = Cfloat::fbits;
-		Cfloat a{ 0 }, b;
+		Cfloat a{};
 		++a;
 		for (int i = 0; i < static_cast<int>(fbits); ++i) {
 			float f = float(a);
-			b = f;
+			Cfloat b = f;
 			std::cout << to_binary(f) << " : " << color_print(f) << " : " << f << '\n';
 			std::cout << to_binary(a) << " : " << color_print(a) << " : " << a << '\n';
 			std::cout << to_binary(b) << " : " << color_print(b) << " : " << b << '\n';
@@ -73,11 +73,11 @@ try {
 		using bt = uint32_t;
 		using Cfloat = cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>;
 		constexpr size_t fbits = Cfloat::fbits;
-		Cfloat a{ 0 }, b;
+		Cfloat a{};
 		++a;
 		for (int i = 0; i < static_cast<int>(fbits); ++i) {
 			double f = double(a);
-			b = f;
+			Cfloat b = f;
 			std::cout << to_binary(f) << " : " << color_print(f) << " : " << f << '\n';
 			std::cout << to_binary(a) << " : " << color_print(a) << " : " << a << '\n';
 			std::cout << to_binary(b) << " : " << color_print(b) << " : " << b << '\n';

--- a/tests/cfloat/conversion/nonsaturating/normal/from_blocktriple.cpp
+++ b/tests/cfloat/conversion/nonsaturating/normal/from_blocktriple.cpp
@@ -43,7 +43,7 @@ void Test()
 // 	constexpr size_t fbits = nbits - es - 1ull;
 //	using Btriple = blocktriple<fbits, op, BlockType>;
 
-	Cfloat a;
+	Cfloat a; // uninitialized
 	std::cout << "\n-----------------\n" << sw::universal::type_tag(a) << '\n';
 
 	Cfloat eps = std::numeric_limits<Cfloat>::epsilon();
@@ -104,7 +104,7 @@ try {
 		constexpr size_t fbits = nbits - es - 1ull;
 		using BlockType = uint8_t;
 		using Cfloat = cfloat<nbits, es, BlockType, hasSubnormals, hasSupernormals, isSaturating>;
-		Cfloat a;
+		Cfloat a; // uninitialized
 		a.assign(std::string("0b0.0111'1111.0'0000'0000'0000'0000'0001"));
 		std::cout << "a =        eps : " << to_binary(a) << " : " << a << '\n';
 	}
@@ -118,7 +118,7 @@ try {
 		constexpr BlockTripleOperator op = BlockTripleOperator::ADD;
 		using Btriple = blocktriple<fbits, op, BlockType>;
 
-		Cfloat a;
+		Cfloat a; // uninitialized
 		a = std::numeric_limits<Cfloat>::epsilon();
 
 		std::cout << '\n';
@@ -157,7 +157,7 @@ try {
 	// then normalize and apply the rounding decision.
 	{
 		using Cfloat = cfloat<4, 2, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
-		Cfloat a; 
+		Cfloat a; // uninitialized
 		a.constexprClassParameters();
 		std::cout << dynamic_range(a) << '\n';
 		std::cout << "maxpos : " << a.maxpos() << '\n';
@@ -174,7 +174,7 @@ try {
 		// checking the other side of the exponential adjustments with cfloats
 		// that expand on the dynamic range of IEEE-754
 		using Cfloat = cfloat<80, 15, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
-		Cfloat a;
+		Cfloat a; // uninitialized
 		a = -1.0f;
 		std::cout << type_tag(a) << '\n' << to_binary(a) << " : " << a << '\n';
 		//			a.constexprClassParameters();

--- a/tests/cfloat/conversion/nonsaturating/subnormal/from_blocktriple.cpp
+++ b/tests/cfloat/conversion/nonsaturating/subnormal/from_blocktriple.cpp
@@ -80,7 +80,7 @@ try {
 		// checking the other side of the exponential adjustments with cfloats
 		// that expand on the dynamic range of IEEE-754
 		using Cfloat = cfloat<80, 15, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
-		Cfloat a;
+		Cfloat a; // uninitialized
 		a = -1.0f;
 		std::cout << type_tag(a) << '\n' << to_binary(a) << " : " << a << '\n';
 		a.constexprClassParameters();

--- a/tests/cfloat/conversion/nonsaturating/subnormal/to_blocktriple.cpp
+++ b/tests/cfloat/conversion/nonsaturating/subnormal/to_blocktriple.cpp
@@ -74,7 +74,7 @@ try {
 			using Cfloat = cfloat<5, 2, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
 			constexpr size_t fbits = Cfloat::fbits;
 			typedef Cfloat::BlockType bt;
-			Cfloat nut;
+			Cfloat nut; // uninitialized
  			nut.setbits(0x1e);
 			float v = float(nut);
 			blocktriple<fbits, BlockTripleOperator::ADD, bt> b, ref; // blocktriple type that comes out of an ADD/SUB operation

--- a/tests/cfloat/conversion/nonsaturating/subsuper/from_blocktriple.cpp
+++ b/tests/cfloat/conversion/nonsaturating/subsuper/from_blocktriple.cpp
@@ -84,7 +84,7 @@ try {
 			b.setbits(0x03);
 			b.setscale(-1);
 			float v = float(b);
-			Cfloat nut, ref;
+			Cfloat nut, ref; // uninitialized
 			convert(b, nut);
 			ref = v;
 			std::cout << "blocktriple: " << to_binary(b) << " : " << float(b) << '\n';
@@ -96,7 +96,7 @@ try {
 			// checking the other side of the exponential adjustments with cfloats
 			// that expand on the dynamic range of IEEE-754
 			using Cfloat = cfloat<80, 15, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
-			Cfloat a;
+			Cfloat a; // uninitialized
 			a = -1.0f;
 			std::cout << type_tag(a) << '\n' << to_binary(a) << " : " << a << '\n';
 			//			a.constexprClassParameters();
@@ -110,7 +110,7 @@ try {
 			// 0b01.1110  == 1.875
 			b.setbits(0x1e);
 			float v = float(b);
-			Cfloat nut, ref;
+			Cfloat nut, ref; // uninitialized
 			convert(b, nut);
 			ref = v;
 			std::cout << "blocktriple: " << to_binary(b) << " : " << float(b) << '\n';

--- a/tests/cfloat/conversion/nonsaturating/subsuper/to_blocktriple.cpp
+++ b/tests/cfloat/conversion/nonsaturating/subsuper/to_blocktriple.cpp
@@ -73,7 +73,7 @@ try {
 			using Cfloat = cfloat<5, 2, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
 			constexpr size_t fbits = Cfloat::fbits;
 			typedef Cfloat::BlockType bt;
-			Cfloat nut;
+			Cfloat nut; // uninitialized
  			nut.setbits(0x1e);
 			float v = float(nut);
 			blocktriple<fbits, BlockTripleOperator::ADD, bt> b, ref; // blocktriple type that comes out of an ADD/SUB operation

--- a/tests/cfloat/conversion/nonsaturating/supernormal/to_blocktriple.cpp
+++ b/tests/cfloat/conversion/nonsaturating/supernormal/to_blocktriple.cpp
@@ -74,7 +74,7 @@ try {
 			using Cfloat = cfloat<5, 2, uint8_t, hasSubnormals, hasSupernormals, isSaturating>;
 			constexpr size_t fbits = Cfloat::fbits;
 			typedef Cfloat::BlockType bt;
-			Cfloat nut;
+			Cfloat nut; // uninitialized
  			nut.setbits(0x1e);
 			float v = float(nut);
 			blocktriple<fbits, BlockTripleOperator::ADD, bt> b, ref; // blocktriple type that comes out of an ADD/SUB operation

--- a/tests/cfloat/logic/logic.cpp
+++ b/tests/cfloat/logic/logic.cpp
@@ -376,7 +376,7 @@ try {
 	return EXIT_SUCCESS;   // ignore errors
 #else
 
-	cfloat<16, 5> a;
+	cfloat<16, 5> a{};
 
 	std::cout << "Logic: operator==()\n";
 

--- a/tests/cfloat/standard/tensorfloat.cpp
+++ b/tests/cfloat/standard/tensorfloat.cpp
@@ -26,7 +26,7 @@ try {
 
 	std::cout << "Standard NVIDIA TensorFloat, which is equivalent to a cfloat<19,8> configuration tests\n";
 
-	tensorfloat r;
+	tensorfloat r; // uninitialized
 	r = 1.2345;
 	std::cout << r << '\n';
 

--- a/tests/numerical/utils/sampling.cpp
+++ b/tests/numerical/utils/sampling.cpp
@@ -86,7 +86,7 @@ try {
 
 
 		{
-			cfloat < 8, 4, uint8_t > a, b, c;
+			cfloat < 8, 4, uint8_t > a, b, c; // uninitialized
 
 			a = fa;
 			b = fb;


### PR DESCRIPTION
Change the default constructor definition to defaulted.
Remove defaulted copy, move, copy-assign and move-assign ops.
Add is_trivial static_asserts for some cfloat types.
Add an initializer to an otherwise uninitialized cfloat in table.hpp

The PyTorch integration of cfloat hit an issue that cfloat is not trivial.
This is easily changed, but is a breaking change; default initialization
becomes a no-op rather than a call to the default constructor.

  https://en.cppreference.com/w/cpp/named_req/TrivialType

cfloat had a default constructor that explicitly zero-initializes _block.
Because it is user-defined, the constructor code is run when a cfloat is
default constructed (in principle at least), guaranteeing the storage is
zeroed out. However, because user code is run, this obstructs compiler
optimizations that treat types as 'bags of bits' with no invariants.
cfloat is therefore termed a non-trivial type.

If the constructor is =default'd then the type becomes trivial.
However, now if a cfloat type is declared without initializer:

    fp64 duble; // truble! uninitialized variable

no construcor is run, no construction is done, and the guarantee of zero-
initialization is lost - the variable remains uninitialized. Compilers
warn about uninitialized variables. In fact, making this change flagged
up an uninitialized cfloat variable in table.hpp

This behavior is expected for built-in scalar types, where it is seen as
a 'zero cost' feature despite the perils (ideally there'd be an explicit
syntax for deliberately uninitialized variables).

This is the correct behavior types like cfloat and other Universal types.