### PR TITLE
fix conjugate computation for lns and cfloat

### DIFF
--- a/include/universal/number/cfloat/math/complex.hpp
+++ b/include/universal/number/cfloat/math/complex.hpp
@@ -29,7 +29,7 @@ imag(std::complex< cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSatur
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 std::complex< cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> > 
 conj(std::complex< cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> > x) {
-	return cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(std::conj(x));
+	return std::complex<cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>>(x.real(), -x.imag());
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns/math/complex.hpp
+++ b/include/universal/number/lns/math/complex.hpp
@@ -26,7 +26,7 @@ imag(std::complex< lns<nbits, rbits, bt, xtra...> > x) {
 template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
 std::complex< lns<nbits, rbits, bt, xtra...> >
 conj(std::complex< lns<nbits, rbits, bt, xtra...> > x) {
-	return lns<nbits, rbits, bt, xtra...>(std::conj(x));
+	return std::complex<lns<nbits, rbits, bt, xtra...>>(x.real(), -x.imag());
 }
 
 }} // namespace sw::universal


### PR DESCRIPTION
For the LNS and CFloat number systems, the complex conjugate implementations lead to compile time errors when trying to compute the eigenvalues of a matrix using Eigen (as a test for https://github.com/openjournals/joss-reviews/issues/5072).

The original error was:
```
test_universal> /build/4ndm3bz7iwnzmvjnc5z6dmykx2ms7zmi-source/src/main.cxx:17:54:   required from here
test_universal> /nix/store/1qanrshbj9lwnfngwj6px0r9iih2z3nc-universal/include/universal/number/cfloat/math/complex.hpp:32:16: error: no matching function for call to 'sw::universal::cfloat<64, 2>::cfloat(std::complex<sw::universal::cfloat<64, 2> >)'
test_universal>    32 |         return cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(std::conj(x));
test_universal>       |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test_universal> In file included from /nix/store/1qanrshbj9lwnfngwj6px0r9iih2z3nc-universal/include/universal/number/cfloat/cfloat.hpp:57:
```
(and similar for lns).

This PR modifies the conjugate functions to be similar to that of the posit. https://github.com/stillwater-sc/universal/blob/2a89a3950838d1a5508741a120003789812e77ef/include/universal/number/posit/math/complex.hpp#L29
