### PR TITLE
Riscv

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,7 +2,7 @@ name: CMake
 
 on:
   push:
-    branches: [ v3.85, main ]
+    branches: [ riscv, main ]
   pull_request:
     branches: [ main ]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,7 +509,7 @@ if(WIN32)
     set(include_install_dir_full Include)
     set(config_install_dir CMake)
 elseif(UNIX)
-    set(include_install_dir include)
+    set(include_install_dir "include/sw")
     set(include_install_dir_postfix "${project_library_target_name}")
     set(include_install_dir_full    "${include_install_dir}/${include_install_dir_postfix}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,7 +509,7 @@ if(WIN32)
     set(include_install_dir_full Include)
     set(config_install_dir CMake)
 elseif(UNIX)
-    set(include_install_dir "include/sw")
+    set(include_install_dir include)
     set(include_install_dir_postfix "${project_library_target_name}")
     set(include_install_dir_full    "${include_install_dir}/${include_install_dir_postfix}")
 

--- a/include/sw/universal/internal/value/value.hpp
+++ b/include/sw/universal/internal/value/value.hpp
@@ -307,7 +307,7 @@ public:
 					extract_fp_components(rhs, _sign, _exponent, _fr, _112b_fraction_without_hidden_bit);
 					_scale = _exponent - 1;
 
-					_fraction = extract_long_double_fraction<fbits>(&_112b_fraction_without_hidden_bit);
+					_fraction = extract_long_double_fraction<fbits>(_112b_fraction_without_hidden_bit);
 					if (_trace_value_conversion) std::cout << "long double " << rhs << " sign " << _sign << " scale " << _scale << " 112b fraction upper 0x" << std::hex << _112b_fraction_without_hidden_bit.upper << " lower 0x" << std::hex << _112b_fraction_without_hidden_bit.lower << " _fraction b" << _fraction << std::dec << std::endl;
 				} else {
 					assert(false);

--- a/include/sw/universal/native/compiler/ieee754_riscv.hpp
+++ b/include/sw/universal/native/compiler/ieee754_riscv.hpp
@@ -1,7 +1,8 @@
 #pragma once
 // ieee754.hpp: RISC-V specific manipulation functions for IEEE-754 native types
 //
-// Copyright (C) 2017-2022 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
@@ -27,6 +28,10 @@ public:
 	static constexpr uint64_t fmsb     = 0x0040'0000ull;
 	static constexpr uint64_t qnanmask = 0x7FC0'0000ull;
 	static constexpr uint64_t snanmask = 0x7FC0'0001ull;
+	static constexpr float    minNormal       = 1.1754943508222875079687365372222e-38f; // == 2^-126
+ 	static constexpr float    minSubnormal    = 1.4012984643248170709237295832899e-45f; // == 2^-149
+	static constexpr int      minNormalExp    = -126;
+	static constexpr int      minSubnormalExp = -149;
 };
 template<>
 class ieee754_parameter<double> {
@@ -44,9 +49,12 @@ public:
 	static constexpr uint64_t fmsb     = 0x0008'0000'0000'0000ull;
 	static constexpr uint64_t qnanmask = 0x7FF8'0000'0000'0000ull;
 	static constexpr uint64_t snanmask = 0x7FF0'0000'0000'0001ull;
+	static constexpr double   minNormal    = 2.2250738585072013830902327173324e-308; // == 2^-1022
+											 static constexpr double   minSubnormal = 4.9406564584124654417656879286220e-324; // == 2^-1074
+											 static constexpr int      minNormalExp = -1022;
+											 static constexpr int      minSubnormalExp = -1074;
 };
 
-	// MSVC long double = double precision
 // IEEE-754 parameter constexpressions for long double
 template<>
 class ieee754_parameter<long double> {
@@ -64,6 +72,10 @@ public:
 	static constexpr uint64_t fmsb     = 0x0008'0000'0000'0000ull;
 	static constexpr uint64_t qnanmask = 0x7FF8'0000'0000'0000ull;
 	static constexpr uint64_t snanmask = 0x7FF0'0000'0000'0001ull;
+	static constexpr long double minNormal       = 3.3621031431120935062626778173218e-4932l; // == 2^-16382
+	static constexpr long double minSubnormal    = 3.6451995318824746025284059336194e-4951l; // == 2^-16445
+	static constexpr int         minNormalExp    = -16382;
+	static constexpr int         minSubnormalExp = -16445;
 };
 
 }} // namespace sw::universal

