### PR TITLE
feat(unum1): implement math functions

### DIFF
--- a/elastic/unum/math.cpp
+++ b/elastic/unum/math.cpp
@@ -188,7 +188,36 @@ try {
 		r = max(a, b);
 		if (r.to_double() != 2.0) { ++nrOfFailedTestCases; std::cout << "  FAIL: max(1,2)=" << r << '\n'; }
 
+		// min/max with NaN propagate NaN
+		Unum nan_val;
+		nan_val.setnan();
+		r = min(a, nan_val);
+		if (!r.isnan()) { ++nrOfFailedTestCases; std::cout << "  FAIL: min(1, NaN) should be NaN\n"; }
+		r = min(nan_val, a);
+		if (!r.isnan()) { ++nrOfFailedTestCases; std::cout << "  FAIL: min(NaN, 1) should be NaN\n"; }
+		r = max(a, nan_val);
+		if (!r.isnan()) { ++nrOfFailedTestCases; std::cout << "  FAIL: max(1, NaN) should be NaN\n"; }
+
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: abs/min/max\n";
+	}
+
+	/////////////////////////////////////////////////////////////////////////////////////
+	// overflow to NaN (unum has no infinity)
+	std::cout << "*** overflow maps to NaN\n";
+	{
+		int start = nrOfFailedTestCases;
+		Unum a, r;
+
+		a = 1000.0;
+		r = exp(a);
+		if (!r.isnan()) { ++nrOfFailedTestCases; std::cout << "  FAIL: exp(1000) should be NaN (overflow)\n"; }
+
+		a = 1000.0;
+		r = sinh(a);
+		if (!r.isnan()) { ++nrOfFailedTestCases; std::cout << "  FAIL: sinh(1000) should be NaN (overflow)\n"; }
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: overflow\n";
+		else std::cout << "  overflow correctly maps to NaN\n";
 	}
 
 	/////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/unum/math_functions.hpp
