### PR TITLE
fix(dfloat,hfloat): add canonical regression test guards to all test files

### DIFF
--- a/static/float/dfloat/api/api.cpp
+++ b/static/float/dfloat/api/api.cpp
@@ -11,12 +11,41 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "dfloat<> Application Programming Interface tests";
+	std::string test_tag = "dfloat<> API";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// important behavioral traits
 	{
@@ -158,8 +187,21 @@ try {
 		std::cout << "decimal32 min       : " << std::numeric_limits<Real>::min() << '\n';
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/arithmetic/addition.cpp
+++ b/static/float/dfloat/arithmetic/addition.cpp
@@ -8,22 +8,43 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
 #define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 0
-#define REGRESSION_LEVEL_4 0
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
 
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "dfloat<> addition validation";
+	std::string test_tag = "dfloat<> addition";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	using Decimal32 = dfloat<7, 6, DecimalEncoding::BID, uint32_t>;
 
-	std::cout << test_suite << '\n';
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic addition
 	std::cout << "+---------    Basic addition\n";
@@ -155,8 +176,21 @@ try {
 		if (!r3.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cerr << "FAIL: NaN + 1 should be NaN\n"; }
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/arithmetic/division.cpp
+++ b/static/float/dfloat/arithmetic/division.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "dfloat<> division validation";
+	std::string test_tag = "dfloat<> division";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	using Decimal32 = dfloat<7, 6, DecimalEncoding::BID, uint32_t>;
 
-	std::cout << test_suite << '\n';
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic division
 	std::cout << "+---------    Basic division\n";
@@ -96,8 +122,21 @@ try {
 		if (!r3.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cerr << "FAIL: NaN / 1 should be NaN\n"; }
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/arithmetic/multiplication.cpp
+++ b/static/float/dfloat/arithmetic/multiplication.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "dfloat<> multiplication validation";
+	std::string test_tag = "dfloat<> multiplication";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	using Decimal32 = dfloat<7, 6, DecimalEncoding::BID, uint32_t>;
 
-	std::cout << test_suite << '\n';
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic multiplication
 	std::cout << "+---------    Basic multiplication\n";
@@ -97,8 +123,21 @@ try {
 		if (!r3.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cerr << "FAIL: NaN * 1 should be NaN\n"; }
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/arithmetic/subtraction.cpp
+++ b/static/float/dfloat/arithmetic/subtraction.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "dfloat<> subtraction validation";
+	std::string test_tag = "dfloat<> subtraction";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	using Decimal32 = dfloat<7, 6, DecimalEncoding::BID, uint32_t>;
 
-	std::cout << test_suite << '\n';
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic subtraction
 	std::cout << "+---------    Basic subtraction\n";
@@ -66,8 +92,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/conversion/assignment.cpp
+++ b/static/float/dfloat/conversion/assignment.cpp
@@ -8,22 +8,41 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
-// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING://
-// is used for style://
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
 #define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 0
-#define REGRESSION_LEVEL_4 0
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
 
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "dfloat<> assignment and conversion validation";
+	std::string test_tag = "dfloat<> assignment";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Integer assignment round-trip for decimal32
 	std::cout << "+---------    Integer assignment round-trip (decimal32)\n";
@@ -110,6 +129,8 @@ try {
 		}
 	}
 
+#endif
+
 #if REGRESSION_LEVEL_2
 	// Test 6: DPD encoding assignment round-trip
 	std::cout << "+---------    DPD encoding assignment round-trip\n";
@@ -127,8 +148,16 @@ try {
 	}
 #endif
 
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/logic/logic.cpp
+++ b/static/float/dfloat/logic/logic.cpp
@@ -8,22 +8,43 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
 #define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 0
-#define REGRESSION_LEVEL_4 0
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
 
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "dfloat<> comparison operator validation";
+	std::string test_tag = "dfloat<> logic";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	using Decimal32 = dfloat<7, 6, DecimalEncoding::BID, uint32_t>;
 
-	std::cout << test_suite << '\n';
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Equality
 	std::cout << "+---------    Equality tests\n";
@@ -154,8 +175,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/standard/decimal128.cpp
+++ b/static/float/dfloat/standard/decimal128.cpp
@@ -8,6 +8,22 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 #ifdef __SIZEOF_INT128__
 
 int main()
@@ -15,13 +31,23 @@ try {
 	using namespace sw::universal;
 
 	std::string test_suite = "decimal128 (dfloat<34,12>) standard format validation";
+	std::string test_tag = "decimal128";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	using decimal128_bid = dfloat<34, 12, DecimalEncoding::BID, uint32_t>;
 	using decimal128_dpd = dfloat<34, 12, DecimalEncoding::DPD, uint32_t>;
 
-	std::cout << test_suite << '\n';
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Verify field widths for decimal128
 	std::cout << "+---------    Field width verification (BID)\n";
@@ -274,8 +300,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/standard/decimal32.cpp
+++ b/static/float/dfloat/standard/decimal32.cpp
@@ -8,18 +8,44 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "decimal32 (dfloat<7,6>) standard format validation";
+	std::string test_tag = "decimal32";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	using decimal32_bid = dfloat<7, 6, DecimalEncoding::BID, uint32_t>;
 	using decimal32_dpd = dfloat<7, 6, DecimalEncoding::DPD, uint32_t>;
 
-	std::cout << test_suite << '\n';
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Verify field widths for decimal32
 	std::cout << "+---------    Field width verification (BID)\n";
@@ -132,8 +158,21 @@ try {
 		std::cout << "  to_binary(42): " << to_binary(a) << '\n';
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/dfloat/standard/dpd_codec.cpp
+++ b/static/float/dfloat/standard/dpd_codec.cpp
@@ -8,12 +8,41 @@
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "DPD (Densely Packed Decimal) codec verification";
+	std::string test_tag = "DPD codec";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Verify all 1000 encode/decode round-trips
 	std::cout << "+---------    Exhaustive DPD encode/decode round-trip test (0-999)\n";
@@ -124,8 +153,21 @@ try {
 		std::cout << "  DPD dfloat<7,6>(0.1) = " << db << " : " << to_binary(b) << '\n';
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -11,12 +11,41 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat<> Application Programming Interface tests";
+	std::string test_tag = "hfloat<> API";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// important behavioral traits
 	{
@@ -170,8 +199,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/arithmetic/addition.cpp
+++ b/static/float/hfloat/arithmetic/addition.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat<> addition validation";
+	std::string test_tag = "hfloat<> addition";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
 	using HfloatShort = hfloat<6, 7, uint32_t>;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic addition
 	std::cout << "+---------    Basic addition\n";
@@ -104,8 +130,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/arithmetic/division.cpp
+++ b/static/float/hfloat/arithmetic/division.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat<> division validation";
+	std::string test_tag = "hfloat<> division";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
 	using HfloatShort = hfloat<6, 7, uint32_t>;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic division
 	std::cout << "+---------    Basic division\n";
@@ -95,8 +121,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/arithmetic/multiplication.cpp
+++ b/static/float/hfloat/arithmetic/multiplication.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat<> multiplication validation";
+	std::string test_tag = "hfloat<> multiplication";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
 	using HfloatShort = hfloat<6, 7, uint32_t>;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic multiplication
 	std::cout << "+---------    Basic multiplication\n";
@@ -93,8 +119,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/arithmetic/subtraction.cpp
+++ b/static/float/hfloat/arithmetic/subtraction.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat<> subtraction validation";
+	std::string test_tag = "hfloat<> subtraction";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
 	using HfloatShort = hfloat<6, 7, uint32_t>;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Basic subtraction
 	std::cout << "+---------    Basic subtraction\n";
@@ -65,8 +91,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/conversion/assignment.cpp
+++ b/static/float/hfloat/conversion/assignment.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat<> assignment and conversion validation";
+	std::string test_tag = "hfloat<> assignment";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
 	using HfloatShort = hfloat<6, 7, uint32_t>;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Integer assignment round-trip
 	std::cout << "+---------    Integer assignment round-trip\n";
@@ -114,8 +140,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/logic/logic.cpp
+++ b/static/float/hfloat/logic/logic.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat<> comparison operator validation";
+	std::string test_tag = "hfloat<> logic";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
 	using HfloatShort = hfloat<6, 7, uint32_t>;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Equality
 	std::cout << "+---------    Equality tests\n";
@@ -86,8 +112,21 @@ try {
 		if (b < a)    { ++nrOfFailedTestCases; if (reportTestCases) std::cerr << "FAIL: -5 not < -10\n"; }
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/standard/short.cpp
+++ b/static/float/hfloat/standard/short.cpp
@@ -8,17 +8,43 @@
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
 	using namespace sw::universal;
 
 	std::string test_suite = "hfloat_short (hfloat<6,7>) standard format validation";
+	std::string test_tag = "hfloat_short standard";
+	bool reportTestCases = false;
 	int nrOfFailedTestCases = 0;
-	bool reportTestCases = true;
 
 	using Short = hfloat<6, 7, uint32_t>;
 
-	std::cout << test_suite << '\n';
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
 
 	// Test 1: Field widths
 	std::cout << "+---------    Field width verification\n";
@@ -111,8 +137,21 @@ try {
 		}
 	}
 
+#endif
+
+#if REGRESSION_LEVEL_2
+#endif
+
+#if REGRESSION_LEVEL_3
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;


### PR DESCRIPTION
## Summary

- Add canonical `MANUAL_TESTING` and `REGRESSION_LEVEL_1..4` guards to all 18 dfloat and hfloat regression test files
- Replace raw `std::cout` with `ReportTestSuiteHeader()` for consistent test output
- Set `reportTestCases = false` (was `true`) to match codebase convention
- Existing test code placed in `REGRESSION_LEVEL_1`; empty L2/L3/L4 stubs added for future use

## Test plan

- [x] 18/18 tests pass with gcc
- [x] 18/18 tests pass with clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure across all float type modules (dfloat and hfloat) to support multi-level regression testing.
  * Added configurable manual testing mode to enable isolated test execution paths.
  * Restructured test execution flow to support staged regression levels, improving test management and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->