### PR TITLE
feat(unum1): implement comparison operators with NaN semantics

### DIFF
--- a/elastic/unum/api.cpp
+++ b/elastic/unum/api.cpp
@@ -149,7 +149,9 @@ try {
 
 		a.setnan();
 		b.setnan();
-		if (a != b) ++nrOfFailedTestCases;  // bit-level equality
+		// NaN != NaN per IEEE semantics
+		if (a == b) ++nrOfFailedTestCases;
+		if (!(a != b)) ++nrOfFailedTestCases;
 
 		if (nrOfFailedTestCases - start > 0) {
 			std::cout << "FAIL: equality\n";

--- a/elastic/unum/logic.cpp
+++ b/elastic/unum/logic.cpp
@@ -1,0 +1,222 @@
+// logic.cpp: comparison and logic operator tests for unum Type I
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+#define UNUM_THROW_ARITHMETIC_EXCEPTION 1
+#include <universal/number/unum/unum.hpp>
+#include <universal/number/unum/manipulators.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "unum Type I comparison and logic tests";
+	std::string test_tag    = "unum logic";
+	bool reportTestCases    = true;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	using Unum = unum<3, 4>;
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// equality
+	std::cout << "*** equality\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum a, b;
+
+		// zero == zero
+		a = 0.0; b = 0.0;
+		if (!(a == b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 0 == 0\n"; }
+
+		// same value
+		a = 1.5; b = 1.5;
+		if (!(a == b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.5 == 1.5\n"; }
+
+		// different values
+		a = 1.0; b = 2.0;
+		if (a == b) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 != 2.0\n"; }
+
+		// negative equality
+		a = -3.5; b = -3.5;
+		if (!(a == b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: -3.5 == -3.5\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: equality\n";
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// inequality
+	std::cout << "*** inequality\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum a, b;
+
+		a = 1.0; b = 2.0;
+		if (!(a != b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 != 2.0\n"; }
+
+		a = 1.0; b = 1.0;
+		if (a != b) { ++nrOfFailedTestCases; std::cout << "  FAIL: !(1.0 != 1.0)\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: inequality\n";
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// less than
+	std::cout << "*** less than\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum a, b;
+
+		a = 1.0; b = 2.0;
+		if (!(a < b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 < 2.0\n"; }
+
+		a = 2.0; b = 1.0;
+		if (a < b) { ++nrOfFailedTestCases; std::cout << "  FAIL: !(2.0 < 1.0)\n"; }
+
+		a = 1.0; b = 1.0;
+		if (a < b) { ++nrOfFailedTestCases; std::cout << "  FAIL: !(1.0 < 1.0)\n"; }
+
+		// negative values
+		a = -2.0; b = -1.0;
+		if (!(a < b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: -2.0 < -1.0\n"; }
+
+		// cross sign
+		a = -1.0; b = 1.0;
+		if (!(a < b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: -1.0 < 1.0\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: less than\n";
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// greater than
+	std::cout << "*** greater than\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum a, b;
+
+		a = 2.0; b = 1.0;
+		if (!(a > b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 2.0 > 1.0\n"; }
+
+		a = 1.0; b = 2.0;
+		if (a > b) { ++nrOfFailedTestCases; std::cout << "  FAIL: !(1.0 > 2.0)\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: greater than\n";
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// less than or equal
+	std::cout << "*** less than or equal\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum a, b;
+
+		a = 1.0; b = 2.0;
+		if (!(a <= b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 <= 2.0\n"; }
+
+		a = 1.0; b = 1.0;
+		if (!(a <= b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 <= 1.0\n"; }
+
+		a = 2.0; b = 1.0;
+		if (a <= b) { ++nrOfFailedTestCases; std::cout << "  FAIL: !(2.0 <= 1.0)\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: less than or equal\n";
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// greater than or equal
+	std::cout << "*** greater than or equal\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum a, b;
+
+		a = 2.0; b = 1.0;
+		if (!(a >= b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 2.0 >= 1.0\n"; }
+
+		a = 1.0; b = 1.0;
+		if (!(a >= b)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 >= 1.0\n"; }
+
+		a = 1.0; b = 2.0;
+		if (a >= b) { ++nrOfFailedTestCases; std::cout << "  FAIL: !(1.0 >= 2.0)\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: greater than or equal\n";
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// NaN comparison semantics
+	std::cout << "*** NaN comparison semantics\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum nan, a;
+		nan.setnan();
+		a = 1.0;
+
+		// NaN != NaN (IEEE semantics)
+		if (nan == nan) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN == NaN should be false\n"; }
+		if (!(nan != nan)) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN != NaN should be true\n"; }
+
+		// NaN is not ordered
+		if (nan < a) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN < 1.0 should be false\n"; }
+		if (nan > a) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN > 1.0 should be false\n"; }
+		if (nan <= a) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN <= 1.0 should be false\n"; }
+		if (nan >= a) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN >= 1.0 should be false\n"; }
+
+		// NaN compared to NaN
+		if (nan < nan) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN < NaN should be false\n"; }
+		if (nan > nan) { ++nrOfFailedTestCases; std::cout << "  FAIL: NaN > NaN should be false\n"; }
+
+		// value compared to NaN
+		if (a == nan) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 == NaN should be false\n"; }
+		if (a < nan) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 < NaN should be false\n"; }
+		if (a > nan) { ++nrOfFailedTestCases; std::cout << "  FAIL: 1.0 > NaN should be false\n"; }
+
+		if (nrOfFailedTestCases - start > 0) {
+			std::cout << "FAIL: NaN semantics\n";
+		}
+		else {
+			std::cout << "  all NaN comparisons follow IEEE semantics\n";
+		}
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// zero comparisons
+	std::cout << "*** zero comparisons\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum zero, pos, neg;
+		zero = 0.0;
+		pos = 1.0;
+		neg = -1.0;
+
+		if (!(zero == zero)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 0 == 0\n"; }
+		if (!(zero < pos)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 0 < 1\n"; }
+		if (!(neg < zero)) { ++nrOfFailedTestCases; std::cout << "  FAIL: -1 < 0\n"; }
+		if (!(zero >= zero)) { ++nrOfFailedTestCases; std::cout << "  FAIL: 0 >= 0\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: zero comparisons\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::unum_arithmetic_exception& err) {
+	std::cerr << "Uncaught unum arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/unum/unum_impl.hpp
+++ b/include/sw/universal/number/unum/unum_impl.hpp
@@ -455,26 +455,38 @@ inline std::istream& operator>>(std::istream& istr, unum<esizesize, fsizesize, b
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 inline bool operator==(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
-	return lhs._bits == rhs._bits;
+	// NaN is not equal to anything, including itself
+	if (lhs.isnan() || rhs.isnan()) return false;
+	// two zeros are equal regardless of encoding
+	if (lhs.iszero() && rhs.iszero()) return true;
+	// compare by value: two unums with different esize/fsize can represent the same value
+	return lhs.to_double() == rhs.to_double();
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 inline bool operator!=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+	// NaN is not equal to anything
+	if (lhs.isnan() || rhs.isnan()) return true;
 	return !operator==(lhs, rhs);
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 inline bool operator< (const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
-	return lhs.to_double() < rhs.to_double();  // stub: compare via double
+	// NaN is not ordered
+	if (lhs.isnan() || rhs.isnan()) return false;
+	return lhs.to_double() < rhs.to_double();
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 inline bool operator> (const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+	if (lhs.isnan() || rhs.isnan()) return false;
 	return operator<(rhs, lhs);
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 inline bool operator<=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+	if (lhs.isnan() || rhs.isnan()) return false;
 	return !operator>(lhs, rhs);
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 inline bool operator>=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+	if (lhs.isnan() || rhs.isnan()) return false;
 	return !operator<(lhs, rhs);
 }
 


### PR DESCRIPTION
## Summary
- Implement value-based comparison operators (==, !=, <, >, <=, >=) for unum Type I
- NaN follows IEEE-754 semantics (NaN != NaN, all ordered comparisons return false)
- Value-based equality: equivalent values with different esize/fsize compare equal

## Changes
- `include/sw/universal/number/unum/unum_impl.hpp` -- proper comparison operators with NaN handling
- `elastic/unum/logic.cpp` -- new test suite: equality, inequality, ordering, NaN semantics, zero
- `elastic/unum/api.cpp` -- update NaN equality test to match IEEE semantics

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| unum1_logic | OK | PASS | OK | PASS |
| unum1_api | OK | PASS | OK | PASS |
| unum1_conversion | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)

Resolves #566
Relates to Epic #192

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NaN (Not-a-Number) comparison semantics to align with IEEE standards for proper handling in equality and ordering operations.

* **Tests**
  * Added comprehensive test suite validating comparison operators including equality, inequality, and relational operations with NaN and zero handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->