### PR TITLE
blocksignificant refactors

### DIFF
--- a/include/universal/internal/blocksignificant/blocksignificant.hpp
+++ b/include/universal/internal/blocksignificant/blocksignificant.hpp
@@ -374,63 +374,7 @@ public:
 	// modifiers
 	 // clear a block binary number
 	inline constexpr void clear() noexcept {
-		if constexpr (1 == nrBlocks) {
-			_block[0] = 0;
-		}
-		else if constexpr (2 == nrBlocks) {
-			_block[0] = 0;
-			_block[1] = 0;
-		}
-		else if constexpr (3 == nrBlocks) {
-			_block[0] = 0;
-			_block[1] = 0;
-			_block[2] = 0;
-		}
-		else if constexpr (4 == nrBlocks) {
-			_block[0] = 0;
-			_block[1] = 0;
-			_block[2] = 0;
-			_block[3] = 0;
-		}
-		else if constexpr (5 == nrBlocks) {
-			_block[0] = 0;
-			_block[1] = 0;
-			_block[2] = 0;
-			_block[3] = 0;
-			_block[4] = 0;
-		}
-		else if constexpr (6 == nrBlocks) {
-			_block[0] = 0;
-			_block[1] = 0;
-			_block[2] = 0;
-			_block[3] = 0;
-			_block[4] = 0;
-			_block[5] = 0;
-		}
-		else if constexpr (7 == nrBlocks) {
-			_block[0] = 0;
-			_block[1] = 0;
-			_block[2] = 0;
-			_block[3] = 0;
-			_block[4] = 0;
-			_block[5] = 0;
-			_block[6] = 0;
-		}
-		else if constexpr (8 == nrBlocks) {
-			_block[0] = 0;
-			_block[1] = 0;
-			_block[2] = 0;
-			_block[3] = 0;
-			_block[4] = 0;
-			_block[5] = 0;
-			_block[6] = 0;
-			_block[7] = 0;
-		}
-		else {
-			for (size_t i = 0; i < nrBlocks; ++i) {
-				_block[i] = static_cast<bt>(0ull);
-			}
-		}
+		*this = {};
 	}
 	inline constexpr void setzero() noexcept { clear(); }
 	inline constexpr void setradix(int radix) { radixPoint = radix; }

--- a/include/universal/internal/blocksignificant/blocksignificant.hpp
+++ b/include/universal/internal/blocksignificant/blocksignificant.hpp
@@ -173,11 +173,11 @@ public:
 #endif
 
 	/// explicit conversion operators
-	explicit operator float()       const noexcept { return float(to_float()); }
-	explicit operator double()      const noexcept { return double(to_double()); }
+	explicit constexpr operator float() const noexcept { return float(to_float()); }
+	explicit constexpr operator double() const noexcept { return double(to_double()); }
 
 #if LONG_DOUBLE_SUPPORT
-	explicit operator long double() const noexcept { return (long double)to_long_double(); }
+	explicit constexpr operator long double() const noexcept { return (long double)to_long_double(); }
 	constexpr long double to_long_double() const noexcept {
 		return (long double)to_double();
 	}
@@ -199,7 +199,7 @@ public:
 	/// arithmetic operators
 	// none
 
