### PR TITLE
Cleanup: fixed compiler warnings (no functional changes)

### DIFF
--- a/elastic/ereal/math/functions/next.cpp
+++ b/elastic/ereal/math/functions/next.cpp
@@ -15,7 +15,7 @@ namespace sw {
     template<typename Real>
     int VerifyNextafter(bool reportTestCases) {
 	    int    nrOfFailedTestCases = 0;
-	    double error_mag;
+	    // double error_mag;
 
 	    Real x, y;
 	    Real result, expected;
@@ -25,7 +25,8 @@ namespace sw {
 	    y         = 0.0;
 	    expected  = 0.0;
 	    result    = nextafter(x, y);
-	    error_mag = std::abs(double(result - expected));
+
+	    // error_mag = std::abs(double(result - expected));
 	    if (!result.iszero()) {
 		    if (reportTestCases)
 			    std::cerr << "FAIL: nextafter(0, 0) != 0\n";

--- a/include/sw/universal/number/cfloat/manipulators.hpp
+++ b/include/sw/universal/number/cfloat/manipulators.hpp
@@ -24,14 +24,13 @@ namespace sw { namespace universal {
 // generate a type_tag for a cfloat
 template<typename CfloatType,
 	std::enable_if_t< is_cfloat<CfloatType>, bool> = true>
-inline std::string type_tag(CfloatType v = {}) {
+inline std::string type_tag([[maybe_unused]] CfloatType v = {}) {
 	constexpr unsigned nbits = CfloatType::nbits;
 	constexpr unsigned es = CfloatType::es;
 	using bt = typename CfloatType::BlockType;
 	constexpr bool hasSubnormals = CfloatType::hasSubnormals;
 	constexpr bool hasSupernormals = CfloatType::hasSupernormals;
 	constexpr bool isSaturating = CfloatType::isSaturating;
-	v = v; // suppress unused parameter warning
 	std::stringstream s;
 	if constexpr (nbits == 64 && es == 11 && hasSubnormals && !hasSupernormals && !isSaturating) {
 		s << "fp64";

--- a/include/sw/universal/number/efloat/manipulators.hpp
+++ b/include/sw/universal/number/efloat/manipulators.hpp
@@ -63,12 +63,12 @@ template<typename EfloatType,
 	std::enable_if_t< is_efloat<EfloatType>, bool> = true
 >
 inline std::string to_hex(const EfloatType& v, bool nibbleMarker = false, bool hexPrefix = true) {
+	std::stringstream s;
+	/*
 	constexpr char hexChar[16] = {
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
 	};
-	std::stringstream s;
-	/*
 	if (hexPrefix) s << "0x" << std::hex;
 	int nrNibbles = int(1ull + ((nbits - 1ull) >> 2ull));
 	for (int n = nrNibbles - 1; n >= 0; --n) {

--- a/include/sw/universal/number/ereal/manipulators.hpp
+++ b/include/sw/universal/number/ereal/manipulators.hpp
@@ -73,12 +73,12 @@ template<typename ErealType,
 	std::enable_if_t< is_ereal<ErealType>, bool> = true
 >
 inline std::string to_hex(const ErealType& v, bool nibbleMarker = false, bool hexPrefix = true) {
+	std::stringstream s;
+	/*
 	constexpr char hexChar[16] = {
 		'0', '1', '2', '3', '4', '5', '6', '7',
 		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
 	};
-	std::stringstream s;
-	/*
 	if (hexPrefix) s << "0x" << std::hex;
 	int nrNibbles = int(1ull + ((nbits - 1ull) >> 2ull));
 	for (int n = nrNibbles - 1; n >= 0; --n) {

--- a/include/sw/universal/number/qd/math/functions/next.hpp
+++ b/include/sw/universal/number/qd/math/functions/next.hpp
@@ -24,13 +24,11 @@ namespace sw { namespace universal {
 		- And math_errhandling has MATH_ERRNO set: the global variable errno is set to ERANGE.
 		- And math_errhandling has MATH_ERREXCEPT set: FE_OVERFLOW is raised.
 		*/
-	inline qd nextafter(qd x, qd target) {
-		target = target; // suppress unused parameter warning
+	inline qd nextafter(qd x, [[maybe_unused]] qd target) {
 		return x;
 	}
 		
-	inline qd nexttoward(qd x, qd target) {
-		target = target; // suppress unused parameter warning
+	inline qd nexttoward(qd x, [[maybe_unused]] qd target) {
 		return x;
 	}
 

--- a/static/qd_cascade/api/constants.cpp
+++ b/static/qd_cascade/api/constants.cpp
@@ -115,7 +115,7 @@ namespace sw {
 			ReportValue(_third, "0.333'333'333'333'333'333'333'333'333'333'3", 35, 32);
 			ReportValue(_third2, "second component approximation", 35, 32);
 
-			qd_cascade a{ 0 }, b, c;
+			[[maybe_unused]] qd_cascade a{ 0 }, b, c;
 			std::cout << std::setprecision(64);
 
 			// 212 bits represent 10log(2) * 212 = 63.8 digits of accuracy 

--- a/static/takum/conversion/assignment.cpp
+++ b/static/takum/conversion/assignment.cpp
@@ -239,7 +239,7 @@ try {
 
 #if MANUAL_TESTING
 
-	using Real = sw::universal::takum<16, uint16_t>;
+//	using Real = sw::universal::takum<16, uint16_t>;
 	double ref{ 0 };
 
 //	goto verify;
@@ -271,7 +271,7 @@ try {
 		f *= 0.5f;
 	}
 
-test1:
+// test1:
 
 	{
 		takum<16, uint16_t> input, result;
@@ -327,7 +327,7 @@ FAIL =               2.91471e-77 !=               3.02266e-77 golden reference i
 	}
 	return 0;
 
-verify:
+// verify:
 
 	reportTestCases = true;
 //	nrOfFailedTestCases = ReportTestResult(VerifyAssignment< 8, uint16_t, double>(reportTestCases), test_tag, "takum< 8,uint16_t>");


### PR DESCRIPTION
## Summary

This PR **addresses compiler warnings** such as:

- Unused variables
- Unused labels
- Unused results / values

There are **no functional or behavioral changes** in this PR.

---

## Scope

- Removes or annotates unused locals and temporaries
- Addresses unused labels left behind by refactors or debug paths
- Marks intentionally unused values explicitly, rather than suppressing warnings globally

No control flow, logic, or numerical behavior is changed.

---

## Non-Goals

- No algorithm changes
- No behavioral changes
- No sanitizer-related fixes (handled in separate PRs)
- No refactors beyond what is required to address warnings

---

## Rationale

Keeping the codebase warning-clean helps:

- Make new warnings visible when they are introduced
- Support stricter warning levels in CI and local builds
- Reduce noise when investigating real issues

---

## Testing

- Full test suite passes
- No expected impact on runtime behavior or results