### PR TITLE
feat(ucalc): breakpoint finder command (diverge)

### DIFF
--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -1467,59 +1467,50 @@ static bool process_command(const std::string& input, ReplState& state) {
 	// diverge <expr> <type1> <type2> <tol> for <var> in [a, b]
 	// Find first input where two types disagree by more than tolerance
 	if (line.substr(0, 8) == "diverge " || line.substr(0, 8) == "diverge\t") {
-		// Parse: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]
-		auto for_pos = line.find(" for ");
-		if (for_pos == std::string::npos) {
-			std::cerr << "Usage: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]\n";
-			state.last_error = EXIT_PARSE_ERROR;
-			return true;
-		}
-		std::string before_for = trim(line.substr(8, for_pos - 8));
-		std::string after_for = line.substr(for_pos + 5);
-		auto in_pos = after_for.find(" in ");
-		if (in_pos == std::string::npos) {
-			std::cerr << "Usage: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]\n";
-			state.last_error = EXIT_PARSE_ERROR;
-			return true;
-		}
-		std::string var = trim(after_for.substr(0, in_pos));
-		std::string range_str = trim(after_for.substr(in_pos + 4));
-
-		// Parse the range [a, b]
-		if (range_str.front() == '[') range_str = range_str.substr(1);
-		if (!range_str.empty() && range_str.back() == ']') range_str.pop_back();
-		std::istringstream rss(range_str);
-		std::string sa, sb;
-		std::getline(rss, sa, ',');
-		std::getline(rss, sb, ',');
-
-		// Parse before_for: <expr> <type1> <type2> <tol>
-		// Work backwards: last token is tolerance, second-last is type2,
-		// third-last is type1, everything before is the expression.
-		// Tokens are space-separated, but expression may contain spaces.
-		std::vector<std::string> tokens;
-		{
-			std::istringstream tss(before_for);
-			std::string tok;
-			while (tss >> tok) tokens.push_back(tok);
-		}
-		if (tokens.size() < 4) {
-			std::cerr << "Usage: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]\n";
-			state.last_error = EXIT_PARSE_ERROR;
-			return true;
-		}
-		std::string tol_str = tokens.back(); tokens.pop_back();
-		std::string type2_name = tokens.back(); tokens.pop_back();
-		std::string type1_name = tokens.back(); tokens.pop_back();
-		std::string expr;
-		for (size_t i = 0; i < tokens.size(); ++i) {
-			if (i > 0) expr += " ";
-			expr += tokens[i];
-		}
-
 		try {
+			// Parse: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]
+			auto for_pos = line.find(" for ");
+			if (for_pos == std::string::npos)
+				throw std::runtime_error("usage: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]");
+			std::string before_for = trim(line.substr(8, for_pos - 8));
+			std::string after_for = line.substr(for_pos + 5);
+			auto in_pos = after_for.find(" in ");
+			if (in_pos == std::string::npos)
+				throw std::runtime_error("usage: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]");
+			std::string var = trim(after_for.substr(0, in_pos));
+			std::string range_str = trim(after_for.substr(in_pos + 4));
+
+			// Parse the range [a, b]
+			if (range_str.empty())
+				throw std::runtime_error("empty range specification");
+			if (range_str.front() == '[') range_str = range_str.substr(1);
+			if (!range_str.empty() && range_str.back() == ']') range_str.pop_back();
+			std::istringstream rss(range_str);
+			std::string sa, sb;
+			std::getline(rss, sa, ',');
+			std::getline(rss, sb, ',');
+			if (trim(sa).empty() || trim(sb).empty())
+				throw std::runtime_error("range must have two values: [a, b]");
 			double lo = std::stod(trim(sa));
 			double hi = std::stod(trim(sb));
+
+			// Parse before_for: <expr> <type1> <type2> <tol>
+			std::vector<std::string> tokens;
+			{
+				std::istringstream tss(before_for);
+				std::string tok;
+				while (tss >> tok) tokens.push_back(tok);
+			}
+			if (tokens.size() < 4)
+				throw std::runtime_error("usage: diverge <expr> <type1> <type2> <tol> for <var> in [a, b]");
+			std::string tol_str = tokens.back(); tokens.pop_back();
+			std::string type2_name = tokens.back(); tokens.pop_back();
+			std::string type1_name = tokens.back(); tokens.pop_back();
+			std::string expr;
+			for (size_t i = 0; i < tokens.size(); ++i) {
+				if (i > 0) expr += " ";
+				expr += tokens[i];
+			}
 
 			// Parse tolerance: plain number (absolute) or "Nulp" (ULP-relative)
 			bool tol_is_ulp = false;
@@ -1530,16 +1521,28 @@ static bool process_command(const std::string& input, ReplState& state) {
 			} else {
 				tol_val = std::stod(tol_str);
 			}
+			if (tol_val < 0.0)
+				throw std::runtime_error("tolerance must be non-negative");
 
 			const TypeOps* ops1 = state.registry.find(type1_name);
 			const TypeOps* ops2 = state.registry.find(type2_name);
 			if (!ops1) {
-				std::cerr << "Error: unknown type '" << type1_name << "'\n";
+				if (fmt == OutputFormat::json) {
+					std::cout << "{\"error\":\"unknown type\",\"type\":\""
+					          << json_escape(type1_name) << "\"}\n";
+				} else {
+					std::cerr << "Error: unknown type '" << type1_name << "'\n";
+				}
 				state.last_error = EXIT_UNKNOWN_TYPE;
 				return true;
 			}
 			if (!ops2) {
-				std::cerr << "Error: unknown type '" << type2_name << "'\n";
+				if (fmt == OutputFormat::json) {
+					std::cout << "{\"error\":\"unknown type\",\"type\":\""
+					          << json_escape(type2_name) << "\"}\n";
+				} else {
+					std::cerr << "Error: unknown type '" << type2_name << "'\n";
+				}
 				state.last_error = EXIT_UNKNOWN_TYPE;
 				return true;
 			}
@@ -1559,54 +1562,63 @@ static bool process_command(const std::string& input, ReplState& state) {
 				return { e1.evaluate(expr), e2.evaluate(expr) };
 			};
 
-			// Check if two values diverge beyond tolerance
-			auto exceeds_tol = [&](const Value& v1, const Value& v2) -> double {
-				double diff = std::abs(v1.num - v2.num);
-				if (tol_is_ulp) {
-					// Compute ULP using the first type at this value
-					double ulp = compute_ulp(*ops1, v1.num);
-					if (ulp > 0.0) return diff / ulp;
-					return 0.0;
+			// Compute both absolute and ULP difference
+			struct DiffResult {
+				double abs_diff;
+				double ulp_diff;
+			};
+			auto compute_diff = [&](const Value& v1, const Value& v2) -> DiffResult {
+				// Handle non-finite values
+				if (!std::isfinite(v1.num) || !std::isfinite(v2.num)) {
+					if (v1.num == v2.num) return { 0.0, 0.0 }; // both same inf
+					return { std::numeric_limits<double>::infinity(),
+					         std::numeric_limits<double>::infinity() };
 				}
-				return diff;
+				double ad = std::abs(v1.num - v2.num);
+				double ud = 0.0;
+				double ulp = compute_ulp(*ops1, v1.num);
+				if (ulp > 0.0) ud = ad / ulp;
+				return { ad, ud };
 			};
 
 			// Scan then binary-search for the first divergence
 			int n_scan = 1000;
-			double step = (hi - lo) / n_scan;
+			double scan_step = (hi - lo) / n_scan;
 			double found_x = std::numeric_limits<double>::quiet_NaN();
-			double found_diff = 0.0;
+			DiffResult found_dr{ 0.0, 0.0 };
 			Value found_v1, found_v2;
 
 			for (int i = 0; i <= n_scan; ++i) {
-				double x = lo + i * step;
+				double x = lo + i * scan_step;
 				auto [v1, v2] = eval_at(x);
-				double d = exceeds_tol(v1, v2);
-				if (d > tol_val) {
+				DiffResult dr = compute_diff(v1, v2);
+				double check = tol_is_ulp ? dr.ulp_diff : dr.abs_diff;
+				if (check > tol_val) {
 					// Binary search to narrow down
-					double x_lo = (i > 0) ? (lo + (i - 1) * step) : lo;
+					double x_lo = (i > 0) ? (lo + (i - 1) * scan_step) : lo;
 					double x_hi = x;
 					for (int j = 0; j < 64; ++j) {
 						double x_mid = (x_lo + x_hi) * 0.5;
 						if (x_mid == x_lo || x_mid == x_hi) break;
 						auto [m1, m2] = eval_at(x_mid);
-						double dm = exceeds_tol(m1, m2);
-						if (dm > tol_val) {
+						DiffResult dm = compute_diff(m1, m2);
+						double mc = tol_is_ulp ? dm.ulp_diff : dm.abs_diff;
+						if (mc > tol_val) {
 							x_hi = x_mid;
-							found_v1 = m1; found_v2 = m2; found_diff = dm;
+							found_v1 = m1; found_v2 = m2; found_dr = dm;
 						} else {
 							x_lo = x_mid;
 						}
 					}
 					found_x = x_hi;
-					if (found_diff == 0.0) {
-						found_v1 = v1; found_v2 = v2; found_diff = d;
+					if (found_dr.abs_diff == 0.0 && found_dr.ulp_diff == 0.0) {
+						found_v1 = v1; found_v2 = v2; found_dr = dr;
 					}
 					break;
 				}
 			}
 
-			// Output
+			// Output -- always report both abs_diff and ulp_diff
 			if (fmt == OutputFormat::json) {
 				std::cout << "{\"expression\":\"" << json_escape(expr) << "\""
 				          << ",\"type1\":\"" << json_escape(type1_name) << "\""
@@ -1623,27 +1635,29 @@ static bool process_command(const std::string& input, ReplState& state) {
 					          << ",\"value1_decimal\":" << json_number(found_v1.num)
 					          << ",\"value2\":\"" << json_escape(found_v2.native_rep) << "\""
 					          << ",\"value2_decimal\":" << json_number(found_v2.num)
-					          << ",\"difference\":" << json_number(found_diff)
+					          << ",\"abs_diff\":" << json_number(found_dr.abs_diff)
+					          << ",\"ulp_diff\":" << json_number(found_dr.ulp_diff)
 					          << "}\n";
 				}
 			} else if (fmt == OutputFormat::csv) {
-				std::cout << "diverged,x,value1,value2,difference\n";
+				std::cout << "diverged,x,value1,value2,abs_diff,ulp_diff\n";
 				if (std::isnan(found_x)) {
-					std::cout << "false,,,,\n";
+					std::cout << "false,,,,,\n";
 				} else {
 					std::cout << "true,"
 					          << std::setprecision(17) << found_x << ","
 					          << csv_quote(found_v1.native_rep) << ","
 					          << csv_quote(found_v2.native_rep) << ","
-					          << std::setprecision(17) << found_diff << "\n";
+					          << std::setprecision(17) << found_dr.abs_diff << ","
+					          << std::setprecision(6) << found_dr.ulp_diff << "\n";
 				}
 			} else if (fmt == OutputFormat::quiet) {
 				if (std::isnan(found_x)) {
 					std::cout << "no divergence\n";
 				} else {
 					std::cout << std::setprecision(17) << found_x << " "
-					          << std::setprecision(6) << found_diff
-					          << (tol_is_ulp ? "ulp" : "") << "\n";
+					          << std::setprecision(6) << found_dr.abs_diff << " "
+					          << std::setprecision(4) << found_dr.ulp_diff << "ulp\n";
 				}
 			} else {
 				// Plain text
@@ -1657,8 +1671,8 @@ static bool process_command(const std::string& input, ReplState& state) {
 					          << found_v1.native_rep << "\n";
 					std::cout << "  " << std::left << std::setw(14) << type2_name
 					          << found_v2.native_rep << "\n";
-					std::cout << "  difference:   " << std::setprecision(4) << found_diff
-					          << (tol_is_ulp ? " ULPs" : "") << "\n";
+					std::cout << "  abs diff:     " << std::setprecision(8) << found_dr.abs_diff << "\n";
+					std::cout << "  ulp diff:     " << std::setprecision(4) << found_dr.ulp_diff << " ULPs\n";
 				}
 			}
 		} catch (const std::exception& ex) {


### PR DESCRIPTION
## Summary

Implements #624 (Tier 3.3 of the ucalc compute engine roadmap).

**`diverge <expr> <type1> <type2> <tol> for <var> in [a, b]`** finds the first input value where two types disagree beyond tolerance.

- 1000-point scan + 64-iteration binary search for precise localization
- Absolute tolerance (e.g., `0.001`) or ULP-relative (e.g., `1ulp`)
- All output formats: `--json`, `--csv`, `--quiet`, plain text

Example:
```
ucalc> diverge sin(x) posit32 float 1ulp for x in [0, 6.28]
  first divergence at x = 0.0031982857035472993
  posit32       3.198280232e-03
  float         0.00319828046
  difference:   4.885 ULPs
```

Closes #624

## Test plan

- [x] ULP tolerance: finds divergence between posit32 and float for sin(x)
- [x] Absolute tolerance: correctly reports no divergence when within bounds
- [x] JSON output validated with Python json.loads()
- [x] Reports "no divergence" when types agree across entire range
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `diverge` command to compare expression evaluation across two numerical types over a specified range.
  * Supports absolute and ULP-relative tolerance thresholds; rejects negative tolerances.
  * Detects first divergence point within the range and reports metrics.
  * Results available in JSON, CSV, quiet, and plain text formats.
  * Help output and command completion updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->