### PR TITLE
feat(ucalc): quantize command with RMSE/QSNR metrics

### DIFF
--- a/tools/ucalc/data_loader.hpp
+++ b/tools/ucalc/data_loader.hpp
@@ -18,30 +18,62 @@
 
 namespace sw { namespace ucalc {
 
+// Distinct exception for file-open failures (maps to EXIT_FILE_NOT_FOUND)
+struct file_not_found : std::runtime_error {
+	using std::runtime_error::runtime_error;
+};
+
+// Parse a single token as a double, rejecting partial matches like "1.5xyz".
+inline double parse_double_strict(const std::string& token) {
+	size_t pos = 0;
+	double v = std::stod(token, &pos);
+	if (pos != token.size()) {
+		throw std::runtime_error("malformed number: '" + token + "'");
+	}
+	return v;
+}
+
+// Split a line by whitespace into tokens (commas pre-replaced with spaces).
+inline std::vector<std::string> tokenize_line(const std::string& line) {
+	std::vector<std::string> tokens;
+	std::istringstream iss(line);
+	std::string tok;
+	while (iss >> tok) {
+		tokens.push_back(tok);
+	}
+	return tokens;
+}
+
 // Load floating-point values from a CSV/text file.
 // Handles: one-per-line, comma-separated, mixed whitespace.
 // Skips blank lines and lines starting with '#' (comments).
+// Throws file_not_found on open failure, runtime_error on parse failure.
 inline std::vector<double> load_csv(const std::string& path) {
 	std::ifstream fin(path);
 	if (!fin.is_open()) {
-		throw std::runtime_error("cannot open file: " + path);
+		throw file_not_found("cannot open file: " + path);
 	}
 	std::vector<double> data;
 	std::string line;
+	int line_num = 0;
 	while (std::getline(fin, line)) {
+		++line_num;
 		// Skip comments and blank lines
 		size_t first = line.find_first_not_of(" \t\r\n");
 		if (first == std::string::npos) continue;
 		if (line[first] == '#') continue;
 
-		// Replace commas with spaces for uniform parsing
+		// Replace commas with spaces for uniform tokenizing
 		for (auto& c : line) {
 			if (c == ',') c = ' ';
 		}
-		std::istringstream iss(line);
-		double v;
-		while (iss >> v) {
-			data.push_back(v);
+		for (const auto& tok : tokenize_line(line)) {
+			try {
+				data.push_back(parse_double_strict(tok));
+			} catch (const std::exception&) {
+				throw std::runtime_error("malformed value '" + tok
+				    + "' at line " + std::to_string(line_num) + " in " + path);
+			}
 		}
 	}
 	if (data.empty()) {
@@ -51,7 +83,7 @@ inline std::vector<double> load_csv(const std::string& path) {
 }
 
 // Parse an inline vector literal: [1.0, -2.5, 3.14]
-// Returns the values as doubles.
+// Returns the values as doubles. Rejects malformed tokens.
 inline std::vector<double> parse_vector_literal(const std::string& text) {
 	std::string s = text;
 	// Strip brackets
@@ -66,11 +98,9 @@ inline std::vector<double> parse_vector_literal(const std::string& text) {
 	for (auto& c : s) {
 		if (c == ',') c = ' ';
 	}
-	std::istringstream iss(s);
 	std::vector<double> data;
-	double v;
-	while (iss >> v) {
-		data.push_back(v);
+	for (const auto& tok : tokenize_line(s)) {
+		data.push_back(parse_double_strict(tok));
 	}
 	if (data.empty()) {
 		throw std::runtime_error("empty vector literal");

--- a/tools/ucalc/scripts/12_agent_quantize_comparison.ucalc
+++ b/tools/ucalc/scripts/12_agent_quantize_comparison.ucalc
@@ -1,7 +1,7 @@
 # 12_agent_quantize_comparison.ucalc -- AI agent script
 # Compare quantization quality across formats for typical weight values
 # Run with: ucalc --json -f 12_agent_quantize_comparison.ucalc
-# Agent parses JSON to select optimal format for accuracy/size tradeoff
+# Output is NDJSON (one JSON object per line); parse line-by-line
 
 quantize fp8e4m3 [0.3, -1.2, 0.007, 2.5, -0.001, 1.8, -3.2, 0.5]
 quantize fp8e5m2 [0.3, -1.2, 0.007, 2.5, -0.001, 1.8, -3.2, 0.5]

--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -1641,6 +1641,13 @@ static bool process_command(const std::string& input, ReplState& state) {
 				std::cout << "  clipped:        " << clipped << "\n";
 				std::cout << "  flushed:        " << flushed << "\n";
 			}
+		} catch (const file_not_found& ex) {
+			if (fmt == OutputFormat::json) {
+				std::cout << "{\"error\":\"" << json_escape(ex.what()) << "\"}\n";
+			} else {
+				std::cerr << "Error: " << ex.what() << "\n";
+			}
+			state.last_error = EXIT_FILE_NOT_FOUND;
 		} catch (const std::exception& ex) {
 			if (fmt == OutputFormat::json) {
 				std::cout << "{\"error\":\"" << json_escape(ex.what()) << "\"}\n";
@@ -1922,6 +1929,9 @@ try {
 		}
 		std::string line;
 		while (std::getline(fin, line)) {
+			// Skip comment lines before semicolon splitting
+			std::string trimmed = trim(line);
+			if (!trimmed.empty() && trimmed[0] == '#') continue;
 			auto cmds = split_commands(line);
 			for (const auto& cmd : cmds) {
 				if (!process_command(cmd, state)) {


### PR DESCRIPTION
## Summary

Implements #627 (Tier 4.1 of the ucalc compute engine roadmap).

**`quantize <format> <data>`** evaluates quantization quality with production-scale metrics:

- **Inline vectors**: `quantize fp8e4m3 [0.3, -1.2, 0.007, 2.5]`
- **CSV file loading**: `quantize fp8e4m3 -f weights.csv` (supports millions of elements)
- **QSNR** (quantization signal-to-noise ratio in dB) alongside RMSE
- **Clip/flush detection**: counts overflow and underflow events
- **Per-element table** for small datasets (<= 64 elements)
- All output formats: `--json`, `--csv`, `--quiet`, plain text

Format comparison example (10K normally-distributed weights):
```
fp8e4m3:  0.0131171 31.6dB 10000
fp8e5m2:  0.0267517 25.4dB 10000
bfloat16: 0.00165137 49.6dB 10000
posit8:   0.0131249 31.6dB 10000
fp16:     0.000103695 73.7dB 10000
float:    1.27871e-08 151.8dB 10000
```

Closes #627

## Test plan

- [x] Inline vector quantization verified across 6 formats
- [x] CSV file loading tested with 10K element weight tensor
- [x] JSON output validated with Python json.loads()
- [x] QSNR correctly computed (inf when quantization is exact)
- [x] Clip/flush detection verified
- [x] New example script: 12_agent_quantize_comparison.ucalc
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a interactive/batch `quantize` command to compare values across multiple numeric formats with metrics (RMSE, Q‑SNR, max/mean error, clipped/flushed counts).
  * Accepts input via CSV files or inline vector literals; outputs in JSON, CSV, plain text, or quiet summaries.
  * Included a sample comparison script demonstrating per-format quantization runs.

* **Bug Fixes / Improvements**
  * Better error reporting for missing or malformed input and safer batch-script comment handling.
* **UX**
  * Added command auto-completion for the new command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->