### PR TITLE
feat(ucalc): MCP server mode for AI assistant integration

### DIFF
--- a/tools/ucalc/mcp_server.hpp
+++ b/tools/ucalc/mcp_server.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <iostream>
 #include <sstream>
+#include <cstdio>
 #include <map>
 
 namespace sw { namespace ucalc {
@@ -95,6 +96,29 @@ inline void write_message(const std::string& json) {
 	std::cout.flush();
 }
 
+// Escape a string for safe embedding in a JSON string literal
+inline std::string mcp_json_escape(const std::string& s) {
+	std::ostringstream ss;
+	for (char c : s) {
+		switch (c) {
+		case '"':  ss << "\\\""; break;
+		case '\\': ss << "\\\\"; break;
+		case '\n': ss << "\\n"; break;
+		case '\r': ss << "\\r"; break;
+		case '\t': ss << "\\t"; break;
+		default:
+			if (static_cast<unsigned char>(c) < 0x20) {
+				char buf[8];
+				std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned>(c));
+				ss << buf;
+			} else {
+				ss << c;
+			}
+		}
+	}
+	return ss.str();
+}
+
 // Build a JSON-RPC response
 inline std::string jsonrpc_result(const std::string& id_str, const std::string& result) {
 	return "{\"jsonrpc\":\"2.0\",\"id\":" + id_str + ",\"result\":" + result + "}";
@@ -103,7 +127,7 @@ inline std::string jsonrpc_result(const std::string& id_str, const std::string& 
 inline std::string jsonrpc_error(const std::string& id_str, int code, const std::string& message) {
 	return "{\"jsonrpc\":\"2.0\",\"id\":" + id_str
 	     + ",\"error\":{\"code\":" + std::to_string(code)
-	     + ",\"message\":\"" + message + "\"}}";
+	     + ",\"message\":\"" + mcp_json_escape(message) + "\"}}";
 }
 
 // Extract the id field (could be int or string)
@@ -185,12 +209,26 @@ inline std::string tools_list_json() {
 	return ss.str();
 }
 
+// Reject command-separator characters that could inject extra REPL commands
+inline bool contains_injection(const std::string& s) {
+	return s.find(';') != std::string::npos
+	    || s.find('\n') != std::string::npos
+	    || s.find('\r') != std::string::npos;
+}
+
 // Map an MCP tool call to a ucalc command string
+// Returns empty string on unknown tool or if arguments contain injection characters.
 inline std::string tool_to_command(const std::string& tool_name, const std::string& args_json) {
 	std::string type_arg = json_get_string(args_json, "type");
 	std::string expr = json_get_string(args_json, "expression");
 	std::string fmt = json_get_string(args_json, "format");
 	std::string data = json_get_string(args_json, "data");
+
+	// Block command injection via separator characters
+	if (contains_injection(type_arg) || contains_injection(expr)
+	    || contains_injection(fmt) || contains_injection(data)) {
+		return "";
+	}
 
 	std::string cmd;
 
@@ -223,30 +261,11 @@ inline std::string tool_to_command(const std::string& tool_name, const std::stri
 
 // Format a tool call result for MCP response
 inline std::string tool_result_json(const std::string& output, bool is_error = false) {
-	std::ostringstream ss;
-	ss << "{\"content\":[{\"type\":\"text\",\"text\":\"";
-	// Escape the output for JSON
-	for (char c : output) {
-		switch (c) {
-		case '"':  ss << "\\\""; break;
-		case '\\': ss << "\\\\"; break;
-		case '\n': ss << "\\n"; break;
-		case '\r': ss << "\\r"; break;
-		case '\t': ss << "\\t"; break;
-		default:
-			if (static_cast<unsigned char>(c) < 0x20) {
-				char buf[8];
-				std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned>(c));
-				ss << buf;
-			} else {
-				ss << c;
-			}
-		}
-	}
-	ss << "\"}]";
-	if (is_error) ss << ",\"isError\":true";
-	ss << "}";
-	return ss.str();
+	std::string result = "{\"content\":[{\"type\":\"text\",\"text\":\""
+	                   + mcp_json_escape(output) + "\"}]";
+	if (is_error) result += ",\"isError\":true";
+	result += "}";
+	return result;
 }
 
 }} // namespace sw::ucalc

--- a/tools/ucalc/ucalc.cpp
+++ b/tools/ucalc/ucalc.cpp
@@ -103,6 +103,7 @@
 
 #ifdef _WIN32
 #include <io.h>
+#include <fcntl.h>
 #define ISATTY _isatty
 #define FILENO _fileno
 #else
@@ -4489,6 +4490,10 @@ try {
 
 	// MCP server mode: ucalc --mcp
 	if (mcp_mode) {
+#ifdef _WIN32
+		_setmode(FILENO(stdin), _O_BINARY);
+		_setmode(FILENO(stdout), _O_BINARY);
+#endif
 		// Disable any buffering on stdout for MCP framing
 		std::setvbuf(stdout, nullptr, _IONBF, 0);
 
@@ -4524,6 +4529,7 @@ try {
 				// Execute the command and capture output
 				std::ostringstream capture;
 				auto old_buf = std::cout.rdbuf(capture.rdbuf());
+				state.last_error = EXIT_OK;
 				auto cmds = split_commands(cmd);
 				for (const auto& c : cmds) {
 					process_command(c, state);
@@ -4531,7 +4537,8 @@ try {
 				std::cout.rdbuf(old_buf);
 
 				std::string output = capture.str();
-				write_message(jsonrpc_result(id_str, tool_result_json(output)));
+				write_message(jsonrpc_result(id_str,
+					tool_result_json(output, state.last_error != EXIT_OK)));
 			}
 			else if (method.empty() && id_str != "null") {
 				// Response to a request we sent (shouldn't happen for server)


### PR DESCRIPTION
## Summary

Implements #638 (Tier 8.5, Phase 5 AI Integration).

**`ucalc --mcp`** starts ucalc as a Model Context Protocol server, exposing 17 tools that AI assistants can call directly over stdio.

**Zero external dependencies** -- 252 lines of native C++ implementing:
- Minimal JSON parser for fixed MCP message structure
- JSON-RPC 2.0 over stdio (Content-Length framing)
- MCP lifecycle: initialize, tools/list, tools/call
- Tool dispatch via existing `process_command()` with JSON capture

### Tools Exposed

eval, show, compare, types, precision, range, ulp, trace, cancel, audit, quantize, suggest, oracle, faithful, steps, heatmap, rewrites

### Usage

```bash
# Start as MCP server
ucalc --mcp

# Configure in Claude Code settings
{
  "mcpServers": {
    "ucalc": {
      "command": "/path/to/ucalc",
      "args": ["--mcp"]
    }
  }
}
```

Resolves #638

## Test plan

- [x] initialize: returns server info and capabilities
- [x] tools/list: returns 17 tools with input schemas
- [x] tools/call (eval): evaluates expression in specified type
- [x] tools/call (show): returns JSON decomposition
- [x] Unknown tool: returns JSON-RPC error
- [x] No external dependencies
- [x] 21/21 CTests pass on gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Model Context Protocol (MCP) server support via a new --mcp mode.
  * MCP mode exposes ucalc tools and handles invocations via JSON-RPC over stdin/stdout for integration with MCP-compatible apps.

* **Bug Fixes**
  * MCP mode now returns proper JSON-RPC errors for unknown methods or unknown tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->