### PR TITLE
feat(ucalc): stochastic rounding simulation command

### DIFF
--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -2837,16 +2837,22 @@ static bool process_command(const std::string& input, ReplState& state) {
 
 			// Parse: stochastic <expr> N
 			// N is the last token
-			auto last_space = args.rfind(' ');
+			auto last_space = args.find_last_of(" \t");
 			if (last_space == std::string::npos)
 				throw std::runtime_error("usage: stochastic <expr> N");
 			std::string expr = trim(args.substr(0, last_space));
-			int trials = std::stoi(trim(args.substr(last_space + 1)));
+			std::string trials_tok = trim(args.substr(last_space + 1));
+			size_t consumed = 0;
+			int trials = std::stoi(trials_tok, &consumed);
+			if (consumed != trials_tok.size())
+				throw std::runtime_error("usage: stochastic <expr> N (N must be an integer)");
 			if (trials < 1 || trials > 10000000)
 				throw std::runtime_error("N must be 1-10000000");
 
-			// Evaluate in qd to get the high-precision reference value,
-			// then stochastically round to the active type
+			// Evaluate in qd for the high-precision reference value.
+			// Note: exact_val is truncated to double for neighbor finding
+			// and probability computation (double interchange limitation).
+			// This is adequate for types <= double precision.
 			const TypeOps* ref_ops = state.registry.find("qd");
 			if (!ref_ops) ref_ops = &state.registry.get("double");
 			ExpressionEvaluator eval(*ref_ops);
@@ -2894,7 +2900,7 @@ static bool process_command(const std::string& input, ReplState& state) {
 			std::mt19937 rng(42); // fixed seed for reproducibility
 			std::uniform_real_distribution<double> dist(0.0, 1.0);
 			std::map<std::string, int> result_counts; // native_rep -> count
-			double sum = 0.0;
+			double mean = 0.0; // online incremental mean (avoids sum overflow)
 
 			for (int t = 0; t < trials; ++t) {
 				double chosen;
@@ -2905,10 +2911,8 @@ static bool process_command(const std::string& input, ReplState& state) {
 				}
 				Value cv = ops.from_double(chosen);
 				result_counts[cv.native_rep]++;
-				sum += cv.num;
+				mean += (cv.num - mean) / static_cast<double>(t + 1);
 			}
-
-			double mean = sum / trials;
 			// Bias relative to the qd reference (already computed above)
 			double bias = mean - exact_val;
 


### PR DESCRIPTION
## Summary

Implements #635 (Tier 7.2, Phase 5 Statistics).

**`stochastic <expr> N`** simulates stochastic rounding over N trials:

```
bfloat16> stochastic 0.1 + 0.2 10000
  unique results: 2
  0.2988                  4024 (40.2%)
  0.3008                  5976 (59.8%)
  mean:  0.2999953125
  exact: 3.000000000...e-01
  bias:  -4.6875e-06
```

Evaluates in qd for the exact value, then stochastically rounds to the active type by randomly choosing between floor/ceil proportional to proximity. Fixed seed for reproducibility.

Resolves #635

## Test plan

- [x] bfloat16 0.1+0.2: two results, ~60/40 split, near-zero bias
- [x] fp8e4m3 1/3: correct probability distribution
- [x] Exact case (1+2 in float): single result, zero bias
- [x] JSON output validated
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `stochastic` command for analyzing numerical rounding via randomized trials (1–10,000,000 samples).
  * Deterministic sampling (fixed seed) with per-representation counts, mean, and bias versus a high-precision reference.
  * Multiple output formats: JSON, CSV, plain text, and quiet mode.
  * Updated command help and REPL auto-completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->