### PR TITLE
docs(dfixpnt): add to Number Systems Guide and docs-site sync

### DIFF
--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -21,6 +21,7 @@ const FILE_MAP = {
   'number-systems/README.md': 'number-systems/index.md',
   'number-systems/integer.md': 'number-systems/integer.md',
   'number-systems/fixpnt.md': 'number-systems/fixpnt.md',
+  'number-systems/dfixpnt.md': 'number-systems/dfixpnt.md',
   'number-systems/rational.md': 'number-systems/rational.md',
   'number-systems/cfloat.md': 'number-systems/cfloat.md',
   'number-systems/bfloat16.md': 'number-systems/bfloat16.md',

--- a/docs/number-systems/README.md
+++ b/docs/number-systems/README.md
@@ -10,6 +10,7 @@ This directory contains comprehensive documentation for each number system in th
 |------|------|-------------|----------|
 | [integer](integer.md) | N | Arbitrary-width signed integer | Cryptography, combinatorics, wide counters |
 | [fixpnt](fixpnt.md) | N | Binary fixed-point with configurable radix | DSP, control systems, embedded (no FPU) |
+| [dfixpnt](dfixpnt.md) | N | Decimal fixed-point with configurable radix | Financial ledgers, COBOL migration, tax/POS |
 | [rational](rational.md) | 2N | Exact numerator/denominator fraction | Symbolic math, exact geometry, financial |
 
 ### Configurable Floating-Point
@@ -88,7 +89,7 @@ This directory contains comprehensive documentation for each number system in th
 | **Deep Learning Inference** | microfloat, mxfloat, nvblock, bfloat16, cfloat(fp8) |
 | **Deep Learning Training** | bfloat16, cfloat(fp16/fp32), posit |
 | **DSP / Signal Processing** | fixpnt, lns, complex |
-| **Financial / Accounting** | dfloat, rational, fixpnt |
+| **Financial / Accounting** | dfixpnt, dfloat, rational, fixpnt |
 | **Embedded (no FPU)** | fixpnt, integer |
 | **Scientific HPC** | dd, qd, posit, cfloat |
 | **Verified / Validated Computing** | interval, valid, areal, sorn |
@@ -108,6 +109,7 @@ This directory contains comprehensive documentation for each number system in th
 | 31 digits | dd, dd_cascade | ~31 |
 | 48 digits | td_cascade | ~48 |
 | 64 digits | qd, qd_cascade | ~64 |
+| Exact (decimal) | dfixpnt | Configurable (ndigits) |
 | Exact | rational, integer, quire | Unlimited (within nbits) |
 
 ## Quick Start


### PR DESCRIPTION
Add dfixpnt to the Guide's type table, application domain recommendations, and precision matrix. Register dfixpnt.md in sync-content.mjs so the docs-site builds the page instead of 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new decimal fixed-point type (dfixpnt) to the documentation.
  * Updated guidance tables to include dfixpnt as an option for financial and exact-decimal use cases with configurable precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->