### PR TITLE
Fix cfloat comparison with fp16

### DIFF
--- a/include/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/universal/number/cfloat/cfloat_impl.hpp
@@ -3750,7 +3750,7 @@ inline bool operator> (const cfloat<nbits, es, bt, hasSubnormals, hasSupernormal
 }
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 inline bool operator<=(const cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>& lhs, int rhs) {
-	return operator<(lhs, cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(rhs)) || operator==(lhs, cfloat<nbits, es, bt>(rhs));
+	return operator<(lhs, cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(rhs)) || operator==(lhs, cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(rhs));
 }
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 inline bool operator>=(const cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>& lhs, int rhs) {
@@ -3776,7 +3776,7 @@ inline bool operator> (const cfloat<nbits, es, bt, hasSubnormals, hasSupernormal
 }
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 inline bool operator<=(const cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>& lhs, long long rhs) {
-	return operator<(lhs, cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(rhs)) || operator==(lhs, cfloat<nbits, es, bt>(rhs));
+	return operator<(lhs, cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(rhs)) || operator==(lhs, cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(rhs));
 }
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasSupernormals, bool isSaturating>
 inline bool operator>=(const cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>& lhs, long long rhs) {


### PR DESCRIPTION
Hello,

Since not all of the parameters are passed to the overloaded operator, when using `fp16` aka `sw::universal::cfloat<16, 5, short unsigned int, true, false, false>` an error is thrown:
~~~
/include/universal/number/cfloat/cfloat_impl.hpp:3753:118: error: no matching function for call to ‘operator==(const sw::universal::cfloat<16, 5, short unsigned int, true, false, false>&, sw::universal::cfloat<16, 5, short unsigned int, false, false, false>)’
 3753 |         return operator<(lhs, cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>(rhs)) || operator==(lhs, cfloat<nbits, es, bt>(rhs));
~~~
This PR fixes this.

Best,
David