### PR TITLE
feat(ucalc): rewrite pattern table and rewrites command

### DIFF
--- a/tools/ucalc/rewrite_patterns.hpp
+++ b/tools/ucalc/rewrite_patterns.hpp
@@ -1,0 +1,109 @@
+#pragma once
+// rewrite_patterns.hpp: database of numerically unstable patterns and stable alternatives
+//
+// Each pattern describes:
+//   - A numerically unstable expression form
+//   - Its stable alternative
+//   - The condition under which the rewrite helps
+//   - A brief explanation of why the original is unstable
+//
+// These patterns are used by the `rewrites` command (listing) and will be
+// used by the `suggest` command (Phase 4: AST matching) to detect and
+// suggest reformulations.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project.
+#include <string>
+#include <vector>
+
+namespace sw { namespace ucalc {
+
+struct RewritePattern {
+	std::string id;              // short identifier, e.g. "sqrt_diff"
+	std::string name;            // human-readable name
+	std::string unstable;        // unstable expression form
+	std::string stable;          // stable alternative
+	std::string condition;       // when the rewrite helps
+	std::string explanation;     // why the original is unstable
+};
+
+// The canonical rewrite pattern database
+inline const std::vector<RewritePattern>& rewrite_database() {
+	static const std::vector<RewritePattern> db = {
+		{
+			"sqrt_diff",
+			"Square root difference",
+			"sqrt(a) - sqrt(b)",
+			"(a - b) / (sqrt(a) + sqrt(b))",
+			"a, b exact inputs, a ~= b > 0",
+			"When a ~= b, sqrt(a) ~= sqrt(b), and the subtraction cancels "
+			"most significant digits. The conjugate form computes the same "
+			"value via division, avoiding the cancellation."
+		},
+		{
+			"quadratic_unstable",
+			"Quadratic formula (unstable root)",
+			"(-b + sqrt(b^2 - 4*a*c)) / (2*a)",
+			"2*c / (-b - sqrt(b^2 - 4*a*c))",
+			"when -b and sqrt(b^2-4ac) nearly cancel (b^2 >> 4ac)",
+			"The standard quadratic formula subtracts two nearly equal values "
+			"when the discriminant is close to b^2. The alternative formula "
+			"uses division instead, preserving precision for the small root."
+		},
+		{
+			"log1p",
+			"Logarithm near 1",
+			"log(1 + x)",
+			"log1p(x)",
+			"|x| << 1",
+			"When x is small, 1+x rounds to 1 in finite precision, losing x "
+			"entirely. log1p(x) computes log(1+x) directly without forming 1+x, "
+			"preserving the contribution of x."
+		},
+		{
+			"expm1",
+			"Exponential minus 1",
+			"exp(x) - 1",
+			"expm1(x)",
+			"|x| << 1",
+			"When x is small, exp(x) ~= 1+x, so exp(x)-1 subtracts two nearly "
+			"equal values. expm1(x) computes exp(x)-1 directly, avoiding the "
+			"cancellation near zero."
+		},
+		{
+			"half_angle",
+			"One minus cosine (half-angle)",
+			"1 - cos(x)",
+			"2 * sin(x/2)^2",
+			"|x| << 1",
+			"When x is small, cos(x) ~= 1 - x^2/2, so 1-cos(x) cancels most "
+			"digits. The half-angle identity 2*sin^2(x/2) computes the same "
+			"value without subtraction of nearly equal quantities."
+		},
+		{
+			"sin_diff",
+			"Sine difference (product-to-sum)",
+			"sin(a) - sin(b)",
+			"2 * cos((a+b)/2) * sin((a-b)/2)",
+			"a ~= b",
+			"When a ~= b, sin(a) ~= sin(b) and the subtraction cancels digits. "
+			"The product-to-sum identity factors the difference into a product "
+			"that avoids the near-cancellation."
+		},
+		{
+			"cos_ratio",
+			"Cosine deviation ratio",
+			"(1 - cos(x)) / x^2",
+			"(sin(x/2) / (x/2))^2 / 2",
+			"|x| << 1",
+			"Combines the 1-cos(x) cancellation with division by x^2. "
+			"The rewrite uses the sinc-like form sin(x/2)/(x/2) which is "
+			"well-conditioned near zero (limit is 1/2)."
+		}
+	};
+	return db;
+}
+
+}} // namespace sw::ucalc

--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -89,6 +89,7 @@
 #include "output_format.hpp"
 #include "steps_ieee.hpp"
 #include "data_loader.hpp"
+#include "rewrite_patterns.hpp"
 
 #ifdef _WIN32
 #include <io.h>
