### PR TITLE
enable quad precision floating point component extraction

### DIFF
--- a/include/universal/internal/value/value.hpp
+++ b/include/universal/internal/value/value.hpp
@@ -277,22 +277,40 @@ public:
 		case FP_NORMAL:
 			{
 				long double _fr{0};
-				unsigned long long _63b_fraction_without_hidden_bit{0};
 				int _exponent{0};
-				extract_fp_components(rhs, _sign, _exponent, _fr, _63b_fraction_without_hidden_bit);
-				_scale = _exponent - 1;
+				// fraction without hidden bit moved into the if
+
 				// how to interpret the fraction bits: TODO: this should be a static compile-time code block
-				if (sizeof(long double) == 8) {
+				if constexpr (sizeof(long double) == 8) {
 					// we are just a double and thus only have 52bits of fraction
+
+					std::uint64_t _63b_fraction_without_hidden_bit{0};
+					extract_fp_components(rhs, _sign, _exponent, _fr, _63b_fraction_without_hidden_bit);
+					_scale = _exponent - 1;
+
 					_fraction = extract_52b_fraction<fbits>(_63b_fraction_without_hidden_bit);
 					if (_trace_value_conversion) std::cout << "long double " << rhs << " sign " << _sign << " scale " << _scale << " 52b fraction 0x" << std::hex << _63b_fraction_without_hidden_bit << " _fraction b" << _fraction << std::dec << std::endl;
 
 				}
-				else if (sizeof(long double) == 16) {
+				else if constexpr (sizeof(long double) == 16 && std::numeric_limits<long double>::digits <= 64) {
 					// how to differentiate between 80bit and 128bit formats?
+
+					std::uint64_t _63b_fraction_without_hidden_bit{0};
+					extract_fp_components(rhs, _sign, _exponent, _fr, _63b_fraction_without_hidden_bit);
+					_scale = _exponent - 1;
+
 					_fraction = extract_63b_fraction<fbits>(_63b_fraction_without_hidden_bit);
 					if (_trace_value_conversion) std::cout << "long double " << rhs << " sign " << _sign << " scale " << _scale << " 63b fraction 0x" << std::hex << _63b_fraction_without_hidden_bit << " _fraction b" << _fraction << std::dec << std::endl;
 
+				} else if constexpr (sizeof(long double) == 16  && std::numeric_limits<long double>::digits <= 128) {
+					internal::uint128 _112b_fraction_without_hidden_bit{0};
+					extract_fp_components(rhs, _sign, _exponent, _fr, _112b_fraction_without_hidden_bit);
+					_scale = _exponent - 1;
+
+					_fraction = extract_long_double_fraction<fbits>(&_112b_fraction_without_hidden_bit);
+					if (_trace_value_conversion) std::cout << "long double " << rhs << " sign " << _sign << " scale " << _scale << " 112b fraction upper 0x" << std::hex << _112b_fraction_without_hidden_bit.upper << " lower 0x" << std::hex << _112b_fraction_without_hidden_bit.lower << " _fraction b" << _fraction << std::dec << std::endl;
+				} else {
+					assert(false);
 				}
 				_nrOfBits = fbits;
 			}

--- a/include/universal/native/nonconstexpr/extract_fp_components.hpp
+++ b/include/universal/native/nonconstexpr/extract_fp_components.hpp
@@ -49,7 +49,7 @@ inline void extract_fp_components(long double fp, bool& _sign, int& _exponent, l
 	_sign = fp < 0.0;
 	_fr = ::std::frexp(fp, &_exponent);
 
-	std::memcpy(&_fr, &_fraction, sizeof(internal::uint128)); // _fraction = reinterpret_cast<uint128>(_fr);
+	std::memcpy(&_fraction, &_fr, sizeof(internal::uint128)); // _fraction = reinterpret_cast<uint128>(_fr);
 
 	// we need to remove the upper bits that are not part of the mantissa. (all bits - mantissa bits - 1). -1 because the first bit is not stored
 	// we only need to do this on the upper part of the uint128, as we asserted that the mantissa has more than 64 bits.

--- a/include/universal/native/nonconstexpr/extract_fp_components.hpp
+++ b/include/universal/native/nonconstexpr/extract_fp_components.hpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cmath>
+#include <universal/internal/bitblock/bitblock.hpp>
 
 /*
  * The frexpf/frexp/frexpl functions have become constexpr in C++23. Universal is using the <bit> library
@@ -30,6 +31,7 @@ inline void extract_fp_components(double fp, bool& _sign, int& _exponent, double
 // this implementation assumes an 80bit extended precision representation
 // TODO: support a full quad precision long double
 inline void extract_fp_components(long double fp, bool& _sign, int& _exponent, long double& _fr, std::uint64_t& _fraction) {
+	assert(sizeof(long double) == 8 || sizeof(long double) == 16 && std::numeric_limits<long double>::digits <= 64);
 	if constexpr (sizeof(long double) == 8) { // check if (long double) is aliased to be just a double
 		_sign = fp < 0.0;
 		_fr = (long double)(::std::frexp(double(fp), &_exponent));
@@ -40,6 +42,20 @@ inline void extract_fp_components(long double fp, bool& _sign, int& _exponent, l
 		_fr = ::std::frexp(fp, &_exponent);
 		_fraction = 0x7FFF'FFFF'FFFF'FFFFull & reinterpret_cast<uint64_t&>(_fr); // 80bit extended format only has 63bits of fraction
 	}
+}
+
+inline void extract_fp_components(long double fp, bool& _sign, int& _exponent, long double& _fr, internal::uint128& _fraction) {
+	assert(sizeof(long double) == 16 && std::numeric_limits<long double>::digits > 64);
+	_sign = fp < 0.0;
+	_fr = ::std::frexp(fp, &_exponent);
+
+	std::memcpy(&_fr, &_fraction, sizeof(internal::uint128)); // _fraction = reinterpret_cast<uint128>(_fr);
+
+	// we need to remove the upper bits that are not part of the mantissa. (all bits - mantissa bits - 1). -1 because the first bit is not stored
+	// we only need to do this on the upper part of the uint128, as we asserted that the mantissa has more than 64 bits.
+	constexpr int shift = 8 * sizeof(long double) - (std::numeric_limits<long double>::digits - 1);
+	_fraction.upper <<= shift;
+	_fraction.upper >>= shift;
 }
 
 }} // namespace sw::universal

--- a/tools/cmd/propenv.cpp
+++ b/tools/cmd/propenv.cpp
@@ -146,19 +146,36 @@ try {
 	bool        sign  	    = false;
 	int         scale 	    = 0;
 	long double fr    	    = 0;
-	unsigned long long fraction = 0;
-	sw::universal::extract_fp_components(ld.da, sign, scale, fr, fraction);
+	if constexpr (std::numeric_limits<long double>::digits <= 64) {
+		std::uint64_t fraction = 0;
+		sw::universal::extract_fp_components(ld.da, sign, scale, fr, fraction);
 
-	std::cout << "value    " << std::setprecision(q_prec) << ld.da << std::setprecision(f_prec) << '\n';
-	std::cout << "hex      ";
-	std::cout << std::hex << std::setfill('0');
-	for (int i = 15; i >= 0; i--) {
-		std::cout << std::setw(2) << (int)(uint8_t)ld.bytes[i] << " ";
+		std::cout << "value    " << std::setprecision(q_prec) << ld.da << std::setprecision(f_prec) << '\n';
+		std::cout << "hex      ";
+		std::cout << std::hex << std::setfill('0');
+		for (int i = 15; i >= 0; i--) {
+			std::cout << std::setw(2) << (int)(uint8_t)ld.bytes[i] << " ";
+		}
+		std::cout << std::dec << std::setfill(' ') << '\n';
+		std::cout << "sign     " << (sign ? "-" : "+") << '\n';
+		std::cout << "scale    " << scale << '\n';
+		std::cout << "fraction " << fraction << '\n';
+	} else {
+		sw::universal::internal::uint128 fraction{0};
+		sw::universal::extract_fp_components(ld.da, sign, scale, fr, fraction);
+
+		std::cout << "value         " << std::setprecision(q_prec) << ld.da << std::setprecision(f_prec) << '\n';
+		std::cout << "hex           ";
+		std::cout << std::hex << std::setfill('0');
+		for (int i = 15; i >= 0; i--) {
+			std::cout << std::setw(2) << (int)(uint8_t)ld.bytes[i] << " ";
+		}
+		std::cout << std::dec << std::setfill(' ') << '\n';
+		std::cout << "sign          " << (sign ? "-" : "+") << '\n';
+		std::cout << "scale         " << scale << '\n';
+		std::cout << "fraction upper" << fraction.upper << '\n';
+		std::cout << "fraction lower" << fraction.lower << '\n';
 	}
-	std::cout << std::dec << std::setfill(' ') << '\n';
-	std::cout << "sign     " << (sign ? "-" : "+") << '\n';
-	std::cout << "scale    " << scale << '\n';
-	std::cout << "fraction " << fraction << '\n';
 
 	std::cout << std::endl;
 


### PR DESCRIPTION
This PR adds the extraction of floating point components for 128 bit long doubles.

Regarding the changes:
- **value.hpp**: Depending on which floating point configuration is used, the `fraction_without_hidden_bit` is either 64 bit or 128 bit in size. To allow for this distinction, the creation of the `fraction_without_hidden_bit` variable was moved into the if expression along with the call to `extract_fp_components()`.
A new condition was added to handle 16 byte long doubles with more than 64 mantissa bits. This uses the unirsals internal::uint128 type to hold the mantissa, but works the same otherwise. One difference is that the uint128 cannot be turned into a string directly, so the output for `_trace_value_conversion` is modified slightly.
- **extract_fp_components.hpp**: An assertion was added to the existing long double version to ensure it's not called when the mantissa does not fit into a 64 bit container. A new overload was added that uses universals internal::uint128 type as mantissa container. This version uses `memcpy` instead of `reinterpret_cast` because the long double could not be `reinterpret_cast`ed into the uint128. Assuming that the memory layout of uint128 is correct, this should be right.
Also, instead of masking away the upper bits, I assert that this function is only called when the long double has more than 64 mantissa bits (i.e. the only removed bits are in the upper part of the uint128) and then use two shifts to remove the upmost bits. The value used for shifting is a part I am not certain about, as the computed shift value emits a lot of compiler warnings when building on architectures, where the long double has fewer mantissa bits.
```
/mnt/RamDisk/patch/universal/./include/universal/native/nonconstexpr/extract_fp_components.hpp:57:18: warning: shift count >= width of type [-Wshift-count-overflow]
        _fraction.upper <<= shift;
                        ^   ~~~~~
/mnt/RamDisk/patch/universal/./include/universal/native/nonconstexpr/extract_fp_components.hpp:58:18: warning: shift count >= width of type [-Wshift-count-overflow]
        _fraction.upper >>= shift;
```
- **propenv.cpp**: This also directly accesses the extract_fp_components function and needed a little modification to use uint128 when appropriate. Because the fraction variable is used later, everything between its creation and final use is moved into the if expression.