### PR TITLE
Silence uninitialized warnings

### DIFF
--- a/include/universal/utility/sampleviz.hpp
+++ b/include/universal/utility/sampleviz.hpp
@@ -6,8 +6,8 @@ namespace sw {
 		template<typename Real, typename NumberSystem, typename EnvelopingNumberSystem>
 		void sampleviz(NumberSystem start, NumberSystem stop, Real sample) {
 			using namespace sw::universal;
-			NumberSystem a, s(sample);
-			EnvelopingNumberSystem b;
+			NumberSystem a{}, s(sample);
+			EnvelopingNumberSystem b{};
 			std::string tag1 = type_tag(a);
 			std::string tag2 = type_tag(b);
 			size_t twidth = tag2.size() + 5;

--- a/tests/integer/binary/api/misc.cpp
+++ b/tests/integer/binary/api/misc.cpp
@@ -50,10 +50,10 @@ void TestSizeof() {
 	using int128 = integer<128, uint32_t>;
 	using int1024 = integer<1024, uint32_t>;
 
-	int8 a;
-	int64 k;
-	int128 m;
-	int1024 o;
+	int8 a{};
+	int64 k{};
+	int128 m{};
+	int1024 o{};
 
 	constexpr int WIDTH = 30;
 	std::cout << std::setw(WIDTH) << type_tag(a) << "  size in bytes " << a.nbits / 8 << '\n';

--- a/tests/integer/binary/logic/bit_manipulation.cpp
+++ b/tests/integer/binary/logic/bit_manipulation.cpp
@@ -90,7 +90,7 @@ void TestNLZ() {
 
 template<size_t nbits, typename BlockType>
 void TestSignBitMask() {
-	sw::universal::integer<nbits, BlockType> a;
+	sw::universal::integer<nbits, BlockType> a{};
 	std::cout << std::right << std::setw(50) << type_tag(a) << '\n';
 	std::cout << "EXACT_FIT           : " << (a.EXACT_FIT ? "yes\n" : "no\n");
 	std::cout << "bitsInBlock         : " << a.bitsInBlock << '\n';


### PR DESCRIPTION
These are all due to type_tag(x) implementations that access their
argument x. Ironically, it looks like these were modified at some
point to access their argument in order to silence warnings about
'unused formal parameter'; a fix for that should be to remove the
formal parameter name (and its superfluous use) - I'll do a PR.