@@ -144,7 +145,7 @@ static void print_help(OutputFormat fmt) {
 	if (fmt == OutputFormat::json) {
 		std::cout << "{\"commands\":[\"type\",\"types\",\"show\",\"compare\","
 		          << "\"bits\",\"range\",\"precision\",\"ulp\",\"sweep\","
-		          << "\"ast\",\"testvec\",\"oracle\",\"steps\",\"trace\",\"cancel\",\"audit\",\"diverge\",\"quantize\",\"block\","
+		          << "\"rewrites\",\"ast\",\"testvec\",\"oracle\",\"steps\",\"trace\",\"cancel\",\"audit\",\"diverge\",\"quantize\",\"block\","
 		          << "\"dot\",\"clip\",\"increment\",\"decrement\",\"cond\",\"errordist\",\"stochastic\","
 		          << "\"histogram\",\"heatmap\",\"numberline\",\"faithful\",\"color\",\"vars\",\"help\",\"quit\"]}\n";
 		return;
@@ -161,6 +162,7 @@ static void print_help(OutputFormat fmt) {
 	std::cout << "  ulp <value>    Show ULP at the given value\n";
 	std::cout << "  sweep <expr> for <var> in [a, b, n]\n";
 	std::cout << "                 Evaluate across a range, show error vs double\n";
+	std::cout << "  rewrites         List numerical rewrite patterns\n";
 	std::cout << "  ast <expr>       Show the expression tree structure\n";
 	std::cout << "  testvec <type> <func> [a, b, n]  Generate golden test vectors\n";
 	std::cout << "  oracle <type> <expr>  Canonical result with rounding verification\n";
@@ -961,6 +963,50 @@ static bool process_command(const std::string& input, ReplState& state) {
 				std::cerr << "Error: " << ex.what() << "\n";
 			}
 			state.last_error = EXIT_PARSE_ERROR;
+		}
+		return true;
+	}
+
+	// rewrites -- list available rewrite patterns
+	if (line == "rewrites") {
+		const auto& db = rewrite_database();
+		if (fmt == OutputFormat::json) {
+			std::cout << "[";
+			for (size_t i = 0; i < db.size(); ++i) {
+				const auto& p = db[i];
+				if (i > 0) std::cout << ",";
+				std::cout << "{\"id\":\"" << json_escape(p.id) << "\""
+				          << ",\"name\":\"" << json_escape(p.name) << "\""
+				          << ",\"unstable\":\"" << json_escape(p.unstable) << "\""
+				          << ",\"stable\":\"" << json_escape(p.stable) << "\""
+				          << ",\"condition\":\"" << json_escape(p.condition) << "\""
+				          << ",\"explanation\":\"" << json_escape(p.explanation) << "\""
+				          << "}";
+			}
+			std::cout << "]\n";
+		} else if (fmt == OutputFormat::csv) {
+			std::cout << "id,name,unstable,stable,condition\n";
+			for (const auto& p : db) {
+				std::cout << csv_quote(p.id) << ","
+				          << csv_quote(p.name) << ","
+				          << csv_quote(p.unstable) << ","
+				          << csv_quote(p.stable) << ","
+				          << csv_quote(p.condition) << "\n";
+			}
+		} else if (fmt == OutputFormat::quiet) {
+			for (const auto& p : db) {
+				std::cout << p.id << ": " << p.unstable << " -> " << p.stable << "\n";
+			}
+		} else {
+			std::cout << "  Numerical Rewrite Patterns (" << db.size() << " patterns)\n\n";
+			for (size_t i = 0; i < db.size(); ++i) {
+				const auto& p = db[i];
+				std::cout << "  " << (i + 1) << ". " << p.name << " (" << p.id << ")\n";
+				std::cout << "     unstable:  " << p.unstable << "\n";
+				std::cout << "     stable:    " << p.stable << "\n";
+				std::cout << "     condition: " << p.condition << "\n";
+				std::cout << "     " << p.explanation << "\n\n";
+			}
 		}
 		return true;
 	}
@@ -4041,7 +4087,7 @@ static char* ucalc_generator(const char* text, int state_idx) {
 		// Complete commands
 		static const char* commands[] = {
 			"type", "types", "show", "compare", "bits", "range", "precision",
-			"ulp", "sweep", "ast", "testvec", "oracle", "steps", "trace", "cancel", "audit", "diverge", "quantize", "block",
+			"ulp", "sweep", "rewrites", "ast", "testvec", "oracle", "steps", "trace", "cancel", "audit", "diverge", "quantize", "block",
 			"dot", "clip", "increment", "decrement", "cond", "errordist", "stochastic", "histogram", "heatmap", "numberline", "faithful", "color", "vars", "help", "quit", "exit", nullptr
 		};
 		for (int i = 0; commands[i]; ++i) {


### PR DESCRIPTION
## Summary

Implements #668 (Phase 3 of Epic #642: Rewrite Suggestion Database).

Adds a curated database of 7 numerically unstable patterns with stable alternatives and a `rewrites` command to list them.

```
ucalc> rewrites
  1. Square root difference (sqrt_diff)
     unstable:  sqrt(a) - sqrt(b)
     stable:    (a - b) / (sqrt(a) + sqrt(b))
     condition: a, b exact inputs, a ~= b > 0
     ...

  2. Quadratic formula (unstable root)
     ...
```

Patterns: sqrt_diff, quadratic_unstable, log1p, expm1, half_angle, sin_diff, cos_ratio. Each with id, name, unstable/stable forms, condition, and explanation.

Data for Phase 4 (#669) AST matching.

Resolves #668

## Test plan

- [x] 7 patterns in database
- [x] Plain output with explanations
- [x] JSON validated with Python json.loads()
- [x] CSV and quiet modes
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `rewrites` command to display numerically stable mathematical rewrite patterns, supporting JSON, CSV, and plain text output formats.

* **Documentation**
  * Updated help documentation and tab-completion to include the new `rewrites` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->