### PR TITLE
posit c api declaration mismatch

### DIFF
--- a/c_api/pure_c/posit/posit8.c
+++ b/c_api/pure_c/posit/posit8.c
@@ -40,7 +40,7 @@ int posit8_cmpp8(posit8_t a, posit8_t b) {
 }
 
 // string conversion functions
-void posit8_str(char* str, posit8_t a) {
+void posit8_str(char str[static 16], posit8_t a) {
 	float f = posit8_tof(a);
 	sprintf(str, "%f", f);
 }


### PR DESCRIPTION
Fixes a warning (gcc12):

c_api/pure_c/posit/posit8.c:43:23: warning:
argument 1 of type ‘char *’ declared as a pointer [-Warray-parameter=]
   43 | void posit8_str(char* str, posit8_t a)

include/universal/number/posit/posit_c_macros.h:90:29: note:
previously declared as an array ‘char[static 16]’
   90 | void POSIT_MKNAME(str)(char out[static POSIT_MKNAME(str_SIZE)],
                               POSIT_T p);
