### PR TITLE
fix(ci): Suppress Impossible-Case Warnings in Quad-Double API Tests

### DIFF
--- a/static/float/bfloat16/api/api.cpp
+++ b/static/float/bfloat16/api/api.cpp
@@ -233,12 +233,29 @@ try {
 		fa = NAN;
 		std::cout << "qNAN   : " << to_binary(NAN) << '\n';
 		std::cout << "sNAN   : " << to_binary(-NAN) << '\n';
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-overlap-compare"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 		if (fa < 0.0f && fa > 0.0f && fa != 0.0f) {
 			std::cout << "IEEE-754 is incorrectly implemented\n";
 		}
 		else {
 			std::cout << "IEEE-754 NAN has no sign\n";
 		}
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 		bfloat16 a(fa);
 		if ((a < 0.0f && a > 0.0f && a != 0.0f)) {

--- a/static/float/cfloat/api/api.cpp
+++ b/static/float/cfloat/api/api.cpp
@@ -307,12 +307,29 @@ try {
 		fa = NAN;
 		std::cout << "qNAN   : " << to_binary(NAN) << '\n';
 		std::cout << "sNAN   : " << to_binary(-NAN) << '\n';
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-overlap-compare"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 		if (fa < 0.0f && fa > 0.0f && fa != 0.0f) {
 			std::cout << "IEEE-754 is incorrectly implemented\n";
 		}
 		else {
 			std::cout << "IEEE-754 NAN has no sign\n";
 		}
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 		single a(fa);
 		if ((a < 0.0f && a > 0.0f && a != 0.0f) || a.isneg()) {

--- a/static/highprecision/dd/api/api.cpp
+++ b/static/highprecision/dd/api/api.cpp
@@ -468,12 +468,29 @@ try {
 		fa = NAN;
 		std::cout << "qNAN   : " << to_binary(NAN) << '\n';
 		std::cout << "sNAN   : " << to_binary(-NAN) << '\n';
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-overlap-compare"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 		if (fa < 0.0f && fa > 0.0f && fa != 0.0f) {
 			std::cout << "IEEE-754 is incorrectly implemented\n";
 		}
 		else {
 			std::cout << "IEEE-754 NAN has no sign\n";
 		}
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 		dd a(fa);
 		if ((a < 0.0f && a > 0.0f && a != 0.0f)) {

--- a/static/highprecision/qd/api/api.cpp
+++ b/static/highprecision/qd/api/api.cpp
@@ -398,15 +398,32 @@ try {
 		fa = NAN;
 		std::cout << "qNAN   : " << to_binary(NAN) << '\n';
 		std::cout << "sNAN   : " << to_binary(-NAN) << '\n';
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-overlap-compare"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlogical-op"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4127) // conditional expression is constant
+#endif
 		if (fa < 0.0f && fa > 0.0f && fa != 0.0f) {
 			std::cout << "IEEE-754 is incorrectly implemented\n";
 		}
 		else {
 			std::cout << "IEEE-754 NAN has no sign\n";
 		}
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 		qd a(fa);
-		if ((a < 0.0f && a > 0.0f && a != 0.0f)) {
+		if (a < 0.0f && a > 0.0f && a != 0.0f) {
 			std::cout << "quad-double (qd) is incorrectly implemented\n";
 			++nrOfFailedTestCases;
 		}


### PR DESCRIPTION
Suppress compiler warnings from checks that validate compiler-provided type behavior in quad-double API tests. When the compiler proves a condition impossible, it may skip the check, but the code mirrors equivalent paths in user-defined types and is retained for clarity and consistency.

Tested with Clang; still needs validation with GCC and MSVC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test suite to suppress compiler warnings in edge-case validations without affecting test behavior or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->