### PR TITLE
feat(bisection): template AuxReal for high-precision interval bisection

### DIFF
--- a/include/sw/universal/number/bisection/attributes.hpp
+++ b/include/sw/universal/number/bisection/attributes.hpp
@@ -11,9 +11,9 @@
 
 namespace sw { namespace universal {
 
-template<typename G, typename R, unsigned nbits, typename bt>
-inline std::string bisection_range(const bisection<G, R, nbits, bt>&) {
-	using Bisection = bisection<G, R, nbits, bt>;
+template<typename G, typename R, unsigned nbits, typename bt, typename A>
+inline std::string bisection_range(const bisection<G, R, nbits, bt, A>&) {
+	using Bisection = bisection<G, R, nbits, bt, A>;
 	Bisection mn, mp;
 	mn.maxneg();
 	mp.maxpos();

--- a/include/sw/universal/number/bisection/bisection_fwd.hpp
+++ b/include/sw/universal/number/bisection/bisection_fwd.hpp
@@ -12,15 +12,21 @@ namespace sw { namespace universal {
 
 // Forward declaration of the bisection number type.
 //
-// Generator: callable with signature real g(real x) producing a bracketing sequence
-// Refinement: callable with signature real f(real a, real b) producing a bisection point
-// nbits: total number of bits (including sign)
-// bt: block storage type
-template<typename Generator, typename Refinement, unsigned nbits, typename bt = uint8_t>
+// Generator  : callable with signature R g(R x)     producing a bracketing sequence
+// Refinement : callable with signature R f(R a, R b) producing a bisection point
+// nbits      : total number of bits (including sign)
+// bt         : block storage type
+// AuxReal    : auxiliary real type used for the interval bisection arithmetic
+//              (default: double; use dd or qd for higher encoding accuracy
+//               at wider nbits -- see Lindstrom CoNGA'19 Section 4)
+template<typename Generator, typename Refinement,
+         unsigned nbits, typename bt = uint8_t,
+         typename AuxReal = double>
 class bisection;
 
-template<typename Generator, typename Refinement, unsigned nbits, typename bt>
-bisection<Generator, Refinement, nbits, bt>
-abs(const bisection<Generator, Refinement, nbits, bt>&);
+template<typename Generator, typename Refinement,
+         unsigned nbits, typename bt, typename AuxReal>
+bisection<Generator, Refinement, nbits, bt, AuxReal>
+abs(const bisection<Generator, Refinement, nbits, bt, AuxReal>&);
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/bisection/bisection_impl.hpp
+++ b/include/sw/universal/number/bisection/bisection_impl.hpp
@@ -24,7 +24,13 @@
 namespace sw { namespace universal {
 
 // sentinel for +/-infinity in bisection interval arithmetic
+// (legacy double-typed constant kept for backward source compatibility;
+//  the encode/decode pipeline now uses per-AuxReal infinity via numeric_limits)
 constexpr double bisection_inf = std::numeric_limits<double>::infinity();
+
+// Helper: +infinity in the auxiliary real type R.
+template<typename R>
+inline R bisection_aux_inf() { return std::numeric_limits<R>::infinity(); }
 
 // --------------------------------------------------------------------
 // Bisection encode: real -> p-bit two's complement integer
@@ -47,29 +53,31 @@ constexpr double bisection_inf = std::numeric_limits<double>::infinity();
 /// Compute the bisection point for interval [xl, xh] using the full
 /// set of bisection rules: bootstrapping, negation, reciprocation,
 /// bracketing (generator), and refinement.
-template<typename Generator, typename Refinement>
-inline double bisection_point(double xl, double xh, Generator g, Refinement f) {
+///
+/// R is the auxiliary real type: double, dd, or qd. All intermediate
+/// arithmetic runs in R so that encoding accuracy scales with the
+/// precision of the auxiliary type, not with double.
+template<typename R, typename Generator, typename Refinement>
+inline R bisection_point(const R& xl, const R& xh, Generator g, Refinement f) {
+	const R pinf = bisection_aux_inf<R>();
+	const R ninf = -pinf;
 	// Bootstrapping rules
-	if (xl == -bisection_inf && xh == bisection_inf) return 0.0;
-	if (xl == -bisection_inf && xh == 0.0)           return -1.0;
-	if (xl == 0.0 && xh == bisection_inf)             return 1.0;
+	if (xl == ninf && xh == pinf) return R(0);
+	if (xl == ninf && xh == R(0)) return R(-1);
+	if (xl == R(0) && xh == pinf) return R(1);
 
 	// Negation: f(a, b) = -f(-b, -a) for a < b < 0
-	if (xh < 0.0) {
-		return -bisection_point(-xh, -xl, g, f);
+	if (xh < R(0)) {
+		return -bisection_point<R>(-xh, -xl, g, f);
 	}
 
 	// Reciprocation: f(0, b) = [f(b^-1, +inf)]^-1
-	if (xl == 0.0) {
-		return 1.0 / bisection_point(1.0 / xh, bisection_inf, g, f);
+	if (xl == R(0)) {
+		return R(1) / bisection_point<R>(R(1) / xh, pinf, g, f);
 	}
 
-	// Negative side with xl < 0 < xh should not occur in a well-formed
-	// bisection (the interval is always on one side of zero after the
-	// first bisection step).
-
 	// Bracketing: [a_i, +inf) -> g(a_i)
-	if (xh == bisection_inf) {
+	if (xh == pinf) {
 		return g(xl);
 	}
 
@@ -77,19 +85,21 @@ inline double bisection_point(double xl, double xh, Generator g, Refinement f) {
 	return f(xl, xh);
 }
 
-template<typename Generator, typename Refinement>
-inline int64_t bisection_encode(double x, unsigned p, Generator g, Refinement f) {
-	if (std::isnan(x)) {
+template<typename R, typename Generator, typename Refinement>
+inline int64_t bisection_encode(const R& x, unsigned p, Generator g, Refinement f) {
+	using std::isnan;
+	if (isnan(x)) {
 		// NaN: all ones (two's complement -1 before sign flip = max negative)
 		return -(int64_t(1) << (p - 1));
 	}
 
-	double xl = -bisection_inf;
-	double xh = bisection_inf;
+	const R pinf = bisection_aux_inf<R>();
+	R xl = -pinf;
+	R xh =  pinf;
 	int64_t y = 0;
 
 	for (unsigned i = 0; i < p; ++i) {
-		double xm = bisection_point(xl, xh, g, f);
+		R xm = bisection_point<R>(xl, xh, g, f);
 
 		y <<= 1;
 		if (x >= xm) {
@@ -105,7 +115,7 @@ inline int64_t bisection_encode(double x, unsigned p, Generator g, Refinement f)
 	// no rounding needed. Otherwise, generate one more bisection
 	// step to determine which adjacent value x rounds to.
 	if (x != xl) {
-		double xm = bisection_point(xl, xh, g, f);
+		R xm = bisection_point<R>(xl, xh, g, f);
 
 		if (x >= xm) {
 			if (x == xm && (y & 1) == 0) {
@@ -135,24 +145,25 @@ inline int64_t bisection_encode(double x, unsigned p, Generator g, Refinement f)
 // Bisection decode: p-bit two's complement integer -> real
 // --------------------------------------------------------------------
 
-/// Decode a p-bit signed integer y back to a real number x.
-/// Reverses the encoding by reading bits MSB to LSB and narrowing
-/// the interval accordingly.
-template<typename Generator, typename Refinement>
-inline double bisection_decode(int64_t y, unsigned p, Generator g, Refinement f) {
+/// Decode a p-bit signed integer y back to a real number x in the
+/// auxiliary real type R. Reverses the encoding by reading bits MSB
+/// to LSB and narrowing the interval accordingly.
+template<typename R, typename Generator, typename Refinement>
+inline R bisection_decode(int64_t y, unsigned p, Generator g, Refinement f) {
 	// Undo two's complement sign flip
 	y ^= (int64_t(1) << (p - 1));
 
 	// NaN check: y == minimum signed value
 	if (y == -(int64_t(1) << (p - 1))) {
-		return std::numeric_limits<double>::quiet_NaN();
+		return std::numeric_limits<R>::quiet_NaN();
 	}
 
-	double xl = -bisection_inf;
-	double xh = bisection_inf;
+	const R pinf = bisection_aux_inf<R>();
+	R xl = -pinf;
+	R xh =  pinf;
 
 	for (unsigned i = 0; i < p; ++i) {
-		double xm = bisection_point(xl, xh, g, f);
+		R xm = bisection_point<R>(xl, xh, g, f);
 
 		// Read bit (MSB first)
 		int bit = (y >> (p - 1 - i)) & 1;
@@ -166,8 +177,8 @@ inline double bisection_decode(int64_t y, unsigned p, Generator g, Refinement f)
 
 	// Return the lower endpoint of the final interval.
 	// For +/-inf endpoints, return the finite one.
-	if (xl == -bisection_inf) return xh;
-	if (xh == bisection_inf) return xl;
+	if (xl == -pinf) return xh;
+	if (xh ==  pinf) return xl;
 	return xl;
 }
 
@@ -175,17 +186,24 @@ inline double bisection_decode(int64_t y, unsigned p, Generator g, Refinement f)
 // The bisection class
 // --------------------------------------------------------------------
 
-/// bisection<Generator, Refinement, nbits, bt>
+/// bisection<Generator, Refinement, nbits, bt, AuxReal>
 ///
 /// A number system defined by a generator (bracketing sequence) and
 /// a refinement (interval bisection) function. The encoding stores
 /// nbits of precision in a two's complement integer.
-template<typename Generator, typename Refinement, unsigned _nbits, typename bt>
+///
+/// AuxReal is the auxiliary real type used for the interval bisection
+/// arithmetic. The default (double) is correct for nbits up to ~50.
+/// For wider encodings (or whenever you need higher round-trip ULP
+/// accuracy) instantiate with sw::universal::dd (~31 digits) or
+/// sw::universal::qd (~63 digits).
+template<typename Generator, typename Refinement, unsigned _nbits, typename bt, typename AuxReal>
 class bisection {
 public:
 	static constexpr unsigned nbits = _nbits;
 	using BlockType = bt;
-	static_assert(nbits <= 64, "bisection currently supports up to 64 bits; wider types require blockbinary storage");
+	using aux_real_type = AuxReal;
+	static_assert(nbits <= 64, "bisection currently supports up to 64 bits; wider types require blockbinary storage (issue #687 follow-up)");
 	static_assert(nbits >= 2, "bisection requires at least 2 bits (sign + one value bit)");
 
 	// Trivially constructible: no in-class initializers
@@ -196,34 +214,39 @@ public:
 	bisection& operator=(const bisection&) = default;
 	bisection& operator=(bisection&&) = default;
 
-	// Constructors from native types
-	bisection(int v)                { *this = static_cast<double>(v); }
-	bisection(unsigned v)           { *this = static_cast<double>(v); }
-	bisection(long long v)          { *this = static_cast<double>(v); }
-	bisection(float v)              { *this = static_cast<double>(v); }
-	bisection(double v)             { *this = v; }
+	// Constructors from native types -- always go through AuxReal so
+	// the encoding accuracy reflects the chosen auxiliary precision.
+	bisection(int v)       { *this = AuxReal(v); }
+	bisection(unsigned v)  { *this = AuxReal(v); }
+	bisection(long long v) { *this = AuxReal(v); }
+	bisection(float v)     { *this = AuxReal(v); }
+	bisection(double v)    { *this = AuxReal(v); }
 
-	// Assignment from double: the core encode path
-	bisection& operator=(double rhs) {
-		if (std::isinf(rhs)) {
-			// +inf: max positive encoding; -inf: max negative encoding
-			if (rhs > 0) maxpos(); else maxneg();
-			return *this;
-		}
-		_bits = bisection_encode(rhs, nbits, Generator{}, Refinement{});
-		return *this;
-	}
-	bisection& operator=(int rhs) { return *this = static_cast<double>(rhs); }
-	bisection& operator=(unsigned rhs) { return *this = static_cast<double>(rhs); }
+	// Assignment from double is the canonical, always-present overload.
+	// It is wide enough for all native arithmetic types and avoids
+	// overload ambiguity with operator=(const AuxReal&) when AuxReal == double.
+	bisection& operator=(double rhs) { return assign_from_aux(AuxReal(rhs)); }
+	bisection& operator=(int rhs)       { return *this = static_cast<double>(rhs); }
+	bisection& operator=(unsigned rhs)  { return *this = static_cast<double>(rhs); }
 	bisection& operator=(long long rhs) { return *this = static_cast<double>(rhs); }
-	bisection& operator=(float rhs) { return *this = static_cast<double>(rhs); }
+	bisection& operator=(float rhs)     { return *this = static_cast<double>(rhs); }
+	// When AuxReal != double, also accept AuxReal directly so callers
+	// that have a high-precision input avoid the lossy double round-trip.
+	template<typename A = AuxReal,
+	         typename = std::enable_if_t<!std::is_same<A, double>::value>>
+	bisection& operator=(const AuxReal& rhs) { return assign_from_aux(rhs); }
 
-	// Conversion to double: the core decode path
+	// Canonical decode to double is always available so legacy callers
+	// (stream I/O, compare-with-double, math wrappers below) keep working.
 	explicit operator double() const {
-		return bisection_decode(_bits, nbits, Generator{}, Refinement{});
+		return static_cast<double>(decode_aux());
 	}
-	explicit operator float() const { return static_cast<float>(double(*this)); }
-	explicit operator long long() const { return static_cast<long long>(double(*this)); }
+	// When AuxReal != double, also expose the high-precision decode.
+	template<typename A = AuxReal,
+	         typename = std::enable_if_t<!std::is_same<A, double>::value>>
+	explicit operator AuxReal() const { return decode_aux(); }
+	explicit operator float() const { return static_cast<float>(static_cast<double>(*this)); }
+	explicit operator long long() const { return static_cast<long long>(static_cast<double>(*this)); }
 
 	// -- Arithmetic operators (decode-compute-encode) --------------
 
@@ -235,20 +258,16 @@ public:
 	}
 
 	bisection& operator+=(const bisection& rhs) {
-		double result = double(*this) + double(rhs);
-		return *this = result;
+		return assign_from_aux(decode_aux() + rhs.decode_aux());
 	}
 	bisection& operator-=(const bisection& rhs) {
-		double result = double(*this) - double(rhs);
-		return *this = result;
+		return assign_from_aux(decode_aux() - rhs.decode_aux());
 	}
 	bisection& operator*=(const bisection& rhs) {
-		double result = double(*this) * double(rhs);
-		return *this = result;
+		return assign_from_aux(decode_aux() * rhs.decode_aux());
 	}
 	bisection& operator/=(const bisection& rhs) {
-		double result = double(*this) / double(rhs);
-		return *this = result;
+		return assign_from_aux(decode_aux() / rhs.decode_aux());
 	}
 
 	// Prefix increment/decrement (move to next/prev representable value)
@@ -347,91 +366,110 @@ public:
 private:
 	int64_t _bits;
 
+	// Core decode in the auxiliary precision -- the single source of truth
+	// used by every public conversion and arithmetic operator.
+	AuxReal decode_aux() const {
+		return bisection_decode<AuxReal>(_bits, nbits, Generator{}, Refinement{});
+	}
+
+	// Core encode helper -- handles the inf saturation rule once.
+	bisection& assign_from_aux(const AuxReal& rhs) {
+		using std::isinf;
+		if (isinf(rhs)) {
+			if (rhs > AuxReal(0)) maxpos(); else maxneg();
+			return *this;
+		}
+		_bits = bisection_encode<AuxReal>(rhs, nbits, Generator{}, Refinement{});
+		return *this;
+	}
+
 	// Grant free functions access
-	template<typename G, typename R, unsigned n, typename b>
-	friend std::string to_binary(const bisection<G, R, n, b>&, bool);
+	template<typename G, typename R, unsigned n, typename b, typename A>
+	friend std::string to_binary(const bisection<G, R, n, b, A>&, bool);
 };
 
 // -- Free binary operators ----------------------------------------
 
-template<typename G, typename R, unsigned n, typename b>
-inline bisection<G, R, n, b> operator+(bisection<G, R, n, b> lhs, const bisection<G, R, n, b>& rhs) {
+template<typename G, typename R, unsigned n, typename b, typename A>
+inline bisection<G, R, n, b, A> operator+(bisection<G, R, n, b, A> lhs, const bisection<G, R, n, b, A>& rhs) {
 	return lhs += rhs;
 }
-template<typename G, typename R, unsigned n, typename b>
-inline bisection<G, R, n, b> operator-(bisection<G, R, n, b> lhs, const bisection<G, R, n, b>& rhs) {
+template<typename G, typename R, unsigned n, typename b, typename A>
+inline bisection<G, R, n, b, A> operator-(bisection<G, R, n, b, A> lhs, const bisection<G, R, n, b, A>& rhs) {
 	return lhs -= rhs;
 }
-template<typename G, typename R, unsigned n, typename b>
-inline bisection<G, R, n, b> operator*(bisection<G, R, n, b> lhs, const bisection<G, R, n, b>& rhs) {
+template<typename G, typename R, unsigned n, typename b, typename A>
+inline bisection<G, R, n, b, A> operator*(bisection<G, R, n, b, A> lhs, const bisection<G, R, n, b, A>& rhs) {
 	return lhs *= rhs;
 }
-template<typename G, typename R, unsigned n, typename b>
-inline bisection<G, R, n, b> operator/(bisection<G, R, n, b> lhs, const bisection<G, R, n, b>& rhs) {
+template<typename G, typename R, unsigned n, typename b, typename A>
+inline bisection<G, R, n, b, A> operator/(bisection<G, R, n, b, A> lhs, const bisection<G, R, n, b, A>& rhs) {
 	return lhs /= rhs;
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> abs(const bisection<G, R, n, b>& v) {
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> abs(const bisection<G, R, n, b, A>& v) {
 	return (v.sign()) ? -v : v;
 }
 
 // -- Math functions (decode-compute-encode via double) ---------------
+// These wrappers always go through double; they exist so that bisection
+// types satisfy the same generic-math API as the rest of Universal.
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> sqrt(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::sqrt(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> sqrt(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::sqrt(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> log(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::log(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> log(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::log(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> exp(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::exp(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> exp(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::exp(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> sin(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::sin(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> sin(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::sin(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> cos(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::cos(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> cos(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::cos(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> tan(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::tan(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> tan(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::tan(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> asin(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::asin(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> asin(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::asin(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> acos(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::acos(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> acos(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::acos(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> atan(const bisection<G, R, n, b>& v) {
-	return bisection<G, R, n, b>(std::atan(double(v)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> atan(const bisection<G, R, n, b, A>& v) {
+	return bisection<G, R, n, b, A>(std::atan(double(v)));
 }
 
-template<typename G, typename R, unsigned n, typename b>
-bisection<G, R, n, b> pow(const bisection<G, R, n, b>& base, const bisection<G, R, n, b>& exp) {
-	return bisection<G, R, n, b>(std::pow(double(base), double(exp)));
+template<typename G, typename R, unsigned n, typename b, typename A>
+bisection<G, R, n, b, A> pow(const bisection<G, R, n, b, A>& base, const bisection<G, R, n, b, A>& exp) {
+	return bisection<G, R, n, b, A>(std::pow(double(base), double(exp)));
 }
 
 // -- Stream I/O ---------------------------------------------------
 
-template<typename G, typename R, unsigned n, typename b>
-inline std::ostream& operator<<(std::ostream& ostr, const bisection<G, R, n, b>& v) {
+template<typename G, typename R, unsigned n, typename b, typename A>
+inline std::ostream& operator<<(std::ostream& ostr, const bisection<G, R, n, b, A>& v) {
 	double d = double(v);
 	return ostr << d;
 }

--- a/include/sw/universal/number/bisection/generators.hpp
+++ b/include/sw/universal/number/bisection/generators.hpp
@@ -5,6 +5,10 @@
 //   g(x): generator producing the bracketing sequence a_i = g^i(1)
 //   f(a, b): refinement bisecting a bounded interval
 //
+// All operator() are function templates parameterized on the real type R,
+// so the same functor can be used with double, dd, qd, or any type with
+// the usual math overloads (sqrt, log2, exp2, ldexp, pow, round).
+//
 // Reference: Lindstrom, "Universal Coding of the Reals using Bisection",
 //            CoNGA'19, Table 1.
 //
@@ -24,8 +28,9 @@ namespace sw { namespace universal {
 /// Used by Unary, Fibonacci, and as the fraction interpolator for
 /// IEEE-like and Posit-like representations.
 struct ArithmeticMean {
-	double operator()(double a, double b) const {
-		return (a + b) / 2.0;
+	template<typename R>
+	R operator()(const R& a, const R& b) const {
+		return (a + b) / R(2);
 	}
 };
 
@@ -33,8 +38,10 @@ struct ArithmeticMean {
 /// Used by LNS and FP representations. Natural refinement for
 /// logarithmic encodings.
 struct GeometricMean {
-	double operator()(double a, double b) const {
-		return std::sqrt(a * b);
+	template<typename R>
+	R operator()(const R& a, const R& b) const {
+		using std::sqrt;
+		return sqrt(a * b);
 	}
 };
 
@@ -42,16 +49,19 @@ struct GeometricMean {
 /// Uses arithmetic mean within a binade, geometric mean across binades.
 /// Used by Posits, Elias codes, and URR.
 struct HyperMean {
-	double operator()(double a, double b) const {
-		if (a <= 0.0 || b <= 0.0) return (a + b) / 2.0;
-		if (b <= 2.0 * a) {
+	template<typename R>
+	R operator()(const R& a, const R& b) const {
+		using std::log2;
+		using std::exp2;
+		if (a <= R(0) || b <= R(0)) return (a + b) / R(2);
+		if (b <= R(2) * a) {
 			// Within one binade: arithmetic mean
-			return (a + b) / 2.0;
+			return (a + b) / R(2);
 		}
 		// Across binades: geometric mean of exponents
-		double la = std::log2(a);
-		double lb = std::log2(b);
-		return std::exp2((la + lb) / 2.0);
+		R la = log2(a);
+		R lb = log2(b);
+		return exp2((la + lb) / R(2));
 	}
 };
 
@@ -60,19 +70,22 @@ struct HyperMean {
 /// Unary: g(x) = x + 1, sequence = 1, 2, 3, 4, ...
 /// Simplest possible generator. Linear bracketing.
 struct UnaryGenerator {
-	double operator()(double x) const { return x + 1.0; }
+	template<typename R>
+	R operator()(const R& x) const { return x + R(1); }
 };
 
 /// Elias gamma: g(x) = 2x, sequence = 1, 2, 4, 8, ...
 /// Exponential bracketing with base 2.
 struct EliasGammaGenerator {
-	double operator()(double x) const { return 2.0 * x; }
+	template<typename R>
+	R operator()(const R& x) const { return R(2) * x; }
 };
 
 /// Elias delta: g(x) = 2x^2, sequence = 1, 2, 8, 128, ...
 /// Super-exponential bracketing.
 struct EliasDeltaGenerator {
-	double operator()(double x) const { return 2.0 * x * x; }
+	template<typename R>
+	R operator()(const R& x) const { return R(2) * x * x; }
 };
 
 /// Posit(m): g(x) = b*x where b = 2^(2^m)
@@ -80,15 +93,21 @@ struct EliasDeltaGenerator {
 template<unsigned m = 0>
 struct PositGenerator {
 	static_assert(m <= 5, "PositGenerator<m>: 2^(2^m) overflows uint64_t for m > 5");
-	static constexpr double base = static_cast<double>(uint64_t(1) << (uint64_t(1) << m));
-	double operator()(double x) const { return base * x; }
+	static constexpr double base_d = static_cast<double>(uint64_t(1) << (uint64_t(1) << m));
+	template<typename R>
+	R operator()(const R& x) const { return R(base_d) * x; }
 };
 
 /// Fibonacci: g(x) = round(phi * x), sequence = 1, 2, 3, 5, 8, 13, ...
 struct FibonacciGenerator {
-	double operator()(double x) const {
-		static const double phi = (1.0 + std::sqrt(5.0)) / 2.0;
-		return std::round(phi * x);
+	template<typename R>
+	R operator()(const R& x) const {
+		using std::sqrt;
+		using std::round;
+		// Recompute phi in the target precision so dd/qd get the full
+		// precision of the golden ratio rather than a double-truncated value.
+		const R phi = (R(1) + sqrt(R(5))) / R(2);
+		return round(phi * x);
 	}
 };
 
@@ -96,17 +115,21 @@ struct FibonacciGenerator {
 /// The fastest-growing generator in the paper. Clamp output to avoid
 /// double overflow (2^(2^16) is far beyond double range).
 struct EliasOmegaGenerator {
-	double operator()(double x) const {
-		if (x > 1023.0) return std::numeric_limits<double>::max();
-		return std::exp2(x);
+	template<typename R>
+	R operator()(const R& x) const {
+		using std::exp2;
+		if (x > R(1023)) return R((std::numeric_limits<double>::max)());
+		return exp2(x);
 	}
 };
 
 /// Golden ratio: g(x) = phi * x, sequence = 1, phi, phi^2, phi^3, ...
 /// Represents integers as sums of Fibonacci numbers.
 struct GoldenRatioGenerator {
-	double operator()(double x) const {
-		static const double phi = (1.0 + std::sqrt(5.0)) / 2.0;
+	template<typename R>
+	R operator()(const R& x) const {
+		using std::sqrt;
+		const R phi = (R(1) + sqrt(R(5))) / R(2);
 		return phi * x;
 	}
 };
@@ -115,7 +138,8 @@ struct GoldenRatioGenerator {
 /// Hamada's representation. Uses squaring for super-exponential bracketing
 /// after the initial step.
 struct URRGenerator {
-	double operator()(double x) const { return (x < 2.0) ? 2.0 : x * x; }
+	template<typename R>
+	R operator()(const R& x) const { return (x < R(2)) ? R(2) : x * x; }
 };
 
 // FP(m) generator: the paper describes FP(m) with a non-standard
@@ -130,8 +154,12 @@ template<unsigned m = 3>
 struct LNSGenerator {
 	static_assert(m >= 1, "LNSGenerator<m>: m must be at least 1");
 	static_assert(m <= 6, "LNSGenerator<m>: 2^(2^(m-1)) overflows uint64_t for m > 6");
-	static constexpr double scale = static_cast<double>(uint64_t(1) << (uint64_t(1) << (m - 1)));
-	double operator()(double x) const { return scale * std::sqrt(x); }
+	static constexpr double scale_d = static_cast<double>(uint64_t(1) << (uint64_t(1) << (m - 1)));
+	template<typename R>
+	R operator()(const R& x) const {
+		using std::sqrt;
+		return R(scale_d) * sqrt(x);
+	}
 };
 
 /// Natural refinement: uses the Kolmogorov mean derived from the
@@ -144,73 +172,80 @@ struct LNSGenerator {
 /// For Posit(m), p = -2^(-m).
 template<unsigned m = 0>
 struct NaturalPositRefinement {
-	double operator()(double a, double b) const {
-		if (a <= 0.0 || b <= 0.0) return (a + b) / 2.0;
-		if (b <= 2.0 * a) {
+	template<typename R>
+	R operator()(const R& a, const R& b) const {
+		using std::log2;
+		using std::exp2;
+		using std::pow;
+		using std::ldexp;
+		if (a <= R(0) || b <= R(0)) return (a + b) / R(2);
+		if (b <= R(2) * a) {
 			// Within one binade: use the power mean with p = -2^(-m)
-			double p = -std::ldexp(1.0, -static_cast<int>(m));
-			double ap = std::pow(a, p);
-			double bp = std::pow(b, p);
-			return std::pow((ap + bp) / 2.0, 1.0 / p);
+			// ldexp may only be available for double in some toolchains;
+			// compute -2^(-m) as a double literal and lift to R.
+			const R p = R(-std::ldexp(1.0, -static_cast<int>(m)));
+			const R ap = pow(a, p);
+			const R bp = pow(b, p);
+			return pow((ap + bp) / R(2), R(1) / p);
 		}
 		// Across binades: geometric mean of exponents
-		double la = std::log2(a);
-		double lb = std::log2(b);
-		return std::exp2((la + lb) / 2.0);
+		const R la = log2(a);
+		const R lb = log2(b);
+		return exp2((la + lb) / R(2));
 	}
 };
 
 // -- Convenience type aliases -------------------------------------
 
 /// bisection_unary<nbits>: Unary coding with arithmetic mean refinement
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_unary = bisection<UnaryGenerator, ArithmeticMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_unary = bisection<UnaryGenerator, ArithmeticMean, nbits, bt, AuxReal>;
 
 /// bisection_elias_gamma<nbits>: Elias gamma with hyper mean refinement
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_elias_gamma = bisection<EliasGammaGenerator, HyperMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_elias_gamma = bisection<EliasGammaGenerator, HyperMean, nbits, bt, AuxReal>;
 
 /// bisection_elias_delta<nbits>: Elias delta with hyper mean refinement
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_elias_delta = bisection<EliasDeltaGenerator, HyperMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_elias_delta = bisection<EliasDeltaGenerator, HyperMean, nbits, bt, AuxReal>;
 
 /// bisection_posit<nbits, m>: Posit(m) with hyper mean refinement
-template<unsigned nbits, unsigned m = 0, typename bt = uint8_t>
-using bisection_posit = bisection<PositGenerator<m>, HyperMean, nbits, bt>;
+template<unsigned nbits, unsigned m = 0, typename bt = uint8_t, typename AuxReal = double>
+using bisection_posit = bisection<PositGenerator<m>, HyperMean, nbits, bt, AuxReal>;
 
 /// bisection_fibonacci<nbits>: Fibonacci coding with arithmetic mean refinement
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_fibonacci = bisection<FibonacciGenerator, ArithmeticMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_fibonacci = bisection<FibonacciGenerator, ArithmeticMean, nbits, bt, AuxReal>;
 
 /// bisection_lns<nbits>: LNS-like coding with geometric mean refinement
 /// (uses Elias gamma generator = base 2, like LNS with 1-bit exponent)
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_lns = bisection<EliasGammaGenerator, GeometricMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_lns = bisection<EliasGammaGenerator, GeometricMean, nbits, bt, AuxReal>;
 
 /// bisection_elias_omega<nbits>: Elias omega with hyper mean refinement
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_elias_omega = bisection<EliasOmegaGenerator, HyperMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_elias_omega = bisection<EliasOmegaGenerator, HyperMean, nbits, bt, AuxReal>;
 
 /// bisection_golden<nbits>: Golden ratio base with arithmetic mean.
 /// Note: the paper's natural refinement for golden ratio is a power mean
 /// with p = -1/log2(phi) ~= -1.44. ArithmeticMean is used here as a
 /// working default; a dedicated GoldenRatioPowerMean refinement can be
 /// added when the natural refinement framework is generalized.
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_golden = bisection<GoldenRatioGenerator, ArithmeticMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_golden = bisection<GoldenRatioGenerator, ArithmeticMean, nbits, bt, AuxReal>;
 
 /// bisection_urr<nbits>: Hamada's URR with hyper mean
-template<unsigned nbits, typename bt = uint8_t>
-using bisection_urr = bisection<URRGenerator, HyperMean, nbits, bt>;
+template<unsigned nbits, typename bt = uint8_t, typename AuxReal = double>
+using bisection_urr = bisection<URRGenerator, HyperMean, nbits, bt, AuxReal>;
 
 // bisection_fp: deferred (see FP(m) comment above)
 
 /// bisection_lns_m<nbits, m>: LNS(m) with geometric mean refinement
-template<unsigned nbits, unsigned m = 3, typename bt = uint8_t>
-using bisection_lns_m = bisection<LNSGenerator<m>, GeometricMean, nbits, bt>;
+template<unsigned nbits, unsigned m = 3, typename bt = uint8_t, typename AuxReal = double>
+using bisection_lns_m = bisection<LNSGenerator<m>, GeometricMean, nbits, bt, AuxReal>;
 
 /// bisection_natposit<nbits, m>: NaturalPosit with smooth density
-template<unsigned nbits, unsigned m = 0, typename bt = uint8_t>
-using bisection_natposit = bisection<PositGenerator<m>, NaturalPositRefinement<m>, nbits, bt>;
+template<unsigned nbits, unsigned m = 0, typename bt = uint8_t, typename AuxReal = double>
+using bisection_natposit = bisection<PositGenerator<m>, NaturalPositRefinement<m>, nbits, bt, AuxReal>;
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/bisection/manipulators.hpp
+++ b/include/sw/universal/number/bisection/manipulators.hpp
@@ -10,8 +10,8 @@
 
 namespace sw { namespace universal {
 
-template<typename G, typename R, unsigned nbits, typename bt>
-inline std::string to_binary(const bisection<G, R, nbits, bt>& v, bool nibbleMarker = true) {
+template<typename G, typename R, unsigned nbits, typename bt, typename A>
+inline std::string to_binary(const bisection<G, R, nbits, bt, A>& v, bool nibbleMarker = true) {
 	uint64_t bits = v.getbits();
 	std::string s = "0b";
 	for (int i = static_cast<int>(nbits) - 1; i >= 0; --i) {
@@ -21,20 +21,20 @@ inline std::string to_binary(const bisection<G, R, nbits, bt>& v, bool nibbleMar
 	return s;
 }
 
-template<typename G, typename R, unsigned nbits, typename bt>
-inline std::string type_tag(const bisection<G, R, nbits, bt>&) {
+template<typename G, typename R, unsigned nbits, typename bt, typename A>
+inline std::string type_tag(const bisection<G, R, nbits, bt, A>&) {
 	std::ostringstream ss;
 	ss << "bisection<" << nbits << ">";
 	return ss.str();
 }
 
-template<typename G, typename R, unsigned nbits, typename bt>
-inline std::string color_print(const bisection<G, R, nbits, bt>& v) {
+template<typename G, typename R, unsigned nbits, typename bt, typename A>
+inline std::string color_print(const bisection<G, R, nbits, bt, A>& v) {
 	return to_binary(v, true);
 }
 
-template<typename G, typename R, unsigned nbits, typename bt>
-inline std::string components(const bisection<G, R, nbits, bt>& v) {
+template<typename G, typename R, unsigned nbits, typename bt, typename A>
+inline std::string components(const bisection<G, R, nbits, bt, A>& v) {
 	std::ostringstream ss;
 	if (v.isnan()) {
 		ss << "NaN";

--- a/include/sw/universal/number/bisection/numeric_limits.hpp
+++ b/include/sw/universal/number/bisection/numeric_limits.hpp
@@ -8,10 +8,10 @@
 
 namespace std {
 
-template<typename Generator, typename Refinement, unsigned nbits, typename bt>
-class numeric_limits<sw::universal::bisection<Generator, Refinement, nbits, bt>> {
+template<typename Generator, typename Refinement, unsigned nbits, typename bt, typename AuxReal>
+class numeric_limits<sw::universal::bisection<Generator, Refinement, nbits, bt, AuxReal>> {
 public:
-	using Bisection = sw::universal::bisection<Generator, Refinement, nbits, bt>;
+	using Bisection = sw::universal::bisection<Generator, Refinement, nbits, bt, AuxReal>;
 
 	static constexpr bool is_specialized = true;
 

--- a/static/bisection/CMakeLists.txt
+++ b/static/bisection/CMakeLists.txt
@@ -1,3 +1,5 @@
-file (GLOB API_SRC       "api/*.cpp")
+file (GLOB API_SRC         "api/*.cpp")
+file (GLOB CONVERSION_SRC  "conversion/*.cpp")
 
 compile_all("true" "bisection" "Number Systems/static/bisection/api" "${API_SRC}")
+compile_all("true" "bisection" "Number Systems/static/bisection/conversion" "${CONVERSION_SRC}")

--- a/static/bisection/conversion/aux_real.cpp
+++ b/static/bisection/conversion/aux_real.cpp
@@ -106,8 +106,9 @@ int monotonic(const std::string& label) {
 template<typename Tdouble, typename Tdd>
 void report_precision_delta(const std::string& label) {
 	static_assert(Tdouble::nbits == Tdd::nbits, "same nbits required");
-	// Encode 1/7 through each pipeline: an irrational fraction that
-	// the bisection search cannot land exactly even at 32 bits.
+	// Encode 1/7 through each pipeline: a rational number that produces
+	// a non-terminating binary fraction, so the bisection search cannot
+	// land on it exactly even at 32 bits.
 	const double x = 1.0 / 7.0;
 	Tdouble a_double(x);
 	Tdd     a_dd(x);

--- a/static/bisection/conversion/aux_real.cpp
+++ b/static/bisection/conversion/aux_real.cpp
@@ -1,0 +1,158 @@
+// aux_real.cpp: verify the AuxReal template parameter of bisection<>
+//
+// bisection<Generator, Refinement, nbits, bt, AuxReal = double>
+//
+// When AuxReal is dd (double-double) instead of double, the interval
+// bisection pipeline runs with ~31 decimal digits of precision, so
+// round-trip accuracy for wider encodings (nbits > 50) stops being
+// limited by double. This test drives the dd- and qd-backed code paths
+// to make sure they compile, encode/decode, monotonically order, and
+// saturate at the interval endpoints correctly.
+//
+// Issue #692 (Epic #687).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project.
+
+#define BISECTION_THROW_ARITHMETIC_EXCEPTION 0
+#define DD_THROW_ARITHMETIC_EXCEPTION 0
+#define QD_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <string>
+
+#include <universal/number/dd/dd.hpp>
+#include <universal/number/qd/qd.hpp>
+#include <universal/number/bisection/bisection.hpp>
+
+namespace {
+
+using sw::universal::bisection_posit;
+using sw::universal::bisection_natposit;
+using sw::universal::dd;
+using sw::universal::qd;
+
+/// Walk all 2^nbits encodings of T. For each non-NaN encoding, decode,
+/// re-encode, and verify the round-trip reproduces the bit pattern.
+template<typename T>
+int round_trip(const std::string& label) {
+	constexpr unsigned p = T::nbits;
+	const int64_t N = int64_t(1) << p;
+	int failures = 0;
+	for (int64_t i = 0; i < N; ++i) {
+		T a;
+		a.setbits(static_cast<uint64_t>(i));
+		if (a.isnan()) continue;
+		double d = double(a);
+		T b(d);
+		if (a != b) {
+			++failures;
+			if (failures <= 5) {
+				std::cerr << "  FAIL " << label
+				          << " enc=" << i
+				          << " decoded=" << std::setprecision(17) << d
+				          << " re-encoded=" << to_binary(b)
+				          << " expected=" << to_binary(a) << "\n";
+			}
+		}
+	}
+	std::cout << "  " << std::left << std::setw(44) << label
+	          << "round-trip " << (failures == 0 ? "PASS" : "FAIL")
+	          << " (" << failures << ")\n";
+	return failures;
+}
+
+/// Verify the decoded sequence is monotonic non-decreasing when we walk
+/// the signed two's-complement encoding order. This is what the paper
+/// calls the "monotone encoding" property -- it must hold regardless of
+/// which AuxReal backs the pipeline.
+template<typename T>
+int monotonic(const std::string& label) {
+	constexpr unsigned p = T::nbits;
+	const int64_t N = int64_t(1) << p;
+	int failures = 0;
+	double prev = -std::numeric_limits<double>::infinity();
+	// Iterate in signed order: start at maxneg (+1 past NaN) and walk up.
+	for (int64_t i = 1; i < N; ++i) {
+		// Map loop index to signed encoding via two's-complement shift.
+		int64_t signed_idx = i - (int64_t(1) << (p - 1));
+		T a;
+		a.setbits(static_cast<uint64_t>(signed_idx));
+		if (a.isnan()) continue;
+		double d = double(a);
+		if (d < prev) {
+			++failures;
+			if (failures <= 5) {
+				std::cerr << "  FAIL " << label
+				          << " monotonic break at enc=" << signed_idx
+				          << " prev=" << prev << " cur=" << d << "\n";
+			}
+		}
+		prev = d;
+	}
+	std::cout << "  " << std::left << std::setw(44) << label
+	          << "monotonic  " << (failures == 0 ? "PASS" : "FAIL")
+	          << " (" << failures << ")\n";
+	return failures;
+}
+
+/// Demonstrate that dd-backed decoding carries visibly more precision
+/// than double-backed decoding at the same encoding. We pick an
+/// encoding that does not land on a dyadic rational so the difference
+/// in the tail bits is observable. Informational, not a pass/fail gate.
+template<typename Tdouble, typename Tdd>
+void report_precision_delta(const std::string& label) {
+	static_assert(Tdouble::nbits == Tdd::nbits, "same nbits required");
+	// Encode 1/7 through each pipeline: an irrational fraction that
+	// the bisection search cannot land exactly even at 32 bits.
+	const double x = 1.0 / 7.0;
+	Tdouble a_double(x);
+	Tdd     a_dd(x);
+	double  d_double = double(a_double);
+	dd      d_dd     = static_cast<dd>(a_dd);
+	std::cout << "  " << label
+	          << "  double path: " << std::setprecision(17) << d_double
+	          << "\n  " << std::string(label.size(), ' ')
+	          << "  dd    path: " << std::setprecision(33) << d_dd << "\n";
+}
+
+} // anonymous namespace
+
+int main() {
+	using namespace sw::universal;
+	int failures = 0;
+
+	std::cout << "bisection<> AuxReal parameterization tests\n";
+	std::cout << "-------------------------------------------\n";
+
+	// 8-bit exhaustive (fast): same encoding, different AuxReal.
+	std::cout << "\n[8-bit exhaustive]\n";
+	failures += round_trip<bisection_posit<8, 0, uint8_t, double>>("bisection_posit<8,0,uint8_t,double>");
+	failures += round_trip<bisection_posit<8, 0, uint8_t, dd>>    ("bisection_posit<8,0,uint8_t,dd>    ");
+	failures += round_trip<bisection_posit<8, 0, uint8_t, qd>>    ("bisection_posit<8,0,uint8_t,qd>    ");
+	failures += monotonic <bisection_posit<8, 0, uint8_t, double>>("bisection_posit<8,0,uint8_t,double>");
+	failures += monotonic <bisection_posit<8, 0, uint8_t, dd>>    ("bisection_posit<8,0,uint8_t,dd>    ");
+
+	// 16-bit exhaustive -- covers the "useful precision" band where
+	// AuxReal=double is still sufficient but the dd path should agree.
+	std::cout << "\n[16-bit exhaustive]\n";
+	failures += round_trip<bisection_posit<16, 0, uint8_t, double>>("bisection_posit<16,0,uint8_t,double>");
+	failures += round_trip<bisection_posit<16, 0, uint8_t, dd>>    ("bisection_posit<16,0,uint8_t,dd>    ");
+	failures += monotonic <bisection_posit<16, 0, uint8_t, dd>>    ("bisection_posit<16,0,uint8_t,dd>    ");
+	failures += round_trip<bisection_natposit<16, 0, uint8_t, dd>> ("bisection_natposit<16,0,uint8_t,dd> ");
+
+	// Informational: show the dd path decodes to extra precision.
+	std::cout << "\n[precision reporting]\n";
+	report_precision_delta<
+		bisection_posit<32, 0, uint8_t, double>,
+		bisection_posit<32, 0, uint8_t, dd>>("posit32 encoding of 1/7");
+
+	std::cout << "\n-------------------------------------------\n";
+	std::cout << "bisection AuxReal tests: "
+	          << (failures == 0 ? "PASS" : "FAIL")
+	          << " (" << failures << " failures)\n";
+	return failures == 0 ? 0 : 1;
+}

--- a/tools/bisection/bisection.cpp
+++ b/tools/bisection/bisection.cpp
@@ -114,6 +114,16 @@ inline TypeRegistry build_bisection_registry() {
 	reg.add("bisection_posit16",
 		make_entry<bisection_posit<16>>("bisection_posit16", "Posit(0) generator, HyperMean"));
 
+	// High-precision AuxReal variants (issue #692): the interval bisection
+	// arithmetic runs in dd (~31 digits) instead of double, giving tighter
+	// round-trip encoding accuracy for wider nbits.
+	reg.add("bisection_posit16_dd",
+		make_entry<bisection_posit<16, 0, uint8_t, dd>>("bisection_posit16_dd", "Posit(0), HyperMean, dd AuxReal"));
+	reg.add("bisection_posit32_dd",
+		make_entry<bisection_posit<32, 0, uint8_t, dd>>("bisection_posit32_dd", "Posit(0), HyperMean, dd AuxReal"));
+	reg.add("bisection_natposit16_dd",
+		make_entry<bisection_natposit<16, 0, uint8_t, dd>>("bisection_natposit16_dd", "Posit(0), NaturalPosit, dd AuxReal"));
+
 	reg.add("bisection_natposit8",
 		make_entry<bisection_natposit<8>>("bisection_natposit8", "Posit(0), NaturalPosit refinement"));
 	reg.add("bisection_natposit16",


### PR DESCRIPTION
## Summary
- Adds a 5th template parameter \`AuxReal\` (default \`double\`) to \`bisection<G, R, nbits, bt, AuxReal>\` so the entire encode/decode pipeline can run in \`dd\` (~31 digits) or \`qd\` (~63 digits) instead of \`double\`.
- Generators and refinements become function templates, using ADL-qualified math calls so \`dd\`/\`qd\` overloads are found automatically.
- Storage stays \`int64_t\` (\`nbits <= 64\`). Promoting to \`blockbinary\` for wider types is a follow-up issue under Epic #687.

## Changes
| File | What changed |
|------|--------------|
| \`bisection_fwd.hpp\` | 5th template parameter \`AuxReal = double\` |
| \`bisection_impl.hpp\` | \`bisection_point/encode/decode\` templatized on \`<R>\`; class gains \`decode_aux()\`/\`assign_from_aux()\` helpers; arithmetic routes through AuxReal |
| \`generators.hpp\` | All generator/refinement \`operator()\` become function templates |
| \`numeric_limits.hpp\`, \`manipulators.hpp\`, \`attributes.hpp\` | Thread AuxReal through template signatures |
| \`static/bisection/conversion/aux_real.cpp\` | New test: dd- and qd-backed round-trip and monotonicity at 8/16 bits |
| \`static/bisection/CMakeLists.txt\` | Wire conversion tests |
| \`tools/bisection/bisection.cpp\` | Register \`bisection_posit{16,32}_dd\` and \`bisection_natposit16_dd\` in REPL |

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| \`bisection_api\` | OK | PASS | OK | PASS |
| \`bisection_aux_real\` | OK | PASS (0 failures) | OK | PASS (0 failures) |
| \`bisection\` (REPL) | OK | smoke PASS | OK | smoke PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready\`

Resolves #692
Relates to #687

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bisection numbers now support an auxiliary real precision parameter (e.g., double-double, quad-double) for higher-precision computations and conversions.
  * REPL/tooling gained new double-double precision variants for posit and natural-posit bisection types.

* **Tests**
  * Added exhaustive round-trip encoding/decoding and monotonicity tests across multiple auxiliary precisions.

* **Chores**
  * Build targets updated to include auxiliary-precision conversion tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->