### PR TITLE
ci: workflow does not contain permissions

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,5 +1,8 @@
 name: Clang-Tidy
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/stillwater-sc/universal/security/code-scanning/1](https://github.com/stillwater-sc/universal/security/code-scanning/1)

To fix the problem, explicitly set `permissions` for the workflow (or for the `clang-tidy` job) so that `GITHUB_TOKEN` has only the minimal scopes required. This job needs to: (1) read the repository contents to allow `actions/checkout` to work, and (2) upload artifacts using `actions/upload-artifact`, which does not require repository write permissions. It does not need to modify contents, issues, or pull requests.

The best fix with no functional behavior change is to add a root-level `permissions` block right after the `name:` (or after `on:`) setting `contents: read`. This will apply to all jobs (there is only `clang-tidy`), ensuring that the token is restricted to read-only for repository contents while all current steps (checkout, building, local file writing, artifact upload) continue to work as before.

Concretely, in `.github/workflows/clang-tidy.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top-level of the file (aligned with `name:` and `on:`). No additional imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->