### PR TITLE
feat(ucalc): dd/qd error-free transformation steps

### DIFF
--- a/tools/ucalc/steps_dd.hpp
+++ b/tools/ucalc/steps_dd.hpp
@@ -89,18 +89,18 @@ inline std::vector<StepDescription> explain_dd_add(double a_val, double b_val) {
 		steps.push_back(std::move(s));
 	}
 
-	// Step 4: Renormalize (fast_two_sum)
+	// Step 4: Renormalize (two_sum)
 	auto [r_hi, r_lo] = two_sum_eft(s_hi, e_total);
 	{
 		StepDescription s;
 		s.step_number = ++step;
-		s.label = "Renormalize with fast_two_sum";
+		s.label = "Renormalize with two_sum";
 		std::ostringstream detail;
 		detail << std::setprecision(17)
-		       << "fast_two_sum(" << s_hi << ", " << e_total << ")\n"
+		       << "two_sum(" << s_hi << ", " << e_total << ")\n"
 		       << "           result.hi = " << r_hi << "\n"
 		       << "           result.lo = " << r_lo << "\n"
-		       << "           (restores non-overlapping property: |lo| <= ulp(hi)/2)";
+		       << "           (restores non-overlapping property)";
 		s.detail = detail.str();
 		steps.push_back(std::move(s));
 	}
@@ -191,7 +191,7 @@ inline std::vector<StepDescription> explain_dd_mul(double a_val, double b_val) {
 	{
 		StepDescription s;
 		s.step_number = ++step;
-		s.label = "Renormalize with fast_two_sum";
+		s.label = "Renormalize with two_sum";
 		std::ostringstream detail;
 		detail << std::setprecision(17)
 		       << "result.hi = " << r_hi << "\n"

--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -1498,6 +1498,7 @@ static bool process_command(const std::string& input, ReplState& state) {
 					}
 					// Detect dd/qd/cascade types (multi-component)
 					else if (ops.type_tag.find("double-double") != std::string::npos ||
+					         ops.type_tag.find("triple-double") != std::string::npos ||
 					         ops.type_tag.find("quad-double") != std::string::npos ||
 					         ops.type_tag.find("_cascade") != std::string::npos) {
 						explanation = explain_dd(va, vb, t.operation);


### PR DESCRIPTION
## Summary

Implements #657 (Phase 6 of step-by-step arithmetic, parent #631).

Shows error-free transformations (`two_sum`, `two_prod`) for dd/qd/cascade types:

```
dd> steps 1.0 + 1e-16
  2. two_sum(a.hi, b.hi) -- error-free transformation
     two_sum(1, 9.99999999e-17)
     sum = 1
     err = 9.99999999e-17
     (sum + err = a.hi + b.hi EXACTLY -- no rounding loss!)
  3. Accumulate error terms
     e_total = 9.99999999e-17
  4. Renormalize with fast_two_sum
     result.hi = 1, result.lo = 9.99999999e-17
```

Students see how each operation captures its rounding error in a lower limb.

Resolves #657

## Test plan

- [x] dd add 1+1e-16: error preserved in lo limb
- [x] dd mul 3.14*2: two_prod via FMA
- [x] Other types unaffected
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REPL "steps" now provides step-by-step decomposition for double-double arithmetic (addition, subtraction, multiplication), showing intermediate terms, errors, carries and renormalization.
  * The tool applies this detailed breakdown for double-double and related multi-component types; if no DD-specific steps are produced, it falls back to the existing IEEE decomposition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->