### PR TITLE
feat(cfloat): implement parse() for string-to-cfloat conversion

### DIFF
--- a/include/sw/universal/number/cfloat/cfloat_fwd.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_fwd.hpp
@@ -21,6 +21,10 @@ template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasM
 		cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>
 		fabs(cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>);
 
+// parsing
+template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
+		bool parse(const std::string& number, cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>& v);
+
 #ifdef CFLOAT_QUIRE
 
 // quire types

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -22,6 +22,7 @@
 // 
 // supporting types and functions
 #include <limits>
+#include <regex>
 #include <type_traits>
 #include <universal/native/ieee754.hpp>
 #include <universal/native/subnormal.hpp>
@@ -3309,12 +3310,72 @@ inline std::ostream& operator<<(std::ostream& ostr, const cfloat<nbits, es, bt, 
 	return ostr << representation;
 }
 
-// istream input: currently marshalling through native double
+// parse a cfloat from a string in either cfloat hex format (nbits.esxHEXVALUEc)
+// or a decimal floating-point representation
+template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
+bool parse(const std::string& txt, cfloat<nbits,es,bt,hasSubnormals,hasMaxExpValues,isSaturating>& v) {
+	// check if the txt is of the native cfloat form: nbits.esX[0x]hexvaluec
+	std::regex cfloat_regex(R"(^[0-9]+\.[0-9]+[xX](0[xX])?[0-9A-Fa-f]+c?$)");
+	if (std::regex_match(txt, cfloat_regex)) {
+		// found a cfloat representation: parse nbits.esxHEXVALUEc
+		std::string nbitsStr, esStr, bitStr;
+		auto it = txt.begin();
+		for (; it != txt.end(); ++it) {
+			if (*it == '.') break;
+			nbitsStr.append(1, *it);
+		}
+		for (++it; it != txt.end(); ++it) {
+			if (*it == 'x' || *it == 'X') break;
+			esStr.append(1, *it);
+		}
+		for (++it; it != txt.end(); ++it) {
+			if (*it == 'c') break;
+			bitStr.append(1, *it);
+		}
+		unsigned nbits_in = 0;
+		unsigned es_in = 0;
+		{
+			std::istringstream ss(nbitsStr);
+			ss >> nbits_in;
+			if (ss.fail()) return false;
+		}
+		{
+			std::istringstream ss(esStr);
+			ss >> es_in;
+			if (ss.fail()) return false;
+		}
+		// native cfloat form must match target configuration
+		if (nbits_in != nbits || es_in != es) return false;
+		uint64_t raw = 0;
+		std::istringstream ss(bitStr);
+		ss >> std::hex >> raw;
+		if (ss.fail()) return false;
+		ss >> std::ws;
+		if (!ss.eof()) return false;
+		v.setbits(raw);
+		return true;
+	}
+	else {
+		// assume it is a float/double/long double representation
+		std::istringstream ss(txt);
+		double d;
+		ss >> d;
+		if (ss.fail()) return false;
+		ss >> std::ws;
+		if (!ss.eof()) return false;
+		v = d;
+		return true;
+	}
+}
+
+// read an ASCII float or cfloat format: nbits.esxNN...NNc, for example: 16.5x7C00c
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
 inline std::istream& operator>>(std::istream& istr, cfloat<nbits,es,bt,hasSubnormals,hasMaxExpValues,isSaturating>& v) {
-	double d(0.0);
-	istr >> d;
-	v = d;
+	std::string txt;
+	istr >> txt;
+	if (!parse(txt, v)) {
+		std::cerr << "unable to parse -" << txt << "- into a cfloat value\n";
+	}
 	return istr;
 }
 

--- a/static/float/cfloat/api/api.cpp
+++ b/static/float/cfloat/api/api.cpp
@@ -376,6 +376,49 @@ try {
 		std::cout << "polynomial(1.0) = " << polyeval(polynomial, 5, single(1.0f)) << '\n';
 	}
 
+	std::cout << "+------------ parsing ----------+\n";
+	{
+		int start = nrOfFailedTestCases;
+
+		// parse a decimal floating-point string
+		half a;
+		if (!parse("1.5", a)) ++nrOfFailedTestCases;
+		if (a != half(1.5)) ++nrOfFailedTestCases;
+
+		// parse a negative value
+		if (!parse("-3.25", a)) ++nrOfFailedTestCases;
+		if (a != half(-3.25)) ++nrOfFailedTestCases;
+
+		// parse scientific notation
+		if (!parse("1.25e3", a)) ++nrOfFailedTestCases;
+		if (a != half(1250.0)) ++nrOfFailedTestCases;
+
+		// parse a cfloat hex format: nbits.esxHEXVALUEc (with or without 0x prefix)
+		half b;
+		if (!parse("16.5x3C00c", b)) ++nrOfFailedTestCases;
+		if (b != half(1.0)) ++nrOfFailedTestCases;
+		// also accept hex_print format which includes 0x prefix
+		if (!parse("16.5x0x3C00c", b)) ++nrOfFailedTestCases;
+		if (b != half(1.0)) ++nrOfFailedTestCases;
+
+		// parse via istream operator>>
+		std::istringstream is("2.5");
+		half c;
+		is >> c;
+		if (c != half(2.5)) ++nrOfFailedTestCases;
+
+		// reject trailing junk
+		half d;
+		if (parse("1.5abc", d)) ++nrOfFailedTestCases;
+
+		// reject mismatched configuration
+		if (parse("32.8x12345678c", a)) ++nrOfFailedTestCases;
+
+		if (nrOfFailedTestCases - start > 0) {
+			std::cout << "FAIL : parsing\n";
+		}
+	}
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }


### PR DESCRIPTION
## Summary
- Implement `parse()` for cfloat that handles both hex format (`nbits.esxHEXVALUEc`) and decimal floating-point strings
- Update `operator>>` to delegate to `parse()` instead of directly casting through double
- Hex format accepts both `16.5x3C00c` and `16.5x0x3C00c` (matching `hex_print()` output)
- Validates config match (nbits/es), rejects trailing junk, handles scientific notation

## Changes
- `include/sw/universal/number/cfloat/cfloat_impl.hpp` -- add `parse()`, update `operator>>`, add `<regex>` include
- `include/sw/universal/number/cfloat/cfloat_fwd.hpp` -- add `parse()` forward declaration
- `static/float/cfloat/api/api.cpp` -- add parsing tests (decimal, negative, scientific, hex, istream, rejection)

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| cfloat_api | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #339

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parsing capability for cfloat numbers from strings, supporting decimal notation, scientific notation, and native cfloat hex format representation.

* **Tests**
  * Added comprehensive test suite validating cfloat parsing across multiple formats including negative values, scientific notation, and native hex representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->