### PR TITLE
lns signature change

### DIFF
--- a/applications/adaptive/double-double.cpp
+++ b/applications/adaptive/double-double.cpp
@@ -45,9 +45,9 @@ try {
 	std::streamsize precision = std::cout.precision();
 	
 	{
-		using lns = lns<16, 10, Saturating, std::uint16_t>;
+		using LNS = lns<16, 10, std::uint16_t>;
 
-		lns a, b, c;
+		LNS a{}, b{}, c{};
 		a = 0.5;
 		b = 2.0;
 		c = a * b;

--- a/applications/numeric/limits.cpp
+++ b/applications/numeric/limits.cpp
@@ -28,7 +28,7 @@ try {
 	using fixpnt32 = fixpnt<32, 16, Modulo, std::uint32_t>;
 	using posit32  = posit<32, 2>;
 	using areal32  = areal<32, 8, std::uint32_t>;
-	using lns32    = lns<32, 8, Saturating, std::uint32_t>;
+	using lns32    = lns<32, 8, std::uint32_t>;
 
 	// report on precision and dynamic range of the number system
 

--- a/applications/numeric/numbers.cpp
+++ b/applications/numeric/numbers.cpp
@@ -129,7 +129,7 @@ try {
 	using cfloat32 = cfloat<32, 8, std::uint32_t, true, true, false>;
 	using posit32 = posit<32, 2>;
 	using areal32 = areal<32, 8, std::uint32_t>;
-	using lns32 = lns<32, 8, Saturating, std::uint32_t>;
+	using lns32 = lns<32, 8, std::uint32_t>;
 
 	// report on precision and dynamic range of the number system
 

--- a/education/number/lns/basic_operators.cpp
+++ b/education/number/lns/basic_operators.cpp
@@ -6,8 +6,8 @@
 #include <universal/number/lns/lns.hpp>
 
 // quick helper to report on a posit's specialness
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt>
-void checkSpecialCases(sw::universal::lns<nbits, rbits, behavior, bt> p) {
+template<size_t nbits, size_t rbits, typename bt, auto... x>
+void checkSpecialCases(sw::universal::lns<nbits, rbits, bt, x...> p) {
 	std::cout << "lns is " << (p.iszero() ? "zero " : "non-zero ") << (p.ispos() ? "positive " : "negative ") << (p.isnan() ? "Not a Number" : "Its a Real") << std::endl;
 }
 
@@ -18,8 +18,8 @@ try {
 
 	constexpr size_t nbits = 16;
 	constexpr size_t rbits = 5;
-	using LNS16 = lns<nbits, rbits, Saturating, std::uint16_t>;
-	LNS16 p1, p2, p3, p4, p5, p6;
+	using LNS16 = lns<nbits, rbits, std::uint16_t>;
+	LNS16 p1{}, p2{}, p3{}, p4{}, p5{}, p6{};
 
 //	/* constexpr */ double minpos = minpos_value<nbits>();
 //	/* constexpr */ double maxpos = maxpos_value<nbits>();

--- a/include/universal/behavior/arithmetic.hpp
+++ b/include/universal/behavior/arithmetic.hpp
@@ -9,34 +9,18 @@
 
 namespace sw { namespace universal {
 
-enum class InfiniteLimit : bool{Finite, Infinite};
-enum class Arithmetic : bool{Modular, Saturating};
 
-struct ArithmeticBehavior {
-	constexpr ArithmeticBehavior(Arithmetic a, InfiniteLimit l) : arith(a), limit(l) {};
-	Arithmetic    arith;
-	InfiniteLimit limit;
-};
+enum class Behavior : uint8_t {Saturating, Wrapping};
 
-constexpr ArithmeticBehavior Modular(Arithmetic::Modular, InfiniteLimit::Finite);
-constexpr ArithmeticBehavior Saturating(Arithmetic::Saturating, InfiniteLimit::Finite);
-constexpr ArithmeticBehavior Projective(Arithmetic::Modular, InfiniteLimit::Infinite);
-constexpr ArithmeticBehavior Real(Arithmetic::Saturating, InfiniteLimit::Infinite);
-
-inline std::string type_tag(const ArithmeticBehavior& behavior) {
-	if (behavior.arith == Arithmetic::Modular && behavior.limit == InfiniteLimit::Finite) {
-		return std::string("Modular");
+inline std::string type_tag(Behavior behavior) {
+	switch (behavior) {
+	case Behavior::Saturating:
+		return "Saturating";
+	case Behavior::Wrapping:
+		return "Wrapping";
+	default:
+		return "unknown arithmetic behavior";
 	}
-	else 	if (behavior.arith == Arithmetic::Saturating && behavior.limit == InfiniteLimit::Finite) {
-		return std::string("Saturating");
-	}
-	else 	if (behavior.arith == Arithmetic::Modular && behavior.limit == InfiniteLimit::Infinite) {
-		return std::string("Saturating");
-	}
-	else 	if (behavior.arith == Arithmetic::Saturating && behavior.limit == InfiniteLimit::Infinite) {
-		return std::string("Saturating");
-	}
-	return std::string("unknown arithmetic behavior");
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/lns_fwd.hpp
+++ b/include/universal/number/lns/lns_fwd.hpp
@@ -10,9 +10,9 @@
 namespace sw { namespace universal {
 
 // core lns types and functions
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt> class lns;
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt> lns<nbits, rbits, behavior, bt> abs(const lns<nbits, rbits, behavior, bt>&);
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt> lns<nbits, rbits, behavior, bt> sqrt(const lns<nbits, rbits, behavior, bt>&);
+template<size_t nbits, size_t rbits, typename bt, auto...x> class lns;
+template<size_t nbits, size_t rbits, typename bt, auto...x> constexpr lns<nbits, rbits, bt, x...> abs(const lns<nbits, rbits, bt, x...>&);
+template<size_t nbits, size_t rbits, typename bt, auto...x> lns<nbits, rbits, bt, x...> sqrt(const lns<nbits, rbits, bt, x...>&);
 
 }} // namespace sw::universal
 

--- a/include/universal/number/lns/lns_traits.hpp
+++ b/include/universal/number/lns/lns_traits.hpp
@@ -15,8 +15,8 @@ struct is_lns_trait
 {
 };
 
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename BlockType>
-struct is_lns_trait< lns<nbits, rbits, behavior, BlockType> >
+template<size_t nbits, size_t rbits, typename BlockType, auto... xtra>
+struct is_lns_trait< lns<nbits, rbits, BlockType, xtra...> >
 	: true_type
 {
 };

--- a/include/universal/number/lns/manipulators.hpp
+++ b/include/universal/number/lns/manipulators.hpp
@@ -14,22 +14,22 @@
 namespace sw { namespace universal {
 
 	// Generate a type tag for this lns
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename BlockType>
-	inline std::string type_tag(const lns<nbits, rbits, behavior, BlockType>& = {}) {
+	template<size_t nbits, size_t rbits, typename BlockType, auto... xtra>
+	inline std::string type_tag(const lns<nbits, rbits, BlockType, xtra...>& = {}) {
 		std::stringstream s;
 		s << "lns<"
 			<< std::setw(3) << nbits << ", "
 			<< std::setw(3) << rbits << ", "
-			<< std::setw(10) << type_tag(behavior) << ", "
+			<< std::setw(10) << type_tag(Behavior{xtra...}) << ", "
 			<< typeid(BlockType).name() << '>';
 		return s.str();
 	}
 
 	// report dynamic range of a type, specialized for lns
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-	inline std::string dynamic_range(const lns<nbits, rbits, behavior, bt>& a) {
+	template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+	inline std::string dynamic_range(const lns<nbits, rbits, bt, xtra...>& a) {
 		std::stringstream s;
-		lns<nbits, rbits, behavior, bt> b(SpecificValue::maxneg), c(SpecificValue::minneg), d(SpecificValue::minpos), e(SpecificValue::maxpos);
+		lns<nbits, rbits, bt, xtra...> b(SpecificValue::maxneg), c(SpecificValue::minneg), d(SpecificValue::minpos), e(SpecificValue::maxpos);
 		s << type_tag(a) << ": ";
 		s << "minpos scale " << std::setw(10) << d.scale() << "     ";
 		s << "maxpos scale " << std::setw(10) << e.scale() << '\n';
@@ -38,27 +38,27 @@ namespace sw { namespace universal {
 		return s.str();
 	}
 
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
+	template<size_t nbits, size_t rbits, typename bt, auto... xtra>
 	inline std::string range() {
 		std::stringstream s;
-		lns<nbits, rbits, behavior, bt> b(SpecificValue::maxneg), c(SpecificValue::minneg), d(SpecificValue::minpos), e(SpecificValue::maxpos);
+		lns<nbits, rbits, bt, xtra...> b(SpecificValue::maxneg), c(SpecificValue::minneg), d(SpecificValue::minpos), e(SpecificValue::maxpos);
 		s << "[" << b << " ... " << c << ", 0, " << d << " ... " << e << "]\n";
 		return s.str();
 	}
 
 	// report if a native floating-point value is within the dynamic range of the lns configuration
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
+	template<size_t nbits, size_t rbits, typename bt, auto... xtra>
 	inline bool isInRange(double v) {
-		using LNS = lns<nbits, rbits, behavior, bt>;
-		LNS a;
+		using LNS = lns<nbits, rbits, bt, xtra...>;
+		LNS a{};
 
 		bool inRange = true;
 		if (v > double(a.maxpos()) || v < double(a.maxneg())) inRange = false;
 		return inRange;
 	}
 
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename BlockType>
-	inline std::string color_print(const lns<nbits, rbits, behavior, BlockType>& l, bool nibbleMarker = false) {
+	template<size_t nbits, size_t rbits, typename BlockType, auto... xtra>
+	inline std::string color_print(const lns<nbits, rbits, BlockType, xtra...>& l, bool nibbleMarker = false) {
 
 		std::stringstream s;
 

--- a/include/universal/number/lns/math/classify.hpp
+++ b/include/universal/number/lns/math/classify.hpp
@@ -8,8 +8,8 @@
 namespace sw { namespace universal {
 
 // STD LIB function for IEEE floats: Categorizes floating point value arg into the following categories: zero, subnormal, normal, infinite, NAN, or implementation-defined category.
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-int fpclassify(const lns<nbits, rbits, behavior, bt>& a) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+int fpclassify(const lns<nbits, rbits, bt, xtra...>& a) {
 	if constexpr (nbits < 33) {
 		return std::fpclassify(float(a));
 	}
@@ -27,37 +27,37 @@ int fpclassify(const lns<nbits, rbits, behavior, bt>& a) {
 	
 // STD LIB function for IEEE floats: Determines if the given floating point number arg has finite value i.e. it is normal, subnormal or zero, but not infinite or NaN.
 // specialized for lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-inline bool isfinite(const lns<nbits, rbits, behavior, bt>& a) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+inline bool isfinite(const lns<nbits, rbits, bt, xtra...>& a) {
 	return !a.isinf() && !a.isnan();
 }
 
 // STD LIB function for IEEE floats: Determines if the given floating point number arg is a posative or negative infinity.
 // specialized for lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-inline bool isinf(const lns<nbits, rbits, behavior, bt>& a) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+inline bool isinf(const lns<nbits, rbits, bt, xtra...>& a) {
 	return a.isinf();
 }
 
 // STD LIB function for IEEE floats: Determines if the given floating point number arg is a not-a-number (NaN) value.
 // specialized for lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-inline bool isnan(const lns<nbits, rbits, behavior, bt>& a) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+inline bool isnan(const lns<nbits, rbits, bt, xtra...>& a) {
 	return a.isnan();
 }
 
 // STD LIB function for IEEE floats: Determines if the given floating point number arg is normal, i.e. is neither zero, subnormal, infinite, nor NaN.
 // specialized for lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-inline bool isnormal(const lns<nbits, rbits, behavior, bt>& a) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+inline bool isnormal(const lns<nbits, rbits, bt, xtra...>& a) {
 	return std::isnormal(double(a));
 }
 
 #ifdef NOW
 // STD LIB function for IEEE floats: Determines if the given floating point number arg is denormal, i.e. is neither zero, normal, infinite, nor NaN.
 // specialized for lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-inline bool isdenorm(const lns<nbits, rbits, behavior, bt>& a) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+inline bool isdenorm(const lns<nbits, rbits, bt, xtra...>& a) {
 	return std::isdenormal(double(a));
 }
 #endif // NOW

--- a/include/universal/number/lns/math/complex.hpp
+++ b/include/universal/number/lns/math/complex.hpp
@@ -9,24 +9,24 @@
 namespace sw { namespace universal {
 
 // Real component of a complex lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> 
-real(std::complex< lns<nbits, rbits, behavior, bt> > x) {
-	return lns<nbits, rbits, behavior, bt>(std::real(x));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...>
+real(std::complex< lns<nbits, rbits, bt, xtra...> > x) {
+	return lns<nbits, rbits, bt, xtra...>(std::real(x));
 }
 
 // Imaginary component of a complex lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt>
-imag(std::complex< lns<nbits, rbits, behavior, bt> > x) {
-	return lns<nbits, rbits, behavior, bt>(std::imag(x));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...>
+imag(std::complex< lns<nbits, rbits, bt, xtra...> > x) {
+	return lns<nbits, rbits, bt, xtra...>(std::imag(x));
 }
 
 // Conjucate of a complex lns
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-std::complex< lns<nbits, rbits, behavior, bt> >
-conj(std::complex< lns<nbits, rbits, behavior, bt> > x) {
-	return lns<nbits, rbits, behavior, bt>(std::conj(x));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+std::complex< lns<nbits, rbits, bt, xtra...> >
+conj(std::complex< lns<nbits, rbits, bt, xtra...> > x) {
+	return lns<nbits, rbits, bt, xtra...>(std::conj(x));
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/math/error_and_gamma.hpp
+++ b/include/universal/number/lns/math/error_and_gamma.hpp
@@ -8,15 +8,15 @@
 namespace sw { namespace universal {
 
 // Compute the error function erf(x) = 2 over sqrt(PI) times Integral from 0 to x of e ^ (-t)^2 dt
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> erf(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::erf(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> erf(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::erf(double(x)));
 }
 
 // Compute the complementary error function: 1 - erf(x)
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> erfc(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::erfc(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> erfc(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::erfc(double(x)));
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/math/exponent.hpp
+++ b/include/universal/number/lns/math/exponent.hpp
@@ -11,10 +11,10 @@ namespace sw { namespace universal {
 // correctly rounded for every input value. Anything less sacrifices bitwise reproducibility of results.
 
 // Base-e exponential function
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> exp(lns<nbits, rbits, behavior, bt> x) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> exp(lns<nbits, rbits, bt, xtra...> x) {
 	if (isnan(x)) return x;
-	lns<nbits, rbits, behavior, bt> p;
+	lns<nbits, rbits, bt, xtra...> p;
 	double d = std::exp(double(x));
 	if (d == 0.0) {
 		p.minpos();
@@ -26,10 +26,10 @@ lns<nbits, rbits, behavior, bt> exp(lns<nbits, rbits, behavior, bt> x) {
 }
 
 // Base-2 exponential function
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> exp2(lns<nbits, rbits, behavior, bt> x) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> exp2(lns<nbits, rbits, bt, xtra...> x) {
 	if (isnan(x)) return x;
-	lns<nbits, rbits, behavior, bt> p;
+	lns<nbits, rbits, bt, xtra...> p;
 	double d = std::exp2(double(x));
 	if (d == 0.0) {
 		p.minpos();
@@ -41,15 +41,15 @@ lns<nbits, rbits, behavior, bt> exp2(lns<nbits, rbits, behavior, bt> x) {
 }
 
 // Base-10 exponential function
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> exp10(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::pow(10.0, double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> exp10(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::pow(10.0, double(x)));
 }
 		
 // Base-e exponential function exp(x)-1
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> expm1(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::expm1(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> expm1(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::expm1(double(x)));
 }
 
 

--- a/include/universal/number/lns/math/fractional.hpp
+++ b/include/universal/number/lns/math/fractional.hpp
@@ -7,9 +7,9 @@
 
 namespace sw { namespace universal {
 
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> lnsmod(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	using Real = lns<nbits, rbits, behavior, bt>;
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> lnsmod(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	using Real = lns<nbits, rbits, bt, xtra...>;
 	if (y.iszero() || x.isinf() || x.isnan() || y.isnan()) {
 		Real nan;
 		nan.setnan();  // quiet NaN
@@ -34,23 +34,23 @@ lns<nbits, rbits, behavior, bt> lnsmod(lns<nbits, rbits, behavior, bt> x, lns<nb
 }
 
 // fmod retuns x - n*y where n = x/y with the fractional part truncated
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> fmod(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> fmod(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
 	return lnsmod(x, y);
 }
 
 // shim to stdlib
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> remainder(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	return lns<nbits, rbits, behavior, bt>(std::remainder(double(x), double(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> remainder(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	return lns<nbits, rbits, bt, xtra...>(std::remainder(double(x), double(y)));
 }
 
 // TODO: validate the rounding of these conversion, versus a method that manipulates the fraction bits directly
 
 // frac returns the fraction of a lns value that is > 1
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> frac(lns<nbits, rbits, behavior, bt> x) {
-	using Real = lns<nbits, rbits, behavior, bt>;
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> frac(lns<nbits, rbits, bt, xtra...> x) {
+	using Real = lns<nbits, rbits, bt, xtra...>;
 	long long intValue = (long long)(x);
 	return abs(x-Real(intValue));  // with the logic that fractions are unsigned quantities
 }

--- a/include/universal/number/lns/math/hyperbolic.hpp
+++ b/include/universal/number/lns/math/hyperbolic.hpp
@@ -11,39 +11,39 @@ namespace sw { namespace universal {
 // One radian is equivalent to 180/PI degrees
 
 // hyperbolic sine of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> sinh(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::sinh(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> sinh(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::sinh(double(x)));
 }
 
 // hyperbolic cosine of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> cosh(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::cosh(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> cosh(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::cosh(double(x)));
 }
 
 // hyperbolic tangent of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> tanh(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::tanh(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> tanh(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::tanh(double(x)));
 }
 
 // hyperbolic cotangent of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> atanh(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::atanh(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> atanh(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::atanh(double(x)));
 }
 
 // hyperbolic cosecant of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> acosh(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::acosh(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> acosh(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::acosh(double(x)));
 }
 
 // hyperbolic secant of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> asinh(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::asinh(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> asinh(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::asinh(double(x)));
 }
 
 

--- a/include/universal/number/lns/math/hypot.hpp
+++ b/include/universal/number/lns/math/hypot.hpp
@@ -40,20 +40,20 @@ hypot(INFINITY, NAN) returns +8, but sqrt(INFINITY*INFINITY+NAN*NAN) returns NaN
 
 namespace sw { namespace universal {
 
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> hypot(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	return lns<nbits, rbits, behavior, bt>(std::hypot(double(x),double(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> hypot(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	return lns<nbits, rbits, bt, xtra...>(std::hypot(double(x),double(y)));
 }
 
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> hypotf(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	return lns<nbits, rbits, behavior, bt>(std::hypotf(float(x),float(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> hypotf(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	return lns<nbits, rbits, bt, xtra...>(std::hypotf(float(x),float(y)));
 }
 
 #if LONG_DOUBLE_SUPPORT
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> hypotl(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	return lns<nbits, rbits, behavior, bt>(std::hypotl((long double)(x),(long double)(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> hypotl(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	return lns<nbits, rbits, bt, xtra...>(std::hypotl((long double)(x),(long double)(y)));
 }
 #endif
 

--- a/include/universal/number/lns/math/logarithm.hpp
+++ b/include/universal/number/lns/math/logarithm.hpp
@@ -8,27 +8,27 @@
 namespace sw { namespace universal {
 
 // Natural logarithm of x
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> log(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::log(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> log(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::log(double(x)));
 }
 
 // Binary logarithm of x
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> log2(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::log2(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> log2(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::log2(double(x)));
 }
 
 // Decimal logarithm of x
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> log10(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::log10(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> log10(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::log10(double(x)));
 }
 		
 // Natural logarithm of 1+x
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> log1p(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::log1p(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> log1p(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::log1p(double(x)));
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/math/minmax.hpp
+++ b/include/universal/number/lns/math/minmax.hpp
@@ -7,16 +7,16 @@
 
 namespace sw { namespace universal {
 
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt>
-min(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	return lns<nbits, rbits, behavior, bt>(std::min(double(x), double(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...>
+min(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	return lns<nbits, rbits, bt, xtra...>(std::min(double(x), double(y)));
 }
 
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt>
-max(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	return lns<nbits, rbits, behavior, bt>(std::max(double(x), double(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...>
+max(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	return lns<nbits, rbits, bt, xtra...>(std::max(double(x), double(y)));
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/math/next.hpp
+++ b/include/universal/number/lns/math/next.hpp
@@ -23,8 +23,8 @@ Return Value
 	- And math_errhandling has MATH_ERRNO set: the global variable errno is set to ERANGE.
 	- And math_errhandling has MATH_ERREXCEPT set: FE_OVERFLOW is raised.
 	*/
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> nextafter(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> target) {
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> nextafter(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> target) {
 	if (x == target) return target;
 	if (target.isnan()) {
 		if (x.isneg()) {
@@ -45,9 +45,9 @@ lns<nbits, rbits, behavior, bt> nextafter(lns<nbits, rbits, behavior, bt> x, lns
 	return x;
 }
 		
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> nexttoward(lns<nbits, rbits, behavior, bt> x, lns<128, 15, behavior, bt> target) {
-	lns<128, 15, behavior, bt> _x(x);
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> nexttoward(lns<nbits, rbits, bt, xtra...> x, lns<128, 15, bt, xtra...> target) {
+	lns<128, 15, bt, xtra...> _x(x);
 	if (_x == target) return x;
 	if (target.isnan()) {
 		if (_x.isneg()) {

--- a/include/universal/number/lns/math/pow.hpp
+++ b/include/universal/number/lns/math/pow.hpp
@@ -7,19 +7,19 @@
 
 namespace sw { namespace universal {
 
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> pow(lns<nbits, rbits, behavior, bt> x, lns<nbits, rbits, behavior, bt> y) {
-	return lns<nbits, rbits, behavior, bt>(std::pow(double(x), double(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> pow(lns<nbits, rbits, bt, xtra...> x, lns<nbits, rbits, bt, xtra...> y) {
+	return lns<nbits, rbits, bt, xtra...>(std::pow(double(x), double(y)));
 }
 		
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> pow(lns<nbits, rbits, behavior, bt> x, int y) {
-	return lns<nbits, rbits, behavior, bt>(std::pow(double(x), double(y)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> pow(lns<nbits, rbits, bt, xtra...> x, int y) {
+	return lns<nbits, rbits, bt, xtra...>(std::pow(double(x), double(y)));
 }
 		
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> pow(lns<nbits, rbits, behavior, bt> x, double y) {
-	return lns<nbits, rbits, behavior, bt>(std::pow(double(x), y));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> pow(lns<nbits, rbits, bt, xtra...> x, double y) {
+	return lns<nbits, rbits, bt, xtra...>(std::pow(double(x), y));
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/math/sqrt.hpp
+++ b/include/universal/number/lns/math/sqrt.hpp
@@ -26,9 +26,9 @@ namespace sw { namespace universal {
 	}
 */
 
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-	inline lns<nbits, rbits, behavior, bt> BabylonianMethod(const lns<nbits, rbits, behavior, bt>& v) {
-		using LnsType = lns<nbits, rbits, behavior, bt>;
+	template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+	inline lns<nbits, rbits, bt, xtra...> BabylonianMethod(const lns<nbits, rbits, bt, xtra...>& v) {
+		using LnsType = lns<nbits, rbits, bt, xtra...>;
 		constexpr double eps = 1.0e-5;
 		LnsType half(0.5);
 		LnsType x_next;
@@ -77,33 +77,33 @@ namespace sw { namespace universal {
 
 #if LNS_NATIVE_SQRT
 	// sqrt for arbitrary lns
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-	inline lns<nbits, rbits, behavior, bt> sqrt(const lns<nbits, rbits, behavior, bt>& a) {
+	template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+	inline lns<nbits, rbits, bt, xtra...> sqrt(const lns<nbits, rbits, bt, xtra...>& a) {
 #if LNS_THROW_ARITHMETIC_EXCEPTION
 		if (a.isneg()) throw lns_negative_sqrt_arg();
 #else
 		if (a.isneg()) std::cerr << "lns argument to sqrt is negative: " << a << std::endl;
 #endif
 		if (a.iszero()) return a;
-		return lns<nbits, rbits, behavior, bt>(std::sqrt((double)a));  // TBD
+		return lns<nbits, rbits, bt, xtra...>(std::sqrt((double)a));  // TBD
 	}
 #else
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-	inline lns<nbits, rbits, behavior, bt> sqrt(const lns<nbits, rbits, behavior, bt>& a) {
+	template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+	inline lns<nbits, rbits, bt, xtra...> sqrt(const lns<nbits, rbits, bt, xtra...>& a) {
 #if LNS_THROW_ARITHMETIC_EXCEPTION
 		if (a.isneg()) throw lns_negative_sqrt_arg();
 #else
 		if (a.isneg()) std::cerr << "lns argument to sqrt is negative: " << a << std::endl;
 #endif
 		if (a.iszero()) return a;
-		return lns<nbits, rbits, behavior, bt>(std::sqrt((double)a));
+		return lns<nbits, rbits, bt, xtra...>(std::sqrt((double)a));
 	}
 #endif
 
 	// reciprocal sqrt
-	template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-	inline lns<nbits, rbits, behavior, bt> rsqrt(const lns<nbits, rbits, behavior, bt>& a) {
-		lns<nbits, rbits, behavior, bt> v = sqrt(a);
+	template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+	inline lns<nbits, rbits, bt, xtra...> rsqrt(const lns<nbits, rbits, bt, xtra...>& a) {
+		lns<nbits, rbits, bt, xtra...> v = sqrt(a);
 		return v.reciprocate();
 	}
 

--- a/include/universal/number/lns/math/sqrt_tables.hpp
+++ b/include/universal/number/lns/math/sqrt_tables.hpp
@@ -11,16 +11,16 @@ namespace sw { namespace universal {
 // need a better code generator for the small lns up to nbits = 8
 // TODO: find if there is any structure in these tables across nbits and es
 
-template<size_t nbits, size_t rbits, typename bt>
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
 void GenerateSqrtTable() {
 	constexpr unsigned int NR_VALUES = (unsigned(1) << (nbits - 1)); // no need for negative posits
 
 	std::cout << std::setprecision(20);
-	lns<nbits, rbits, bt> a;
+	lns<nbits, rbits, bt, xtra...> a;
 	for (unsigned int i = 0; i < NR_VALUES; ++i) {
 		a.setbits(i);
 		double ref = std::sqrt(double(a));
-		lns<nbits, rbits, bt> csqrt(ref);
+		lns<nbits, rbits, bt, xtra...> csqrt(ref);
 		std::cout << to_binary(a) << " " << to_binary(csqrt) << "      " << a << " " << csqrt << " ref: " << ref << std::endl;
 	}
 	std::cout << std::setprecision(5);

--- a/include/universal/number/lns/math/trigonometry.hpp
+++ b/include/universal/number/lns/math/trigonometry.hpp
@@ -12,63 +12,63 @@ namespace sw { namespace universal {
 // One radian is equivalent to 180/PI degrees
 
 // sine of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> sin(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::sin(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> sin(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::sin(double(x)));
 }
 
 // cosine of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> cos(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::cos(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> cos(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::cos(double(x)));
 }
 
 // tangent of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> tan(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::tan(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> tan(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::tan(double(x)));
 }
 
 // cotangent of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> atan(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::atan(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> atan(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::atan(double(x)));
 }
 		
 // Arc tangent with two parameters
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> atan2(lns<nbits, rbits, behavior, bt> y, lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::atan2(double(y),double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> atan2(lns<nbits, rbits, bt, xtra...> y, lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::atan2(double(y),double(x)));
 }
 
 // cosecant of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> acos(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::acos(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> acos(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::acos(double(x)));
 }
 
 // secant of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> asin(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::asin(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> asin(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::asin(double(x)));
 }
 
 // cotangent an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> cot(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::tan(sw::universal::m_pi_2-double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> cot(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::tan(sw::universal::m_pi_2-double(x)));
 }
 
 // secant of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> sec(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(1.0/std::cos(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> sec(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(1.0/std::cos(double(x)));
 }
 
 // cosecant of an angle of x radians
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> csc(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(1.0/std::sin(double(x)));
+template<size_t nbits, size_t rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> csc(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(1.0/std::sin(double(x)));
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/math/truncate.hpp
+++ b/include/universal/number/lns/math/truncate.hpp
@@ -8,27 +8,27 @@
 namespace sw { namespace universal {
 
 // Truncate value by rounding toward zero, returning the nearest integral value that is not larger in magnitude than x
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> trunc(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::trunc(double(x)));
+template<size_t nbits, size_t rbits, typename bt,  auto... xtra>
+lns<nbits, rbits, bt, xtra...> trunc(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::trunc(double(x)));
 }
 
 // Round to nearest: returns the integral value that is nearest to x, with halfway cases rounded away from zero
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> round(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::round(double(x)));
+template<size_t nbits, size_t rbits, typename bt,  auto... xtra>
+lns<nbits, rbits, bt, xtra...> round(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::round(double(x)));
 }
 
 // Round x downward, returning the largest integral value that is not greater than x
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> floor(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::floor(double(x)));
+template<size_t nbits, size_t rbits, typename bt,  auto... xtra>
+lns<nbits, rbits, bt, xtra...> floor(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::floor(double(x)));
 }
 
 // Round x upward, returning the smallest integral value that is greater than x
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-lns<nbits, rbits, behavior, bt> ceil(lns<nbits, rbits, behavior, bt> x) {
-	return lns<nbits, rbits, behavior, bt>(std::ceil(double(x)));
+template<size_t nbits, size_t rbits, typename bt,  auto... xtra>
+lns<nbits, rbits, bt, xtra...> ceil(lns<nbits, rbits, bt, xtra...> x) {
+	return lns<nbits, rbits, bt, xtra...>(std::ceil(double(x)));
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/numeric_limits.hpp
+++ b/include/universal/number/lns/numeric_limits.hpp
@@ -7,10 +7,10 @@
 
 namespace std {
 
-template <size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt>
-class numeric_limits< sw::universal::lns<nbits, rbits, behavior, bt> > {
+template <size_t nbits, size_t rbits, typename bt, auto... xtra>
+class numeric_limits< sw::universal::lns<nbits, rbits, bt, xtra...> > {
 public:
-	using LNS = sw::universal::lns<nbits, rbits, behavior, bt>;
+	using LNS = sw::universal::lns<nbits, rbits, bt, xtra...>;
 	static constexpr bool is_specialized = true;
 	static constexpr LNS  min() { // return minimum value
 		LNS lminpos(0);

--- a/include/universal/number/lns/table.hpp
+++ b/include/universal/number/lns/table.hpp
@@ -8,10 +8,10 @@
 namespace sw { namespace universal {
 
 // generate a full binary representation table for a given posit configuration
-template<size_t nbits, size_t rbits, ArithmeticBehavior behavior = Saturating, typename BlockType = std::uint8_t>
+template<size_t nbits, size_t rbits, typename BlockType = std::uint8_t, auto... xtra>
 void GenerateLnsTable(std::ostream& ostr, bool csvFormat = false) {
 	const size_t size = (1 << nbits);
-	sw::universal::lns<nbits, rbits, behavior, BlockType> v;
+	sw::universal::lns<nbits, rbits, BlockType, xtra...> v;
 	if (csvFormat) {
 		ostr << "\"Generate Value table for an LNS<" << nbits << "," << rbits << "> in CSV format\"" << std::endl;
 		ostr << "#, Binary, sign, scale, value\n";

--- a/tests/appenv/multifile/logs.cpp
+++ b/tests/appenv/multifile/logs.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <vector>
 
-using LNS8 = sw::universal::lns<8, 2, sw::universal::Saturating, std::uint8_t>;
+using LNS8 = sw::universal::lns<8, 2, std::uint8_t>;
 
 LNS8 lnsPolynomial(const std::vector<int>& coef, const LNS8& x) {
 	using namespace sw::universal;

--- a/tests/lns/api/api.cpp
+++ b/tests/lns/api/api.cpp
@@ -54,11 +54,11 @@ try {
 	// configuration
 	std::cout << "+---------    arithmetic operators with explicit alignment bahavior   --------+\n";
 	{
-		using Real = lns<16, 5, Saturating, std::uint16_t>;
+		using Real = lns<16, 5, std::uint16_t>;
 		ArithmeticOperators<Real>(1.0f, 1.0f);
 	}
 	{
-		using Real = lns<24, 5, Saturating, std::uint32_t>;
+		using Real = lns<24, 5, std::uint32_t>;
 		ArithmeticOperators<Real>(1.0f, 1.0f);
 	}
 
@@ -75,7 +75,7 @@ try {
 	{
 		constexpr size_t nbits = 10;
 		constexpr size_t rbits = 3;
-		using Real = lns<nbits, rbits>;  // behavior = Saturating, BlockType = uint8_t
+		using Real = lns<nbits, rbits>;  // BlockType = uint8_t, behavior = Saturating
 
 		CONSTEXPRESSION Real a{}; // zero constexpr
 		std::cout << type_tag(a) << '\n';
@@ -95,7 +95,7 @@ try {
 	{
 		constexpr size_t nbits = 10;
 		constexpr size_t rbits = 3;
-		using Real = lns<nbits, rbits>;  // behavior = Saturating, BlockType = uint8_t
+		using Real = lns<nbits, rbits>;  // BlockType = uint8_t, behavior = Saturating
 
 		Real a, b, c;
 
@@ -121,7 +121,7 @@ try {
 
 	std::cout << "+---------    comparison to classic floats   --------+\n";
 	{
-		using LNS = lns<16, 8, Saturating, std::uint16_t>;
+		using LNS = lns<16, 8, std::uint16_t>;
 		using Real = cfloat<16, 5, std::uint16_t>;
 		LNS a;
 		Real b;

--- a/tests/lns/arithmetic/addition.cpp
+++ b/tests/lns/arithmetic/addition.cpp
@@ -21,7 +21,7 @@ namespace sw { namespace universal {
 	int VerifyAddition(bool reportTestCases) {
 		constexpr size_t nbits = LnsType::nbits;
 		constexpr size_t rbits = LnsType::rbits;
-		constexpr ArithmeticBehavior behavior = LnsType::behavior;
+		constexpr Behavior behavior = LnsType::behavior;
 		using bt = typename LnsType::BlockType;
 		constexpr size_t NR_ENCODINGS = (1ull << nbits);
 
@@ -36,8 +36,8 @@ namespace sw { namespace universal {
 				double db = double(b);
 
 				double ref = da + db;
-				if (reportTestCases && !isInRange<nbits, rbits, behavior, bt>(ref)) {
-					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, behavior, bt>() << '\n';
+				if (reportTestCases && !isInRange<nbits, rbits, bt, behavior>(ref)) {
+					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, bt, behavior>() << '\n';
 				}
 				c = a + b;
 				cref = ref;
@@ -91,43 +91,43 @@ try {
 
 #if MANUAL_TESTING
 
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-	using LNS4_2_sat = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS5_2_sat = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_3_sat = lns<8, 3, Saturating, std::uint8_t>;
-	using LNS9_4_sat = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS16_5_sat = lns<16, 5, Saturating, std::uint16_t>;
+	using LNS4_1_sat = lns<4, 1, std::uint8_t>;
+	using LNS4_2_sat = lns<4, 2, std::uint8_t>;
+	using LNS5_2_sat = lns<5, 2, std::uint8_t>;
+	using LNS8_3_sat = lns<8, 3, std::uint8_t>;
+	using LNS9_4_sat = lns<9, 4, std::uint8_t>;
+	using LNS16_5_sat = lns<16, 5, std::uint16_t>;
 
 	// generate individual testcases to hand trace/debug
 	TestCase< LNS16_5_sat, double>(TestCaseOperator::ADD, INFINITY, INFINITY);
 	TestCase< LNS8_3_sat, float>(TestCaseOperator::ADD, 0.5f, -0.5f);
 
 	// manual exhaustive test
-	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS4_2_sat>(reportTestCases), "lns<4,2,Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS4_2_sat>(reportTestCases), "lns<4,2,uint8_t>", test_tag);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
 #else
 
 #if REGRESSION_LEVEL_1
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-	using LNS4_2_sat = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS5_2_sat = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_3_sat = lns<8, 3, Saturating, std::uint8_t>;
+	using LNS4_1_sat = lns<4, 1, std::uint8_t>;
+	using LNS4_2_sat = lns<4, 2, std::uint8_t>;
+	using LNS5_2_sat = lns<5, 2, std::uint8_t>;
+	using LNS8_3_sat = lns<8, 3, std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS4_1_sat>(reportTestCases), "lns<4,1,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS4_2_sat>(reportTestCases), "lns<4,2,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS5_2_sat>(reportTestCases), "lns<5,2,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS8_3_sat>(reportTestCases), "lns<8,3,Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS4_1_sat>(reportTestCases), "lns<4,1,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS4_2_sat>(reportTestCases), "lns<4,2,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS5_2_sat>(reportTestCases), "lns<5,2,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS8_3_sat>(reportTestCases), "lns<8,3,uint8_t>", test_tag);
 
 #endif
 
 #if REGRESSION_LEVEL_2
-	using LNS9_4_sat = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS10_4_sat = lns<10, 4, Saturating, std::uint8_t>;
+	using LNS9_4_sat = lns<9, 4, std::uint8_t>;
+	using LNS10_4_sat = lns<10, 4, std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS9_4_sat>(reportTestCases), "lns<9,4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS10_4_sat>(reportTestCases), "lns<10,4,Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS9_4_sat>(reportTestCases), "lns<9,4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition<LNS10_4_sat>(reportTestCases), "lns<10,4,uint8_t>", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/tests/lns/arithmetic/behavior.cpp
+++ b/tests/lns/arithmetic/behavior.cpp
@@ -1,4 +1,4 @@
-// bheavior.cpp: test suite runner for arithmetic behavior experiment
+// behavior.cpp: test suite runner for arithmetic behavior experiment
 //
 // Copyright (C) 2017-2022 Stillwater Supercomputing, Inc.
 //
@@ -10,7 +10,7 @@
 
 namespace sw { namespace universal {
 
-	template<size_t _nbits, size_t _rbits, ArithmeticBehavior behavior, typename bt>
+	template<size_t _nbits, size_t _rbits, typename bt, auto... xtra>
 	class lns2 {
 	public:
 		static constexpr size_t   nbits = _nbits;
@@ -40,18 +40,14 @@ namespace sw { namespace universal {
 	private:
 		BlockType _block[nrBlocks];
 
-		template<size_t nnbits, size_t rrbits, ArithmeticBehavior bbehave, typename nbt>
-		friend std::ostream& operator<< (std::ostream& ostr, const lns2<nnbits, rrbits, bbehave, nbt>& r);
+		friend std::ostream& operator<< (std::ostream& ostr, const lns2& r) {
+			return ostr << double(r);
+		}
 
 	};
 
-	template<size_t nnbits, size_t rrbits, ArithmeticBehavior bbehave, typename nbt>
-	std::ostream& operator<< (std::ostream& ostr, const lns2<nnbits, rrbits, bbehave, nbt>& r) {
-		return ostr << double(r);
-	}
-
-	template<size_t nnbits, size_t rrbits, ArithmeticBehavior bbehave, typename nbt>
-	std::string to_binary(const lns2<nnbits, rrbits, bbehave, nbt>& r) {
+	template<size_t nbits, size_t rbits, typename bt, auto... x>
+	std::string to_binary(const lns2<nbits, rbits, bt, x...>& r) {
 		std::stringstream s;
 		s << to_binary(r.block(0));
 		return s.str();
@@ -90,7 +86,7 @@ try {
 #if MANUAL_TESTING
 
 	{
-		using Real = lns<8, 2, Modular, std::uint8_t>;
+		using Real = lns<8, 2, std::uint8_t, Behavior::Wrapping>;
 		bool isTrivial = bool(std::is_trivial<Real>());
 		static_assert(std::is_trivial<Real>(), "lns should be trivial but failed the assertion");
 		std::cout << (isTrivial ? "lns is trivial" : "lns failed trivial: FAIL") << '\n';
@@ -111,7 +107,7 @@ try {
 	std::cout << '\n';
 
 	{
-		using Real = lns<8, 2, Saturating, std::uint8_t>;
+		using Real = lns<8, 2, std::uint8_t>; // Saturating by default (a smaller symbol results from not providing an explicit Saturating argument)
 		bool isTrivial = bool(std::is_trivial<Real>());
 		static_assert(std::is_trivial<Real>(), "lns should be trivial but failed the assertion");
 		std::cout << (isTrivial ? "lns is trivial" : "lns failed trivial: FAIL") << '\n';
@@ -132,11 +128,11 @@ try {
 	std::cout << '\n';
 
 	{
-		using ModularLns = lns<8, 4, Modular, std::uint8_t>;
-		using SaturatingLns = lns<8, 4, Saturating, std::uint8_t>;
+		using WrappingLns = lns<8, 4, std::uint8_t, Behavior::Wrapping>;
+		using SaturatingLns = lns<8, 4, std::uint8_t>;
 
 		{
-			ModularLns a, b, c;
+			WrappingLns a{}, b{}, c{};
 			std::cout << dynamic_range(a) << '\n';
 			a = 4;
 			b = 4;
@@ -146,7 +142,7 @@ try {
 		}
 		std::cout << '\n';
 		{
-			SaturatingLns a, b, c;
+			SaturatingLns a{}, b{}, c{};
 			std::cout << dynamic_range(a) << '\n';
 			a = 4;
 			b = 4;

--- a/tests/lns/arithmetic/division.cpp
+++ b/tests/lns/arithmetic/division.cpp
@@ -19,14 +19,14 @@ namespace sw { namespace universal {
 	int VerifyDivision(bool reportTestCases) {
 		constexpr size_t nbits = LnsType::nbits;
 		constexpr size_t rbits = LnsType::rbits;
-		constexpr ArithmeticBehavior behavior = LnsType::behavior;
+		constexpr Behavior behavior = LnsType::behavior;
 		using bt = typename LnsType::BlockType;
 		constexpr size_t NR_ENCODINGS = (1ull << nbits);
 
 		int nrOfFailedTestCases = 0;
 		bool firstTime = true;
-		LnsType a, b, c, cref;
-		double ref;
+		LnsType a{}, b{}, c{}, cref{};
+		double ref{};
 		if (reportTestCases) a.debugConstexprParameters();
 		for (size_t i = 0; i < NR_ENCODINGS; ++i) {
 			a.setbits(i);
@@ -57,8 +57,8 @@ namespace sw { namespace universal {
 				c = a / b;
 				ref = da / db;
 #endif
-				if (reportTestCases && !isInRange<nbits, rbits, behavior, bt>(ref)) {
-					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, behavior, bt>() << '\n';
+				if (reportTestCases && !isInRange<nbits, rbits, bt, behavior>(ref)) {
+					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, bt, behavior>() << '\n';
 				}
 				cref = ref;
 //				std::cout << "ref  : " << to_binary(ref) << " : " << ref << '\n';
@@ -164,13 +164,13 @@ try {
 
 #if MANUAL_TESTING
 
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-	using LNS4_2_sat = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS5_2_sat = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_3_sat = lns<8, 3, Saturating, std::uint8_t>;
-	using LNS8_4_sat = lns<8, 4, Saturating, std::uint8_t>;
-	using LNS9_4_sat = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS16_5_sat = lns<16, 5, Saturating, std::uint16_t>;
+	using LNS4_1_sat = lns<4, 1, std::uint8_t>;
+	using LNS4_2_sat = lns<4, 2, std::uint8_t>;
+	using LNS5_2_sat = lns<5, 2, std::uint8_t>;
+	using LNS8_3_sat = lns<8, 3, std::uint8_t>;
+	using LNS8_4_sat = lns<8, 4, std::uint8_t>;
+	using LNS9_4_sat = lns<9, 4, std::uint8_t>;
+	using LNS16_5_sat = lns<16, 5, std::uint16_t>;
 
 	// : FAIL 1                    / 267.33408830141792123 != 0.0037406378152288035158 golden reference is 62757.488603861726006
 	// : result 0b0.1111.1111
@@ -202,35 +202,35 @@ try {
 
 	// GenerateLnsTable<5, 2>(std::cout);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS4_1_sat>(reportTestCases), "lns<4,1,Saturating,uint8_t>>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS4_2_sat>(reportTestCases), "lns<4,2,Saturating,uint8_t>>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS5_2_sat>(reportTestCases), "lns<5,2,Saturating,uint8_t>>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS8_3_sat>(reportTestCases), "lns<8,3,Saturating,uint8_t>>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS9_4_sat>(reportTestCases), "lns<9,4,Saturating,uint8_t>>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS4_1_sat>(reportTestCases), "lns<4,1,uint8_t>>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS4_2_sat>(reportTestCases), "lns<4,2,uint8_t>>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS5_2_sat>(reportTestCases), "lns<5,2,uint8_t>>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS8_3_sat>(reportTestCases), "lns<8,3,uint8_t>>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS9_4_sat>(reportTestCases), "lns<9,4,uint8_t>>", test_tag);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
 #else
 
 #if REGRESSION_LEVEL_1
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-//	using LNS4_2_sat = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS5_2_sat = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_3_sat = lns<8, 3, Saturating, std::uint8_t>;
+	using LNS4_1_sat = lns<4, 1, std::uint8_t>;
+//	using LNS4_2_sat = lns<4, 2, std::uint8_t>;
+	using LNS5_2_sat = lns<5, 2, std::uint8_t>;
+	using LNS8_3_sat = lns<8, 3, std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS4_1_sat>(reportTestCases),  "lns< 4,1,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS5_2_sat>(reportTestCases),  "lns< 5,2,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS8_3_sat>(reportTestCases),  "lns< 8,3,Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS4_1_sat>(reportTestCases), "lns< 4,1,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS5_2_sat>(reportTestCases), "lns< 5,2,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS8_3_sat>(reportTestCases), "lns< 8,3,uint8_t>", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2
-	using LNS9_4_sat = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS9_4_sat_uint16 = lns<9, 4, Saturating, std::uint16_t>;
-	using LNS10_4_sat = lns<10, 4, Saturating, std::uint8_t>;
+	using LNS9_4_sat = lns<9, 4, std::uint8_t>;
+	using LNS9_4_sat_uint16 = lns<9, 4, std::uint16_t>;
+	using LNS10_4_sat = lns<10, 4, std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS9_4_sat>(reportTestCases), "lns< 9,4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS9_4_sat_uint16>(reportTestCases), "lns< 9,4,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS10_4_sat>(reportTestCases), "lns<10,4,Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS9_4_sat>(reportTestCases), "lns< 9,4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS9_4_sat_uint16>(reportTestCases), "lns< 9,4,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyDivision<LNS10_4_sat>(reportTestCases), "lns<10,4,uint8_t>", test_tag);
 
 #endif
 

--- a/tests/lns/arithmetic/multiplication.cpp
+++ b/tests/lns/arithmetic/multiplication.cpp
@@ -19,13 +19,13 @@ namespace sw { namespace universal {
 	int VerifyMultiplication(bool reportTestCases) {
 		constexpr size_t nbits = LnsType::nbits;
 		constexpr size_t rbits = LnsType::rbits;
-		constexpr ArithmeticBehavior behavior = LnsType::behavior;
+		constexpr Behavior behavior = LnsType::behavior;
 		using bt = typename LnsType::BlockType;
 		constexpr size_t NR_ENCODINGS = (1ull << nbits);
 
 		int nrOfFailedTestCases = 0;
 
-		LnsType a, b, c, cref;
+		LnsType a{}, b{}, c{}, cref{};
 		for (size_t i = 0; i < NR_ENCODINGS; ++i) {
 			a.setbits(i);
 			double da = double(a);
@@ -34,8 +34,8 @@ namespace sw { namespace universal {
 				double db = double(b);
 
 				double ref = da * db;
-				if (reportTestCases && !isInRange<nbits, rbits, behavior, bt>(ref)) {
-					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, behavior, bt>() << '\n';
+				if (reportTestCases && !isInRange<nbits, rbits, bt, behavior>(ref)) {
+					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, bt, behavior>() << '\n';
 				}
 				c = a * b;
 				cref = ref;
@@ -163,13 +163,13 @@ try {
 
 #if MANUAL_TESTING
 
-	using LNS4_1_mod = lns<4, 1, Modular, std::uint8_t>;
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-	using LNS4_2     = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS5_2     = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_3     = lns<8, 3, Saturating, std::uint8_t>;
-	using LNS9_4     = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS16_5    = lns<16, 5, Saturating, std::uint16_t>;
+	using LNS4_1_mod = lns<4, 1, std::uint8_t, Behavior::Wrapping>;
+	using LNS4_1_sat = lns<4, 1, std::uint8_t>;
+	using LNS4_2     = lns<4, 2, std::uint8_t>;
+	using LNS5_2     = lns<5, 2, std::uint8_t>;
+	using LNS8_3     = lns<8, 3, std::uint8_t>;
+	using LNS9_4     = lns<9, 4, std::uint8_t>;
+	using LNS16_5    = lns<16, 5, std::uint16_t>;
 
 	// generate individual testcases to hand trace/debug
 	TestCase<LNS4_1_sat, float>(TestCaseOperator::MUL, 0.353f, -0.353f);
@@ -178,52 +178,52 @@ try {
 
 	// GenerateLnsTable<5, 2>(std::cout);
 
-//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_1_mod>(false), "lns<4,1, Modular,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_1_sat>(reportTestCases), "lns<4,1, Saturating,uint8_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_2>(reportTestCases), "lns<4,2, Saturating,uint8_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS5_2>(reportTestCases), "lns<5,2, Saturating,uint8_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_3>(reportTestCases), "lns<8,3, Saturating,uint8_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_4>(reportTestCases), "lns<9,4, Saturating,uint8_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_1_mod>(false), "lns<4,1,uint8_t,Behavior::Wrapping>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_1_sat>(reportTestCases), "lns<4,1, uint8_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_2>(reportTestCases), "lns<4,2, uint8_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS5_2>(reportTestCases), "lns<5,2, uint8_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_3>(reportTestCases), "lns<8,3, uint8_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_4>(reportTestCases), "lns<9,4, uint8_t>", test_tag);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
 #else
 
 #if REGRESSION_LEVEL_1
-	using LNS4_0_sat = lns<4, 0, Saturating, std::uint8_t>;
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-	using LNS4_2_sat = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS4_3_sat = lns<4, 3, Saturating, std::uint8_t>;
-	using LNS5_2_sat = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_1_sat = lns<8, 1, Saturating, std::uint8_t>;
-	using LNS8_4_sat = lns<8, 4, Saturating, std::uint8_t>;
-	using LNS8_7_sat = lns<8, 7, Saturating, std::uint8_t>;
-	using LNS9_0_sat = lns<9, 0, Saturating, std::uint8_t>;
-	using LNS9_4_sat = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS9_8_sat = lns<9, 8, Saturating, std::uint8_t>;
+	using LNS4_0_sat = lns<4, 0, std::uint8_t>;
+	using LNS4_1_sat = lns<4, 1, std::uint8_t>;
+	using LNS4_2_sat = lns<4, 2, std::uint8_t>;
+	using LNS4_3_sat = lns<4, 3, std::uint8_t>;
+	using LNS5_2_sat = lns<5, 2, std::uint8_t>;
+	using LNS8_1_sat = lns<8, 1, std::uint8_t>;
+	using LNS8_4_sat = lns<8, 4, std::uint8_t>;
+	using LNS8_7_sat = lns<8, 7, std::uint8_t>;
+	using LNS9_0_sat = lns<9, 0, std::uint8_t>;
+	using LNS9_4_sat = lns<9, 4, std::uint8_t>;
+	using LNS9_8_sat = lns<9, 8, std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_0_sat>(reportTestCases), "lns<4,0, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_1_sat>(reportTestCases), "lns<4,1, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_2_sat>(reportTestCases), "lns<4,2, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_3_sat>(reportTestCases), "lns<4,3, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS5_2_sat>(reportTestCases), "lns<5,2, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_1_sat>(reportTestCases), "lns<8,1, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_4_sat>(reportTestCases), "lns<8,4, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_7_sat>(reportTestCases), "lns<8,7, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_0_sat>(reportTestCases), "lns<9,0, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_4_sat>(reportTestCases), "lns<9,4, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_8_sat>(reportTestCases), "lns<9,8, Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_0_sat>(reportTestCases), "lns<4,0, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_1_sat>(reportTestCases), "lns<4,1, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_2_sat>(reportTestCases), "lns<4,2, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS4_3_sat>(reportTestCases), "lns<4,3, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS5_2_sat>(reportTestCases), "lns<5,2, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_1_sat>(reportTestCases), "lns<8,1, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_4_sat>(reportTestCases), "lns<8,4, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS8_7_sat>(reportTestCases), "lns<8,7, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_0_sat>(reportTestCases), "lns<9,0, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_4_sat>(reportTestCases), "lns<9,4, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS9_8_sat>(reportTestCases), "lns<9,8, uint8_t>", test_tag);
 
 #endif
 
 #if REGRESSION_LEVEL_2
-	using LNS10_0_sat = lns<10, 0, Saturating, std::uint8_t>;
-	using LNS10_4_sat = lns<10, 4, Saturating, std::uint8_t>;
-	using LNS10_9_sat = lns<10, 9, Saturating, std::uint8_t>;
+	using LNS10_0_sat = lns<10, 0, std::uint8_t>;
+	using LNS10_4_sat = lns<10, 4, std::uint8_t>;
+	using LNS10_9_sat = lns<10, 9, std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS10_0_sat>(reportTestCases), "lns<10,0, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS10_4_sat>(reportTestCases), "lns<10,4, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS10_9_sat>(reportTestCases), "lns<10,9, Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS10_0_sat>(reportTestCases), "lns<10,0, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS10_4_sat>(reportTestCases), "lns<10,4, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplication<LNS10_9_sat>(reportTestCases), "lns<10,9, uint8_t>", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/tests/lns/arithmetic/subtraction.cpp
+++ b/tests/lns/arithmetic/subtraction.cpp
@@ -21,13 +21,13 @@ namespace sw { namespace universal {
 	int VerifySubtraction(bool reportTestCases) {
 		constexpr size_t nbits = LnsType::nbits;
 		constexpr size_t rbits = LnsType::rbits;
-		constexpr ArithmeticBehavior behavior = LnsType::behavior;
+		constexpr Behavior behavior = LnsType::behavior;
 		using bt = typename LnsType::BlockType;
 		constexpr size_t NR_ENCODINGS = (1ull << nbits);
 
 		int nrOfFailedTestCases = 0;
 
-		LnsType a, b, c, cref;
+		LnsType a{}, b{}, c{}, cref{};
 		for (size_t i = 0; i < NR_ENCODINGS; ++i) {
 			a.setbits(i);
 			double da = double(a);
@@ -36,8 +36,8 @@ namespace sw { namespace universal {
 				double db = double(b);
 
 				double ref = da - db;
-				if (reportTestCases && !isInRange<nbits, rbits, behavior, bt>(ref)) {
-					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, behavior, bt>() << '\n';
+				if (reportTestCases && !isInRange<nbits, rbits, bt, behavior>(ref)) {
+					std::cerr << da << " * " << db << " = " << ref << " which is not in range " << range<nbits, rbits, bt, behavior>() << '\n';
 				}
 				c = a - b;
 				cref = ref;
@@ -91,43 +91,43 @@ try {
 
 #if MANUAL_TESTING
 
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-	using LNS4_2_sat = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS5_2_sat = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_3_sat = lns<8, 3, Saturating, std::uint8_t>;
-	using LNS9_4_sat = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS16_5_sat = lns<16, 5, Saturating, std::uint16_t>;
+	using LNS4_1_sat = lns<4, 1,std::uint8_t>;
+	using LNS4_2_sat = lns<4, 2,std::uint8_t>;
+	using LNS5_2_sat = lns<5, 2,std::uint8_t>;
+	using LNS8_3_sat = lns<8, 3,std::uint8_t>;
+	using LNS9_4_sat = lns<9, 4,std::uint8_t>;
+	using LNS16_5_sat = lns<16, 5,std::uint16_t>;
 
 	// generate individual testcases to hand trace/debug
 	TestCase< LNS16_5_sat, double>(TestCaseOperator::SUB, INFINITY, INFINITY);
 	TestCase< LNS8_3_sat, float>(TestCaseOperator::SUB, 0.5f, -0.5f);
 
 	// manual exhaustive test
-	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS8_3_sat>(reportTestCases), "lns<8,2,Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS8_3_sat>(reportTestCases), "lns<8,2,uint8_t>", test_tag);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
 #else
 
 #if REGRESSION_LEVEL_1
-	using LNS4_1_sat = lns<4, 1, Saturating, std::uint8_t>;
-	using LNS4_2_sat = lns<4, 2, Saturating, std::uint8_t>;
-	using LNS5_2_sat = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS8_3_sat = lns<8, 3, Saturating, std::uint8_t>;
+	using LNS4_1_sat = lns<4, 1,std::uint8_t>;
+	using LNS4_2_sat = lns<4, 2,std::uint8_t>;
+	using LNS5_2_sat = lns<5, 2,std::uint8_t>;
+	using LNS8_3_sat = lns<8, 3,std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS4_1_sat>(reportTestCases), "lns<4,1, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS4_2_sat>(reportTestCases), "lns<4,2, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS5_2_sat>(reportTestCases), "lns<5,2, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS8_3_sat>(reportTestCases), "lns<8,3, Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS4_1_sat>(reportTestCases), "lns<4,1, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS4_2_sat>(reportTestCases), "lns<4,2, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS5_2_sat>(reportTestCases), "lns<5,2, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS8_3_sat>(reportTestCases), "lns<8,3, uint8_t>", test_tag);
 
 #endif
 
 #if REGRESSION_LEVEL_2
-	using LNS9_4_sat = lns<9, 4, Saturating, std::uint8_t>;
-	using LNS10_4_sat = lns<10, 4, Saturating, std::uint8_t>;
+	using LNS9_4_sat = lns<9, 4,std::uint8_t>;
+	using LNS10_4_sat = lns<10, 4,std::uint8_t>;
 
-	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS9_4_sat>(reportTestCases), "lns<9,4, Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS10_4_sat>(reportTestCases), "lns<10,4, Saturating,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS9_4_sat>(reportTestCases), "lns<9,4, uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySubtraction<LNS10_4_sat>(reportTestCases), "lns<10,4, uint8_t>", test_tag);
 
 #endif
 

--- a/tests/lns/conversion/assignment.cpp
+++ b/tests/lns/conversion/assignment.cpp
@@ -97,11 +97,11 @@ try {
 
 #if MANUAL_TESTING
 
-	using LNS16_5 = lns<16, 5, Saturating, std::uint16_t>;
-	using LNS11_5 = lns<11, 5, Saturating, std::uint8_t>;
-	using LNS8_2 = lns<8, 2, Saturating, std::uint8_t>;
-	using LNS5_2 = lns<5, 2, Saturating, std::uint8_t>;
-	using LNS4_1 = lns<4, 1, Saturating, std::uint8_t>;
+//	using LNS16_5 = lns<16, 5, std::uint16_t>;
+//	using LNS11_5 = lns<11, 5, std::uint8_t>;
+//	using LNS8_2 = lns<8, 2, std::uint8_t>;
+	using LNS5_2 = lns<5, 2, std::uint8_t>;
+//	using LNS4_1 = lns<4, 1, std::uint8_t>;
 
 	// GenerateBitWeightTable<double>();
 	SampleTest(1024.0f);

--- a/tests/lns/conversion/conversion.cpp
+++ b/tests/lns/conversion/conversion.cpp
@@ -57,15 +57,15 @@ namespace sw { namespace universal {
 		}
 
 		// enumerate all conversion cases for a posit configuration
-		template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
+		template<size_t nbits, size_t rbits, typename bt, auto... x>
 		int VerifyConversion(bool reportTestCases) {
 			// we are going to generate a test set that consists of all lns configs and their midpoints
 			// we do this by enumerating an lns that is 1-bit larger than the test configuration
 			// These larger posits will be at the mid-point between the smaller sample values
 			// and we'll enumerate the exact value, and a perturbation smaller and a perturbation larger
 			// to test the rounding logic of the conversion.
-			using TestType = lns<nbits, rbits, behavior, bt>;
-			using ContainingType = lns<nbits + 1, rbits + 1, behavior, bt>;
+			using TestType = lns<nbits, rbits, bt, x...>;
+			using ContainingType = lns<nbits + 1, rbits + 1, bt, x...>;
 
 			constexpr size_t max = nbits > 16 ? 16 : nbits;
 			size_t NR_TEST_CASES = (size_t(1) << (max + 1));
@@ -181,9 +181,9 @@ namespace sw { namespace universal {
 		}
 
 		// enumerate all conversion cases for integers
-		template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
+		template<size_t nbits, size_t rbits, typename bt, auto... x>
 		int VerifyIntegerConversion(bool reportTestCases) {
-			using TestType = lns<nbits, rbits, behavior, bt>;
+			using TestType = lns<nbits, rbits, bt, x...>;
 
 			// we generate numbers from 1 via maxpos to -1 and through the special case of 0 back to 1
 			constexpr unsigned max = nbits > 20 ? 20 : nbits;
@@ -255,7 +255,7 @@ try {
 #if MANUAL_TESTING
 
 	{
-		using LNS5_2 = lns<5, 2, Saturating, std::uint8_t>;
+		using LNS5_2 = lns<5, 2, std::uint8_t>;
 		LNS5_2 minpos(SpecificValue::minpos);
 		double mp = double(minpos);
 		LNS5_2 result = mp;
@@ -270,7 +270,7 @@ try {
 		result = threeQuarterMinpos;
 		GenerateTestCase<LNS5_2, double>(threeQuarterMinpos, mp, result);
 
-		using LNS6_3 = lns<6, 3, Saturating, std::uint8_t>;
+		using LNS6_3 = lns<6, 3, std::uint8_t>;
 		LNS6_3 ref;
 		ref.setbits(17);
 		std::cout << to_binary(ref) << " : " << ref << '\n';
@@ -281,8 +281,8 @@ try {
 	}
 
 	{
-		using LNS5_2 = lns<5, 2, Saturating, std::uint8_t>;
-		using LNS6_3 = lns<6, 3, Saturating, std::uint8_t>;
+		using LNS5_2 = lns<5, 2, std::uint8_t>;
+		using LNS6_3 = lns<6, 3, std::uint8_t>;
 
 		constexpr size_t NR_SAMPLES = 32;
 		LNS5_2 a;
@@ -299,18 +299,18 @@ try {
 		}
 	}
 
-	nrOfFailedTestCases += VerifyConversion<5, 2, Saturating, std::uint8_t>(true);
+	nrOfFailedTestCases += VerifyConversion<5, 2, std::uint8_t>(true);
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return 0; 
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<4, 1, Saturating, std::uint8_t>(true), "lns<4,1>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<5, 2, Saturating, std::uint8_t>(true), "lns<5,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<4, 1, std::uint8_t>(true), "lns<4,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<5, 2, std::uint8_t>(true), "lns<5,2>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<4, 1, Saturating, std::uint8_t>(true), "lns<4,1>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<5, 2, Saturating, std::uint8_t>(true), "lns<5,2>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<6, 3, Saturating, std::uint8_t>(true), "lns<6,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<4, 1, std::uint8_t>(true), "lns<4,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<5, 2, std::uint8_t>(true), "lns<5,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<6, 3, std::uint8_t>(true), "lns<6,3>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<4, 1, Saturating, std::uint8_t>(true), "lns<4,1>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<5, 2, Saturating, std::uint8_t>(true), "lns<5,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<4, 1, std::uint8_t>(true), "lns<4,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<5, 2, std::uint8_t>(true), "lns<5,2>", test_tag);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
@@ -318,49 +318,49 @@ try {
 
 #if REGRESSION_LEVEL_1
 	/*
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<3, 0, Saturating, std::uint8_t>(reportTestCases), "lns<3,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<4, 0, Saturating, std::uint8_t>(reportTestCases), "lns<4,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<5, 0, Saturating, std::uint8_t>(reportTestCases), "lns<5,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<6, 0, Saturating, std::uint8_t>(reportTestCases), "lns<6,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<7, 0, Saturating, std::uint8_t>(reportTestCases), "lns<7,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<8, 0, Saturating, std::uint8_t>(reportTestCases), "lns<8,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<9, 0, Saturating, std::uint8_t>(reportTestCases), "lns<9,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<3, 0, std::uint8_t>(reportTestCases), "lns<3,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<4, 0, std::uint8_t>(reportTestCases), "lns<4,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<5, 0, std::uint8_t>(reportTestCases), "lns<5,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<6, 0, std::uint8_t>(reportTestCases), "lns<6,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<7, 0, std::uint8_t>(reportTestCases), "lns<7,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<8, 0, std::uint8_t>(reportTestCases), "lns<8,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyIntegerConversion<9, 0, std::uint8_t>(reportTestCases), "lns<9,0>", test_tag);
 	*/
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 3, 0, Saturating, std::uint8_t>(reportTestCases), "lns<3,0,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 3, 1, Saturating, std::uint8_t>(reportTestCases), "lns<3,1,Saturating>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 3, 0, std::uint8_t>(reportTestCases), "lns<3,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 3, 1, std::uint8_t>(reportTestCases), "lns<3,1>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 0, Saturating, std::uint8_t>(reportTestCases), "lns<4,0,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 1, Saturating, std::uint8_t>(reportTestCases), "lns<4,1,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 2, Saturating, std::uint8_t>(reportTestCases), "lns<4,2,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 3, Saturating, std::uint8_t>(reportTestCases), "lns<4,3,Saturating>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 0, std::uint8_t>(reportTestCases), "lns<4,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 1, std::uint8_t>(reportTestCases), "lns<4,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 2, std::uint8_t>(reportTestCases), "lns<4,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 4, 3, std::uint8_t>(reportTestCases), "lns<4,3>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 0, Saturating, std::uint8_t>(reportTestCases), "lns<6,0,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 1, Saturating, std::uint8_t>(reportTestCases), "lns<6,1,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 2, Saturating, std::uint8_t>(reportTestCases), "lns<6,2,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 3, Saturating, std::uint8_t>(reportTestCases), "lns<6,3,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 4, Saturating, std::uint8_t>(reportTestCases), "lns<6,4,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 5, Saturating, std::uint8_t>(reportTestCases), "lns<6,5,Saturating>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 0, std::uint8_t>(reportTestCases), "lns<6,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 1, std::uint8_t>(reportTestCases), "lns<6,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 2, std::uint8_t>(reportTestCases), "lns<6,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 3, std::uint8_t>(reportTestCases), "lns<6,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 4, std::uint8_t>(reportTestCases), "lns<6,4>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 6, 5, std::uint8_t>(reportTestCases), "lns<6,5>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 0, Saturating, std::uint8_t>(reportTestCases), "lns<8,0,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 1, Saturating, std::uint8_t>(reportTestCases), "lns<8,1,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 2, Saturating, std::uint8_t>(reportTestCases), "lns<8,2,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 3, Saturating, std::uint8_t>(reportTestCases), "lns<8,3,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 4, Saturating, std::uint8_t>(reportTestCases), "lns<8,4,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 5, Saturating, std::uint8_t>(reportTestCases), "lns<8,5,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 6, Saturating, std::uint8_t>(reportTestCases), "lns<8,6,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 7, Saturating, std::uint8_t>(reportTestCases), "lns<8,7,Saturating>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 0, std::uint8_t>(reportTestCases), "lns<8,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 1, std::uint8_t>(reportTestCases), "lns<8,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 2, std::uint8_t>(reportTestCases), "lns<8,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 3, std::uint8_t>(reportTestCases), "lns<8,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 4, std::uint8_t>(reportTestCases), "lns<8,4>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 5, std::uint8_t>(reportTestCases), "lns<8,5>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 6, std::uint8_t>(reportTestCases), "lns<8,6>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 8, 7, std::uint8_t>(reportTestCases), "lns<8,7>", test_tag);
 
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 0, Saturating, std::uint8_t>(reportTestCases), "lns<9,0,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 1, Saturating, std::uint8_t>(reportTestCases), "lns<9,1,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 2, Saturating, std::uint8_t>(reportTestCases), "lns<9,2,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 3, Saturating, std::uint8_t>(reportTestCases), "lns<9,3,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 4, Saturating, std::uint8_t>(reportTestCases), "lns<9,4,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 5, Saturating, std::uint8_t>(reportTestCases), "lns<9,5,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 6, Saturating, std::uint8_t>(reportTestCases), "lns<9,6,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 7, Saturating, std::uint8_t>(reportTestCases), "lns<9,7,Saturating>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 8, Saturating, std::uint8_t>(reportTestCases), "lns<9,8,Saturating>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 0, std::uint8_t>(reportTestCases), "lns<9,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 1, std::uint8_t>(reportTestCases), "lns<9,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 2, std::uint8_t>(reportTestCases), "lns<9,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 3, std::uint8_t>(reportTestCases), "lns<9,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 4, std::uint8_t>(reportTestCases), "lns<9,4>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 5, std::uint8_t>(reportTestCases), "lns<9,5>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 6, std::uint8_t>(reportTestCases), "lns<9,6>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 7, std::uint8_t>(reportTestCases), "lns<9,7>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion< 9, 8, std::uint8_t>(reportTestCases), "lns<9,8>", test_tag);
 
 
 #endif
@@ -374,25 +374,25 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 0, Saturating, std::uint8_t>(reportTestCases), "lns<10,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 1, Saturating, std::uint8_t>(reportTestCases), "lns<10,1>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 2, Saturating, std::uint8_t>(reportTestCases), "lns<10,2>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 3, Saturating, std::uint8_t>(reportTestCases), "lns<10,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 0, std::uint8_t>(reportTestCases), "lns<10,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 1, std::uint8_t>(reportTestCases), "lns<10,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 2, std::uint8_t>(reportTestCases), "lns<10,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<10, 3, std::uint8_t>(reportTestCases), "lns<10,3>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 0, Saturating, std::uint8_t>(reportTestCases), "lns<12,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 1, Saturating, std::uint8_t>(reportTestCases), "lns<12,1>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 2, Saturating, std::uint8_t>(reportTestCases), "lns<12,2>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 3, Saturating, std::uint8_t>(reportTestCases), "lns<12,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 0, std::uint8_t>(reportTestCases), "lns<12,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 1, std::uint8_t>(reportTestCases), "lns<12,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 2, std::uint8_t>(reportTestCases), "lns<12,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<12, 3, std::uint8_t>(reportTestCases), "lns<12,3>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 0, Saturating, std::uint8_t>(reportTestCases), "lns<14,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 1, Saturating, std::uint8_t>(reportTestCases), "lns<14,1>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 2, Saturating, std::uint8_t>(reportTestCases), "lns<14,2>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 3, Saturating, std::uint8_t>(reportTestCases), "lns<14,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 0, std::uint8_t>(reportTestCases), "lns<14,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 1, std::uint8_t>(reportTestCases), "lns<14,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 2, std::uint8_t>(reportTestCases), "lns<14,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<14, 3, std::uint8_t>(reportTestCases), "lns<14,3>", test_tag);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 0, Saturating, std::uint8_t>(reportTestCases), "lns<16,0>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 1, Saturating, std::uint8_t>(reportTestCases), "lns<16,1>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 2, Saturating, std::uint8_t>(reportTestCases), "lns<16,2>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 3, Saturating, std::uint8_t>(reportTestCases), "lns<16,3>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 0, std::uint8_t>(reportTestCases), "lns<16,0>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 1, std::uint8_t>(reportTestCases), "lns<16,1>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 2, std::uint8_t>(reportTestCases), "lns<16,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyConversion<16, 3, std::uint8_t>(reportTestCases), "lns<16,3>", test_tag);
 #endif // REGRESSION_LEVEL_4
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/tests/lns/logic/logic.cpp
+++ b/tests/lns/logic/logic.cpp
@@ -36,34 +36,34 @@ int VerifyZeroEncodings(bool reportTestCases) {
 	std::string test_tag = "iszero()";
 
 	// single block configurations
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns< 8,  4, Saturating, std::uint8_t > >(reportTestCases), "lns< 8, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<16,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<16, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<32, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<32,16,Saturating,uint32_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<64, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<64,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns< 8, 4, std::uint8_t > >(reportTestCases), "lns< 8, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<16, 8, std::uint16_t> >(reportTestCases), "lns<16, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<32, 16, std::uint32_t> >(reportTestCases), "lns<32,16,uint32_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<64, 32, std::uint64_t> >(reportTestCases), "lns<64,32,uint64_t>", test_tag);
 
 	// double block configurations with all special bits in the MSU
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<10,  4, Saturating, std::uint8_t > >(reportTestCases), "lns<10, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<18,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<18, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<34, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<34,16,Saturating,uint32_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<66,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<10, 4, std::uint8_t > >(reportTestCases), "lns<10, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<18, 8, std::uint16_t> >(reportTestCases), "lns<18, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<34, 16, std::uint32_t> >(reportTestCases), "lns<34,16,uint32_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, std::uint64_t> >(reportTestCases), "lns<66,32,uint64_t>", test_tag);
 
 	// double block configurations with special bits split between MSU and MSU - 1
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns< 9,  4, Saturating, std::uint8_t > >(reportTestCases), "lns< 9, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<17,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<17, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<33, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<33,16,Saturating,uint32_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<65,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns< 9, 4, std::uint8_t > >(reportTestCases), "lns< 9, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<17, 8, std::uint16_t> >(reportTestCases), "lns<17, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<33, 16, std::uint32_t> >(reportTestCases), "lns<33,16,uint32_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, std::uint64_t> >(reportTestCases), "lns<65,32,uint64_t>", test_tag);
 
 	// triple block configurations with all special bits in the MSU
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<26,  4, Saturating, std::uint8_t > >(reportTestCases), "lns<26, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<50,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<50, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<98, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<98,16,Saturating,uint32_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<66,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<26, 4, std::uint8_t > >(reportTestCases), "lns<26, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<50, 8, std::uint16_t> >(reportTestCases), "lns<50, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<98, 16, std::uint32_t> >(reportTestCases), "lns<98,16,uint32_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, std::uint64_t> >(reportTestCases), "lns<66,32,uint64_t>", test_tag);
 
 	// triple block configurations with special bits split between MSU and MSU - 1
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<25,  4, Saturating, std::uint8_t > >(reportTestCases), "lns<25, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<49,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<49, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<97, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<97,16,Saturating,uint32_t>", test_tag);
-//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<65,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<25, 4, std::uint8_t > >(reportTestCases), "lns<25, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<49, 8, std::uint16_t> >(reportTestCases), "lns<49, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<97, 16, std::uint32_t> >(reportTestCases), "lns<97,16,uint32_t>", test_tag);
+//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, std::uint64_t> >(reportTestCases), "lns<65,32,uint64_t>", test_tag);
 
 	return nrOfFailedTestCases;
 }
@@ -94,34 +94,34 @@ int VerifyNaNEncodings(bool reportTestCases) {
 	std::string test_tag = "isnan()";
 
 	// single block configurations
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns< 8,  4, Saturating, std::uint8_t > >(reportTestCases), "lns< 8, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<16,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<16, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<32, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<32,16,Saturating,uint32_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<64, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<64,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns< 8, 4, std::uint8_t > >(reportTestCases), "lns< 8, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<16, 8, std::uint16_t> >(reportTestCases), "lns<16, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<32, 16, std::uint32_t> >(reportTestCases), "lns<32,16,uint32_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<64, 32, std::uint64_t> >(reportTestCases), "lns<64,32,uint64_t>", test_tag);
 
 	// double block configurations with all special bits in the MSU
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<10,  4, Saturating, std::uint8_t > >(reportTestCases), "lns<10, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<18,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<18, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<34, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<34,16,Saturating,uint32_t>", test_tag);
-	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<66,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<10, 4, std::uint8_t > >(reportTestCases), "lns<10, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<18, 8, std::uint16_t> >(reportTestCases), "lns<18, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<34, 16, std::uint32_t> >(reportTestCases), "lns<34,16,uint32_t>", test_tag);
+	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, std::uint64_t> >(reportTestCases), "lns<66,32,uint64_t>", test_tag);
 
 		// double block configurations with special bits split between MSU and MSU - 1
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns< 9,  4, Saturating, std::uint8_t > >(reportTestCases), "lns< 9, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<17,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<17, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<33, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<33,16,Saturating,uint32_t>", test_tag);
-	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, Saturating, std::uint64_t> (reportTestCases), "lns<65,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns< 9, 4, std::uint8_t > >(reportTestCases), "lns< 9, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<17, 8, std::uint16_t> >(reportTestCases), "lns<17, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<33, 16, std::uint32_t> >(reportTestCases), "lns<33,16,uint32_t>", test_tag);
+	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, std::uint64_t> (reportTestCases), "lns<65,32,uint64_t>", test_tag);
 
 		// triple block configurations with all special bits in the MSU
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<26,  4, Saturating, std::uint8_t > >(reportTestCases), "lns<26, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<50,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<50, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<98, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<98,16,Saturating,uint32_t>", test_tag);
-	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<66,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<26, 4, std::uint8_t > >(reportTestCases), "lns<26, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<50, 8, std::uint16_t> >(reportTestCases), "lns<50, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<98, 16, std::uint32_t> >(reportTestCases), "lns<98,16,uint32_t>", test_tag);
+	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<66, 32, std::uint64_t> >(reportTestCases), "lns<66,32,uint64_t>", test_tag);
 
 		// triple block configurations with special bits split between MSU and MSU - 1
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<25,  4, Saturating, std::uint8_t > >(reportTestCases), "lns<25, 4,Saturating,uint8_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<49,  8, Saturating, std::uint16_t> >(reportTestCases), "lns<49, 8,Saturating,uint16_t>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<97, 16, Saturating, std::uint32_t> >(reportTestCases), "lns<97,16,Saturating,uint32_t>", test_tag);
-	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, Saturating, std::uint64_t> >(reportTestCases), "lns<65,32,Saturating,uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<25, 4, std::uint8_t > >(reportTestCases), "lns<25, 4,uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<49, 8, std::uint16_t> >(reportTestCases), "lns<49, 8,uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNaNEncoding< lns<97, 16, std::uint32_t> >(reportTestCases), "lns<97,16,uint32_t>", test_tag);
+	//	nrOfFailedTestCases += ReportTestResult(VerifyZeroEncoding< lns<65, 32, std::uint64_t> >(reportTestCases), "lns<65,32,uint64_t>", test_tag);
 
 	return nrOfFailedTestCases;
 }

--- a/tests/lns/math/classify.cpp
+++ b/tests/lns/math/classify.cpp
@@ -40,7 +40,7 @@ try {
 	constexpr size_t nbits = 32;
 	constexpr size_t rbits = 8;
 	using bt = uint32_t;
-	using Number = lns<nbits, rbits, Saturating, bt>;
+	using Number = lns<nbits, rbits, bt>;
 	Number cnan; cnan.setnan();
 	Number cinf; cinf.setinf(false);
 	Number czero(0);

--- a/tests/lns/math/exponent.cpp
+++ b/tests/lns/math/exponent.cpp
@@ -92,22 +92,22 @@ try {
 
 #else
 
-	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns< 8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "exp");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns< 8, 3, Saturating, uint8_t> >(reportTestCases), "lns<8,3>", "exp");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns< 9, 2, Saturating, uint8_t> >(reportTestCases), "lns<9,2>", "exp");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<10, 2, Saturating, uint8_t> >(reportTestCases), "lns<10,2>", "exp");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<10, 3, Saturating, uint8_t> >(reportTestCases), "lns<10,3>", "exp");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<12, 4, Saturating, uint8_t> >(reportTestCases), "lns<12,4>", "exp");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<16, 5, Saturating, uint8_t> >(reportTestCases), "lns<16,5>", "exp");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns< 8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "exp");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns< 8, 3, uint8_t> >(reportTestCases), "lns<8,3>", "exp");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns< 9, 2, uint8_t> >(reportTestCases), "lns<9,2>", "exp");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<10, 2, uint8_t> >(reportTestCases), "lns<10,2>", "exp");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<10, 3, uint8_t> >(reportTestCases), "lns<10,3>", "exp");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<12, 4, uint8_t> >(reportTestCases), "lns<12,4>", "exp");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp< lns<16, 5, uint8_t> >(reportTestCases), "lns<16,5>", "exp");
 
 	// base-2 exponent testing
-	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "exp2");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<8, 3, Saturating, uint8_t> >(reportTestCases), "lns<8,3>", "exp2");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<9, 2, Saturating, uint8_t> >(reportTestCases), "lns<9,2>", "exp2");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<10, 2, Saturating, uint8_t> >(reportTestCases), "lns<10,2>", "exp2");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<10, 3, Saturating, uint8_t> >(reportTestCases), "lns<10,3>", "exp2");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<12, 4, Saturating, uint8_t> >(reportTestCases), "lns<12,4>", "exp2");
-	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<16, 5, Saturating, uint8_t> >(reportTestCases), "lns<16,5>", "exp2");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "exp2");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<8, 3, uint8_t> >(reportTestCases), "lns<8,3>", "exp2");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<9, 2, uint8_t> >(reportTestCases), "lns<9,2>", "exp2");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<10, 2, uint8_t> >(reportTestCases), "lns<10,2>", "exp2");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<10, 3, uint8_t> >(reportTestCases), "lns<10,3>", "exp2");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<12, 4, uint8_t> >(reportTestCases), "lns<12,4>", "exp2");
+	nrOfFailedTestCases += ReportTestResult(VerifyExp2< lns<16, 5, uint8_t> >(reportTestCases), "lns<16,5>", "exp2");
 
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/tests/lns/math/fractional.cpp
+++ b/tests/lns/math/fractional.cpp
@@ -14,7 +14,7 @@ int VerifyLnsFractionExponent(bool reportTestCases) {
 	constexpr size_t nbits = TestType::nbits;
 	constexpr size_t NR_TEST_CASES = (1 << nbits);
 	int nrOfFailedTests = 0;
-	TestType a, b, c;
+	TestType a{}, b{}, c{};
 	int exp;
 
 	for (size_t i = 1; i < NR_TEST_CASES; ++i) {
@@ -43,7 +43,7 @@ int VerifyLnsFmod(bool reportTestCases) {
 	constexpr size_t nbits = TestType::nbits;
 	constexpr size_t NR_TEST_CASES = (1 << nbits);
 	int nrOfFailedTests = 0;
-	TestType a, b, c, n, fref;
+	TestType a{}, b{}, c{}, n{}, fref{};
 
 	for (size_t i = 0; i < NR_TEST_CASES; ++i) {
 		a.setbits(i);
@@ -141,7 +141,7 @@ Real trace_fmod(Real x, Real y) {
 std::remainder(x, y)
 The IEEE floating-point remainder of the division operation x/y calculated by this function is 
 exactly the value x - n*y, where the value n is the integral value nearest the exact value x/y. 
-When |n-x/y| = ½, the value n is chosen to be even.
+When |n-x/y| = 1/2, the value n is chosen to be even.
 
 In contrast to std::fmod(), the returned value is not guaranteed to have the same sign as x.
 
@@ -250,7 +250,7 @@ try {
 	}
 
 	{
-		using Real = sw::universal::lns<32, 8, Saturating, uint32_t>;
+		using Real = sw::universal::lns<32, 8, uint32_t>;
 		Real pi = Real(3.14159265358979);
 		std::cout << to_binary(pi) << " : " << pi << '\n';
 		for (int i = 0; i < 10; ++i) {
@@ -272,7 +272,7 @@ try {
 		constexpr size_t nbits = 32;
 		constexpr size_t es = 8;
 		using bt = uint32_t;
-		using Real = lns<nbits, es, Saturating, bt>;
+		using Real = lns<nbits, es, bt>;
 
 		float fa(1.5), fb(2.25);
 		Real a(fa), b(fb);
@@ -304,7 +304,7 @@ try {
 	}
 
 	{
-		using Real = lns<16, 2, Saturating, uint8_t>;
+		using Real = lns<16, 2, uint8_t>;
 		Real a;
 		a = -1.5;
 //		a.showLimbs();
@@ -312,7 +312,7 @@ try {
 	}
 
 	{
-		using Real = lns<16, 2, Saturating, uint8_t>;
+		using Real = lns<16, 2, uint8_t>;
 		Real a, b, c;
 		a = 1.5; b = 2.25;
 		c = trace_fmod(a, b);
@@ -326,7 +326,7 @@ try {
 	}
 
 	{
-		using Real = lns<32, 8, Saturating, uint8_t>;
+		using Real = lns<32, 8, uint8_t>;
 		Real a, b, c;
 		a = 1.5; b = 2.25;
 		c = trace_fmod(a, b);
@@ -336,7 +336,7 @@ try {
 	}
 
 	{
-		using Real = lns<32, 8, Saturating, uint32_t>;
+		using Real = lns<32, 8, uint32_t>;
 		float fa(1e9f), fb(3.14159265358979f), fc;
 		Real a(fa), b(fb), c;
 		std::cout << "lns    : " << fmod(Real(a), Real(b)) << "\n";
@@ -348,7 +348,7 @@ try {
 	}
 
 	{
-		using Real = lns<32, 8, Saturating, uint8_t>;
+		using Real = lns<32, 8, uint8_t>;
 		Real a;
 		a = 1.5;
 		test_frac(a);
@@ -359,7 +359,7 @@ try {
 	}
 
 	{
-		using Real = lns<32, 23, Saturating, std::uint32_t>;
+		using Real = lns<32, 23, std::uint32_t>;
 		Real a, b, c;
 		float fa(32.0f), fb(0.0625f + 0.125f);
 		a = fa;

--- a/tests/lns/math/hyperbolic.cpp
+++ b/tests/lns/math/hyperbolic.cpp
@@ -10,10 +10,10 @@
 
 // generate specific test case that you can trace with the trace conditions in lns.hpp
 // for most bugs they are traceable with _trace_conversion and _trace_add
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCaseSinh(Ty v) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> a, aref, asinh;
+	sw::universal::lns<nbits, rbits, bt> a, aref, asinh;
 	a = v;
 	ref = std::sinh(v);
 	aref = ref;
@@ -25,10 +25,10 @@ void GenerateTestCaseSinh(Ty v) {
 	std::cout << std::setprecision(5);
 }
 
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCaseCosh(Ty v) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> a, aref, acosh;
+	sw::universal::lns<nbits, rbits, bt> a, aref, acosh;
 	a = v;
 	ref = std::cosh(v);
 	aref = ref;
@@ -40,10 +40,10 @@ void GenerateTestCaseCosh(Ty v) {
 	std::cout << std::setprecision(5);
 }
 
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCaseTanh(Ty v) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> a, aref, atanh;
+	sw::universal::lns<nbits, rbits, bt> a, aref, atanh;
 	a = v;
 	ref = std::tanh(v);
 	aref = ref;
@@ -54,10 +54,10 @@ void GenerateTestCaseTanh(Ty v) {
 	std::cout << std::setprecision(5);
 }
 
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCaseAsinh(Ty v) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> a, aref, aasinh;
+	sw::universal::lns<nbits, rbits, bt> a, aref, aasinh;
 	a = v;
 	ref = std::asinh(v);
 	aref = ref;
@@ -69,10 +69,10 @@ void GenerateTestCaseAsinh(Ty v) {
 	std::cout << std::setprecision(5);
 }
 
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCaseAcosh(Ty v) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> a, aref, aacosh;
+	sw::universal::lns<nbits, rbits, bt> a, aref, aacosh;
 	a = v;
 	ref = std::acosh(v);
 	aref = ref;
@@ -84,10 +84,10 @@ void GenerateTestCaseAcosh(Ty v) {
 	std::cout << std::setprecision(5);
 }
 
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCaseAtanh(Ty v) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> a, aref, aatanh;
+	sw::universal::lns<nbits, rbits, bt> a, aref, aatanh;
 	a = v;
 	ref = std::atanh(v);
 	aref = ref;
@@ -117,22 +117,22 @@ try {
 
 #if MANUAL_TESTING
 	// generate individual testcases to hand trace/debug
-	GenerateTestCaseSinh<16, 1, Saturating, uint16_t, double>(pi / 4.0);
-	GenerateTestCaseCosh<16, 1, Saturating, uint16_t, double>(pi / 4.0);
-	GenerateTestCaseTanh<16, 1, Saturating, uint16_t, double>(pi / 4.0);
-	GenerateTestCaseAsinh<16, 1, Saturating, uint16_t, double>(pi / 2.0);
-	GenerateTestCaseAcosh<16, 1, Saturating, uint16_t, double>(pi / 2.0);
-	GenerateTestCaseAtanh<16, 1, Saturating, uint16_t, double>(pi / 4.0);
+	GenerateTestCaseSinh<16, 1, uint16_t, double>(pi / 4.0);
+	GenerateTestCaseCosh<16, 1, uint16_t, double>(pi / 4.0);
+	GenerateTestCaseTanh<16, 1, uint16_t, double>(pi / 4.0);
+	GenerateTestCaseAsinh<16, 1, uint16_t, double>(pi / 2.0);
+	GenerateTestCaseAcosh<16, 1, uint16_t, double>(pi / 2.0);
+	GenerateTestCaseAtanh<16, 1, uint16_t, double>(pi / 4.0);
 
 	std::cout << '\n';
 
 	// manual exhaustive test
-	nrOfFailedTestCases += ReportTestResult(VerifySinh< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "sinh");
-	nrOfFailedTestCases += ReportTestResult(VerifyCosh< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "cosh");
-	nrOfFailedTestCases += ReportTestResult(VerifyTanh< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "tanh");
-	nrOfFailedTestCases += ReportTestResult(VerifyAtanh< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "atanh");
-	nrOfFailedTestCases += ReportTestResult(VerifyAcosh< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "acosh");
-	nrOfFailedTestCases += ReportTestResult(VerifyAsinh< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns<8,2>", "asinh");
+	nrOfFailedTestCases += ReportTestResult(VerifySinh< lns<8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "sinh");
+	nrOfFailedTestCases += ReportTestResult(VerifyCosh< lns<8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "cosh");
+	nrOfFailedTestCases += ReportTestResult(VerifyTanh< lns<8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "tanh");
+	nrOfFailedTestCases += ReportTestResult(VerifyAtanh< lns<8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "atanh");
+	nrOfFailedTestCases += ReportTestResult(VerifyAcosh< lns<8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "acosh");
+	nrOfFailedTestCases += ReportTestResult(VerifyAsinh< lns<8, 2, uint8_t> >(reportTestCases), "lns<8,2>", "asinh");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS; // ignore failures

--- a/tests/lns/math/hypotenuse.cpp
+++ b/tests/lns/math/hypotenuse.cpp
@@ -9,9 +9,9 @@
 
 // generate specific test case that you can trace with the trace conditions in lns.hpp
 // for most bugs they are traceable with _trace_conversion and _trace_add
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCase(Ty _a, Ty _b) {
-	sw::universal::lns<nbits, rbits, behavior, bt> a, b, pref, result;
+	sw::universal::lns<nbits, rbits, bt> a, b, pref, result;
 	a = _a;
 	b = _b;
 	Ty ref = std::hypot(_a, _b);
@@ -57,22 +57,22 @@ try {
 	// generate individual testcases to hand trace/debug
 	lns<8, 3, std::uint8_t> a(SpecificValue::maxpos);
 	std::cout << "maxpos " << type_tag(a) << " : " << a << '\n';
-	GenerateTestCase< 8, 3, Saturating, std::uint8_t, float>(3.0f, 4.0f);
-	GenerateTestCase<16, 5, Saturating, std::uint8_t, float>(3.0f, 4.0f);
+	GenerateTestCase< 8, 3, std::uint8_t, float>(3.0f, 4.0f);
+	GenerateTestCase<16, 5, std::uint8_t, float>(3.0f, 4.0f);
 
-	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<4, 1, Saturating, std::uint8_t> >(reportTestCases), "lns<4, 1>", "hypot");
-	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<8, 4, Saturating, std::uint8_t> >(reportTestCases), "lns<8, 4>", "hypot");
+	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<4, 1, std::uint8_t> >(reportTestCases), "lns<4, 1>", "hypot");
+	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<8, 4, std::uint8_t> >(reportTestCases), "lns<8, 4>", "hypot");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;   // ignore errors
 #else
 
 #if REGRESSION_LEVEL_1
-	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<4, 1, Saturating, std::uint8_t> >(reportTestCases), "lns<4, 1>", "hypot");
-	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<5, 1, Saturating, std::uint8_t> >(reportTestCases), "lns<5, 1>", "hypot");
-	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<6, 2, Saturating, std::uint8_t> >(reportTestCases), "lns<6, 2>", "hypot");
-	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<7, 2, Saturating, std::uint8_t> >(reportTestCases), "lns<7, 2>", "hypot");
-	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<8, 3, Saturating, std::uint8_t> >(reportTestCases), "lns<8, 3>", "hypot");
+	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<4, 1, std::uint8_t> >(reportTestCases), "lns<4, 1>", "hypot");
+	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<5, 1, std::uint8_t> >(reportTestCases), "lns<5, 1>", "hypot");
+	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<6, 2, std::uint8_t> >(reportTestCases), "lns<6, 2>", "hypot");
+	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<7, 2, std::uint8_t> >(reportTestCases), "lns<7, 2>", "hypot");
+	nrOfFailedTestCases += ReportTestResult(VerifyHypot< lns<8, 3, std::uint8_t> >(reportTestCases), "lns<8, 3>", "hypot");
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/tests/lns/math/logarithm.cpp
+++ b/tests/lns/math/logarithm.cpp
@@ -9,10 +9,10 @@
 
 // generate specific test case that you can trace with the trace conditions in lns.hpp
 // for most bugs they are traceable with _trace_conversion and _trace_add
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCase(Ty a) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> pa, pref, plog;
+	sw::universal::lns<nbits, rbits, bt> pa{}, pref{}, plog{};
 	pa = a;
 	ref = std::log(a);
 	pref = ref;
@@ -40,7 +40,7 @@ try {
 
 #if MANUAL_TESTING
 	// generate individual testcases to hand trace/debug
-	GenerateTestCase<16, 1, Saturating, uint8_t>(4.0f);
+	GenerateTestCase<16, 1, uint8_t>(4.0f);
 
 #if GENERATE_LOG_TABLES
 	GenerateLogarithmTable<3, 0>();
@@ -57,9 +57,9 @@ try {
 #endif
 
 	// manual exhaustive test
-	nrOfFailedTestCases += ReportTestResult(VerifyLog< lns<8, 4, Saturating, uint8_t> >(reportTestCases), "lns<8,4>", "log");
-	nrOfFailedTestCases += ReportTestResult(VerifyLog2< lns<8, 4, Saturating, uint8_t> >(reportTestCases), "lns<8,4>", "log2");
-	nrOfFailedTestCases += ReportTestResult(VerifyLog10< lns <8, 4, Saturating, uint8_t > >(reportTestCases), "lns<8,4>", "log10");
+	nrOfFailedTestCases += ReportTestResult(VerifyLog< lns<8, 4, uint8_t> >(reportTestCases), "lns<8,4>", "log");
+	nrOfFailedTestCases += ReportTestResult(VerifyLog2< lns<8, 4, uint8_t> >(reportTestCases), "lns<8,4>", "log2");
+	nrOfFailedTestCases += ReportTestResult(VerifyLog10< lns <8, 4, uint8_t > >(reportTestCases), "lns<8,4>", "log10");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS; // ignore failures

--- a/tests/lns/math/next.cpp
+++ b/tests/lns/math/next.cpp
@@ -42,7 +42,7 @@ try {
 #if MANUAL_TESTING
 	// generate individual testcases to hand trace/debug
 
-	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 16, 5, Saturating, std::uint16_t> >(reportTestCases), "lns< 16, 5>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 16, 5, std::uint16_t> >(reportTestCases), "lns< 16, 5>", test_tag);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;   // ignore errors
@@ -50,10 +50,10 @@ try {
 #else
 
 #if REGRESSION_LEVEL_1
-	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns<  8, 2, Saturating, std::uint8_t > >(reportTestCases), "lns<  8, 2>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 16, 5, Saturating, std::uint16_t> >(reportTestCases), "lns< 16, 5>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 32, 8, Saturating, std::uint32_t> >(reportTestCases), "lns< 32, 8>", test_tag);
-	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 64,11, Saturating, std::uint64_t> >(reportTestCases), "lns< 64,11>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns<  8, 2, std::uint8_t > >(reportTestCases), "lns<  8, 2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 16, 5, std::uint16_t> >(reportTestCases), "lns< 16, 5>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 32, 8, std::uint32_t> >(reportTestCases), "lns< 32, 8>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNextafter< lns< 64,11, std::uint64_t> >(reportTestCases), "lns< 64,11>", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/tests/lns/math/pow.cpp
+++ b/tests/lns/math/pow.cpp
@@ -9,10 +9,10 @@
 
 // generate specific test case that you can trace with the trace conditions in lns.hpp
 // for most bugs they are traceable with _trace_conversion and _trace_add
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCase(Ty a, Ty b) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> pa, pb, pref, ppow;
+	sw::universal::lns<nbits, rbits, bt> pa{}, pb{}, pref{}, ppow{};
 	pa = a;
 	pb = b;
 	ref = std::pow(a,b);
@@ -41,7 +41,7 @@ try {
 
 #if MANUAL_TESTING
 	// generate individual testcases to hand trace/debug
-	GenerateTestCase<16, 1, Saturating, std::uint16_t, float>(4.0f, 2.0f);
+	GenerateTestCase<16, 1, std::uint16_t, float>(4.0f, 2.0f);
 
 #if GENERATE_POW_TABLES
 	GeneratePowTable<3, 0>();

--- a/tests/lns/math/trigonometry.cpp
+++ b/tests/lns/math/trigonometry.cpp
@@ -161,10 +161,10 @@ double haversine(double lat1, double lon1, double lat2, double lon2, double radi
 
 // generate specific test case that you can trace with the trace conditions in lns.hpp
 // for most bugs they are traceable with _trace_conversion and _trace_add
-template<size_t nbits, size_t rbits, sw::universal::ArithmeticBehavior behavior, typename bt, typename Ty>
+template<size_t nbits, size_t rbits, typename bt, typename Ty>
 void GenerateTestCase(Ty a) {
 	Ty ref;
-	sw::universal::lns<nbits, rbits, behavior, bt> pa, pref, psin;
+	sw::universal::lns<nbits, rbits, bt> pa{}, pref{}, psin{};
 	pa = a;
 	ref = std::sin(a);
 	pref = ref;
@@ -216,12 +216,12 @@ try {
 	return EXIT_SUCCESS;  // ignore failures in manual testing mode
 #else
 
-	nrOfFailedTestCases += ReportTestResult(VerifySine   < lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns< 8,2>", "sin");
-	nrOfFailedTestCases += ReportTestResult(VerifyCosine < lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns< 8,2>", "cos");
-	nrOfFailedTestCases += ReportTestResult(VerifyTangent< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns< 8,2>", "tan");
-	nrOfFailedTestCases += ReportTestResult(VerifyAtan   < lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns< 8,2>", "atan");
-	nrOfFailedTestCases += ReportTestResult(VerifyAsin   < lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns< 8,2>", "asin");
-	nrOfFailedTestCases += ReportTestResult(VerifyAcos   < lns<8, 2, Saturating, uint8_t> >(reportTestCases), "lns< 8,2>", "acos");
+	nrOfFailedTestCases += ReportTestResult(VerifySine   < lns<8, 2, uint8_t> >(reportTestCases), "lns< 8,2>", "sin");
+	nrOfFailedTestCases += ReportTestResult(VerifyCosine < lns<8, 2, uint8_t> >(reportTestCases), "lns< 8,2>", "cos");
+	nrOfFailedTestCases += ReportTestResult(VerifyTangent< lns<8, 2, uint8_t> >(reportTestCases), "lns< 8,2>", "tan");
+	nrOfFailedTestCases += ReportTestResult(VerifyAtan   < lns<8, 2, uint8_t> >(reportTestCases), "lns< 8,2>", "atan");
+	nrOfFailedTestCases += ReportTestResult(VerifyAsin   < lns<8, 2, uint8_t> >(reportTestCases), "lns< 8,2>", "asin");
+	nrOfFailedTestCases += ReportTestResult(VerifyAcos   < lns<8, 2, uint8_t> >(reportTestCases), "lns< 8,2>", "acos");
 
 	// nbits=64 requires long double compiler support
 	// nrOfFailedTestCases += ReportTestResult(VerifyThroughRandoms<64, 2>(reportTestCases, OPCODE_SQRT, 1000), "lns<64,2>", "sin");

--- a/tests/lns/math/truncate.cpp
+++ b/tests/lns/math/truncate.cpp
@@ -94,16 +94,16 @@ try {
 #if MANUAL_TESTING
 	// generate individual testcases to hand trace/debug
 
-	nrOfFailedTestCases = ReportTestResult(VerifyFloor< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "floor", "lns<8,2>");
-	nrOfFailedTestCases = ReportTestResult(VerifyCeil < lns<8, 2, Saturating, uint8_t> >(reportTestCases), "ceil ", "lns<8,2>");
+	nrOfFailedTestCases = ReportTestResult(VerifyFloor< lns<8, 2, uint8_t> >(reportTestCases), "floor", "lns<8,2>");
+	nrOfFailedTestCases = ReportTestResult(VerifyCeil < lns<8, 2, uint8_t> >(reportTestCases), "ceil ", "lns<8,2>");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;  // ignore failures in manual testing mode
 #else
 
 #if REGRESSION_LEVEL_1
-	nrOfFailedTestCases = ReportTestResult(VerifyFloor< lns<8, 2, Saturating, uint8_t> >(reportTestCases), "floor", "lns<8,2>");
-	nrOfFailedTestCases = ReportTestResult(VerifyCeil < lns<8, 2, Saturating, uint8_t> >(reportTestCases), "ceil ", "lns<8,2>");
+	nrOfFailedTestCases = ReportTestResult(VerifyFloor< lns<8, 2, uint8_t> >(reportTestCases), "floor", "lns<8,2>");
+	nrOfFailedTestCases = ReportTestResult(VerifyCeil < lns<8, 2, uint8_t> >(reportTestCases), "ceil ", "lns<8,2>");
 
 #endif
 

--- a/tests/lns/performance/perf.cpp
+++ b/tests/lns/performance/perf.cpp
@@ -119,34 +119,34 @@ namespace sw::universal::internal {
 		std::cout << "\nArithmetic operator performance\n";
 
 		size_t NR_OPS = 1024ull * 1024ull;
-		PerformanceRunner("lns< 4, 1, Saturating, uint8_t >   add/subtract   ", AdditionSubtractionWorkload< lns< 4, 1, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns< 8, 3, Saturating, uint8_t >   add/subtract   ", AdditionSubtractionWorkload< lns< 8, 3, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<12, 4, Saturating, uint8_t >   add/subtract   ", AdditionSubtractionWorkload< lns<12, 4, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<12, 4, Saturating, uint16_t>   add/subtract   ", AdditionSubtractionWorkload< lns<12, 4, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint16_t>   add/subtract   ", AdditionSubtractionWorkload< lns<16, 5, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint32_t>   add/subtract   ", AdditionSubtractionWorkload< lns<16, 5, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<20, 6, Saturating, uint32_t>   add/subtract   ", AdditionSubtractionWorkload< lns<20, 6, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<32, 8, Saturating, uint32_t>   add/subtract   ", AdditionSubtractionWorkload< lns<32, 8, Saturating, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns< 4, 1, uint8_t >   add/subtract   ", AdditionSubtractionWorkload< lns< 4, 1, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns< 8, 3, uint8_t >   add/subtract   ", AdditionSubtractionWorkload< lns< 8, 3, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<12, 4, uint8_t >   add/subtract   ", AdditionSubtractionWorkload< lns<12, 4, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<12, 4, uint16_t>   add/subtract   ", AdditionSubtractionWorkload< lns<12, 4, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint16_t>   add/subtract   ", AdditionSubtractionWorkload< lns<16, 5, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint32_t>   add/subtract   ", AdditionSubtractionWorkload< lns<16, 5, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<20, 6, uint32_t>   add/subtract   ", AdditionSubtractionWorkload< lns<20, 6, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<32, 8, uint32_t>   add/subtract   ", AdditionSubtractionWorkload< lns<32, 8, uint32_t> >, NR_OPS);
 
 		NR_OPS = 1024ull * 1024ull;
-		PerformanceRunner("lns< 4, 1, Saturating, uint8_t >   multiplication ", MultiplicationWorkload< lns< 4, 1, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns< 8, 3, Saturating, uint8_t >   multiplication ", MultiplicationWorkload< lns< 8, 3, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<12, 4, Saturating, uint8_t >   multiplication ", MultiplicationWorkload< lns<12, 4, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<12, 4, Saturating, uint16_t>   multiplication ", MultiplicationWorkload< lns<12, 4, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint16_t>   multiplication ", MultiplicationWorkload< lns<16, 5, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint32_t>   multiplication ", MultiplicationWorkload< lns<16, 5, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<20, 6, Saturating, uint32_t>   multiplication ", MultiplicationWorkload< lns<20, 6, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<32, 8, Saturating, uint32_t>   multiplication ", MultiplicationWorkload< lns<32, 8, Saturating, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns< 4, 1, uint8_t >   multiplication ", MultiplicationWorkload< lns< 4, 1, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns< 8, 3, uint8_t >   multiplication ", MultiplicationWorkload< lns< 8, 3, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<12, 4, uint8_t >   multiplication ", MultiplicationWorkload< lns<12, 4, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<12, 4, uint16_t>   multiplication ", MultiplicationWorkload< lns<12, 4, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint16_t>   multiplication ", MultiplicationWorkload< lns<16, 5, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint32_t>   multiplication ", MultiplicationWorkload< lns<16, 5, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<20, 6, uint32_t>   multiplication ", MultiplicationWorkload< lns<20, 6, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<32, 8, uint32_t>   multiplication ", MultiplicationWorkload< lns<32, 8, uint32_t> >, NR_OPS);
 
 		NR_OPS = 1024ull * 1024ull;
-		PerformanceRunner("lns< 4, 1, Saturating, uint8_t >   division       ", DivisionWorkload< lns< 4, 1, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns< 8, 3, Saturating, uint8_t >   division       ", DivisionWorkload< lns< 8, 3, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<12, 4, Saturating, uint8_t >   division       ", DivisionWorkload< lns<12, 4, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<12, 4, Saturating, uint16_t>   division       ", DivisionWorkload< lns<12, 4, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint16_t>   division       ", DivisionWorkload< lns<16, 5, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint32_t>   division       ", DivisionWorkload< lns<16, 5, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<20, 6, Saturating, uint32_t>   division       ", DivisionWorkload< lns<20, 6, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<32, 8, Saturating, uint32_t>   division       ", DivisionWorkload< lns<32, 8, Saturating, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns< 4, 1, uint8_t >   division       ", DivisionWorkload< lns< 4, 1, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns< 8, 3, uint8_t >   division       ", DivisionWorkload< lns< 8, 3, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<12, 4, uint8_t >   division       ", DivisionWorkload< lns<12, 4, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<12, 4, uint16_t>   division       ", DivisionWorkload< lns<12, 4, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint16_t>   division       ", DivisionWorkload< lns<16, 5, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint32_t>   division       ", DivisionWorkload< lns<16, 5, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<20, 6, uint32_t>   division       ", DivisionWorkload< lns<20, 6, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<32, 8, uint32_t>   division       ", DivisionWorkload< lns<32, 8, uint32_t> >, NR_OPS);
 
 	}
 
@@ -176,25 +176,25 @@ namespace sw::universal::internal {
 		std::cout << "\nArithmetic operator performance\n";
 
 		size_t NR_OPS = 1024ull * 1024ull;
-		PerformanceRunner("lns<  8, 2, Saturating, uint8_t >  add/subtract  ", AdditionSubtractionWorkload< lns<  8,  2, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns< 16, 5, Saturating, uint16_t>  add/subtract  ", AdditionSubtractionWorkload< lns< 16,  5, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns< 32, 8, Saturating, uint32_t>  add/subtract  ", AdditionSubtractionWorkload< lns< 32,  8, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns< 64,11, Saturating, uint32_t>  add/subtract  ", AdditionSubtractionWorkload< lns< 64, 11, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<128,15, Saturating, uint32_t>  add/subtract  ", AdditionSubtractionWorkload< lns<128, 15, Saturating, uint32_t> >, NR_OPS / 2);
+		PerformanceRunner("lns<  8, 2, uint8_t >  add/subtract  ", AdditionSubtractionWorkload< lns<  8,  2, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns< 16, 5, uint16_t>  add/subtract  ", AdditionSubtractionWorkload< lns< 16,  5, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns< 32, 8, uint32_t>  add/subtract  ", AdditionSubtractionWorkload< lns< 32,  8, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns< 64,11, uint32_t>  add/subtract  ", AdditionSubtractionWorkload< lns< 64, 11, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<128,15, uint32_t>  add/subtract  ", AdditionSubtractionWorkload< lns<128, 15, uint32_t> >, NR_OPS / 2);
 
 		NR_OPS = 1024ull * 1024ull;
-		PerformanceRunner("lns<  8, 2, Saturating, uint8_t >  multiplication", MultiplicationWorkload< lns<  8,  2, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns< 16, 5, Saturating, uint16_t>  multiplication", MultiplicationWorkload< lns< 16,  5, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns< 32, 8, Saturating, uint32_t>  multiplication", MultiplicationWorkload< lns< 32,  8, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns< 64,11, Saturating, uint32_t>  multiplication", MultiplicationWorkload< lns< 64, 11, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<128,15, Saturating, uint32_t>  multiplication", MultiplicationWorkload< lns<128, 15, Saturating, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<  8, 2, uint8_t >  multiplication", MultiplicationWorkload< lns<  8,  2, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns< 16, 5, uint16_t>  multiplication", MultiplicationWorkload< lns< 16,  5, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns< 32, 8, uint32_t>  multiplication", MultiplicationWorkload< lns< 32,  8, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns< 64,11, uint32_t>  multiplication", MultiplicationWorkload< lns< 64, 11, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<128,15, uint32_t>  multiplication", MultiplicationWorkload< lns<128, 15, uint32_t> >, NR_OPS);
 
 		NR_OPS = 1024ull * 1024ull;
-		PerformanceRunner("lns<  8, 2, Saturating, uint8_t >  division      ", DivisionWorkload< lns<  8,  2, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns< 16, 5, Saturating, uint16_t>  division      ", DivisionWorkload< lns< 16,  5, Saturating, uint16_t> >, NR_OPS);
-		PerformanceRunner("lns< 32, 8, Saturating, uint32_t>  division      ", DivisionWorkload< lns< 32,  8, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns< 64,11, Saturating, uint32_t>  division      ", DivisionWorkload< lns< 64, 11, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<128,15, Saturating, uint32_t>  division      ", DivisionWorkload< lns<128, 15, Saturating, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<  8, 2, uint8_t >  division      ", DivisionWorkload< lns<  8,  2, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns< 16, 5, uint16_t>  division      ", DivisionWorkload< lns< 16,  5, uint16_t> >, NR_OPS);
+		PerformanceRunner("lns< 32, 8, uint32_t>  division      ", DivisionWorkload< lns< 32,  8, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns< 64,11, uint32_t>  division      ", DivisionWorkload< lns< 64, 11, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<128,15, uint32_t>  division      ", DivisionWorkload< lns<128, 15, uint32_t> >, NR_OPS);
 	}
 
 	/*
@@ -217,17 +217,17 @@ namespace sw::universal::internal {
 
 		constexpr size_t NR_OPS = 32ull * 1024ull * 1024ull;
 
-		PerformanceRunner("lns< 8, 2, Saturating, uint8_t>    assignment/copy   ", AssignmentCopyWorkload< lns< 8, 2, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint8_t>    assignment/copy   ", AssignmentCopyWorkload< lns<16, 5, Saturating, uint8_t> >, NR_OPS);
-		PerformanceRunner("lns<32, 8, Saturating, uint8_t>    assignment/copy   ", AssignmentCopyWorkload< lns<32, 8, Saturating, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns< 8, 2, uint8_t>    assignment/copy   ", AssignmentCopyWorkload< lns< 8, 2, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint8_t>    assignment/copy   ", AssignmentCopyWorkload< lns<16, 5, uint8_t> >, NR_OPS);
+		PerformanceRunner("lns<32, 8, uint8_t>    assignment/copy   ", AssignmentCopyWorkload< lns<32, 8, uint8_t> >, NR_OPS);
 
-		PerformanceRunner("lns< 8, 2, Saturating, uint32_t>   assignment/copy   ", AssignmentCopyWorkload< lns< 8, 2, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint32_t>   assignment/copy   ", AssignmentCopyWorkload< lns<16, 5, Saturating, uint32_t> >, NR_OPS);
-		PerformanceRunner("lns<32, 8, Saturating, uint32_t>   assignment/copy   ", AssignmentCopyWorkload< lns<32, 8, Saturating, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns< 8, 2, uint32_t>   assignment/copy   ", AssignmentCopyWorkload< lns< 8, 2, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint32_t>   assignment/copy   ", AssignmentCopyWorkload< lns<16, 5, uint32_t> >, NR_OPS);
+		PerformanceRunner("lns<32, 8, uint32_t>   assignment/copy   ", AssignmentCopyWorkload< lns<32, 8, uint32_t> >, NR_OPS);
 
-		PerformanceRunner("lns< 8, 2, Saturating, uint64_t>   assignment/copy   ", AssignmentCopyWorkload< lns< 8, 2, Saturating, uint64_t> >, NR_OPS);
-		PerformanceRunner("lns<16, 5, Saturating, uint64_t>   assignment/copy   ", AssignmentCopyWorkload< lns<16, 5, Saturating, uint64_t> >, NR_OPS);
-		PerformanceRunner("lns<32, 8, Saturating, uint64_t>   assignment/copy   ", AssignmentCopyWorkload< lns<32, 8, Saturating, uint64_t> >, NR_OPS);
+		PerformanceRunner("lns< 8, 2, uint64_t>   assignment/copy   ", AssignmentCopyWorkload< lns< 8, 2, uint64_t> >, NR_OPS);
+		PerformanceRunner("lns<16, 5, uint64_t>   assignment/copy   ", AssignmentCopyWorkload< lns<16, 5, uint64_t> >, NR_OPS);
+		PerformanceRunner("lns<32, 8, uint64_t>   assignment/copy   ", AssignmentCopyWorkload< lns<32, 8, uint64_t> >, NR_OPS);
 	}
 
 }

--- a/tools/cmd/lns.cpp
+++ b/tools/cmd/lns.cpp
@@ -9,8 +9,8 @@ namespace sw {
 	namespace universal {
 
 		// return in triple form (sign, scale, fraction)
-		template<size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
-		inline std::string to_triple(const lns<nbits, rbits, behavior, bt>& number) {
+		template<size_t nbits, size_t rbits, typename bt, auto... x>
+		inline std::string to_triple(const lns<nbits, rbits, bt, x...>& number) {
 			std::stringstream ss;
 
 			// print sign bit
@@ -46,7 +46,7 @@ try {
 		return EXIT_SUCCESS;  // signal successful completion for ctest
 	}
 	std::string arg = argv[1];
-	lns<32, 8, Saturating, std::uint32_t> v;
+	lns<32, 8, std::uint32_t> v{};
 
 	constexpr size_t columnWidth = 50;
 	std::cout << std::setw(columnWidth) << std::left << typeid(v).name() << ": " << std::setprecision(max_digits10) << std::right << v << " " << to_triple(v) << '\n';


### PR DESCRIPTION
Change lns template signature:
  <size_t nbits, size_t rbits, ArithmeticBehavior behavior, typename bt>
> <size_t nbits, size_t rbits, typename bt, auto...x>

The default case where x... vanishes is Saturating behavior.
To opt in to Wrapping behavior, add trailing Behavior::Wrapping:

  lns<nbits, rbits, bt>                       Saturating by default
  lns<nbits, rbits, bt, Behaviour::Wrapping>  Opt in to Wrapping

This has a benefit of a short symbol size in the default case.

Unfortunately the changed signature meant changing ~50 files.
Pay attention to these file changes:

arithmetic.hpp:
2-valued Behavior enum replaces 4-valued ArithmeticBehavior class.

            Behavior::Saturating, Behavior::Wrapping

'Wrapping' replaces 'Modular' (modular only applies to unsigned integer)
'Finite' and 'Infinite' Limit are removed as not pertinent distinctions.

lns_impl.hpp:
Lots (too many) changes in one go, including implementation changes
(not intended to change functionality - review carefully)

operator== now delegates directly to blockbinary operator==
(note: blockbinary operator== is not yet declared constexpr)

operator< is simplified to return a ternary expression.

Other comparison operators are slightly refactored to avoid redundant
checking of NaN cases where possible.

Most other operators are made hidden friends.
'inline' specifiers are removed or changed to 'constexpr' as appropriate.
