### PR TITLE
Fix cmake instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ project("my-numerical-experiment")
 find_package(UNIVERSAL CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} src/mymain.cpp)
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
 target_link_libraries(${PROJECT_NAME} universal::universal)
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ project("my-numerical-experiment")
 find_package(UNIVERSAL CONFIG REQUIRED)
 
 add_executable(${PROJECT_NAME} src/mymain.cpp)
-target_link_libraries(${PROJECT_NAME} UNIVERSAL::UNIVERSAL)
+target_link_libraries(${PROJECT_NAME} universal::universal)
 ```
 
 ## Controlling the build to include different components


### PR DESCRIPTION
A few minor fixes to the cmake instructions in README.md for how to link to universal.