--- a/include/sw/universal/native/compiler/ieee754_riscv.hpp
+++ b/include/sw/universal/native/compiler/ieee754_riscv.hpp
@@ -50,9 +50,9 @@ public:
 	static constexpr uint64_t qnanmask = 0x7FF8'0000'0000'0000ull;
 	static constexpr uint64_t snanmask = 0x7FF0'0000'0000'0001ull;
 	static constexpr double   minNormal    = 2.2250738585072013830902327173324e-308; // == 2^-1022
-											 static constexpr double   minSubnormal = 4.9406564584124654417656879286220e-324; // == 2^-1074
-											 static constexpr int      minNormalExp = -1022;
-											 static constexpr int      minSubnormalExp = -1074;
+	static constexpr double   minSubnormal = 4.9406564584124654417656879286220e-324; // == 2^-1074
+	static constexpr int      minNormalExp = -1022;
+	static constexpr int      minSubnormalExp = -1074;
 };
 
 // IEEE-754 parameter constexpressions for long double

--- a/include/sw/universal/native/ieee754_decoder.hpp
+++ b/include/sw/universal/native/ieee754_decoder.hpp
@@ -109,7 +109,7 @@ namespace sw { namespace universal {
 		uint64_t bits[2];
 	};
 
-#else 
+#elif defined(UNIVERSAL_ARCH_ARM)
     // long double is mapped to double in ARM64
 	union long_double_decoder {
 		long_double_decoder() : ld{ 0.0l } {}
@@ -123,6 +123,23 @@ namespace sw { namespace universal {
 		uint64_t bits[2];
 	};
 
+#elif defined(UNIVERSAL_ARCH_RISCV)
+
+	// how does RISC-V model its long double?
+	// for the moment, just use the x86 interpretation
+	union long_double_decoder {
+		long double ld;
+		struct {
+			uint64_t fraction : 63;
+			uint64_t bit63 : 1;
+			uint64_t exponent : 15;
+			uint64_t sign : 1;
+		} parts;
+		uint64_t bits[2];
+	};
+
+#else
+#pragma message("long double unsupported for unidentified architecture")
 #endif
 
 }} // namespace sw::universal

--- a/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
@@ -1,7 +1,8 @@
 #pragma once
 // clang_long_double.hpp: nonconstexpr implementation of IEEE-754 long double manipulators
 //
-// Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 

--- a/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
@@ -1,7 +1,8 @@
 #pragma once
 // gcc_long_double.hpp: nonconstexpr implementation of IEEE-754 long double manipulators
 //
-// Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 

--- a/include/sw/universal/native/nonconstexpr/msvc_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/msvc_long_double.hpp
@@ -1,7 +1,8 @@
 #pragma once
 // msvc_long_double.hpp: nonconstexpr implementation of IEEE-754 long double manipulators
 //
-// Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 

--- a/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
@@ -1,7 +1,8 @@
 #pragma once
 // riscv_long_double.hpp: nonconstexpr implementation of IEEE-754 long double manipulators
 //
-// Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
@@ -19,16 +20,6 @@ namespace sw { namespace universal {
  * Bit 63 will be 1 on all normalized numbers.
  */
 
- // long double decoder
-union long_double_decoder {
-	long double ld;
-	struct {
-		uint64_t fraction : 63;
-		uint64_t bit63 : 1;
-		uint64_t exponent : 15;
-		uint64_t sign : 1;
-	} parts;
-};
 
 inline void extractFields(long double value, bool& s, uint64_t& rawExponentBits, uint64_t& rawFractionBits) {
 	long_double_decoder decoder;

--- a/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
@@ -30,7 +30,7 @@ inline void extractFields(long double value, bool& s, uint64_t& rawExponentBits,
 }
 
 // specialization for IEEE long double precision floats
-inline std::string to_base2_scientific(long double number) {
+inline std::string to_base2_scientific_(long double number) {
 	std::stringstream s;
 	long_double_decoder decoder;
 	decoder.ld = number;
@@ -44,19 +44,7 @@ inline std::string to_base2_scientific(long double number) {
 	return s.str();
 }
 
-#ifdef DEPRECATED
-// DEPRECATED: we have standardized on raw bit hex, not field hex format
-// generate a binary string for a native double precision IEEE floating point
-inline std::string to_hex(long double number) {
-	std::stringstream s;
-	long_double_decoder decoder;
-	decoder.ld = number;
-	s << (decoder.parts.sign ? '1' : '0') << '.' << std::hex << int(decoder.parts.exponent) << '.' << decoder.parts.fraction;
-	return s.str();
-}
-#endif // DEPRECATED
-
-inline std::string to_hex(long double number, bool nibbleMarker = false, bool hexPrefix = true) {
+inline std::string to_hex_(long double number, bool nibbleMarker = false, bool hexPrefix = true) {
 	char hexChar[16] = {
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
@@ -97,7 +85,7 @@ inline std::string to_hex(long double number, bool nibbleMarker = false, bool he
 }
 
 // generate a binary string for a native double precision IEEE floating point
-inline std::string to_binary(long double number, bool bNibbleMarker = false) {
+inline std::string to_binary_(long double number, bool bNibbleMarker = false) {
 	std::stringstream s;
 	long_double_decoder decoder;
 	decoder.ld = number;
@@ -131,7 +119,7 @@ inline std::string to_binary(long double number, bool bNibbleMarker = false) {
 }
 
 // return in triple form (+, scale, fraction)
-inline std::string to_triple(long double number) {
+inline std::string to_triple_(long double number) {
 	std::stringstream s;
 	long_double_decoder decoder;
 	decoder.ld = number;
@@ -166,7 +154,7 @@ inline std::string to_triple(long double number) {
 }
 
 // generate a color coded binary string for a native double precision IEEE floating point
-inline std::string color_print(long double number) {
+inline std::string color_print_(long double number) {
 	std::stringstream s;
 	long_double_decoder decoder;
 	decoder.ld = number;
@@ -210,7 +198,7 @@ inline std::string color_print(long double number) {
 	return s.str();
 }
 
-inline void extract_fp_components(long double fp, bool& _sign, int& _exponent, long double& _fr, uint64_t& _fraction) {
+inline void extract_fp_components_(long double fp, bool& _sign, int& _exponent, long double& _fr, uint64_t& _fraction) {
 	// RISC-V ABI defines long double as a 128-bit quadprecision floating point
 	if (std::numeric_limits<long double>::digits <= 64) {
 		if (sizeof(long double) == 8) { // it is just a double

--- a/include/sw/universal/utility/long_double.hpp
+++ b/include/sw/universal/utility/long_double.hpp
@@ -21,7 +21,11 @@
 
 #elif defined(__GNUC__) || defined(__GNUG__)
 /* GNU GCC/G++. --------------------------------------------- */
+#if defined(__riscv)
+#define LONG_DOUBLE_SUPPORT 0
+#else
 #define LONG_DOUBLE_SUPPORT 1
+#endif
 
 #elif defined(__HP_cc) || defined(__HP_aCC)
 /* Hewlett-Packard C/aC++. ---------------------------------- */


### PR DESCRIPTION
RISC-V port of Universal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added RISC-V–specific handling for long double decoding.
  - Exposed min normal/subnormal values and corresponding exponents for float, double, and long double.

- Refactor
  - Renamed several long double helper functions to underscore-suffixed variants; removed deprecated hex formatter.
  - Adjusted GCC behavior: long double support disabled on RISC-V toolchains.

- Chores
  - Updated CI to run on push for riscv and main branches.
  - Standardized license headers and added SPDX identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->