### PR TITLE
Comment out unused retval variable

### DIFF
--- a/tests/blocktriple/conversion/rounding.cpp
+++ b/tests/blocktriple/conversion/rounding.cpp
@@ -50,8 +50,8 @@ That is:  patterns of the form
 			// for add/sub ops    0b0ii.fffff with only a single bit of rounding. 
 			// TODO is that always true? if you have dynamic range, don't you have 2*fhbits of bits to examine?
 			// for mul op         0bii.fffff`fffff with fbits of rounding
-			auto retval = a.roundingDecision();
-//			std::cout << to_triple(a) << (retval.first ? " rounds up\n" : " rounds down\n");
+			//auto retval = a.roundingDecision();
+			//std::cout << to_triple(a) << (retval.first ? " rounds up\n" : " rounds down\n");
 
 			bool correct = true;
 			if (!correct) {


### PR DESCRIPTION
Looks like it should've been commented out in recent change
"cleaning up blocktriple regression tests to reduce output"
which commented out retval's useage.

Commenting out rather than removing because there's a TODO.

(Third time I've prepared this change, it keeps getting lost.)
(I think this is the last of the non _block related warnings.)
