### PR TITLE
fix(lns): implement fraction() and fix components() formatting

### DIFF
--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -940,11 +940,11 @@ template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
 std::string components(const lns<nbits, rbits, bt, xtra...>& v) {
 	std::stringstream s;
 	if (v.iszero()) {
-		s << " zero b" << to_binary(v.fraction());
+		s << " zero " << to_binary(v.fraction());
 		return s.str();
 	}
 	else if (v.isinf()) {
-		s << " infinite b" << to_binary(v.fraction());
+		s << " infinite " << to_binary(v.fraction());
 		return s.str();
 	}
 	s << "(" << (v.sign() ? "-" : "+") << "," << v.scale() << "," << to_binary(v.fraction()) << ")";


### PR DESCRIPTION
## Summary
- Implement `lns::fraction()` which was an `assert(false)` stub, blocking `to_triple()` and `components()` from working at runtime
- Fix `components()` to use `to_binary()` instead of `operator<<` on the `Unsigned` blockbinary fraction, which triggered a `static_assert` in `longdivision`

The `fraction()` implementation extracts the lower `rbits` bits from the internal block storage — the fractional part of the fixed-point exponent.

Resolves #509

## Test plan
- [x] `lns_api` passes with gcc
- [x] `lns_api` passes with clang
- [x] `to_triple()` produces correct hex output for `lns<8,4>`, `lns<16,8>`, `lns<64,32>`
- [x] `components()` produces correct binary output without assertion failures
- [x] Identical output between gcc and clang

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved fractional extraction and representation so fractional parts are now computed and shown in binary; zero and infinite values now display their binary fraction consistently. This yields clearer, more accurate visualizations of fractional components across numeric displays and special-case representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->