### PR TITLE
Drop type_tag formal arg

### DIFF
--- a/include/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/universal/internal/blockbinary/blockbinary.hpp
@@ -663,9 +663,8 @@ private:
 
 // Generate a type tag for blockbinary
 template<size_t N, typename B, BinaryNumberType T>
-std::string type_tag(const blockbinary<N, B, T>& v) {
+std::string type_tag(const blockbinary<N, B, T>& = {}) {
 	std::stringstream str;
-	if (v.isneg()) str << ' '; // remove 'unreferenced formal parameter warning from compilation log
 	str << "blockbinary<"
 		<< std::setw(4) << N << ", "
 		<< typeid(B).name() << ", "

--- a/include/universal/internal/blocktriple/blocktriple.hpp
+++ b/include/universal/internal/blocktriple/blocktriple.hpp
@@ -93,7 +93,7 @@ blocktriple<fbits, op, bt>& convert(unsigned long long uint, blocktriple<fbits, 
 
 // Generate a type tag for this type: blocktriple<fbits, operator, unsigned int>
 template<size_t fbits, BlockTripleOperator op, typename bt>
-std::string type_tag(const blocktriple<fbits, op, bt>& v) {
+std::string type_tag(const blocktriple<fbits, op, bt>& = {}) {
 	std::stringstream s;
 	s << "blocktriple<"
 		<< fbits << ", ";
@@ -117,7 +117,6 @@ std::string type_tag(const blocktriple<fbits, op, bt>& v) {
 		s << "unknown operator, ";
 	}
 	s << typeid(bt).name() << '>';
-	if (v.iszero()) s << ' ';
 	return s.str();
 }
 

--- a/include/universal/native/manipulators.hpp
+++ b/include/universal/native/manipulators.hpp
@@ -11,9 +11,9 @@ namespace sw { namespace universal {
 	template<typename Real, 
 		std::enable_if_t< std::is_floating_point<Real>::value, bool> = true
 	>
-	std::string type_tag(Real f) {
+	std::string type_tag(Real = {}) {
 		// can't use a simple typeid(Real).name() because gcc and clang obfuscate the native types
-		constexpr unsigned nbits = sizeof(f) * 8;
+		constexpr unsigned nbits = sizeof(Real) * 8;
 		std::string real;
 		if constexpr (nbits == 32) {
 			real = std::string("float");
@@ -28,14 +28,6 @@ namespace sw { namespace universal {
 			real = std::string("unknown");
 		}
 		return real;
-	}
-
-	template<typename Real,
-		std::enable_if_t< std::is_floating_point<Real>::value, bool > = true
-	>
-	std::string type_tag() {
-		Real f{ 0.0 };
-		return type_tag(f);
 	}
 
 }} // namespace sw::universal

--- a/include/universal/number/adaptiveint/manipulators.hpp
+++ b/include/universal/number/adaptiveint/manipulators.hpp
@@ -10,20 +10,10 @@ namespace sw { namespace universal {
 
 // Generate a type tag for adaptiveint
 template<typename BlockType>
-std::string type_tag(const adaptiveint<BlockType>& v) {
+std::string type_tag(const adaptiveint<BlockType>& = {}) {
 	std::stringstream s;
-	if (v.iszero()) s << ' '; // remove 'unreferenced formal parameter warning from compilation log
 	s << "adaptiveint<" << typeid(BlockType).name() << '>';
 	return s.str();
 }
-
-
-#ifdef ADAPTIVEINT_TYPE_GUARD
-// Generate a type tag for adaptiveint
-template<typename AdaptiveInt>
-std::string type_tag() {
-	return type_tag(adaptiveint());
-}
-#endif
 
 }} // namespace sw::universal

--- a/include/universal/number/areal/manipulators.hpp
+++ b/include/universal/number/areal/manipulators.hpp
@@ -18,7 +18,7 @@ namespace sw { namespace universal {
 
 // Generate a type tag for this posit, for example, posit<8,1>
 template<size_t nbits, size_t es, typename bt>
-std::string type_tag(const areal<nbits, es, bt>& v) {
+std::string type_tag(const areal<nbits, es, bt>& = {}) {
 	std::stringstream ss;
 	ss << "areal<" << nbits << "," << es << ">";
 	return ss.str();

--- a/include/universal/number/cfloat/manipulators.hpp
+++ b/include/universal/number/cfloat/manipulators.hpp
@@ -18,7 +18,7 @@ namespace sw { namespace universal {
 
 // Generate a type tag for this cfloat, for example, cfloat<8,1, unsigned char, hasSubnormals, noSupernormals, notSaturating>
 template<size_t nbits, size_t es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
-std::string type_tag(const cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>& v) {
+std::string type_tag(const cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>& = {}) {
 	std::stringstream s;
 	s << "cfloat<"
 		<< std::setw(3) << nbits << ", "
@@ -27,7 +27,6 @@ std::string type_tag(const cfloat<nbits, es, bt, hasSubnormals, hasSupernormals,
 		<< (hasSubnormals ? "hasSubnormals, " : " noSubnormals, ")
 		<< (hasSupernormals ? "hasSupernormals, " : " noSupernormals, ")
 		<< (isSaturating ? "   Saturating>" : "notSaturating>");
-	if (v.iszero()) s << ' ';
 	return s.str();
 }
 

--- a/include/universal/number/fixpnt/manipulators.hpp
+++ b/include/universal/number/fixpnt/manipulators.hpp
@@ -10,9 +10,8 @@ namespace sw { namespace universal {
 
 // Generate a type tag for general fixpnt
 template<size_t nbits, size_t rbits, bool arithmetic, typename bt>
-std::string type_tag(const fixpnt<nbits, rbits, arithmetic, bt>& v) {
+std::string type_tag(const fixpnt<nbits, rbits, arithmetic, bt>& = {}) {
 	std::stringstream s;
-	if (v.iszero()) s << ' '; // remove 'unreferenced formal parameter warning from compilation log
 	s << "fixpnt<"
 		<< std::setw(3) << nbits << ", "
 		<< std::setw(3) << rbits << ", "
@@ -20,22 +19,6 @@ std::string type_tag(const fixpnt<nbits, rbits, arithmetic, bt>& v) {
 			             "Saturating, ")
 		<< typeid(bt).name() << '>';
 	return s.str();
-}
-
-// TODO: you need to guard this with a fixpnt type
-// as right now this type_tag() design matches any type
-// and is thus ambiguous
-
-// Generate a type tag for this fixpnt
-template<typename Fixpnt,
-	std::enable_if_t<is_fixpnt<Fixpnt>, Fixpnt> = 0
->
-std::string type_tag() {
-	constexpr size_t nbits = Fixpnt::nbits;
-	constexpr size_t rbits = Fixpnt::rbits;
-	constexpr bool arithmetic = Fixpnt::arithmetic;
-	using bt = typename Fixpnt::BlockType;
-	return type_tag(fixpnt<nbits, rbits, arithmetic, bt>());
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/integer/manipulators.hpp
+++ b/include/universal/number/integer/manipulators.hpp
@@ -10,9 +10,8 @@ namespace sw { namespace universal {
 
 // Generate a type tag for general integer
 template<size_t nbits, typename BlockType, IntegerNumberType NumberType>
-std::string type_tag(const integer<nbits, BlockType, NumberType>& v) {
+std::string type_tag(const integer<nbits, BlockType, NumberType>& = {}) {
 	std::stringstream str;
-	if (v.iszero()) str << ' '; // remove 'unreferenced formal parameter warning from compilation log
 	str << "integer<"
 	    << std::setw(4) << nbits << ", "
 	    << typeid(BlockType).name() << ", "

--- a/include/universal/number/lns/manipulators.hpp
+++ b/include/universal/number/lns/manipulators.hpp
@@ -15,22 +15,13 @@ namespace sw { namespace universal {
 
 	// Generate a type tag for this lns
 	template<size_t nbits, size_t rbits, typename BlockType>
-	std::string type_tag(const lns<nbits, rbits, BlockType>& l) {
+	std::string type_tag(const lns<nbits, rbits, BlockType>& = {}) {
 		std::stringstream s;
 		s << "lns<"
 			<< std::setw(3) << nbits << ", "
 			<< std::setw(3) << rbits << ", "
 			<< typeid(BlockType).name() << '>';
-		if (l.iszero()) s << ' ';
 		return s.str();
-	}
-
-	template<typename LnsType,
-		std::enable_if_t<is_lns<LnsType>, LnsType> = 0
-	>
-	std::string type_tag() {
-		LnsType l{ 1.0 };
-		return type_tag(l);
 	}
 
 	// report dynamic range of a type, specialized for lns

--- a/include/universal/number/posit/manipulators.hpp
+++ b/include/universal/number/posit/manipulators.hpp
@@ -55,12 +55,11 @@ std::string posit_range() {
 
 // Generate a type tag for this posit, for example, posit<8,1>
 template<size_t nbits, size_t es>
-std::string type_tag(const posit<nbits, es>& p) {
+std::string type_tag(const posit<nbits, es>& = {}) {
 	std::stringstream str;
 	str << "sw::universal::posit<" 
 		<< std::setw(3) << nbits << ", " 
 		<< std::setw(1) << es << '>';
-	if (p.iszero()) str << ' '; // to get rid of unused parameter warning
 	return str.str();
 }
 

--- a/include/universal/number/rational/manipulators.hpp
+++ b/include/universal/number/rational/manipulators.hpp
@@ -8,11 +8,8 @@
 namespace sw { namespace universal {
 
 // Generate a type tag for rational type
-std::string type_tag(rational& v) {
-	std::stringstream str;
-	if (v.iszero()) str << ' '; // remove 'unreferenced formal parameter warning from compilation log
-	str << "rational";
-	return str.str();
+std::string type_tag(const rational& = {}) {
+	return "rational";
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/unum/manipulators.hpp
+++ b/include/universal/number/unum/manipulators.hpp
@@ -34,7 +34,7 @@ std::string unum_range() {
 
 // Generate a type tag for this unum, for example, unum<8,1>
 template<size_t essize, size_t fsize>
-std::string type_tag(const unum<essize, fsize>& p) {
+std::string type_tag(const unum<essize, fsize>& = {}) {
 	std::stringstream ss;
 	ss << "unum<" << essize << "," << fsize << ">";
 	return ss.str();

--- a/include/universal/number/unum2/manipulators.hpp
+++ b/include/universal/number/unum2/manipulators.hpp
@@ -33,7 +33,7 @@ std::string unum2_range() {
 
 // Generate a type tag for this unum, for example, unum<8,1>
 template<size_t essize, size_t fsize>
-std::string type_tag(const unum2<essize, fsize>& p) {
+std::string type_tag(const unum2<essize, fsize>& = {}) {
 	std::stringstream ss;
 	ss << "unum2<" << essize << "," << fsize << ">";
 	return ss.str();


### PR DESCRIPTION
The type_tag(x) overload implementations deduce their argument type:

    template <typename X> string type_tag(X x);
 or template <typename X> string type_tag(X const& x);

The formal argument x shouldn't be used; only its type X is pertinent.
The declarations should drop the name:

  template <typename X> string type_tag(X);

An alternative signature then takes no argument; convenient when there
is no variable to use so it saves declaring one uneccesarily:

  template <typename X> string type_tag();

Here the type cannot be deduced so must be provided: type_tag<X>().
The two overloads can be combined into a one with a default argument:

  template <typename X> string type_tag(X = {});

(assuming that X is default constructible).

Note that type_tag should really be a constexpr function (or a variable
template, or a type trait) because it deals only with types. However,
relying on C++ runtime typeinfo disallows any compile-time definition,
as does returning std::string (and implementing with stringstream).

If the signature is changed to return a 'constexpr string' type then
I can PR a constexpr type_tag implementation.