-	void increment() noexcept {
+	constexpr void increment() noexcept {
 		bool carry = true;
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			// cast up so we can test for overflow
@@ -573,7 +573,7 @@ public:
 
 	// determine the rounding direction for round-to-even: returns true if we need to round up, false if we need to truncate
 	// Function argument is the bit position of the LSB of the target number.
-	bool roundingDirection(size_t targetLsb) const noexcept {
+	constexpr bool roundingDirection(size_t targetLsb) const noexcept {
 		bool lsb    = at(targetLsb);
 		bool guard  = (targetLsb == 0 ? false : at(targetLsb - 1));
 		bool round  = (targetLsb <= 1 ? false : at(targetLsb - 2));
@@ -581,7 +581,7 @@ public:
 		bool tie = guard && !round && !sticky;
 		return (lsb && tie) || (guard && !tie);
 	}
-	bool any(size_t msb) const noexcept {
+	constexpr bool any(size_t msb) const noexcept {
 		msb = (msb > nbits - 1 ? nbits - 1 : msb);
 		size_t topBlock = msb / bitsInBlock;
 		bt mask = bt(ALL_ONES >> (bitsInBlock - 1 - (msb % bitsInBlock)));
@@ -608,9 +608,9 @@ private:
 
 	// integer - integer logic comparisons
 	template<size_t N, typename B>
-	friend bool operator==(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept;
+	friend constexpr bool operator==(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept;
 	template<size_t N, typename B>
-	friend bool operator!=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept;
+	friend constexpr bool operator!=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept;
 	// the other logic operators are defined in terms of arithmetic terms
 
 	template<size_t N, typename B>
@@ -671,7 +671,7 @@ std::string to_hex(const blocksignificant<nbits, bt>& number, bool wordMarker = 
 // logic operators
 
 template<size_t N, typename B>
-inline bool operator==(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
+constexpr bool operator==(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
 	for (size_t i = 0; i < lhs.nrBlocks; ++i) {
 		if (lhs._block[i] != rhs._block[i]) {
 			return false;
@@ -680,25 +680,25 @@ inline bool operator==(const blocksignificant<N, B>& lhs, const blocksignificant
 	return true;
 }
 template<size_t N, typename B>
-inline bool operator!=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
+constexpr bool operator!=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
 	return !operator==(lhs, rhs);
 }
 template<size_t N, typename B>
-inline bool operator<(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
+constexpr bool operator<(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
 	blocksignificant<N, B> diff;
 	diff.sub(lhs, rhs);
 	return diff.isneg();
 }
 template<size_t N, typename B>
-inline bool operator<=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
+constexpr bool operator<=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
 	return (lhs < rhs || lhs == rhs);
 }
 template<size_t N, typename B>
-inline bool operator>(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
+constexpr bool operator>(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
 	return !(lhs <= rhs);
 }
 template<size_t N, typename B>
-inline bool operator>=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
+constexpr bool operator>=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
 	return !(lhs < rhs);
 }
 

--- a/include/universal/internal/blocksignificant/blocksignificant.hpp
+++ b/include/universal/internal/blocksignificant/blocksignificant.hpp
@@ -602,29 +602,63 @@ public:
 	BitEncoding encoding;
 	bt _block[nrBlocks];
 
-private:
 	//////////////////////////////////////////////////////////////////////////////
 	// friend functions
 
 	// integer - integer logic comparisons
-	template<size_t N, typename B>
-	friend constexpr bool operator==(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept;
-	template<size_t N, typename B>
-	friend constexpr bool operator!=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept;
-	// the other logic operators are defined in terms of arithmetic terms
+	friend constexpr bool operator==(const blocksignificant& lhs, const blocksignificant& rhs) noexcept {
+		for (size_t i = 0; i < lhs.nrBlocks; ++i) {
+			if (lhs._block[i] != rhs._block[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-	template<size_t N, typename B>
-	friend std::ostream& operator<<(std::ostream& ostr, const blocksignificant<N, B>& v);
+	friend constexpr bool operator!=(const blocksignificant& lhs, const blocksignificant& rhs) noexcept {
+		return !operator==(lhs, rhs);
+	}
+
+	//////////////////////////////////////////////////////////////////////////////////
+	// logic operators
+
+	friend constexpr bool operator<(const blocksignificant& lhs, const blocksignificant& rhs) noexcept {
+		blocksignificant diff;
+		diff.sub(lhs, rhs);
+		return diff.isneg();
+	}
+
+	friend constexpr bool operator<=(const blocksignificant& lhs, const blocksignificant& rhs) noexcept {
+		return (lhs < rhs || lhs == rhs);
+	}
+
+	friend constexpr bool operator>(const blocksignificant& lhs, const blocksignificant& rhs) noexcept {
+		return !(lhs <= rhs);
+	}
+
+	friend constexpr bool operator>=(const blocksignificant& lhs, const blocksignificant& rhs) noexcept {
+		return !(lhs < rhs);
+	}
+
+	///////////////////////////////////////////////////////////////////////////////
+	// binary operators
+
+	friend constexpr  blocksignificant operator<<(const blocksignificant& a, const long b) noexcept {
+		blocksignificant c(a);
+		return c <<= b;
+	}
+
+	friend constexpr  blocksignificant operator>>(const blocksignificant& a, const long b) noexcept {
+		blocksignificant c(a);
+		return c >>= b;
+	}
+
+
+	// ostream operator
+	friend std::ostream& operator<<(std::ostream& ostr, const blocksignificant& v) {
+		return ostr << double(v);
+	}
 };
-
-//////////////////////////////////////////////////////////////////////////////////
-// stream operators
-
-// ostream operator
-template<size_t nbits, typename bt>
-std::ostream& operator<<(std::ostream& ostr, const blocksignificant<nbits, bt>& number) {
-	return ostr << double(number);
-}
 
 //////////////////////////////////////////////////////////////////////////////
 // conversions to string representations
@@ -665,55 +699,6 @@ std::string to_hex(const blocksignificant<nbits, bt>& number, bool wordMarker = 
 		if (wordMarker && n > 0 && ((n * 4ll) % bitsInBlock) == 0) ss << '\'';
 	}
 	return ss.str();
-}
-
-//////////////////////////////////////////////////////////////////////////////////
-// logic operators
-
-template<size_t N, typename B>
-constexpr bool operator==(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
-	for (size_t i = 0; i < lhs.nrBlocks; ++i) {
-		if (lhs._block[i] != rhs._block[i]) {
-			return false;
-		}
-	}
-	return true;
-}
-template<size_t N, typename B>
-constexpr bool operator!=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
-	return !operator==(lhs, rhs);
-}
-template<size_t N, typename B>
-constexpr bool operator<(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
-	blocksignificant<N, B> diff;
-	diff.sub(lhs, rhs);
-	return diff.isneg();
-}
-template<size_t N, typename B>
-constexpr bool operator<=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
-	return (lhs < rhs || lhs == rhs);
-}
-template<size_t N, typename B>
-constexpr bool operator>(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
-	return !(lhs <= rhs);
-}
-template<size_t N, typename B>
-constexpr bool operator>=(const blocksignificant<N, B>& lhs, const blocksignificant<N, B>& rhs) noexcept {
-	return !(lhs < rhs);
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// binary operators
-
-template<size_t nbits, typename bt>
-inline blocksignificant<nbits, bt> operator<<(const blocksignificant<nbits, bt>& a, const long b) noexcept {
-	blocksignificant<nbits, bt> c(a);
-	return c <<= b;
-}
-template<size_t nbits, typename bt>
-inline blocksignificant<nbits, bt> operator>>(const blocksignificant<nbits, bt>& a, const long b) noexcept {
-	blocksignificant<nbits, bt> c(a);
-	return c >>= b;
 }
 
 // divide a by b and return both quotient and remainder

--- a/include/universal/internal/blocksignificant/blocksignificant.hpp
+++ b/include/universal/internal/blocksignificant/blocksignificant.hpp
@@ -178,7 +178,7 @@ public:
 
 #if LONG_DOUBLE_SUPPORT
 	explicit operator long double() const noexcept { return (long double)to_long_double(); }
-	inline constexpr long double to_long_double() const noexcept {
+	constexpr long double to_long_double() const noexcept {
 		return (long double)to_double();
 	}
 #endif
@@ -356,12 +356,12 @@ public:
 
 	// modifiers
 	 // clear a block binary number
-	inline constexpr void clear() noexcept {
+	constexpr void clear() noexcept {
 		*this = {};
 	}
-	inline constexpr void setzero() noexcept { clear(); }
-	inline constexpr void setradix(int radix) noexcept { radixPoint = radix; }
-	inline constexpr void setbit(size_t i, bool v = true) noexcept {
+	constexpr void setzero() noexcept { clear(); }
+	constexpr void setradix(int radix) noexcept { radixPoint = radix; }
+	constexpr void setbit(size_t i, bool v = true) noexcept {
 		if (i < nbits) {
 			bt block = _block[i / bitsInBlock];
 			bt null = ~(1ull << (i % bitsInBlock));
@@ -371,11 +371,11 @@ public:
 		}
 		// when i is out of bounds, fail silently as no-op
 	}
-	inline constexpr void setblock(size_t b, const bt& block) noexcept {
+	constexpr void setblock(size_t b, const bt& block) noexcept {
 		if (b < nrBlocks) _block[b] = block;
 		// when b is out of bounds, fail silently as no-op
 	}
-	inline constexpr void setbits(uint64_t value) noexcept {
+	constexpr void setbits(uint64_t value) noexcept {
 		// radixPoint needs to be set, either using the constructor or the setradix() function
 		if constexpr (1 == nrBlocks) {
 			_block[0] = value & storageMask;
@@ -394,7 +394,7 @@ public:
 		}
 		_block[MSU] &= MSU_MASK; // enforce precondition for fast comparison by properly nulling bits that are outside of nbits
 	}
-	inline constexpr blocksignificant& flip() noexcept { // in-place one's complement
+	constexpr blocksignificant& flip() noexcept { // in-place one's complement
 		for (size_t i = 0; i < nrBlocks; ++i) {
 			_block[i] = bt(~_block[i]);
 		}		
@@ -402,7 +402,7 @@ public:
 		return *this;
 	}
 	// in-place 2's complement
-	inline constexpr blocksignificant& twosComplement() noexcept {
+	constexpr blocksignificant& twosComplement() noexcept {
 		blocksignificant<nbits, bt> plusOne;
 		plusOne.setbit(0);
 		flip();
@@ -411,26 +411,26 @@ public:
 	}
 
 	// selectors
-	inline constexpr bool iszero() const noexcept {
+	constexpr bool iszero() const noexcept {
 		for (size_t i = 0; i < nrBlocks; ++i) if (_block[i] != 0) return false;
 		return true;
 	}
-	inline constexpr int  radix() const noexcept { return radixPoint; }
-	inline constexpr bool isodd() const noexcept { return _block[0] & 0x1;	}
-	inline constexpr bool iseven() const noexcept { return !isodd(); }
-	inline constexpr bool sign() const noexcept { return test(nbits - 1); }
-	inline constexpr bool isneg() const noexcept { return sign(); }
-	inline constexpr bool test(size_t bitIndex) const noexcept { return at(bitIndex); }
-	inline constexpr bool at(size_t bitIndex) const noexcept {
+	constexpr int  radix() const noexcept { return radixPoint; }
+	constexpr bool isodd() const noexcept { return _block[0] & 0x1;	}
+	constexpr bool iseven() const noexcept { return !isodd(); }
+	constexpr bool sign() const noexcept { return test(nbits - 1); }
+	constexpr bool isneg() const noexcept { return sign(); }
+	constexpr bool test(size_t bitIndex) const noexcept { return at(bitIndex); }
+	constexpr bool at(size_t bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false;
 		bt word = _block[bitIndex / bitsInBlock];
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (word & mask);
 	}
 	// check carry bit in output of the ALU
-	inline constexpr bool checkCarry() const noexcept { return at(nbits - 2); }
+	constexpr bool checkCarry() const noexcept { return at(nbits - 2); }
 	// helpers
-	inline constexpr uint8_t nibble(size_t n) const noexcept {
+	constexpr uint8_t nibble(size_t n) const noexcept {
 		if (n < (1 + ((nbits - 1) >> 2))) {
 			bt word = _block[(n * 4) / bitsInBlock];
 			size_t nibbleIndexInWord = n % (bitsInBlock >> 2);
@@ -440,7 +440,7 @@ public:
 		}
 		throw "nibble index out of bounds";
 	}
-	inline constexpr bt block(size_t b) const noexcept {
+	constexpr bt block(size_t b) const noexcept {
 		if (b >= nrBlocks) return bt{ 0 };
 		return _block[b];
 	}
@@ -450,7 +450,7 @@ public:
 		fractionBits.setbit(static_cast<size_t>(radixPoint), false);
 		return fractionBits;
 	}
-	inline constexpr uint64_t fraction_ull() const noexcept {
+	constexpr uint64_t fraction_ull() const noexcept {
 		uint64_t raw = significant_ull();
 		// remove the non-fraction bits
 		uint64_t fractionBits = (0xFFFF'FFFF'FFFF'FFFFull >> (64 - radixPoint));
@@ -515,7 +515,7 @@ public:
 	}
 #endif
 	// return the position of the most significant bit, -1 if v == 0
-	inline int msb() const noexcept {
+	constexpr int msb() const noexcept {
 		for (int i = int(MSU); i >= 0; --i) {
 			if (_block[i] != 0) {
 				bt mask = (bt(1u) << (bitsInBlock-1));
@@ -531,10 +531,10 @@ public:
 	}
 
 	// conversion to native types
-	inline constexpr float to_float() const noexcept {
+	constexpr float to_float() const noexcept {
 		return float(to_double());
 	}
-	inline constexpr double to_double() const noexcept {
+	constexpr double to_double() const noexcept {
 		double d{ 0.0 };
 		double s{ 1.0 };
 		blocksignificant<nbits, bt> tmp(*this);


### PR DESCRIPTION
This is a pure refactor PR, not meant to change functionality
(it doesn't address warnings or errors like other recent PRs).

The six commits are only checked to build on gcc12, they may
break other builds or tests;
Test thoroughly in CI and regression.

The comments in blocksignificant suggest it is due for a deeper
refactor, e.g. to shrink the representation. As such, you may
decide to defer these changes; feel free to ignore for now,
or review and cherry-pick, or test and merge if they pass.
Your call. Enjoy.

- Simplify clear()
- Reduce repetitive array code with variadics
- Apply noexcept consistently
- Remove inline specifier from member functions defined in class
- Add more constexpr, for consistency
- Make more friends, make them public and hidden
