### PR TITLE
feat(ucalc): block format simulation command

### DIFF
--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -2023,13 +2023,15 @@ static bool process_command(const std::string& input, ReplState& state) {
 				}
 			};
 
-			if (format_name == "mxfp4")       run_mxblock(mxfp4{}, "MX FP4 (e2m1, block=32, e8m0 scale)");
-			else if (format_name == "mxfp6")   run_mxblock(mxfp6{}, "MX FP6 (e3m2, block=32, e8m0 scale)");
-			else if (format_name == "mxfp8")   run_mxblock(mxfp8{}, "MX FP8 (e4m3, block=32, e8m0 scale)");
+			if (format_name == "mxfp4")          run_mxblock(mxfp4{}, "MX FP4 (e2m1, block=32, e8m0 scale)");
+			else if (format_name == "mxfp6")     run_mxblock(mxfp6{}, "MX FP6 (e3m2, block=32, e8m0 scale)");
+			else if (format_name == "mxfp6e2m3") run_mxblock(mxfp6e2m3{}, "MX FP6 (e2m3, block=32, e8m0 scale)");
+			else if (format_name == "mxfp8")     run_mxblock(mxfp8{}, "MX FP8 (e4m3, block=32, e8m0 scale)");
 			else if (format_name == "mxfp8e5m2") run_mxblock(mxfp8e5m2{}, "MX FP8 (e5m2, block=32, e8m0 scale)");
-			else if (format_name == "nvfp4")   run_nvblock(nvfp4{}, "NVFP4 (e2m1, block=16, e4m3 scale)");
+			else if (format_name == "mxint8")    run_mxblock(mxint8{}, "MX INT8 (int8, block=32, e8m0 scale)");
+			else if (format_name == "nvfp4")     run_nvblock(nvfp4{}, "NVFP4 (e2m1, block=16, e4m3 scale)");
 			else throw std::runtime_error("unknown block format '" + format_name
-			     + "'. Available: mxfp4, mxfp6, mxfp8, mxfp8e5m2, nvfp4");
+			     + "'. Available: mxfp4, mxfp6, mxfp6e2m3, mxfp8, mxfp8e5m2, mxint8, nvfp4");
 
 			// Compute aggregate metrics
 			double sum_sq_signal = 0.0, sum_sq_error = 0.0;


### PR DESCRIPTION
## Summary

Implements #628 (Tier 4.2 of the ucalc compute engine roadmap).

**`block <format> [data]`** shows the full MX/NV block decomposition: shared scale, per-element encoding, decoded values, and error.

Supported formats: `mxfp4`, `mxfp6`, `mxfp8`, `mxfp8e5m2`, `nvfp4`

Example:
```
ucalc> block mxfp4 [0.3, -1.2, 0.007, 2.5, -0.001, 1.8, -3.2, 0.5]
  format:    MX FP4 (e2m1, block=32, e8m0 scale)
  block 0  scale: 0.5 (0.5)
  idx       original  element        decoded       error
  0              0.3  0.5               0.25        0.05
  1             -1.2  -2                  -1        -0.2
  ...
  RMSE:  0.21579794
  QSNR:  17.6 dB
```

NVFP4 supports `tensor_scale=N` for NVIDIA's two-level scaling model.

Closes #628

## Test plan

- [x] mxfp4 block decomposition with per-element encoding verified
- [x] nvfp4 with tensor_scale parameter verified
- [x] JSON output validated with Python json.loads()
- [x] CSV and quiet modes verified
- [x] File loading via -f tested
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new block command for block-format quantization and analysis (mxfp4, mxfp6, mxfp6e2m3, mxfp8, mxfp8e5m2, mxint8, nvfp4). Accepts CSV files or inline vectors, optional tensor_scale for NV formats, and reports block-level scale plus per-element decoded and error values.
  * Outputs RMSE and QSNR; supports JSON, CSV, plain, and quiet output modes.

* **Bug Fixes / UX**
  * Improved REPL help text, command listing, completion, and structured error reporting (JSON when requested).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->