### PR TITLE
Fix missing <cstring> include for paranoia.c strrchr

### DIFF
--- a/tests/numerical/properties/paranoia.cpp
+++ b/tests/numerical/properties/paranoia.cpp
@@ -3,6 +3,8 @@
 // Copyright (C) 2017-2021 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstring>
+
 #include "common.hpp"
 #include <universal/number/posit/posit.hpp> // the NUT: number system under test
 


### PR DESCRIPTION
The missing #include breaks the build (on gcc12)
