### PR TITLE
feat(ucalc): error propagation tracing command

### DIFF
--- a/tools/ucalc/expression.hpp
+++ b/tools/ucalc/expression.hpp
@@ -129,12 +129,28 @@ private:
 	size_t pos_;
 };
 
+// Trace step: records one arithmetic operation during evaluation
+struct TraceStep {
+	int step_number;
+	std::string operation;       // e.g. "add", "sub", "mul", "sin"
+	std::string description;     // human-readable, e.g. "1.0 + 1e-4"
+	double operand_a;            // first operand (as double)
+	double operand_b;            // second operand (as double, 0 for unary)
+	double result;               // result in the active type (as double)
+	std::string result_rep;      // native_rep of the result
+	std::string result_binary;   // binary_rep of the result
+};
+
 // Parser and evaluator
 class ExpressionEvaluator {
 public:
 	explicit ExpressionEvaluator(const TypeOps& ops) : ops_(&ops) {}
 
 	void set_type(const TypeOps& ops) { ops_ = &ops; }
+
+	// Enable/disable trace mode
+	void enable_trace(bool on = true) { tracing_ = on; trace_steps_.clear(); }
+	const std::vector<TraceStep>& trace_steps() const { return trace_steps_; }
 
 	// Evaluate an expression string, return the result as a Value
 	Value evaluate(const std::string& input) {
@@ -171,6 +187,44 @@ public:
 	}
 
 private:
+	// Record a trace step for a binary operation
+	void record_binary(const std::string& op, const std::string& sym,
+	                   const Value& a, const Value& b, const Value& result) {
+		if (!tracing_) return;
+		TraceStep step;
+		step.step_number = static_cast<int>(trace_steps_.size()) + 1;
+		step.operation = op;
+		std::ostringstream desc;
+		desc << a.native_rep << " " << sym << " " << b.native_rep;
+		step.description = desc.str();
+		step.operand_a = a.num;
+		step.operand_b = b.num;
+		step.result = result.num;
+		step.result_rep = result.native_rep;
+		step.result_binary = result.binary_rep;
+		trace_steps_.push_back(std::move(step));
+	}
+
+	// Record a trace step for a unary operation
+	void record_unary(const std::string& op, const Value& a, const Value& result) {
+		if (!tracing_) return;
+		TraceStep step;
+		step.step_number = static_cast<int>(trace_steps_.size()) + 1;
+		step.operation = op;
+		std::ostringstream desc;
+		if (op == "negate")
+			desc << "-(" << a.native_rep << ")";
+		else
+			desc << op << "(" << a.native_rep << ")";
+		step.description = desc.str();
+		step.operand_a = a.num;
+		step.operand_b = 0.0;
+		step.result = result.num;
+		step.result_rep = result.native_rep;
+		step.result_binary = result.binary_rep;
+		trace_steps_.push_back(std::move(step));
+	}
+
 	const Token& current() const { return tokens_[pos_]; }
 	const Token& advance() { return tokens_[pos_++]; }
 	const Token& peek(size_t offset = 0) const { return tokens_[pos_ + offset]; }
@@ -203,9 +257,13 @@ private:
 			advance();
 			Value right = parse_term();
 			if (op == TokenType::Plus) {
-				left = ops_->add(left, right);
+				Value r = ops_->add(left, right);
+				record_binary("add", "+", left, right, r);
+				left = r;
 			} else {
-				left = ops_->sub(left, right);
+				Value r = ops_->sub(left, right);
+				record_binary("sub", "-", left, right, r);
+				left = r;
 			}
 		}
 		return left;
@@ -218,9 +276,13 @@ private:
 			advance();
 			Value right = parse_unary();
 			if (op == TokenType::Star) {
-				left = ops_->mul(left, right);
+				Value r = ops_->mul(left, right);
+				record_binary("mul", "*", left, right, r);
+				left = r;
 			} else {
-				left = ops_->div(left, right);
+				Value r = ops_->div(left, right);
+				record_binary("div", "/", left, right, r);
+				left = r;
 			}
 		}
 		return left;
