### PR TITLE
Implement specialized posit<16,2> addition

### DIFF
--- a/static/posit/specialized/posit_16_2.cpp
+++ b/static/posit/specialized/posit_16_2.cpp
@@ -53,7 +53,7 @@ try {
 #endif
 
 	std::string test_tag    = "arithmetic type tests";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -78,6 +78,9 @@ try {
 
 	float fa, fb;
 	posit<16, 1> a, b, c;
+
+	nrOfFailedTestCases += ReportTestResult(VerifyAddition         <nbits, es>(reportTestCases), tag, "add            (native)  ");
+	return 0;
 /*
 	{
 
@@ -130,6 +133,14 @@ try {
 		std::cout << "\n+----------------      0b0.1'1110.11.1000'0010\n";
 		a.setbits(0x7B02);   // 0b0.1'1110.11.1000'0010
 		b.setbits(0x4002);   // 0b0.10.00.000'0000'0010
+		ReportValue(a, "a");
+		ReportValue(b, "b");
+		c = a + b;
+		ReportValue(c, "c");
+
+		std::cout << "\n+----------------      0b0.0'0001.10.1000'0010\n";
+		a.setbits(0x0682);   // 0b0.0'0001.10.1000'0010
+		b.setbits(0x0582);   // 0b0.0'0001.01.1000'0010
 		ReportValue(a, "a");
 		ReportValue(b, "b");
 		c = a + b;


### PR DESCRIPTION
Following issue #343 I implemented the specialized posit<16,2> addition following the guidelines from softposit. I think it is working correctly, but the tests are not computing the golden solution correctly. When I run the exhaustive tests with the `reportTestCases=true`, I get the following fails:
~~~
.
.
.
8.8817841970012523234e-16 +                -8.0703125 !=                -8.0703125 golden reference is             -3.0087890625
    0b0.00000000000001.1. +     0b1.10.11.00000010010 !=     0b1.10.11.00000010010 golden reference is     0b1.10.01.10000001001
FAIL
8.8817841970012523234e-16 +               -8.06640625 !=               -8.06640625 golden reference is                -3.0078125
    0b0.00000000000001.1. +     0b1.10.11.00000010001 !=     0b1.10.11.00000010001 golden reference is     0b1.10.01.10000001000
FAIL
8.8817841970012523234e-16 +                   -8.0625 !=                   -8.0625 golden reference is                -3.0078125
    0b0.00000000000001.1. +     0b1.10.11.00000010000 !=     0b1.10.11.00000010000 golden reference is     0b1.10.01.10000001000
FAIL
8.8817841970012523234e-16 +               -8.05859375 !=               -8.05859375 golden reference is             -3.0068359375
    0b0.00000000000001.1. +     0b1.10.11.00000001111 !=     0b1.10.11.00000001111 golden reference is     0b1.10.01.10000000111
FAIL
8.8817841970012523234e-16 +                -8.0546875 !=                -8.0546875 golden reference is             -3.0068359375
    0b0.00000000000001.1. +     0b1.10.11.00000001110 !=     0b1.10.11.00000001110 golden reference is     0b1.10.01.10000000111
FAIL
8.8817841970012523234e-16 +               -8.05078125 !=               -8.05078125 golden reference is              -3.005859375
    0b0.00000000000001.1. +     0b1.10.11.00000001101 !=     0b1.10.11.00000001101 golden reference is     0b1.10.01.10000000110
FAIL
8.8817841970012523234e-16 +                 -8.046875 !=                 -8.046875 golden reference is              -3.005859375
    0b0.00000000000001.1. +     0b1.10.11.00000001100 !=     0b1.10.11.00000001100 golden reference is     0b1.10.01.10000000110
FAIL
8.8817841970012523234e-16 +               -8.04296875 !=               -8.04296875 golden reference is             -3.0048828125
    0b0.00000000000001.1. +     0b1.10.11.00000001011 !=     0b1.10.11.00000001011 golden reference is     0b1.10.01.10000000101
FAIL
8.8817841970012523234e-16 +                -8.0390625 !=                -8.0390625 golden reference is             -3.0048828125
    0b0.00000000000001.1. +     0b1.10.11.00000001010 !=     0b1.10.11.00000001010 golden reference is     0b1.10.01.10000000101
FAIL
8.8817841970012523234e-16 +               -8.03515625 !=               -8.03515625 golden reference is               -3.00390625
    0b0.00000000000001.1. +     0b1.10.11.00000001001 !=     0b1.10.11.00000001001 golden reference is     0b1.10.01.10000000100
FAIL
8.8817841970012523234e-16 +                  -8.03125 !=                  -8.03125 golden reference is               -3.00390625
    0b0.00000000000001.1. +     0b1.10.11.00000001000 !=     0b1.10.11.00000001000 golden reference is     0b1.10.01.10000000100
.
.
.
~~~
Where I believe the computed value is correct and the golden one isn't.

I checked the `to_double()` function and it seems to be correct, but calls some other functions in `posit_impl.hpp` that I don't know. Could you have a look at this @Ravenwater @theo-lemurian ?