### PR TITLE
fix(posit): correct NaR in to_binary, to_triple, and color_print

### DIFF
--- a/include/sw/universal/number/posit/manipulators.hpp
+++ b/include/sw/universal/number/posit/manipulators.hpp
@@ -153,39 +153,41 @@ namespace sw { namespace universal {
 
 		Color red(ColorCode::FG_RED);
 		Color yellow(ColorCode::FG_YELLOW);
-		Color blue(ColorCode::FG_BLUE);
-		Color magenta(ColorCode::FG_MAGENTA);
 		Color cyan(ColorCode::FG_CYAN);
-		Color white(ColorCode::FG_WHITE);
+		Color magenta(ColorCode::FG_MAGENTA);
 		Color def(ColorCode::FG_DEFAULT);
-		str << red << (p.isneg() ? "1" : "0");
 
+		// sign bit
+		str << red << (_sign ? '1' : '0');
+
+		// regime bits: read decoded field bits directly (no inversion)
 		blockbinary<nbits - 1, bt, BinaryNumberType::Unsigned> r = _regime.bits();
 		int regimeBits = (int)_regime.nrBits();
 		int nrOfRegimeBitsProcessed = 0;
 		for (unsigned i = 0; i < nbits - 1; ++i) {
 			unsigned bitIndex = nbits - 2ull - i;
 			if (regimeBits > nrOfRegimeBitsProcessed++) {
-					str << yellow << (_sign ? (r.test(bitIndex) ? '0' : '1') : (r.test(bitIndex) ? '1' : '0'));
+				str << yellow << (r.test(bitIndex) ? '1' : '0');
 			}
 		}
 
+		// exponent bits: read decoded field bits directly (no inversion)
 		blockbinary<es, bt, BinaryNumberType::Unsigned> e = _exponent.bits();
 		int exponentBits = (int)_exponent.nrBits();
 		int nrOfExponentBitsProcessed = 0;
 		for (int i = es - 1; i >= 0; --i) {
 			if (exponentBits > nrOfExponentBitsProcessed++) {
-					str << cyan << (_sign ? (e.test(static_cast<unsigned>(i)) ? '0' : '1') : (e.test(static_cast<unsigned>(i)) ? '1' : '0'));
+				str << cyan << (e.test(static_cast<unsigned>(i)) ? '1' : '0');
 			}
 		}
 
+		// fraction bits: read decoded field bits directly
 		blockbinary<posit<nbits, es>::fbits, bt, BinaryNumberType::Unsigned> f = _fraction.bits();
-		//f = (_sign ? twosComplement(f) : f);
 		int fractionBits = (int)_fraction.nrBits();
 		int nrOfFractionBitsProcessed = 0;
 		for (int i = int(p.fbits) - 1; i >= 0; --i) {
 			if (fractionBits > nrOfFractionBitsProcessed++) {
-					str << magenta << (f.test(static_cast<unsigned>(i)) ? "1" : "0");
+				str << magenta << (f.test(static_cast<unsigned>(i)) ? '1' : '0');
 			}
 		}
 

--- a/include/sw/universal/number/posit/posit_exponent.hpp
+++ b/include/sw/universal/number/posit/posit_exponent.hpp
@@ -157,14 +157,17 @@ inline std::string to_string(const positExponent<nbits, es, bt>& e, bool dashExt
 	if constexpr (es > 0) {
 		for (unsigned i = 0; i < es; ++i) {
 			unsigned bitIndex = es - 1ull - i;
+			bool emitted = false;
 			if (e.nrBits() > nrOfExponentBitsProcessed++) {
 				UnsignedExponent positExponentBits = e.bits();
 				s << (positExponentBits.test(bitIndex) ? '1' : '0');
+				emitted = true;
 			}
-			else {
-				s << (dashExtent ? "-" : "");
+			else if (dashExtent) {
+				s << '-';
+				emitted = true;
 			}
-			if (nibbleMarker && ((bitIndex % 4) == 0) && bitIndex != 0) s << '\'';
+			if (emitted && nibbleMarker && ((bitIndex % 4) == 0) && bitIndex != 0) s << '\'';
 		}
 	}
 	else {

--- a/include/sw/universal/number/posit/posit_fraction.hpp
+++ b/include/sw/universal/number/posit/posit_fraction.hpp
@@ -254,13 +254,16 @@ inline std::string to_string(const positFraction<nfbits, bbt>& f, bool dashExten
 		blockbinary<nfbits, bbt, BinaryNumberType::Unsigned> bb = f.bits();
 		for (unsigned i = 0; i < nfbits; ++i) {
 			unsigned bitIndex = nfbits - 1ull - i;
+			bool emitted = false;
 			if (f.nrBits() > nrOfFractionBitsProcessed++) {
 				s << (bb.test(bitIndex) ? '1' : '0');
+				emitted = true;
 			}
-			else {
-				s << (dashExtent ? "-" : "");
+			else if (dashExtent) {
+				s << '-';
+				emitted = true;
 			}
-			if (nibbleMarker && ((bitIndex % 4) == 0) && bitIndex != 0) s << '\'';
+			if (emitted && nibbleMarker && ((bitIndex % 4) == 0) && bitIndex != 0) s << '\'';
 		}
 	}
 	if (nrOfFractionBitsProcessed == 0) s << '~'; // for proper alignment in tables

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -139,7 +139,7 @@ int decode_regime(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bi
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits>
 void extract_fields(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits, bool& _sign, positRegime<nbits, es, bt>& _regime, positExponent<nbits, es, bt>& _exponent, positFraction<fbits, bt>& _fraction) {
 	using TwosComplementNumber = blockbinary<nbits, bt, BinaryNumberType::Signed>;
-	// check special case
+	// check special case: zero
 	if (raw_bits.iszero()) {
 		_sign = false;
 		_regime.setzero();
@@ -147,8 +147,19 @@ void extract_fields(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_
 		_fraction.setzero();
 		return;
 	}
-	TwosComplementNumber tmp(raw_bits);
+	// check special case: NaR (sign bit set, all other bits zero)
 	_sign = raw_bits.test(nbits - 1);
+	if (_sign) {
+		TwosComplementNumber tmp(raw_bits);
+		tmp.reset(nbits - 1);
+		if (tmp.none()) {
+			_regime.setinf();
+			_exponent.setzero();
+			_fraction.setzero();
+			return;
+		}
+	}
+	TwosComplementNumber tmp(raw_bits);
 	if (_sign) tmp = twosComplement(tmp);
 	unsigned nrRegimeBits = _regime.assign_regime_pattern(decode_regime(tmp));
 
@@ -1753,6 +1764,7 @@ template<unsigned nbits, unsigned es, typename bt>
 inline std::string to_binary(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
 	
 	constexpr unsigned fbits = (es + 2ull >= nbits ? 0ull : nbits - 3ull - es);             // maximum number of fraction bits: derived
+
 	bool negative{ false };
 	positRegime<nbits, es, bt> r;
 	positExponent<nbits, es, bt> e;
@@ -1772,6 +1784,7 @@ inline std::string to_binary(const posit<nbits, es, bt>& number, bool nibbleMark
 template<unsigned nbits, unsigned es, typename bt>
 inline std::string to_triple(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
 	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);             // maximum number of fraction bits: derived
+
 	bool s{ false };
 	positRegime<nbits, es, bt> r;
 	positExponent<nbits, es, bt> e;
@@ -1781,7 +1794,7 @@ inline std::string to_triple(const posit<nbits, es, bt>& number, bool nibbleMark
 	extract_fields(raw, s, r, e, f);
 
 	ss << (s ? "(-, " : "(+, ");
-	ss << scale(number) 
+	ss << scale(number)
 	   << ", "
 	   << to_string(f, false, nibbleMarker)
 	   << ')';

--- a/static/tapered/posit/api/api.cpp
+++ b/static/tapered/posit/api/api.cpp
@@ -140,6 +140,30 @@ try {
 		a.maxneg();		ReportValue(a, "maxneg  ");
 	}
 
+	// verify to_binary renders NaR correctly (issue #559)
+	{
+		int start = nrOfFailedTestCases;
+		posit<8, 2> p8;  p8.setnar();
+		posit<16, 2> p16; p16.setnar();
+		posit<32, 2> p32; p32.setnar();
+		// NaR has sign=1, regime=all zeros (nbits-1 bits), empty exponent and fraction
+		// Format: 0b1.{regime}.{exponent}.{fraction} with empty exponent and fraction
+		if (to_binary(p8)  != "0b1.0000000..") ++nrOfFailedTestCases;
+		if (to_binary(p16) != "0b1.000000000000000..") ++nrOfFailedTestCases;
+		if (to_binary(p32) != "0b1.0000000000000000000000000000000..") ++nrOfFailedTestCases;
+		// verify nibbleMarker is honored
+		if (to_binary(p8, true)  != "0b1.000'0000..") ++nrOfFailedTestCases;
+		if (to_binary(p16, true) != "0b1.000'0000'0000'0000..") ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) {
+			std::cout << "FAIL: to_binary NaR representation (issue #559)\n";
+			std::cout << "  posit<8,2>  NaR:           " << to_binary(p8)  << '\n';
+			std::cout << "  posit<16,2> NaR:           " << to_binary(p16) << '\n';
+			std::cout << "  posit<32,2> NaR:           " << to_binary(p32) << '\n';
+			std::cout << "  posit<8,2>  NaR w/ marker: " << to_binary(p8, true)  << '\n';
+			std::cout << "  posit<16,2> NaR w/ marker: " << to_binary(p16, true) << '\n';
+		}
+	}
+
 	std::cout << "*** binary, color, and value printing\n";
 	{
 		using Posit = posit<5, 1>;


### PR DESCRIPTION
## Summary
- `extract_fields()` did not handle the NaR bit pattern (sign bit set, all other bits zero) — two's complement of the minimum signed integer wraps to itself, causing `decode_regime()` to produce wrong regime bits. Added NaR detection so it properly sets regime to inf with empty exponent and fraction.
- `color_print()` inverted decoded field bits for negative posits (bit inversion != two's complement), producing wrong bit values. Fixed by reading decoded field bits directly without inversion, matching `to_binary()`.
- Exponent and fraction `to_string()` emitted spurious nibble separator characters when no content bits were output, producing trailing apostrophes for NaR/zero in larger posit sizes.

## Changes
- `include/sw/universal/number/posit/posit_impl.hpp` — add NaR handling to `extract_fields()`, remove broken early-returns from `to_binary()` and `to_triple()`
- `include/sw/universal/number/posit/manipulators.hpp` — remove bit inversion in `color_print()` for negative posits
- `include/sw/universal/number/posit/posit_exponent.hpp` — only emit nibbleMarker when content was actually output
- `include/sw/universal/number/posit/posit_fraction.hpp` — only emit nibbleMarker when content was actually output
- `static/tapered/posit/api/api.cpp` — add regression tests for NaR `to_binary()` with and without nibbleMarker

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| posit_api | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #559

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Not-a-Real (NaR) posit number detection and field initialization.
  * Refined binary output formatting for nibble markers and separator placement.

* **Tests**
  * Added comprehensive NaR rendering validation across multiple posit configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->