### PR TITLE
feat(ucalc): add takum and decimal fixed-point types to REPL engine

### DIFF
--- a/docs/tutorials/ucalc-repl.md
+++ b/docs/tutorials/ucalc-repl.md
@@ -79,7 +79,7 @@ posit32> precision
 
 ---
 
-## Example 2: How 0.1 Looks Across 36 Types
+## Example 2: How 0.1 Looks Across 42 Types
 
 The decimal value 0.1 cannot be represented exactly in binary floating-point.
 The `compare` command reveals how each type approximates it, grouped by
@@ -96,15 +96,69 @@ posit32            1.000000001e-01  0b0.01.00.100110011001100110011001101
 bfloat16                       0.1  0x0.01111011.1001100
 fp16                    9.9976e-02  0b0.01011.1001100110
 fp32                9.99999940e-02  0b0.01111011.10011001100110011001100
-...
+fp8e2m5                   0.00e+00  0b0.00.00000
+fp8e3m4                   9.38e-02  0b0.000.0110
+fp8e4m3                   1.02e-01  0b0.0011.101
+fp8e5m2                    9.4e-02  0b0.01011.10
+fixpnt16                0.10156250  0b00000000.00011010
+fixpnt32        0.1000061035156250  0b0000000000000000.0001100110011010
+lns8                       0.10511  0b0.11100.11
+int8                             0  0b00000000
+int16                            0  0b0000000000000000
+int32                            0  0b00000000000000000000000000000000
+takum8                       0.125  0b0.0.110.0.00
+takum16                   0.099976  0b0.0.101.11.100110011
+takum32              0.09999999963  0b0.0.101.11.1001100110011001100110011
+hfloat32               0.099999964  0b0.1000000.000110011001100110011001
 decimal32                0.1000000  0b0.01001.011110.00000000000000000000
