### PR TITLE
fix(ci): resolve CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -27,6 +27,9 @@ on:
       - '.clang-tidy'
       - '.gitignore'
 
+permissions:
+  contents: read
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,9 @@ on:
       - '.gitignore'
   workflow_dispatch:  # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     if: |

--- a/.github/workflows/full-regression.yml
+++ b/.github/workflows/full-regression.yml
@@ -13,6 +13,9 @@ on:
           - Debug
           - RelWithDebInfo
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "${{ matrix.name }}"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -18,6 +18,9 @@ on:
       - '.gitignore'
   workflow_dispatch:  # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   sanitizers:
     if: |

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -164,7 +164,8 @@ function addFrontmatter(content, srcRelative, extraFields = {}) {
   const extra = Object.entries(extraFields)
     .map(([k, v]) => `${k}: ${v}`)
     .join('\n');
-  const fm = extra ? `---\ntitle: "${title.replace(/"/g, '\\"')}"\n${extra}\n---` : `---\ntitle: "${title.replace(/"/g, '\\"')}"\n---`;
+  const safeTitle = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const fm = extra ? `---\ntitle: "${safeTitle}"\n${extra}\n---` : `---\ntitle: "${safeTitle}"\n---`;
   return `${fm}\n\n${body}`;
 }
 

--- a/include/sw/universal/number/posit1/positExponent.hpp
+++ b/include/sw/universal/number/posit1/positExponent.hpp
@@ -107,14 +107,15 @@ public:
 			_Bits[i] = my_positExponent & mask;
 			mask <<= 1;
 		}
-		_NrOfBits = (nbits - 1 - nrRegimeBits > es ? es : nbits - 1 - nrRegimeBits);
+		unsigned remaining = (nbits > 1u + nrRegimeBits) ? nbits - 1u - nrRegimeBits : 0u;
+		_NrOfBits = (remaining > es ? es : remaining);
 		if (_NrOfBits > 0) {
 			if (_NrOfBits < es) {
 				rounding_mode = _Bits[static_cast<uint64_t>(es) - 1ull - _NrOfBits] ? GEOMETRIC_ROUND_UP : GEOMETRIC_ROUND_DOWN; // check the next bit to see if we need to geometric round
 				if (_trace_rounding) std::cout << "truncated exp" << (rounding_mode == GEOMETRIC_ROUND_UP ? " geo-up " : " geo-dw ");
 			}
 			else {
-				if (nbits - 1 - nrRegimeBits - es > 0) {
+				if (remaining > es) {
 					// use the fraction to determine rounding as this posit has fraction bits
 					rounding_mode = ARITHMETIC_ROUNDING;
 					if (_trace_rounding) std::cout << "arithmetic  rounding ";

--- a/mixedprecision/roots/rpoly.cpp
+++ b/mixedprecision/roots/rpoly.cpp
@@ -34,7 +34,7 @@ sw::numeric::containers::vector<Real> Head(const sw::numeric::containers::vector
 template <typename Real>
 sw::numeric::containers::vector<Real> Tail(const sw::numeric::containers::vector<Real>& vector, size_t size){
     sw::numeric::containers::vector<Real> tail(size);
-    size_t startIdx = vector.size() - size > 0 ? vector.size() - size : 0;
+    size_t startIdx = vector.size() > size ? vector.size() - size : 0;
     for (size_t i = startIdx; i < vector.size(); ++i){
         tail[i] = vector[i - startIdx];
     }

--- a/static/integer/binary/arithmetic/division.cpp
+++ b/static/integer/binary/arithmetic/division.cpp
@@ -75,7 +75,7 @@ private:
 		int p;
 		unsigned ad, anc, delta{ 0 }, q1, r1, q2, r2, t;
 		const unsigned two31 = 0x80000000u;
-		ad = static_cast<unsigned>(d == 0) ? 1u : abs(d);
+		ad = (d == 0) ? 1u : static_cast<unsigned>(abs(d));
 		t = two31 + ((unsigned int)d >> 31);
 		anc = t - 1 - t % ad;
 		p = 31;


### PR DESCRIPTION
## Summary
Fix all 11 open CodeQL code scanning alerts across 4 categories.

## Changes

### C++ unsigned subtraction (3 alerts)
- `mixedprecision/roots/rpoly.cpp:37` -- compare before subtract to avoid unsigned wrap
- `include/sw/universal/number/posit1/positExponent.hpp:110,117` -- compute remaining bits safely

### C++ uncontrolled arithmetic (1 alert)
- `static/integer/binary/arithmetic/division.cpp:78` -- fix operator precedence: `static_cast<unsigned>(d == 0)` was casting the boolean, not the value

### JS incomplete sanitization (2 alerts)
- `docs-site/sync-content.mjs:167` -- escape backslash before escaping quotes in frontmatter title

### Workflow permissions (5 alerts)
- `cmake.yml`, `sanitizers.yml`, `full-regression.yml`, `coverage.yml` -- add `permissions: contents: read`

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| posit1_api | PASS | PASS |

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed documentation title rendering to properly handle special characters and backslashes
  * Corrected numeric computation accuracy in division and exponent bit operations
  * Fixed vector index calculation edge cases to prevent underflow errors

* **Chores**
  * Enhanced GitHub Actions workflow security permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->