### PR TITLE
fix: compare operators for bfloat8 and bfloat16

### DIFF
--- a/include/universal/number/bfloat/bfloat16_impl.hpp
+++ b/include/universal/number/bfloat/bfloat16_impl.hpp
@@ -483,7 +483,7 @@ inline bool operator!=(bfloat16 lhs, bfloat16 rhs) {
 }
 
 inline bool operator< (bfloat16 lhs, bfloat16 rhs) {
-	return (float(lhs) - float(rhs)) > 0;
+	return (float(lhs) - float(rhs)) < 0;
 }
 
 inline bool operator> (bfloat16 lhs, bfloat16 rhs) {

--- a/include/universal/number/bfloat/bfloat8_impl.hpp
+++ b/include/universal/number/bfloat/bfloat8_impl.hpp
@@ -446,7 +446,7 @@ inline bool operator!=(bfloat8 lhs, bfloat8 rhs) {
 }
 
 inline bool operator< (bfloat8 lhs, bfloat8 rhs) {
-	return (float(lhs) - float(rhs)) > 0;
+	return (float(lhs) - float(rhs)) < 0;
 }
 
 inline bool operator> (bfloat8 lhs, bfloat8 rhs) {


### PR DESCRIPTION
I was shocked to find that `sw::universal::bfloat16{4} < sw::universal::bfloat16{5}` evaluates to `false` for my tests. I assume this to be a bug or typo.