@@ -230,7 +292,9 @@ private:
 		if (current().type == TokenType::Minus) {
 			advance();
 			Value val = parse_unary();
-			return ops_->negate(val);
+			Value r = ops_->negate(val);
+			record_unary("negate", val, r);
+			return r;
 		}
 		if (current().type == TokenType::Plus) {
 			advance();
@@ -244,7 +308,9 @@ private:
 		if (current().type == TokenType::Caret) {
 			advance();
 			Value exp = parse_unary(); // right-associative
-			return ops_->fn_pow(base, exp);
+			Value r = ops_->fn_pow(base, exp);
+			record_binary("pow", "^", base, exp, r);
+			return r;
 		}
 		return base;
 	}
@@ -310,16 +376,17 @@ private:
 	}
 
 	Value call_function(const std::string& name, const std::vector<Value>& args) {
+		Value r;
 		if (args.size() == 1) {
-			if (name == "sqrt") return ops_->fn_sqrt(args[0]);
-			if (name == "abs")  return ops_->fn_abs(args[0]);
-			if (name == "log")  return ops_->fn_log(args[0]);
-			if (name == "exp")  return ops_->fn_exp(args[0]);
-			if (name == "sin")  return ops_->fn_sin(args[0]);
-			if (name == "cos")  return ops_->fn_cos(args[0]);
+			if (name == "sqrt") { r = ops_->fn_sqrt(args[0]); record_unary("sqrt", args[0], r); return r; }
+			if (name == "abs")  { r = ops_->fn_abs(args[0]);  record_unary("abs",  args[0], r); return r; }
+			if (name == "log")  { r = ops_->fn_log(args[0]);  record_unary("log",  args[0], r); return r; }
+			if (name == "exp")  { r = ops_->fn_exp(args[0]);  record_unary("exp",  args[0], r); return r; }
+			if (name == "sin")  { r = ops_->fn_sin(args[0]);  record_unary("sin",  args[0], r); return r; }
+			if (name == "cos")  { r = ops_->fn_cos(args[0]);  record_unary("cos",  args[0], r); return r; }
 		}
 		if (args.size() == 2) {
-			if (name == "pow")  return ops_->fn_pow(args[0], args[1]);
+			if (name == "pow")  { r = ops_->fn_pow(args[0], args[1]); record_binary("pow", ",", args[0], args[1], r); return r; }
 		}
 		throw std::runtime_error("unknown function or wrong arity: " + name +
 		                         "(" + std::to_string(args.size()) + " args)");
@@ -329,6 +396,8 @@ private:
 	std::vector<Token> tokens_;
 	size_t pos_;
 	std::map<std::string, Value> variables_;
+	bool tracing_ = false;
+	std::vector<TraceStep> trace_steps_;
 };
 
 }} // namespace sw::ucalc

--- a/tools/ucalc/regression.cpp
+++ b/tools/ucalc/regression.cpp
@@ -381,6 +381,78 @@ try {
 	}
 
 	// ================================================================
