### PR TITLE
Mark blfloat non-tmpl functions as inline

### DIFF
--- a/include/sw/universal/number/bfloat/bfloat16_fwd.hpp
+++ b/include/sw/universal/number/bfloat/bfloat16_fwd.hpp
@@ -10,6 +10,6 @@ namespace sw { namespace universal {
 
 // forward references
 class bfloat16;
-bool parse(const std::string& number, bfloat16& v);
+inline bool parse(const std::string& number, bfloat16& v);
 
 }}  // namespace sw::universal

--- a/include/sw/universal/number/bfloat/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat/bfloat16_impl.hpp
@@ -430,7 +430,7 @@ inline bfloat16 abs(bfloat16 a) {
 /// stream operators
 
 // parse a bfloat16 ASCII format and make a binary bfloat16 out of it
-bool parse(const std::string& number, bfloat16& value) {
+inline bool parse(const std::string& number, bfloat16& value) {
 	bool bSuccess = false;
 	value.zero();
 	return bSuccess;
@@ -453,7 +453,7 @@ inline std::istream& operator>>(std::istream& istr, bfloat16& p) {
 
 ////////////////// string operators
 
-std::string to_binary(bfloat16 bf, bool bNibbleMarker = false) {
+inline std::string to_binary(bfloat16 bf, bool bNibbleMarker = false) {
 	std::stringstream s;
 	unsigned short bits = bf.bits();
 	unsigned short mask = 0x8000u;

--- a/include/sw/universal/number/bfloat/manipulators.hpp
+++ b/include/sw/universal/number/bfloat/manipulators.hpp
@@ -15,7 +15,7 @@
 namespace sw { namespace universal {
 
 	// Generate a type tag for bfloat16
-	std::string type_tag(const bfloat16& = {}) {
+	inline std::string type_tag(const bfloat16& = {}) {
 		return std::string("bfloat16");
 	}
 
@@ -96,7 +96,7 @@ namespace sw { namespace universal {
 	}
 
 	// generate a binary, color-coded representation of the bfloat16
-	std::string color_print(const bfloat16& r, bool nibbleMarker = false) {
+	inline std::string color_print(const bfloat16& r, bool nibbleMarker = false) {
 		constexpr unsigned es = 8;
 		constexpr unsigned fbits = 7;
 		std::stringstream s;

--- a/include/sw/universal/number/bfloat/math/next.hpp
+++ b/include/sw/universal/number/bfloat/math/next.hpp
@@ -23,7 +23,7 @@ Return Value
 	- And math_errhandling has MATH_ERRNO set: the global variable errno is set to ERANGE.
 	- And math_errhandling has MATH_ERREXCEPT set: FE_OVERFLOW is raised.
 	*/
-bfloat16 nextafter(bfloat16 x, bfloat16 target) {
+inline bfloat16 nextafter(bfloat16 x, bfloat16 target) {
 	if (x == target) return target;
 	if (target.isnan()) {
 		if (x.isneg()) {

--- a/include/sw/universal/number/bfloat/math/pow.hpp
+++ b/include/sw/universal/number/bfloat/math/pow.hpp
@@ -8,17 +8,17 @@
 
 namespace sw { namespace universal {
 
-bfloat16 pow(bfloat16 x, bfloat16 y) {
+inline bfloat16 pow(bfloat16 x, bfloat16 y) {
 	using std::pow;
 	return bfloat16(std::pow(float(x), float(y)));
 }
 		
-bfloat16 pow(bfloat16 x, int y) {
+inline bfloat16 pow(bfloat16 x, int y) {
 	using std::pow;
 	return bfloat16(std::pow(float(x), float(y)));
 }
 		
-bfloat16 pow(bfloat16 x, float y) {
+inline bfloat16 pow(bfloat16 x, float y) {
 	using std::pow;
 	return bfloat16(std::pow(float(x), y));
 }


### PR DESCRIPTION
This PR fixes ODR linking issues with multiple TU:

```
..universal/number/bfloat/math/pow.hpp:11: multiple definition of `sw::universal::pow(sw::universal::bfloat16, sw::universal::bfloat16)';..
..universal/number/bfloat/math/pow.hpp:16: multiple definition of `sw::universal::pow(sw::universal::bfloat16, int)';..
```

.. and many more.

The last PR baffled me as the v3.83 branch is ahead of main. So I assume this is where the development is going on. If you want a PR to main, I can do that too.