+++ b/include/sw/universal/number/unum/math_functions.hpp
@@ -14,6 +14,20 @@
 
 namespace sw { namespace universal {
 
+// helper: convert a native double result back to unum, mapping non-finite values to NaN
+// since unum Type I has no infinity encoding
+template<unsigned esizesize, unsigned fsizesize, typename bt>
+inline unum<esizesize, fsizesize, bt> from_native(double d) {
+	unum<esizesize, fsizesize, bt> result;
+	if (!std::isfinite(d)) {
+		result.setnan();
+	}
+	else {
+		result = d;
+	}
+	return result;
+}
+
 // classification
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 bool isnan(const unum<esizesize, fsizesize, bt>& v) { return v.isnan(); }
@@ -47,10 +61,8 @@ unum<esizesize, fsizesize, bt> sqrt(const unum<esizesize, fsizesize, bt>& v) {
 // exponential
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 unum<esizesize, fsizesize, bt> exp(const unum<esizesize, fsizesize, bt>& v) {
-	unum<esizesize, fsizesize, bt> result;
-	if (v.isnan()) { result.setnan(); return result; }
-	result = std::exp(v.to_double());
-	return result;
+	if (v.isnan()) { unum<esizesize, fsizesize, bt> r; r.setnan(); return r; }
+	return from_native<esizesize, fsizesize, bt>(std::exp(v.to_double()));
 }
 
 // natural logarithm
@@ -83,10 +95,8 @@ unum<esizesize, fsizesize, bt> log10(const unum<esizesize, fsizesize, bt>& v) {
 // power
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 unum<esizesize, fsizesize, bt> pow(const unum<esizesize, fsizesize, bt>& base, const unum<esizesize, fsizesize, bt>& exponent) {
-	unum<esizesize, fsizesize, bt> result;
-	if (base.isnan() || exponent.isnan()) { result.setnan(); return result; }
-	result = std::pow(base.to_double(), exponent.to_double());
-	return result;
+	if (base.isnan() || exponent.isnan()) { unum<esizesize, fsizesize, bt> r; r.setnan(); return r; }
+	return from_native<esizesize, fsizesize, bt>(std::pow(base.to_double(), exponent.to_double()));
 }
 
 // trigonometric functions
@@ -145,36 +155,32 @@ unum<esizesize, fsizesize, bt> acos(const unum<esizesize, fsizesize, bt>& v) {
 // hyperbolic functions
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 unum<esizesize, fsizesize, bt> sinh(const unum<esizesize, fsizesize, bt>& v) {
-	unum<esizesize, fsizesize, bt> result;
-	if (v.isnan()) { result.setnan(); return result; }
-	result = std::sinh(v.to_double());
-	return result;
+	if (v.isnan()) { unum<esizesize, fsizesize, bt> r; r.setnan(); return r; }
+	return from_native<esizesize, fsizesize, bt>(std::sinh(v.to_double()));
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 unum<esizesize, fsizesize, bt> cosh(const unum<esizesize, fsizesize, bt>& v) {
-	unum<esizesize, fsizesize, bt> result;
-	if (v.isnan()) { result.setnan(); return result; }
-	result = std::cosh(v.to_double());
-	return result;
+	if (v.isnan()) { unum<esizesize, fsizesize, bt> r; r.setnan(); return r; }
+	return from_native<esizesize, fsizesize, bt>(std::cosh(v.to_double()));
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 unum<esizesize, fsizesize, bt> tanh(const unum<esizesize, fsizesize, bt>& v) {
-	unum<esizesize, fsizesize, bt> result;
-	if (v.isnan()) { result.setnan(); return result; }
-	result = std::tanh(v.to_double());
-	return result;
+	if (v.isnan()) { unum<esizesize, fsizesize, bt> r; r.setnan(); return r; }
+	return from_native<esizesize, fsizesize, bt>(std::tanh(v.to_double()));
 }
 
-// min/max
+// min/max with explicit NaN propagation
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 unum<esizesize, fsizesize, bt> min(const unum<esizesize, fsizesize, bt>& a, const unum<esizesize, fsizesize, bt>& b) {
+	if (a.isnan() || b.isnan()) { unum<esizesize, fsizesize, bt> r; r.setnan(); return r; }
 	return (a < b) ? a : b;
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 unum<esizesize, fsizesize, bt> max(const unum<esizesize, fsizesize, bt>& a, const unum<esizesize, fsizesize, bt>& b) {
+	if (a.isnan() || b.isnan()) { unum<esizesize, fsizesize, bt> r; r.setnan(); return r; }
 	return (a > b) ? a : b;
 }
 

--- a/include/sw/universal/number/unum/unum_impl.hpp
+++ b/include/sw/universal/number/unum/unum_impl.hpp
@@ -150,7 +150,7 @@ public:
 	unum& operator=(double rhs) {
 		_bits.clear();
 		if (rhs == 0.0) return *this;  // zero is all bits clear
-		if (std::isnan(rhs)) { setnan(); return *this; }
+		if (std::isnan(rhs) || std::isinf(rhs)) { setnan(); return *this; }
 
 		bool s = std::signbit(rhs);
 		double v = std::abs(rhs);


### PR DESCRIPTION
## Summary
- Implement standard math library for unum Type I via double delegation
- sqrt, exp, log, log2, log10, pow, trig (sin/cos/tan/asin/acos/atan),
  hyperbolic (sinh/cosh/tanh), abs, min, max, floor, ceil, trunc
- NaN propagation and domain error handling
- Move abs() from unum_impl.hpp to math_functions.hpp

## Changes
- `include/sw/universal/number/unum/math_functions.hpp` -- full rewrite with all math functions
- `include/sw/universal/number/unum/unum_impl.hpp` -- remove duplicate abs()
- `elastic/unum/math.cpp` -- test suite: sqrt, exp/log, trig, pow, floor/ceil/trunc, abs/min/max, NaN

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| unum1_math | OK | PASS | OK | PASS |
| unum1_api | OK | PASS | OK | PASS |
| unum1_conversion | OK | PASS | OK | PASS |

Resolves #569
Relates to Epic #192

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive math support for unum types: classification (isnan, isinf, iszero), abs, sqrt, exp, log/log2/log10, pow, trig (sin/cos/tan/asin/acos/atan), hyperbolic, min/max, floor/ceil/trunc.

* **Tests**
  * Added a thorough test suite validating math correctness and NaN propagation for unum Type I.

* **Refactor**
  * Consolidated math implementations and adjusted numeric assignment semantics so infinities are treated consistently as NaN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->