+	// 16. Trace: step recording
+	// ================================================================
+	{
+		const TypeOps& ops = reg.get("double");
+		ExpressionEvaluator eval(ops);
+		eval.enable_trace(true);
+		eval.evaluate("2 + 3 * 4");
+		const auto& steps = eval.trace_steps();
+		// 2 + 3 * 4 = 2 + 12 = 14
+		// Expect 2 steps: mul(3,4)->12, add(2,12)->14
+		if (steps.size() != 2) {
+			std::cerr << "FAIL: trace step count: got " << steps.size() << " expected 2\n";
+			++nrOfFailedTests;
+		} else {
+			if (steps[0].operation != "mul") {
+				std::cerr << "FAIL: trace step 1 op: got " << steps[0].operation << " expected mul\n";
+				++nrOfFailedTests;
+			}
+			if (std::abs(steps[0].result - 12.0) > 1e-15) {
+				std::cerr << "FAIL: trace step 1 result: got " << steps[0].result << " expected 12\n";
+				++nrOfFailedTests;
+			}
+			if (steps[1].operation != "add") {
+				std::cerr << "FAIL: trace step 2 op: got " << steps[1].operation << " expected add\n";
+				++nrOfFailedTests;
+			}
+			if (std::abs(steps[1].result - 14.0) > 1e-15) {
+				std::cerr << "FAIL: trace step 2 result: got " << steps[1].result << " expected 14\n";
+				++nrOfFailedTests;
+			}
+		}
+	}
+
+	// ================================================================
+	// 17. Trace: function calls recorded
+	// ================================================================
+	{
+		const TypeOps& ops = reg.get("double");
+		ExpressionEvaluator eval(ops);
+		eval.enable_trace(true);
+		eval.evaluate("sqrt(4) + 1");
+		const auto& steps = eval.trace_steps();
+		// sqrt(4) -> 2, then 2 + 1 -> 3
+		if (steps.size() != 2) {
+			std::cerr << "FAIL: trace fn step count: got " << steps.size() << " expected 2\n";
+			++nrOfFailedTests;
+		} else {
+			if (steps[0].operation != "sqrt") {
+				std::cerr << "FAIL: trace fn step 1: got " << steps[0].operation << " expected sqrt\n";
+				++nrOfFailedTests;
+			}
+			if (steps[1].operation != "add") {
+				std::cerr << "FAIL: trace fn step 2: got " << steps[1].operation << " expected add\n";
+				++nrOfFailedTests;
+			}
+		}
+	}
+
+	// ================================================================
+	// 18. Trace: tracing disabled by default
+	// ================================================================
+	{
+		const TypeOps& ops = reg.get("double");
+		ExpressionEvaluator eval(ops);
+		eval.evaluate("2 + 3");
+		if (!eval.trace_steps().empty()) {
+			std::cerr << "FAIL: trace should be empty when not enabled\n";
+			++nrOfFailedTests;
+		}
+	}
+
+	// ================================================================
 	// Report
 	// ================================================================
 	if (nrOfFailedTests > 0) {

--- a/tools/ucalc/scripts/11_agent_trace_analysis.ucalc
+++ b/tools/ucalc/scripts/11_agent_trace_analysis.ucalc
@@ -1,0 +1,20 @@
+# 11_agent_trace_analysis.ucalc -- AI agent script
+# Trace error propagation through expressions in different types
+# Run with: ucalc --json -f 11_agent_trace_analysis.ucalc
+# Agent parses JSON to identify which operations lose precision
+
+# Classic catastrophic cancellation example in fp16
+type fp16
+trace (1.0 + 1e-4) - 1.0
+
+# Same expression in double -- still loses information but less
+type double
+trace (1.0 + 1e-15) - 1.0
+
+# Pythagorean identity: sin^2 + cos^2 should equal 1
+type bfloat16
+trace sin(0.5) * sin(0.5) + cos(0.5) * cos(0.5)
+
+# Quadratic formula cancellation
+type float
+trace (-1e8 + sqrt(1e16 - 4)) / 2

--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -135,7 +135,7 @@ static void print_help(OutputFormat fmt) {
 	if (fmt == OutputFormat::json) {
 		std::cout << "{\"commands\":[\"type\",\"types\",\"show\",\"compare\","
 		          << "\"bits\",\"range\",\"precision\",\"ulp\",\"sweep\","
-		          << "\"faithful\",\"color\",\"vars\",\"help\",\"quit\"]}\n";
+		          << "\"trace\",\"faithful\",\"color\",\"vars\",\"help\",\"quit\"]}\n";
 		return;
 	}
 	std::cout << "ucalc -- Universal Mixed-Precision REPL Calculator\n\n";
@@ -150,6 +150,7 @@ static void print_help(OutputFormat fmt) {
 	std::cout << "  ulp <value>    Show ULP at the given value\n";
 	std::cout << "  sweep <expr> for <var> in [a, b, n]\n";
 	std::cout << "                 Evaluate across a range, show error vs double\n";
+	std::cout << "  trace <expr>   Show each operation with ULP error and rounding direction\n";
 	std::cout << "  faithful <expr> Check if result is faithfully rounded\n";
 	std::cout << "  color [on|off] Toggle ANSI color-coded bit fields in show\n";
 	std::cout << "  vars           List defined variables\n";
@@ -183,18 +184,23 @@ struct ReplState {
 	int last_error;     // last error exit code (for batch mode error reporting)
 };
 
-// Compute ULP at a given double value using the active type
+// Compute ULP at a given double value using the active type.
+// Finds the smallest increment that changes the type's representation.
 static double compute_ulp(const TypeOps& ops, double v) {
 	if (v == 0.0) {
 		Value tiny = ops.minpos();
 		return tiny.num;
 	}
-	double step = std::abs(v);
+	// Round v to the nearest representable value in the active type first,
+	// then probe for the ULP at that representable value.
+	double base = ops.from_double(v).num;
+	double step = std::max(std::abs(base), std::numeric_limits<double>::min());
 	double ulp_est = step;
 	for (int i = 0; i < 200; ++i) {
 		step *= 0.5;
-		Value test = ops.from_double(v + step);
-		if (test.num == v) {
+		if (step == 0.0) break;
+		Value test = ops.from_double(base + step);
+		if (test.num == base) {
 			ulp_est = step * 2.0;
 			break;
 		}
@@ -793,6 +799,213 @@ static bool process_command(const std::string& input, ReplState& state) {
 		return true;
 	}
 
+	// trace <expr> -- show each operation with ULP error and rounding direction
+	if (line.substr(0, 6) == "trace " || line.substr(0, 6) == "trace\t") {
+		std::string expr = trim(line.substr(6));
+		try {
+			const TypeOps& ops = state.registry.get(state.active_type);
+
+			// Evaluate in the active type with tracing enabled
+			ExpressionEvaluator eval(ops);
+			for (const auto& kv : state.evaluator->variables()) {
+				eval.set_variable(kv.first, kv.second);
+			}
+			eval.enable_trace(true);
+			Value result = eval.evaluate(expr);
+			const auto& steps = eval.trace_steps();
+
+			// Compute reference for each step using qd
+			const TypeOps* ref_ops = state.registry.find("qd");
+			if (!ref_ops) ref_ops = &state.registry.get("double");
+
+			// Build reference results: replay each operation in qd
+			struct TraceAnnotation {
+				double exact;           // qd reference result (as double)
+				std::string exact_rep;  // qd reference native_rep
+				double ulp_error;       // |result - exact| / ulp
+				std::string rounding;   // "exact", "up", "down"
+				bool cancellation;      // catastrophic cancellation detected
+				int cancelled_digits;   // significant digits lost
+			};
+			std::vector<TraceAnnotation> annotations;
+
+			for (const auto& s : steps) {
+				TraceAnnotation ann;
+				ann.cancellation = false;
+				ann.cancelled_digits = 0;
+				ann.ulp_error = 0.0;
+				ann.rounding = "exact";
+
+				// Compute exact result in qd
+				double exact_d = 0.0;
+				std::string exact_rep;
+				try {
+					if (s.operation == "add") {
+						Value a = ref_ops->from_double(s.operand_a);
+						Value b = ref_ops->from_double(s.operand_b);
+						Value r = ref_ops->add(a, b);
+						exact_d = r.num; exact_rep = r.native_rep;
+					} else if (s.operation == "sub") {
+						Value a = ref_ops->from_double(s.operand_a);
+						Value b = ref_ops->from_double(s.operand_b);
+						Value r = ref_ops->sub(a, b);
+						exact_d = r.num; exact_rep = r.native_rep;
+					} else if (s.operation == "mul") {
+						Value a = ref_ops->from_double(s.operand_a);
+						Value b = ref_ops->from_double(s.operand_b);
+						Value r = ref_ops->mul(a, b);
+						exact_d = r.num; exact_rep = r.native_rep;
+					} else if (s.operation == "div") {
+						Value a = ref_ops->from_double(s.operand_a);
+						Value b = ref_ops->from_double(s.operand_b);
+						Value r = ref_ops->div(a, b);
+						exact_d = r.num; exact_rep = r.native_rep;
+					} else if (s.operation == "negate") {
+						Value a = ref_ops->from_double(s.operand_a);
+						Value r = ref_ops->negate(a);
+						exact_d = r.num; exact_rep = r.native_rep;
+					} else if (s.operation == "pow") {
+						Value a = ref_ops->from_double(s.operand_a);
+						Value b = ref_ops->from_double(s.operand_b);
+						Value r = ref_ops->fn_pow(a, b);
+						exact_d = r.num; exact_rep = r.native_rep;
+					} else {
+						// Unary math functions
+						Value a = ref_ops->from_double(s.operand_a);
+						Value r;
+						if (s.operation == "sqrt") r = ref_ops->fn_sqrt(a);
+						else if (s.operation == "abs") r = ref_ops->fn_abs(a);
+						else if (s.operation == "log") r = ref_ops->fn_log(a);
+						else if (s.operation == "exp") r = ref_ops->fn_exp(a);
+						else if (s.operation == "sin") r = ref_ops->fn_sin(a);
+						else if (s.operation == "cos") r = ref_ops->fn_cos(a);
+						else r = ref_ops->from_double(s.result);
+						exact_d = r.num; exact_rep = r.native_rep;
+					}
+				} catch (...) {
+					exact_d = s.result; exact_rep = s.result_rep;
+				}
+				ann.exact = exact_d;
+				ann.exact_rep = exact_rep;
+
+				// Compute ULP error
+				if (exact_d != 0.0 && std::isfinite(exact_d) && std::isfinite(s.result)) {
+					double abs_err = std::abs(s.result - exact_d);
+					double ulp = compute_ulp(ops, exact_d);
+					if (ulp > 0.0) ann.ulp_error = abs_err / ulp;
+				}
+
+				// Determine rounding direction
+				if (s.result == exact_d) {
+					ann.rounding = "exact";
+				} else if (s.result > exact_d) {
+					ann.rounding = "up";
+				} else {
+					ann.rounding = "down";
+				}
+
+				// Detect catastrophic cancellation for subtraction
+				if (s.operation == "sub" && s.operand_a != 0.0 && s.operand_b != 0.0) {
+					double mag = std::max(std::abs(s.operand_a), std::abs(s.operand_b));
+					double res_mag = std::abs(exact_d);
+					if (mag > 0.0 && res_mag > 0.0) {
+						double ratio = res_mag / mag;
+						if (ratio < 1e-3) {
+							ann.cancellation = true;
+							ann.cancelled_digits = static_cast<int>(-std::log10(ratio));
+						}
+					}
+				}
+
+				annotations.push_back(std::move(ann));
+			}
+
+			// Output
+			if (fmt == OutputFormat::json) {
+				std::cout << "{\"expression\":\"" << json_escape(expr) << "\""
+				          << ",\"type\":\"" << json_escape(ops.type_tag) << "\""
+				          << ",\"result\":\"" << json_escape(result.native_rep) << "\""
+				          << ",\"result_decimal\":" << json_number(result.num)
+				          << ",\"steps\":[";
+				for (size_t i = 0; i < steps.size(); ++i) {
+					const auto& s = steps[i];
+					const auto& a = annotations[i];
+					if (i > 0) std::cout << ",";
+					std::cout << "{\"step\":" << s.step_number
+					          << ",\"operation\":\"" << json_escape(s.operation) << "\""
+					          << ",\"description\":\"" << json_escape(s.description) << "\""
+					          << ",\"result\":\"" << json_escape(s.result_rep) << "\""
+					          << ",\"result_decimal\":" << json_number(s.result)
+					          << ",\"exact\":\"" << json_escape(a.exact_rep) << "\""
+					          << ",\"exact_decimal\":" << json_number(a.exact)
+					          << ",\"ulp_error\":" << json_number(a.ulp_error)
+					          << ",\"rounding\":\"" << a.rounding << "\"";
+					if (a.cancellation) {
+						std::cout << ",\"cancellation\":true"
+						          << ",\"cancelled_digits\":" << a.cancelled_digits;
+					}
+					std::cout << "}";
+				}
+				std::cout << "]}\n";
+			} else if (fmt == OutputFormat::csv) {
+				std::cout << "step,operation,description,result,exact,ulp_error,rounding,cancellation\n";
+				for (size_t i = 0; i < steps.size(); ++i) {
+					const auto& s = steps[i];
+					const auto& a = annotations[i];
+					std::cout << s.step_number << ","
+					          << csv_quote(s.operation) << ","
+					          << csv_quote(s.description) << ","
+					          << csv_quote(s.result_rep) << ","
+					          << csv_quote(a.exact_rep) << ","
+					          << std::setprecision(4) << a.ulp_error << ","
+					          << a.rounding << ","
+					          << (a.cancellation ? "yes" : "no") << "\n";
+				}
+			} else if (fmt == OutputFormat::quiet) {
+				for (size_t i = 0; i < steps.size(); ++i) {
+					const auto& s = steps[i];
+					const auto& a = annotations[i];
+					std::cout << s.step_number << " " << s.operation << " "
+					          << s.result_rep << " " << std::setprecision(2) << std::fixed
+					          << a.ulp_error << std::defaultfloat << " " << a.rounding;
+					if (a.cancellation) std::cout << " CANCEL";
+					std::cout << "\n";
+				}
+				std::cout << "= " << result.native_rep << "\n";
+			} else {
+				// Plain text output
+				for (size_t i = 0; i < steps.size(); ++i) {
+					const auto& s = steps[i];
+					const auto& a = annotations[i];
+					std::cout << "  step " << s.step_number << ": " << s.description << "\n";
+					std::cout << "          = " << s.result_rep;
+					if (a.rounding == "exact") {
+						std::cout << "  (exact)";
+					} else {
+						std::cout << "  (exact: " << a.exact_rep
+						          << ", ulp_err: " << std::setprecision(2) << std::fixed
+						          << a.ulp_error << std::defaultfloat
+						          << ", ROUNDED " << (a.rounding == "up" ? "UP" : "DOWN") << ")";
+					}
+					if (a.cancellation) {
+						std::cout << "\n          WARNING: catastrophic cancellation (~"
+						          << a.cancelled_digits << " digits lost)";
+					}
+					std::cout << "\n";
+				}
+				std::cout << "  result: " << result.native_rep << "\n";
+			}
+		} catch (const std::exception& ex) {
+			if (fmt == OutputFormat::json) {
+				std::cout << "{\"error\":\"" << json_escape(ex.what()) << "\"}\n";
+			} else {
+				std::cerr << "Error: " << ex.what() << "\n";
+			}
+			state.last_error = EXIT_PARSE_ERROR;
+		}
+		return true;
+	}
+
 	// faithful <expr> -- check if result is faithfully rounded
 	if (line.substr(0, 9) == "faithful ") {
 		std::string expr = trim(line.substr(9));
@@ -918,7 +1131,7 @@ static char* ucalc_generator(const char* text, int state_idx) {
 		// Complete commands
 		static const char* commands[] = {
 			"type", "types", "show", "compare", "bits", "range", "precision",
-			"ulp", "sweep", "faithful", "color", "vars", "help", "quit", "exit", nullptr
+			"ulp", "sweep", "trace", "faithful", "color", "vars", "help", "quit", "exit", nullptr
 		};
 		for (int i = 0; commands[i]; ++i) {
 			if (std::string(commands[i]).substr(0, prefix.size()) == prefix) {


### PR DESCRIPTION
## Summary

Implements #621 (Tier 2.1 of the ucalc compute engine roadmap).

- **`trace <expr>`** command shows each arithmetic operation step-by-step with:
  - ULP error vs quad-double reference
  - Rounding direction (up/down/exact)
  - Catastrophic cancellation detection (warns when subtraction loses 3+ significant digits)
- Supports all output formats: `--json`, `--csv`, `--quiet`, plain text
- Fix: `compute_ulp()` now rounds input to nearest representable value before probing, fixing incorrect ULP estimates for values not exactly representable in the active type

Example:
```
ucalc> type fp16
ucalc> trace (1.0 + 1e-4) - 1.0
  step 1: 1.0000e+00 + 1.0002e-04
          = 1.0000e+00  (exact: 1.0001..., ulp_err: 0.10, ROUNDED DOWN)
  step 2: 1.0000e+00 - 1.0000e+00
          = 0.0000e+00  (exact)
  result: 0.0000e+00
```

Closes #621

## Test plan

- [x] 3 new regression tests: step recording, function tracing, disabled-by-default
- [x] New example script `11_agent_trace_analysis.ucalc`
- [x] JSON output validated with Python json.loads()
- [x] 20/20 CTests pass on both gcc and clang
- [x] Existing `ulp` command verified correct after `compute_ulp` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added expression evaluation tracing exposing per-operation metrics and precision data
  - New `trace` REPL command with per-operation error analysis and rounding direction information
  - Precision analysis script for evaluating expressions across multiple numeric types

* **Tests**
  - Added regression tests validating trace functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->