-rational32                     0.1  0b0000'...0001 / 0b0000'...1010
+rational8                      0.1  0b0000'0001 / 0b0000'1010
+rational16                     0.1  0b0000'0000'0000'0001 / 0b0000'0000'0000'1010
+rational32                     0.1  0b0000'0000'0000'0000'0000'0000'0000'0001 / 0b0000'0000'0000'0000'0000'0000'0000'1010
+
+Type                            Value  Binary
+--------------------------------------------------------------------------------
+double            0.10000000000000001  0b0.01111111011.1001100110011001100110011001100110011001100110011010
+posit64     1.0000000000000000002e-01  0b0.01.00.10011001100110011001100110011001100110011001100110011001101
+fp64          9.99999999999999917e-02  0b0.01111111011.1001100110011001100110011001100110011001100110011001
+lns16         0.100112047230168338396  0b0.1111100.10101110
+int64                               0  0b0000000000000000000000000000000000000000000000000000000000000000
+takum64        0.10000000000000000555  0b0.0.101.11.100110011001100110011001100110011001100110011001101000000
+dfixpnt8_4                     0.1000  0.0000000000000000.0001000000000000
+dfixpnt16_8                0.10000000  0.00000000000000000000000000000000.00010000000000000000000000000000
+hfloat64         0.099999999999999992  0b0.1000000.00011001100110011001100110011001100110011001100110011001
+decimal64          0.1000000000000000  0b0.01001.01111110.00000000000000000000000000000000000000000000000000
+
+Type        Value / Binary
+--------------------------------------------------------------------------------
+fp128       9.99999999999999999999999999999999928e-02
+            0b0.011111111111011.1001100110011001100110011001100110011001100110011001100110011001100110011001100110011001100110011001100110011001
+lns32       0.09999987268604650092473917766255908645689487457275390625
+            0b0.111111111111100.1010110110010110
+dd          1.0000000000000000000000000000000e-01
+            0b0.01111111011.1001100110011001100110011001100110011001100110011010|01100110011001100110011001100110011001100110011001101
+dd_cascade  9.999999999999999999999999999999969e-02
+            0b0.01111111011.1001100110011001100110011001100110011001100110011010|01100110011001100110011001100110011001100110011001101
+td_cascade  1.0000000000000000000000000000000000000000000000002e-01
+            0b0.01111111011.1001100110011001100110011001100110011001100110011010|00000000000000000000000000000000000000000000000000000|00000000000000000000000000000000000000000000000000000
+qd          1.000000000000000000000000000000000000000000000000000000000000000e-01
+            0b0.01111111011.1001100110011001100110011001100110011001100110011010|00000000000000000000000000000000000000000000000000000|00000000000000000000000000000000000000000000000000000|00000000000000000000000000000000000000000000000000000
+qd_cascade  9.99999999999999999999999999999999999999999999999999999999999999991e-02
+            0b0.01111111011.1001100110011001100110011001100110011001100110011010|00000000000000000000000000000000000000000000000000000|00000000000000000000000000000000000000000000000000000|00000000000000000000000000000000000000000000000000000
 ```
 
 Notice that `decimal32` and `rational32` represent 0.1 exactly -- decimal
 uses base-10 encoding and rational stores the fraction 1/10 directly. Every
 binary type introduces rounding error, but the magnitude differs by orders
 of magnitude across types.
+
+Now try:
+```text
+double> compare 0.1
+```
+
+The results are different as we are giving the number systems a double precision 
+floating-point number, `0.1`, which approximates `1/10`, and that approximation 
+propagates through all the number systems.
 
 ---
 
@@ -387,20 +441,186 @@ sin(pi) depends on how many digits of pi the type can represent.
 
 ---
 
+## Example 9: Exact Decimal Arithmetic for Financial Calculations
+
+Binary floating-point cannot represent 0.1, 0.01, or most decimal
+fractions exactly. In financial software this causes accumulation errors
+that violate accounting identities. Decimal fixed-point (`dfixpnt`)
+uses BCD encoding and carries every decimal digit without rounding:
+
+```text
+double> show 0.1 + 0.2 - 0.3
+  value:      5.5511151231257827e-17
+  binary:     0b0.01111001001.0000000000000000000000000000000000000000000000000000
+  components: sign: +, scale: -54, significand: 1
+  type:       double (IEEE-754 binary64)
+
+double> type dfixpnt16_8
+Active type: dfixpnt16_8 (dfixpnt< 16,   8, BCD,     Modulo, uint8_t>)
+dfixpnt16_8> show 0.1 + 0.2 - 0.3
+  value:      0.00000000
+  binary:     0.00000000000000000000000000000000.00000000000000000000000000000000
+  components: dfixpnt< 16,   8, BCD,     Modulo, uint8_t>: 0
+  type:       dfixpnt< 16,   8, BCD,     Modulo, uint8_t>
+```
+
+Double produces a non-zero residual (~5.55e-17) because 0.1 and 0.2
+are rounded on entry. `dfixpnt16_8` yields exactly zero.
+
+This matters when totals must balance to the penny. Consider an invoice
+with three items at $19.99, two at $5.99, and one at $1.50, plus
+7.25% sales tax:
+
+```text
+dfixpnt16_8> tax = 0.0725
+0.07250000
+dfixpnt16_8> subtotal = 19.99 * 3 + 5.99 * 2 + 1.50
+73.45000000
+dfixpnt16_8> show subtotal + subtotal * tax
+  value:      78.77512500
+  binary:     0.00000000000000000000000001111000.01110111010100010010010100000000
+  components: dfixpnt< 16,   8, BCD,     Modulo, uint8_t>: 78.7751
+  type:       dfixpnt< 16,   8, BCD,     Modulo, uint8_t>
+```
+
+The subtotal is exactly $73.45, tax is exactly $5.325125, and the grand
+total is exactly $78.775125. The same calculation in double:
+
+```text
+double> tax = 0.0725
+0.072499999999999995
+double> subtotal = 19.99 * 3 + 5.99 * 2 + 1.50
+73.450000000000003
+double> show subtotal + subtotal * tax
+  value:      78.775125000000003
+  binary:     0b0.10000000101.0011101100011001101110100101111000110101001111111000
+  components: sign: +, scale: 6, significand: 1.230861328125
+  type:       double (IEEE-754 binary64)
+```
+
+Double's subtotal is already 73.450000000000003 -- off by 3e-15. These
+errors are invisible in a single calculation but accumulate across
+thousands of line items in a ledger, eventually causing reconciliation
+failures. Decimal fixed-point eliminates this class of error entirely.
+
+---
+
+## Example 10: Takum's Uniform Precision Across the Dynamic Range
+
+Posit arithmetic concentrates precision near 1.0 by using a variable-length
+regime field: values close to 1.0 get many fraction bits, but extreme
+values consume most bits on the regime, leaving few for the significand.
+Takum (Hunhold, 2024) replaces the variable-length regime with a bounded
+characteristic field, giving a more uniform precision distribution and
+a dramatically wider dynamic range.
+
+At 32 bits, both types deliver identical precision near 1.0:
+
+```text
+takum32> precision
+  type:           takum< 32, 3, uint32_t>
+  binary digits:  27
+  decimal digits: 8.1
+  epsilon:        7.450580597e-09
+  minpos:         1.727235358e-77
+  maxpos:         5.789601701e+76
+
+posit32> precision
+  type:           posit< 32, 2, uint32_t>
+  binary digits:  27
+  decimal digits: 8.1
+  epsilon:        7.450580597e-09
+  minpos:         7.523163845e-37
+  maxpos:         1.329227996e+36
+```
+
+Same epsilon, same 27 binary digits at 1.0. But takum32 spans 10^77
+while posit32 reaches only 10^36 -- over twice the dynamic range in
+decades.
+
+The difference becomes dramatic away from 1.0. Compare the ULP at
+increasing scales:
+
+| Scale | takum32 ULP | posit32 ULP | Relative ULP (takum) | Relative ULP (posit) |
+|-------|------------|------------|---------------------|---------------------|
+| 1     | 7.45e-9    | 7.45e-9    | 7.45e-9             | 7.45e-9             |
+| 1e5   | 5.96e-3    | 5.96e-3    | 5.96e-8             | 5.96e-8             |
+| 1e10  | 1,192      | 9,537      | 1.19e-7             | 9.54e-7             |
+| 1e15  | 1.19e8     | 1.53e10    | 1.19e-7             | 1.53e-5             |
+| 1e20  | 2.38e13    | 2.44e16    | 2.38e-7             | 2.44e-4             |
+| 1e30  | 2.38e23    | 6.44e28    | 2.38e-7             | 6.44e-2             |
+
+Takum's relative precision stays nearly constant (~2e-7) across 30
+decades of scale. Posit's degrades from 7.45e-9 at 1.0 to 0.064 at
+1e30 -- a factor of 8.6 million. At 1e30, posit32 has barely one
+significant digit left.
+
+This is visible in the representations themselves:
+
+```text
+takum32> show 1e20
+  value:      1.00000002e+20
+  binary:     0b0.1.110.000011.010110101111000111011
+  components: ... Characteristic :    66 Scale :    66
+  type:       takum< 32, 3, uint32_t>
+
+posit32> show 1e20
+  value:      1.000159405e+20
+  binary:     0b0.111111111111111110.10.01011011000
+  components: sign: +, regime: 16, exponent: 4, significand: 1.35546875
+  type:       posit< 32, 2, uint32_t>
+```
+
+Takum32 represents 1e20 to 8 significant digits (1.00000002e+20).
+Posit32 manages only 4 (1.000159405e+20 -- off by 1.6e16). The
+posit's regime field has expanded to 18 bits, leaving only 11 for
+exponent and significand. Takum's characteristic field stays bounded,
+preserving fraction bits at every scale.
+
+A sweep of sqrt(x) across a wide range confirms the pattern:
+
+```text
+takum16> sweep sqrt(x) for x in [0.001, 1e12, 8]
+x                                      result               double ref      ULP error
+-------------------------------------------------------------------------------------
+0.001                                0.031616     0.031622776601683791           0.21
+1.4285714e+11                      3.7888e+05       377964.47300922842           0.31
+4.2857143e+11                      6.5536e+05       654653.67070797761           0.14
+8.5714286e+11                       9.257e+05       925820.09977255156           0.03
+1e+12                              9.9942e+05       1000000.0000000001           0.29
+
+posit16> sweep sqrt(x) for x in [0.001, 1e12, 8]
+x                                      result               double ref      ULP error
+-------------------------------------------------------------------------------------
+0.001                              3.1616e-02     0.031622776601683791           0.43
+1.4285714e+11                      3.7069e+05       377964.47300922842           2.46
+4.2857143e+11                      6.4307e+05       654653.67070797761           2.26
+8.5714286e+11                      9.0931e+05       925820.09977255156           4.56
+1e+12                              9.7894e+05       1000000.0000000001          10.78
+```
+
+At 1e12, posit16's sqrt has 10.78 ULP error vs takum16's 0.29 -- a 37x
+improvement. Takum maintains sub-ULP accuracy across the entire range
+because it never runs out of fraction bits.
+
+---
+
 ## Available Types
 
-ucalc registers 35 types spanning the major number system families:
+ucalc registers 42 types spanning the major number system families:
 
 | Family | Types |
 |--------|-------|
 | Integer | int8, int16, int32, int64 |
 | Fixed-point | fixpnt16, fixpnt32 |
+| Decimal fixed-point | dfixpnt8_4, dfixpnt16_8 |
 | Native IEEE | float, double |
 | Classic float | fp16, fp32, fp64, fp128 |
 | Google Brain Float | bfloat16 |
 | FP8 (Deep Learning) | fp8e2m5, fp8e3m4, fp8e4m3, fp8e5m2 |
 | Logarithmic | lns8, lns16, lns32 |
 | Posit | posit8, posit16, posit32, posit64 |
+| Takum | takum8, takum16, takum32, takum64 |
 | Decimal float | decimal32, decimal64 |
 | Hexadecimal float | hfloat32, hfloat64 |
 | Rational | rational8, rational16, rational32 |

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -782,4 +782,10 @@ constexpr takum<nbits, rbits, bt> abs(const takum<nbits, rbits, bt>& v) {
 	return v;
 }
 
+// sqrt via double fallback (satisfies the forward declaration in takum_fwd.hpp)
+template<unsigned nbits, unsigned rbits, typename bt>
+takum<nbits, rbits, bt> sqrt(const takum<nbits, rbits, bt>& v) {
+	return takum<nbits, rbits, bt>(std::sqrt(double(v)));
+}
+
 }}  // namespace sw::universal

--- a/tools/ucalc/README.md
+++ b/tools/ucalc/README.md
@@ -18,9 +18,10 @@ Universal's number types.
 
 `ucalc` is a REPL (Read-Eval-Print Loop) calculator that:
 
-- Supports **29 number types** out of the box: IEEE float/double, posit (8-64),
-  cfloat (8-64), bfloat16, fixed-point, LNS, integer, hexadecimal float,
-  decimal float, double-double, quad-double, and cascaded variants.
+- Supports **42 number types** out of the box: IEEE float/double, posit (8-64),
+  takum (8-64), cfloat (8-64), bfloat16, fixed-point, decimal fixed-point,
+  LNS, integer, hexadecimal float, decimal float, rational, double-double,
+  quad-double, and cascaded variants.
 - Parses **infix arithmetic** with standard operator precedence, parentheses,
   variables, constants (`pi`, `e`), and math functions (`sqrt`, `abs`, `log`,
   `exp`, `sin`, `cos`, `pow`).
@@ -35,7 +36,7 @@ Universal's number types.
 
 ```
 tools/ucalc/
