### PR TITLE
Add integration for cmath functions.

### DIFF
--- a/include/universal/number/areal/areal.hpp
+++ b/include/universal/number/areal/areal.hpp
@@ -43,4 +43,7 @@
 /// math functions
 #include <universal/number/areal/math_functions.hpp>
 
+// no enable_if_areal
+// #include <universal/number/areal/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/areal/cmath_integration.hpp
+++ b/include/universal/number/areal/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_areal<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_areal<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_areal<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_areal<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/areal/cmath_integration.hpp
+++ b/include/universal/number/areal/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_areal<T, std::string> to_string(const T &t) {

--- a/include/universal/number/cfloat/cfloat.hpp
+++ b/include/universal/number/cfloat/cfloat.hpp
@@ -66,6 +66,8 @@
 /// elementary math functions library
 #include <universal/number/cfloat/mathlib.hpp>
 
+#include <universal/number/cfloat/cmath_integration.hpp>
+
 ///////////////////////////////////////////////////////////////////////////////////////
 /// aliases for industry standard floating point configurations
 namespace sw { namespace universal {

--- a/include/universal/number/cfloat/cmath_integration.hpp
+++ b/include/universal/number/cfloat/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_cfloat<T, std::string> to_string(const T &t) {

--- a/include/universal/number/cfloat/cmath_integration.hpp
+++ b/include/universal/number/cfloat/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_cfloat<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_cfloat<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_cfloat<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_cfloat<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/cfloat/math/complex.hpp
+++ b/include/universal/number/cfloat/math/complex.hpp
@@ -29,7 +29,7 @@ imag(std::complex< cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSatur
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 std::complex< cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> > 
 conj(std::complex< cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating> > x) {
-	return cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(std::conj(x));
+	return std::complex<cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>>(x.real(), -x.imag());
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/decimal/cmath_integration.hpp
+++ b/include/universal/number/decimal/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_decimal<T, std::string> to_string(const T &t) {

--- a/include/universal/number/decimal/cmath_integration.hpp
+++ b/include/universal/number/decimal/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_decimal<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_decimal<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_decimal<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_decimal<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/decimal/decimal.hpp
+++ b/include/universal/number/decimal/decimal.hpp
@@ -47,4 +47,8 @@
 /// math functions
 #include <universal/number/decimal/mathlib.hpp>
 
+
+// no enable_if_decimal
+// #include <universal/number/decimal/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/efloat/cmath_integration.hpp
+++ b/include/universal/number/efloat/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_efloat<T, std::string> to_string(const T &t) {

--- a/include/universal/number/efloat/cmath_integration.hpp
+++ b/include/universal/number/efloat/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_efloat<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_efloat<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_efloat<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_efloat<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/efloat/efloat.hpp
+++ b/include/universal/number/efloat/efloat.hpp
@@ -35,4 +35,7 @@
 /// math functions
 //#include <universal/number/efloat/math_functions.hpp>
 
+// no enable_if_efloat
+// #include <universal/number/efloat/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/einteger/cmath_integration.hpp
+++ b/include/universal/number/einteger/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_einteger<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_einteger<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_einteger<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_einteger<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/einteger/cmath_integration.hpp
+++ b/include/universal/number/einteger/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_einteger<T, std::string> to_string(const T &t) {

--- a/include/universal/number/einteger/einteger.hpp
+++ b/include/universal/number/einteger/einteger.hpp
@@ -38,4 +38,7 @@
 /// math functions
 //#include <universal/number/einteger/math_functions.hpp>
 
+// no enable_if_einteger
+// #include <universal/number/einteger/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/eposit/cmath_integration.hpp
+++ b/include/universal/number/eposit/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_eposit<T, std::string> to_string(const T &t) {

--- a/include/universal/number/eposit/cmath_integration.hpp
+++ b/include/universal/number/eposit/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_eposit<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_eposit<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_eposit<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_eposit<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/eposit/eposit.hpp
+++ b/include/universal/number/eposit/eposit.hpp
@@ -35,4 +35,7 @@
 /// math functions
 //#include <universal/number/eposit/math_functions.hpp>
 
+// no enable_if_eposit
+// #include <universal/number/eposit/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/fixpnt/cmath_integration.hpp
+++ b/include/universal/number/fixpnt/cmath_integration.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_fixpnt<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    // TODO: missing to_string implemantation
+    /*
+    template <typename T>
+    sw::universal::enable_if_fixpnt<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+    */
+
+    template <typename T>
+    sw::universal::enable_if_fixpnt<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_fixpnt<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/fixpnt/cmath_integration.hpp
+++ b/include/universal/number/fixpnt/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     // TODO: missing to_string implemantation
     /*

--- a/include/universal/number/fixpnt/fixpnt.hpp
+++ b/include/universal/number/fixpnt/fixpnt.hpp
@@ -66,4 +66,6 @@
 /// math functions
 #include <universal/number/fixpnt/mathlib.hpp>
 
+#include <universal/number/fixpnt/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/integer/cmath_integration.hpp
+++ b/include/universal/number/integer/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_integer<T, std::string> to_string(const T &t) {

--- a/include/universal/number/integer/cmath_integration.hpp
+++ b/include/universal/number/integer/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_integer<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_integer<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_integer<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_integer<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/integer/integer.hpp
+++ b/include/universal/number/integer/integer.hpp
@@ -54,4 +54,7 @@
 /// math library specialized for integer<>
 #include <universal/number/integer/mathlib.hpp>
 
+// no enable_if_integer
+// #include <universal/number/integer/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/lns/cmath_integration.hpp
+++ b/include/universal/number/lns/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_lns<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_lns<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_lns<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_lns<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/lns/cmath_integration.hpp
+++ b/include/universal/number/lns/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_lns<T, std::string> to_string(const T &t) {

--- a/include/universal/number/lns/lns.hpp
+++ b/include/universal/number/lns/lns.hpp
@@ -59,4 +59,7 @@
 /// math functions
 #include <universal/number/lns/mathlib.hpp>
 
+// no enable_if_lns
+// #include <universal/number/lns/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/lns/math/complex.hpp
+++ b/include/universal/number/lns/math/complex.hpp
@@ -26,7 +26,7 @@ imag(std::complex< lns<nbits, rbits, bt, xtra...> > x) {
 template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
 std::complex< lns<nbits, rbits, bt, xtra...> >
 conj(std::complex< lns<nbits, rbits, bt, xtra...> > x) {
-	return lns<nbits, rbits, bt, xtra...>(std::conj(x));
+	return std::complex<lns<nbits, rbits, bt, xtra...>>(x.real(), -x.imag());
 }
 
 }} // namespace sw::universal

--- a/include/universal/number/lns2b/cmath_integration.hpp
+++ b/include/universal/number/lns2b/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_lns2b<T, std::string> to_string(const T &t) {

--- a/include/universal/number/lns2b/cmath_integration.hpp
+++ b/include/universal/number/lns2b/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_lns2b<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_lns2b<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_lns2b<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_lns2b<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/lns2b/lns2b.hpp
+++ b/include/universal/number/lns2b/lns2b.hpp
@@ -59,4 +59,7 @@
 /// math functions
 //#include <universal/number/lns2b/mathlib.hpp>
 
+// no enable_if_lns2b
+// #include <universal/number/lns2b/cmath_integration.hpp>
+
 #endif // _LNS2B_STANDARD_HEADER_

--- a/include/universal/number/posit/cmath_integration.hpp
+++ b/include/universal/number/posit/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_posit<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_posit<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_posit<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_posit<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/posit/cmath_integration.hpp
+++ b/include/universal/number/posit/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_posit<T, std::string> to_string(const T &t) {

--- a/include/universal/number/posit/posit.hpp
+++ b/include/universal/number/posit/posit.hpp
@@ -93,4 +93,6 @@
 /// numerical functions
 #include <universal/number/posit/twoSum.hpp>
 
+#include <universal/number/posit/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/rational/cmath_integration.hpp
+++ b/include/universal/number/rational/cmath_integration.hpp
@@ -14,6 +14,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_rational<T, std::string> to_string(const T &t) {

--- a/include/universal/number/rational/cmath_integration.hpp
+++ b/include/universal/number/rational/cmath_integration.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_rational<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    // TODO: no abs implementation for rational
+    // make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_rational<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_rational<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_rational<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/rational/rational.hpp
+++ b/include/universal/number/rational/rational.hpp
@@ -52,4 +52,6 @@
 /// math functions
 #include <universal/number/rational/mathlib.hpp>
 
+#include <universal/number/rational/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/sorn/cmath_integration.hpp
+++ b/include/universal/number/sorn/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_sorn<T, std::string> to_string(const T &t) {

--- a/include/universal/number/sorn/cmath_integration.hpp
+++ b/include/universal/number/sorn/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_sorn<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_sorn<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_sorn<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_sorn<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/sorn/sorn.hpp
+++ b/include/universal/number/sorn/sorn.hpp
@@ -47,4 +47,7 @@
 /// math functions
 // #include <universal/number/sorn/mathlib.hpp>
 
+// no enable_if_sorn
+// #include <universal/number/sorn/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/unum/cmath_integration.hpp
+++ b/include/universal/number/unum/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_unum<T, std::string> to_string(const T &t) {

--- a/include/universal/number/unum/cmath_integration.hpp
+++ b/include/universal/number/unum/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_unum<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_unum<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_unum<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_unum<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/unum/unum.hpp
+++ b/include/universal/number/unum/unum.hpp
@@ -34,4 +34,7 @@
 /// math functions
 #include <universal/number/unum/math_functions.hpp>
 
+// no enable_if_unum
+// #include <universal/number/unum/cmath_integration.hpp>
+
 #endif

--- a/include/universal/number/unum2/cmath_integration.hpp
+++ b/include/universal/number/unum2/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_unum2<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_unum2<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_unum2<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_unum2<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/unum2/cmath_integration.hpp
+++ b/include/universal/number/unum2/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_unum2<T, std::string> to_string(const T &t) {

--- a/include/universal/number/unum2/unum2_impl.hpp
+++ b/include/universal/number/unum2/unum2_impl.hpp
@@ -318,3 +318,6 @@ unum2<esizesize,fsizesize> abs(const unum2<esizesize,fsizesize,bt>& v) {
 
 
 }} // namespace sw::universal
+
+// no enable_if_unum2
+// #include <universal/number/unum2/cmath_integration.hpp>

--- a/include/universal/number/valid/cmath_integration.hpp
+++ b/include/universal/number/valid/cmath_integration.hpp
@@ -13,6 +13,7 @@ namespace std {
     make_std_fun(exp)
     make_std_fun(log)
     make_std_fun(atan)
+    make_std_fun(tan)
 
     template <typename T>
     sw::universal::enable_if_valid<T, std::string> to_string(const T &t) {

--- a/include/universal/number/valid/cmath_integration.hpp
+++ b/include/universal/number/valid/cmath_integration.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+
+#define make_std_fun(name) template <typename T> sw::universal::enable_if_valid<T, T> name(const T &t) { return sw::universal::name(t); }
+
+namespace std {
+    make_std_fun(sin)
+    make_std_fun(cos)
+    make_std_fun(sqrt)
+    make_std_fun(abs)
+    make_std_fun(floor)
+    make_std_fun(ceil)
+    make_std_fun(exp)
+    make_std_fun(log)
+    make_std_fun(atan)
+
+    template <typename T>
+    sw::universal::enable_if_valid<T, std::string> to_string(const T &t) {
+        return sw::universal::to_string(t);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_valid<T, T> pow(const T &base, T &exp) {
+        return sw::universal::pow(base, exp);
+    }
+
+    template <typename T>
+    sw::universal::enable_if_valid<T, T> atan2(const T &y, const T &x) {
+        return sw::universal::atan2(y, x);
+    }
+}
+
+#undef make_std_fun

--- a/include/universal/number/valid/valid.hpp
+++ b/include/universal/number/valid/valid.hpp
@@ -12,4 +12,7 @@
 #include <universal/number/valid/manipulators.hpp>
 #include <universal/number/valid/attributes.hpp>
 
+// no enable_if_valid
+// #include <universal/number/valid/cmath_integration.hpp>
+
 #endif


### PR DESCRIPTION
As of now, this does not compile for me with Scalar being any of the universal types:
```
#include <cmath>

using Scalar = ... // arbitrary universal type

int main() {
  Scalar a = 1507.2; // arbitrary number
  Scalar b = std::sqrt(a); // arbitrary function from cmath
  return 0;
}
```

It's working for posits when using the sqrt function like this though:
```
#include <cmath>

using Scalar = ... // arbitrary universal type

int main() {
  using std::sqrt;
  Scalar a = 1507.2; // arbitrary number
  Scalar b = sqrt(a); // arbitrary function from cmath
  return 0;
}
```

However, changing the way the sqrt function is called is only something one can do in ones own code and can become very hard when a library (Eigen/Bembel) would need to be modified.

Back during my thesis, I therefore added templated overloads for these functions for posits into the `std::` namespace and this PR intends to do this for all types in universal.

I stumbled over this again, because I intended to run as many number systems as possible through a set of Eigen algorithms (for https://github.com/openjournals/joss-reviews/issues/5072), but most of them turned out to fail compiling due to not being able to call `std::sqrt` or some other such function (log, abs, atan, tan come to mind).

Currently, this is a draft, because I am not sure adding stuff into std:: is a good idea (see https://stackoverflow.com/questions/320798/adding-types-to-the-std-namespace and https://en.cppreference.com/w/cpp/language/extending_std). Additionally, most types did not provide an appropriate `enable_if_`, so they are currently not implemented. For the cfloat however, these changes allowed me to compile programs which would not compile otherwise.