### PR TITLE
feat(ucalc): provenance tracking on AST nodes

### DIFF
--- a/tools/ucalc/expression.hpp
+++ b/tools/ucalc/expression.hpp
@@ -39,8 +39,15 @@ namespace sw { namespace ucalc {
 
 enum class ASTKind { Literal, Variable, Constant, BinaryOp, UnaryOp, FunctionCall };
 
+// Provenance: tracks whether a value is an exact input or a computed intermediate
+enum class Provenance {
+	exact,      // literal, variable, or constant -- known with full precision
+	computed    // result of an arithmetic operation -- subject to rounding
+};
+
 struct ASTNode {
 	ASTKind kind;
+	Provenance provenance = Provenance::exact;
 	// Literal
 	double literal_value = 0.0;
 	// Variable / Constant / FunctionCall name / BinaryOp/UnaryOp operator
@@ -72,6 +79,7 @@ struct ASTNode {
 	    std::shared_ptr<ASTNode> l, std::shared_ptr<ASTNode> r) {
 		auto n = std::make_shared<ASTNode>();
 		n->kind = ASTKind::BinaryOp;
+		n->provenance = Provenance::computed;
 		n->name = op;
 		n->left = std::move(l);
 		n->right = std::move(r);
@@ -81,6 +89,7 @@ struct ASTNode {
 	    std::shared_ptr<ASTNode> operand) {
 		auto n = std::make_shared<ASTNode>();
 		n->kind = ASTKind::UnaryOp;
+		n->provenance = Provenance::computed;
 		n->name = op;
 		n->left = std::move(operand);
 		return n;
@@ -89,6 +98,7 @@ struct ASTNode {
 	    std::vector<std::shared_ptr<ASTNode>> arguments) {
 		auto n = std::make_shared<ASTNode>();
 		n->kind = ASTKind::FunctionCall;
+		n->provenance = Provenance::computed;
 		n->name = fname;
 		n->args = std::move(arguments);
 		return n;
@@ -97,40 +107,43 @@ struct ASTNode {
 
 // Print AST as indented tree
 inline void print_ast(const std::shared_ptr<ASTNode>& node, std::ostream& out,
-                      const std::string& prefix = "", bool is_last = true) {
+                      const std::string& prefix = "", bool is_last = true,
+                      bool show_provenance = false) {
 	if (!node) return;
 	out << prefix << (is_last ? "`-- " : "|-- ");
+	std::string ptag = show_provenance
+	    ? (node->provenance == Provenance::exact ? " [exact]" : " [computed]") : "";
 	switch (node->kind) {
 	case ASTKind::Literal:
-		out << node->literal_value << "\n";
+		out << node->literal_value << ptag << "\n";
 		break;
 	case ASTKind::Variable:
-		out << "var:" << node->name << "\n";
+		out << "var:" << node->name << ptag << "\n";
 		break;
 	case ASTKind::Constant:
-		out << "const:" << node->name << "\n";
+		out << "const:" << node->name << ptag << "\n";
 		break;
 	case ASTKind::BinaryOp:
-		out << "op:" << node->name << "\n";
+		out << "op:" << node->name << ptag << "\n";
 		{
 			std::string child_prefix = prefix + (is_last ? "    " : "|   ");
-			print_ast(node->left, out, child_prefix, false);
-			print_ast(node->right, out, child_prefix, true);
+			print_ast(node->left, out, child_prefix, false, show_provenance);
+			print_ast(node->right, out, child_prefix, true, show_provenance);
 		}
 		break;
 	case ASTKind::UnaryOp:
-		out << "unary:" << node->name << "\n";
+		out << "unary:" << node->name << ptag << "\n";
 		{
 			std::string child_prefix = prefix + (is_last ? "    " : "|   ");
-			print_ast(node->left, out, child_prefix, true);
+			print_ast(node->left, out, child_prefix, true, show_provenance);
 		}
 		break;
 	case ASTKind::FunctionCall:
-		out << "fn:" << node->name << "\n";
+		out << "fn:" << node->name << ptag << "\n";
 		{
 			std::string child_prefix = prefix + (is_last ? "    " : "|   ");
 			for (size_t i = 0; i < node->args.size(); ++i) {
-				print_ast(node->args[i], out, child_prefix, i + 1 == node->args.size());
+				print_ast(node->args[i], out, child_prefix, i + 1 == node->args.size(), show_provenance);
 			}
 		}
 		break;

--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -978,30 +978,37 @@ static bool process_command(const std::string& input, ReplState& state) {
 				std::function<void(const std::shared_ptr<ASTNode>&)> to_json;
 				to_json = [&](const std::shared_ptr<ASTNode>& n) {
 					if (!n) { std::cout << "null"; return; }
+					auto prov = [&]() { return n->provenance == Provenance::exact ? "exact" : "computed"; };
 					std::cout << "{\"kind\":\"";
 					switch (n->kind) {
 					case ASTKind::Literal:
-						std::cout << "literal\",\"value\":" << json_number(n->literal_value) << "}";
+						std::cout << "literal\",\"provenance\":\"" << prov()
+						          << "\",\"value\":" << json_number(n->literal_value) << "}";
 						return;
 					case ASTKind::Variable:
-						std::cout << "variable\",\"name\":\"" << json_escape(n->name) << "\"}";
+						std::cout << "variable\",\"provenance\":\"" << prov()
+						          << "\",\"name\":\"" << json_escape(n->name) << "\"}";
 						return;
 					case ASTKind::Constant:
-						std::cout << "constant\",\"name\":\"" << json_escape(n->name) << "\"}";
+						std::cout << "constant\",\"provenance\":\"" << prov()
+						          << "\",\"name\":\"" << json_escape(n->name) << "\"}";
 						return;
 					case ASTKind::BinaryOp:
-						std::cout << "binary\",\"op\":\"" << json_escape(n->name)
+						std::cout << "binary\",\"provenance\":\"" << prov()
+						          << "\",\"op\":\"" << json_escape(n->name)
 						          << "\",\"left\":"; to_json(n->left);
 						std::cout << ",\"right\":"; to_json(n->right);
 						std::cout << "}";
 						return;
 					case ASTKind::UnaryOp:
-						std::cout << "unary\",\"op\":\"" << json_escape(n->name)
+						std::cout << "unary\",\"provenance\":\"" << prov()
+						          << "\",\"op\":\"" << json_escape(n->name)
 						          << "\",\"operand\":"; to_json(n->left);
 						std::cout << "}";
 						return;
 					case ASTKind::FunctionCall:
-						std::cout << "function\",\"name\":\"" << json_escape(n->name)
+						std::cout << "function\",\"provenance\":\"" << prov()
+						          << "\",\"name\":\"" << json_escape(n->name)
 						          << "\",\"args\":[";
 						for (size_t i = 0; i < n->args.size(); ++i) {
 							if (i > 0) std::cout << ",";
@@ -1020,7 +1027,7 @@ static bool process_command(const std::string& input, ReplState& state) {
 				std::cout << "  expression: " << expr << "\n";
 				std::cout << "  tree:\n";
 				std::ostringstream ss;
-				print_ast(tree, ss, "    ");
+				print_ast(tree, ss, "    ", true, true);
 				std::cout << ss.str();
 			}
 		} catch (const std::exception& ex) {


### PR DESCRIPTION
## Summary

Implements #667 (Phase 2 of Epic #642: Rewrite Suggestion Database).

Adds `Provenance` enum (exact/computed) to every `ASTNode`:
- **exact**: Literal, Variable, Constant -- known with full precision
- **computed**: BinaryOp, UnaryOp, FunctionCall -- subject to rounding

```
ucalc> ast sqrt(a) - sqrt(b)
  `-- op:- [computed]
      |-- fn:sqrt [computed]
      |   `-- var:a [exact]
      `-- fn:sqrt [computed]
          `-- var:b [exact]
```

JSON output includes `"provenance":"exact"` or `"provenance":"computed"` on every node.

This enables Phase 4 (AST matching) to check whether subtraction operands derive from exact inputs before suggesting rewrites.

Resolves #667

## Test plan

- [x] Leaves (literals, variables, constants) tagged exact
- [x] Operations (binary, unary, function) tagged computed
- [x] JSON provenance on every node
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AST output now includes provenance information to distinguish between exact and computed nodes.
  * JSON serialization of AST nodes now includes a provenance field.
  * Plain-text AST display can optionally show provenance annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->