-  type_dispatch.hpp   -- TypeRegistry + SFINAE math dispatch (29 types)
+  type_dispatch.hpp   -- TypeRegistry + SFINAE math dispatch (42 types)
   expression.hpp      -- Tokenizer + recursive-descent parser/evaluator
   ucalc.cpp           -- REPL loop, commands, native type specializations
   CMakeLists.txt      -- Build config with optional readline detection

--- a/tools/ucalc/registry.hpp
+++ b/tools/ucalc/registry.hpp
@@ -159,7 +159,15 @@ inline TypeRegistry build_default_registry() {
 	reg.add("int32",    register_type<integer<32, uint32_t>>("int32"));
 	reg.add("int64",    register_type<integer<64, uint64_t>>("int64"));
 
-	// Note: dbns and takum omitted -- math function stubs cause link errors
+	// Takum (tapered floating-point, linear encoding)
+	reg.add("takum8",   register_type<takum<8, 3, uint8_t>>("takum8"));
+	reg.add("takum16",  register_type<takum<16, 3, uint16_t>>("takum16"));
+	reg.add("takum32",  register_type<takum<32, 3, uint32_t>>("takum32"));
+	reg.add("takum64",  register_type<takum<64, 3, uint64_t>>("takum64"));
+
+	// Decimal fixed-point (BCD encoding, Modulo arithmetic)
+	reg.add("dfixpnt8_4",  register_type<dfixpnt<8, 4>>("dfixpnt8_4"));
+	reg.add("dfixpnt16_8", register_type<dfixpnt<16, 8>>("dfixpnt16_8"));
 
 	// Hexadecimal floating-point
 	reg.add("hfloat32", register_type<hfloat<6, 7>>("hfloat32"));

--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -29,7 +29,8 @@
 #define QD_THROW_ARITHMETIC_EXCEPTION 0
 #define LNS_THROW_ARITHMETIC_EXCEPTION 0
 #define INTEGER_THROW_ARITHMETIC_EXCEPTION 0
-// dbns and takum omitted -- math function stubs cause link errors
+#define TAKUM_THROW_ARITHMETIC_EXCEPTION 0
+#define DFIXPNT_THROW_ARITHMETIC_EXCEPTION 0
 #define HFLOAT_THROW_ARITHMETIC_EXCEPTION 0
 #define DFLOAT_THROW_ARITHMETIC_EXCEPTION 0
 #define RATIONAL_THROW_ARITHMETIC_EXCEPTION 0
@@ -51,7 +52,8 @@
 // Extended types
 #include <universal/number/lns/lns.hpp>
 #include <universal/number/integer/integer.hpp>
-// dbns and takum omitted -- math function stubs cause link errors
+#include <universal/number/takum/takum.hpp>
+#include <universal/number/dfixpnt/dfixpnt.hpp>
 #include <universal/number/rational/rational.hpp>
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/number/dfloat/dfloat.hpp>


### PR DESCRIPTION
## Summary

- Register **takum** (8/16/32/64) and **dfixpnt** (8_4/16_8) in the ucalc type registry, bringing the total from 36 to 42 number types
- Add `sqrt()` definition for takum via double fallback, resolving the forward declaration in `takum_fwd.hpp` that previously caused link errors
- Add **Example 9** to the tutorial: exact decimal arithmetic for financial calculations (dfixpnt vs double for invoice totals and tax)
- Add **Example 10** to the tutorial: takum's uniform precision across the dynamic range (ULP comparison table, representation analysis, sweep comparison vs posit)

## Test plan

- [x] `ucalc` builds and runs with gcc
- [x] `ucalc` builds and runs with clang
- [x] `type takum32; show 1/3` produces correct output
- [x] `type dfixpnt16_8; show 0.1 + 0.2 - 0.3` yields exactly zero
- [x] `types` lists all 42 registered types
- [x] Existing smoke test (`type posit32; 1/3 + 1/3 + 1/3`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Takum (8–64 bits) and decimal fixed-point number types in ucalc
  * Expanded numeric type support from 29 to 42 types

* **Documentation**
  * Added tutorial examples demonstrating decimal fixed-point arithmetic and Takum precision analysis
  * Updated type registry documentation reflecting newly supported number families

<!-- end of auto-generated comment: release notes by coderabbit.ai -->