### PR TITLE
feat(posit): enable constexpr integer construction (Phase 1 of #713)

### DIFF
--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -90,7 +90,7 @@ constexpr unsigned ES_IS_5 = 5;
 // and thus is too coarse to make this decision.
 // Using the scale directly is the simplest expression of the inward projection test.
 template<unsigned nbits, unsigned es, typename bt>
-bool check_inward_projection_range(int scale) {
+constexpr bool check_inward_projection_range(int scale) {
 	// calculate the min/max k factor for this posit config
 	int posit_size = nbits;
 	int k = scale < 0 ? -(posit_size - 2) : (posit_size - 2);
@@ -574,20 +574,19 @@ public:
 	CONSTEXPRESSION posit(double initial_value)       noexcept : _block{ 0 } { *this = initial_value; }
 
 	// assignment operators for native types
-	// Route integer assignments through convert_ieee754 via double cast.
-	// The blocktriple path has a known issue where round() shifts the hidden
-	// bit below the radix position, causing convert(blocktriple, posit) to
-	// misread it as a fraction bit, producing off-by-one rounding errors.
-	constexpr posit& operator=(signed char rhs)        noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(short rhs)              noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(int rhs)                noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(long rhs)               noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(long long rhs)          noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(char rhs)               noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(unsigned short rhs)     noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(unsigned int rhs)       noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(unsigned long rhs)      noexcept { return convert_ieee754(static_cast<double>(rhs)); }
-	constexpr posit& operator=(unsigned long long rhs) noexcept { return convert_ieee754(static_cast<double>(rhs)); }
+	// Integer assignments route through convert_signed_integer / convert_unsigned_integer,
+	// which are constexpr for nbits <= 64. The previous double-cast route through
+	// convert_ieee754 was not actually constexpr because std::frexp is not constexpr.
+	constexpr posit& operator=(signed char rhs)        noexcept { return convert_signed_integer(rhs); }
+	constexpr posit& operator=(short rhs)              noexcept { return convert_signed_integer(rhs); }
+	constexpr posit& operator=(int rhs)                noexcept { return convert_signed_integer(rhs); }
+	constexpr posit& operator=(long rhs)               noexcept { return convert_signed_integer(rhs); }
+	constexpr posit& operator=(long long rhs)          noexcept { return convert_signed_integer(rhs); }
+	constexpr posit& operator=(char rhs)               noexcept { return convert_unsigned_integer(static_cast<unsigned char>(rhs)); }
+	constexpr posit& operator=(unsigned short rhs)     noexcept { return convert_unsigned_integer(rhs); }
+	constexpr posit& operator=(unsigned int rhs)       noexcept { return convert_unsigned_integer(rhs); }
+	constexpr posit& operator=(unsigned long rhs)      noexcept { return convert_unsigned_integer(rhs); }
+	constexpr posit& operator=(unsigned long long rhs) noexcept { return convert_unsigned_integer(rhs); }
 	CONSTEXPRESSION posit& operator=(float rhs) noexcept { return convert_ieee754(rhs); }
 	CONSTEXPRESSION posit& operator=(double rhs) noexcept { return convert_ieee754(rhs); }
 
@@ -1202,6 +1201,142 @@ private:
 		return s * r * e * f;
 	}
 	
+	// Encode a positive integer magnitude into the posit bit pattern as a uint64_t,
+	// returning a saturation flag in `saturated` (true means we hit maxpos and the caller
+	// should not apply rounding twice). All work is on uint64_t, so this is constexpr-clean
+	// for nbits <= 64.
+	static constexpr uint64_t encode_positive_uint64(uint64_t v, bool& saturated) noexcept {
+		saturated = false;
+		if (v == 0ull) return 0ull;
+
+		int scale = static_cast<int>(find_msb(v)) - 1;
+
+		if (check_inward_projection_range<nbits, es, bt>(scale)) {
+			saturated = true;
+			// maxpos encoding: 0 sign + (nbits-1) ones
+			constexpr unsigned tw = nbits - 1u;
+			return (tw >= 64u) ? ~0ull : ((1ull << tw) - 1ull);
+		}
+
+		constexpr unsigned target_width = nbits - 1u; // payload width (excludes sign)
+		int k = scale >> es;
+		uint64_t exp_field = static_cast<uint64_t>(scale & static_cast<int>((1u << es) - 1u));
+
+		// Encoding layout (msb-first within target_width payload bits):
+		//   [k+1 ones] [0 terminator] [es exp bits] [scale fraction bits]
+		unsigned regime_ones = static_cast<unsigned>(k + 1);
+		unsigned ones_to_place = (regime_ones < target_width) ? regime_ones : target_width;
+
+		uint64_t encoded = ((1ull << ones_to_place) - 1ull) << (target_width - ones_to_place);
+
+		if (ones_to_place < target_width) {
+			// Terminator zero is implicitly present at position (target_width - ones_to_place - 1)
+			unsigned bits_after_regime = target_width - ones_to_place - 1u; // -1 for terminator
+			unsigned exp_bits_to_place = (es < bits_after_regime) ? static_cast<unsigned>(es) : bits_after_regime;
+			if (exp_bits_to_place > 0u) {
+				uint64_t exp_top = (es > exp_bits_to_place) ? (exp_field >> (es - exp_bits_to_place)) : exp_field;
+				encoded |= exp_top << (bits_after_regime - exp_bits_to_place);
+			}
+
+			unsigned bits_after_exp = bits_after_regime - exp_bits_to_place;
+			unsigned scale_u = static_cast<unsigned>(scale);
+			unsigned frac_to_embed = (scale_u < bits_after_exp) ? scale_u : bits_after_exp;
+			if (frac_to_embed > 0u) {
+				uint64_t frac_value = (v >> (scale_u - frac_to_embed)) & ((1ull << frac_to_embed) - 1ull);
+				// Fraction is MSB-aligned within its field; pad LSBs with zeros if scale < bits_after_exp
+				encoded |= frac_value << (bits_after_exp - frac_to_embed);
+			}
+
+			// Round-to-nearest-even on the bits we discarded.
+			// Discarded sequence (msb-first):
+			//   low (es - exp_bits_to_place) bits of exp_field, then low (scale - frac_to_embed) bits of v
+			bool round_bit = false;
+			bool sticky_bit = false;
+
+			unsigned discarded_exp = static_cast<unsigned>(es) - exp_bits_to_place;
+			unsigned discarded_frac = scale_u - frac_to_embed;
+
+			if (discarded_exp > 0u) {
+				round_bit = ((exp_field >> (discarded_exp - 1u)) & 1ull) != 0ull;
+				if (discarded_exp > 1u) {
+					uint64_t low_exp_mask = (1ull << (discarded_exp - 1u)) - 1ull;
+					if ((exp_field & low_exp_mask) != 0ull) sticky_bit = true;
+				}
+				if (scale_u > 0u) {
+					uint64_t frac_mask = (scale_u >= 64u) ? ~0ull : ((1ull << scale_u) - 1ull);
+					if ((v & frac_mask) != 0ull) sticky_bit = true;
+				}
+			}
+			else if (discarded_frac > 0u) {
+				round_bit = ((v >> (discarded_frac - 1u)) & 1ull) != 0ull;
+				if (discarded_frac > 1u) {
+					uint64_t low_frac_mask = (1ull << (discarded_frac - 1u)) - 1ull;
+					if ((v & low_frac_mask) != 0ull) sticky_bit = true;
+				}
+			}
+
+			bool last_bit = (encoded & 1ull) != 0ull;
+			if (round_bit && (sticky_bit || last_bit)) {
+				++encoded;
+				// Rounding could have overflowed past target_width into the sign bit.
+				// In that case the integer rounded up to maxpos's neighbor; saturate.
+				if ((encoded >> target_width) != 0ull) {
+					saturated = true;
+					return (target_width >= 64u) ? ~0ull : ((1ull << target_width) - 1ull);
+				}
+			}
+		}
+		return encoded;
+	}
+
+	// Constexpr integer-to-posit conversion for nbits <= 64.
+	// Builds the posit encoding directly via uint64_t shift/mask, bypassing convert_<>()
+	// (which is not constexpr because it relies on non-constexpr blockbinary operators).
+	// For nbits > 64, the existing IEEE-754 path is used at runtime.
+	template<typename Ty>
+	constexpr posit<nbits, es, bt>& convert_unsigned_integer(Ty rhs) noexcept {
+		clear();
+		if (rhs == Ty(0)) return *this;
+
+		if constexpr (nbits > 64) {
+			return convert_ieee754(static_cast<double>(rhs));
+		}
+		else {
+			bool saturated = false;
+			uint64_t encoded = encode_positive_uint64(static_cast<uint64_t>(rhs), saturated);
+			setbits(encoded);
+			return *this;
+		}
+	}
+
+	template<typename Ty>
+	constexpr posit<nbits, es, bt>& convert_signed_integer(Ty rhs) noexcept {
+		clear();
+		if (rhs == Ty(0)) return *this;
+
+		if constexpr (nbits > 64) {
+			return convert_ieee754(static_cast<double>(rhs));
+		}
+		else {
+			bool s = (rhs < Ty(0));
+			using UnsignedTy = std::make_unsigned_t<Ty>;
+			UnsignedTy abs_v = s
+				? static_cast<UnsignedTy>(UnsignedTy(0) - static_cast<UnsignedTy>(rhs))
+				: static_cast<UnsignedTy>(rhs);
+
+			bool saturated = false;
+			uint64_t encoded = encode_positive_uint64(static_cast<uint64_t>(abs_v), saturated);
+			if (s) {
+				// Posit negation = two's complement on the full nbits encoding.
+				// Done in uint64_t to avoid the non-constexpr blockbinary::operator+= chain.
+				constexpr uint64_t nbits_mask = (nbits >= 64u) ? ~uint64_t(0) : ((uint64_t(1) << nbits) - 1ull);
+				encoded = (~encoded + 1ull) & nbits_mask;
+			}
+			setbits(encoded);
+			return *this;
+		}
+	}
+
 	template <typename Real>
 	CONSTEXPRESSION posit<nbits, es, bt>& convert_ieee754(const Real& rhs) noexcept {
 		// Direct IEEE-754 to posit conversion using frexp to extract scale and fraction.

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -582,7 +582,17 @@ public:
 	constexpr posit& operator=(int rhs)                noexcept { return convert_signed_integer(rhs); }
 	constexpr posit& operator=(long rhs)               noexcept { return convert_signed_integer(rhs); }
 	constexpr posit& operator=(long long rhs)          noexcept { return convert_signed_integer(rhs); }
-	constexpr posit& operator=(char rhs)               noexcept { return convert_unsigned_integer(static_cast<unsigned char>(rhs)); }
+	constexpr posit& operator=(char rhs)               noexcept {
+		// Plain char is implementation-defined as either signed or unsigned;
+		// dispatch to the matching conversion so negative values on signed-char
+		// platforms (the common case) sign-extend correctly.
+		if constexpr (std::is_signed_v<char>) {
+			return convert_signed_integer(rhs);
+		}
+		else {
+			return convert_unsigned_integer(static_cast<unsigned char>(rhs));
+		}
+	}
 	constexpr posit& operator=(unsigned short rhs)     noexcept { return convert_unsigned_integer(rhs); }
 	constexpr posit& operator=(unsigned int rhs)       noexcept { return convert_unsigned_integer(rhs); }
 	constexpr posit& operator=(unsigned long rhs)      noexcept { return convert_unsigned_integer(rhs); }

--- a/static/tapered/posit/api/api.cpp
+++ b/static/tapered/posit/api/api.cpp
@@ -40,6 +40,56 @@ try {
 	/////////////////////////////////////////////////////////////////////////////////////
 	//// posit construction, initialization, assignment and comparisions
 
+	std::cout << "+-----------------   constexpr integer construction (issue #713)\n";
+	{
+		// constexpr construction from integer literals must succeed at compile time
+		// for nbits <= 64. The encoded bit pattern must match the runtime path exactly.
+		constexpr posit<32, 2>  cx_pos_42(42);
+		constexpr posit<32, 2>  cx_neg_42(-42);
+		constexpr posit<32, 2>  cx_zero(0);
+		constexpr posit<8,  0>  cx_three(3);
+		constexpr posit<16, 1>  cx_kilo(1024);
+		constexpr posit<64, 3>  cx_big(123456789LL);
+		constexpr posit<8,  0>  cx_sat_pos(1000);   // saturates to maxpos
+		constexpr posit<8,  0>  cx_sat_neg(-1000);  // saturates to maxneg
+		constexpr posit<32, 2>  cx_int_min(int32_t(-2147483647 - 1));
+
+		// runtime construction for cross-check
+		posit<32, 2>  rt_pos_42; rt_pos_42 = 42;
+		posit<32, 2>  rt_neg_42; rt_neg_42 = -42;
+		posit<32, 2>  rt_zero;   rt_zero   = 0;
+		posit<8,  0>  rt_three;  rt_three  = 3;
+		posit<16, 1>  rt_kilo;   rt_kilo   = 1024;
+		posit<64, 3>  rt_big;    rt_big    = 123456789LL;
+		posit<8,  0>  rt_sat_pos; rt_sat_pos = 1000;
+		posit<8,  0>  rt_sat_neg; rt_sat_neg = -1000;
+		posit<32, 2>  rt_int_min; rt_int_min = int32_t(-2147483647 - 1);
+
+		auto same_bits = [](auto cx, auto rt) {
+			auto a = cx.bits();
+			auto b = rt.bits();
+			constexpr unsigned nrBlocks = decltype(a)::nrBlocks;
+			for (unsigned i = 0; i < nrBlocks; ++i) {
+				if (a.block(i) != b.block(i)) return false;
+			}
+			return true;
+		};
+
+		int start = nrOfFailedTestCases;
+		if (!same_bits(cx_pos_42,  rt_pos_42))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(42)\n"; }
+		if (!same_bits(cx_neg_42,  rt_neg_42))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(-42)\n"; }
+		if (!same_bits(cx_zero,    rt_zero))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(0)\n"; }
+		if (!same_bits(cx_three,   rt_three))   { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(3)\n"; }
+		if (!same_bits(cx_kilo,    rt_kilo))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<16,1>(1024)\n"; }
+		if (!same_bits(cx_big,     rt_big))     { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<64,3>(123456789)\n"; }
+		if (!same_bits(cx_sat_pos, rt_sat_pos)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(1000) sat\n"; }
+		if (!same_bits(cx_sat_neg, rt_sat_neg)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(-1000) sat\n"; }
+		if (!same_bits(cx_int_min, rt_int_min)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(INT_MIN)\n"; }
+		if (nrOfFailedTestCases - start == 0) {
+			std::cout << "PASS constexpr integer construction\n";
+		}
+	}
+
 	std::cout << "+-----------------   posit construction, initialization, comparisons\n";
 	{
 		int start = nrOfFailedTestCases;

--- a/static/tapered/posit/api/api.cpp
+++ b/static/tapered/posit/api/api.cpp
@@ -43,7 +43,11 @@ try {
 	std::cout << "+-----------------   constexpr integer construction (issue #713)\n";
 	{
 		// constexpr construction from integer literals must succeed at compile time
-		// for nbits <= 64. The encoded bit pattern must match the runtime path exactly.
+		// for nbits <= 64. The encoded bit pattern must match an INDEPENDENT
+		// reference path (convert_ieee754 via double-cast) so that a bug in
+		// encode_positive_uint64 cannot mask itself.
+		// All test values fit exactly in double's 53-bit mantissa, so the double
+		// cast is bit-exact and provides a valid reference.
 		constexpr posit<32, 2>  cx_pos_42(42);
 		constexpr posit<32, 2>  cx_neg_42(-42);
 		constexpr posit<32, 2>  cx_zero(0);
@@ -54,20 +58,21 @@ try {
 		constexpr posit<8,  0>  cx_sat_neg(-1000);  // saturates to maxneg
 		constexpr posit<32, 2>  cx_int_min(int32_t(-2147483647 - 1));
 
-		// runtime construction for cross-check
-		posit<32, 2>  rt_pos_42; rt_pos_42 = 42;
-		posit<32, 2>  rt_neg_42; rt_neg_42 = -42;
-		posit<32, 2>  rt_zero;   rt_zero   = 0;
-		posit<8,  0>  rt_three;  rt_three  = 3;
-		posit<16, 1>  rt_kilo;   rt_kilo   = 1024;
-		posit<64, 3>  rt_big;    rt_big    = 123456789LL;
-		posit<8,  0>  rt_sat_pos; rt_sat_pos = 1000;
-		posit<8,  0>  rt_sat_neg; rt_sat_neg = -1000;
-		posit<32, 2>  rt_int_min; rt_int_min = int32_t(-2147483647 - 1);
+		// Reference path: float literal constructor still routes through the
+		// pre-existing convert_ieee754, independent of the new constexpr code.
+		posit<32, 2>  ref_pos_42 (42.0);
+		posit<32, 2>  ref_neg_42 (-42.0);
+		posit<32, 2>  ref_zero   (0.0);
+		posit<8,  0>  ref_three  (3.0);
+		posit<16, 1>  ref_kilo   (1024.0);
+		posit<64, 3>  ref_big    (123456789.0);
+		posit<8,  0>  ref_sat_pos(1000.0);
+		posit<8,  0>  ref_sat_neg(-1000.0);
+		posit<32, 2>  ref_int_min(static_cast<double>(int32_t(-2147483647 - 1)));
 
-		auto same_bits = [](auto cx, auto rt) {
+		auto same_bits = [](auto cx, auto ref) {
 			auto a = cx.bits();
-			auto b = rt.bits();
+			auto b = ref.bits();
 			constexpr unsigned nrBlocks = decltype(a)::nrBlocks;
 			for (unsigned i = 0; i < nrBlocks; ++i) {
 				if (a.block(i) != b.block(i)) return false;
@@ -76,15 +81,25 @@ try {
 		};
 
 		int start = nrOfFailedTestCases;
-		if (!same_bits(cx_pos_42,  rt_pos_42))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(42)\n"; }
-		if (!same_bits(cx_neg_42,  rt_neg_42))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(-42)\n"; }
-		if (!same_bits(cx_zero,    rt_zero))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(0)\n"; }
-		if (!same_bits(cx_three,   rt_three))   { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(3)\n"; }
-		if (!same_bits(cx_kilo,    rt_kilo))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<16,1>(1024)\n"; }
-		if (!same_bits(cx_big,     rt_big))     { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<64,3>(123456789)\n"; }
-		if (!same_bits(cx_sat_pos, rt_sat_pos)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(1000) sat\n"; }
-		if (!same_bits(cx_sat_neg, rt_sat_neg)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(-1000) sat\n"; }
-		if (!same_bits(cx_int_min, rt_int_min)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(INT_MIN)\n"; }
+		if (!same_bits(cx_pos_42,  ref_pos_42))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(42)\n"; }
+		if (!same_bits(cx_neg_42,  ref_neg_42))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(-42)\n"; }
+		if (!same_bits(cx_zero,    ref_zero))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(0)\n"; }
+		if (!same_bits(cx_three,   ref_three))   { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(3)\n"; }
+		if (!same_bits(cx_kilo,    ref_kilo))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<16,1>(1024)\n"; }
+		if (!same_bits(cx_big,     ref_big))     { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<64,3>(123456789)\n"; }
+		if (!same_bits(cx_sat_pos, ref_sat_pos)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(1000) sat\n"; }
+		if (!same_bits(cx_sat_neg, ref_sat_neg)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(-1000) sat\n"; }
+		if (!same_bits(cx_int_min, ref_int_min)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(INT_MIN)\n"; }
+
+		// Plain-char regression: on signed-char platforms (the common case),
+		// posit<8,0>(char(-3)) must encode -3, not 253.
+		constexpr posit<32, 2> cx_neg_char(static_cast<char>(-3));
+		posit<32, 2> ref_neg_char(-3.0);
+		if (!same_bits(cx_neg_char, ref_neg_char)) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL constexpr posit<32,2>(char(-3)) - char signedness dispatch\n";
+		}
+
 		if (nrOfFailedTestCases - start == 0) {
 			std::cout << "PASS constexpr integer construction\n";
 		}

--- a/static/tapered/posit/api/api.cpp
+++ b/static/tapered/posit/api/api.cpp
@@ -91,13 +91,25 @@ try {
 		if (!same_bits(cx_sat_neg, ref_sat_neg)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<8,0>(-1000) sat\n"; }
 		if (!same_bits(cx_int_min, ref_int_min)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit<32,2>(INT_MIN)\n"; }
 
-		// Plain-char regression: on signed-char platforms (the common case),
-		// posit<8,0>(char(-3)) must encode -3, not 253.
-		constexpr posit<32, 2> cx_neg_char(static_cast<char>(-3));
-		posit<32, 2> ref_neg_char(-3.0);
-		if (!same_bits(cx_neg_char, ref_neg_char)) {
-			++nrOfFailedTestCases;
-			std::cout << "FAIL constexpr posit<32,2>(char(-3)) - char signedness dispatch\n";
+		// Plain-char regression: char is implementation-defined as signed or
+		// unsigned, so the reference value must match the platform's char model.
+		// On signed-char platforms (the common case) char(-3) is -3; on
+		// unsigned-char platforms it wraps to 253. The dispatch in operator=(char)
+		// is what we are validating: it should produce the matching reference.
+		constexpr posit<32, 2> cx_char_neg3(static_cast<char>(-3));
+		if constexpr (std::is_signed_v<char>) {
+			posit<32, 2> ref_char_neg3(-3.0);
+			if (!same_bits(cx_char_neg3, ref_char_neg3)) {
+				++nrOfFailedTestCases;
+				std::cout << "FAIL constexpr posit<32,2>(char(-3)) on signed-char platform\n";
+			}
+		}
+		else {
+			posit<32, 2> ref_char_neg3(253.0);
+			if (!same_bits(cx_char_neg3, ref_char_neg3)) {
+				++nrOfFailedTestCases;
+				std::cout << "FAIL constexpr posit<32,2>(char(-3)) on unsigned-char platform\n";
+			}
 		}
 
 		if (nrOfFailedTestCases - start == 0) {


### PR DESCRIPTION
## Summary

Phase 1 of issue #713: posit can now be constructed in `constexpr` context from integer literals.

```cpp
constexpr posit<32, 2> p(42);          // now works
constexpr posit<32, 2> q(-42);         // now works
constexpr posit<64, 3> r(123456789LL); // now works
```

The blocker was that the integer ctors all routed through `convert_ieee754(static_cast<double>(rhs))`, and `convert_ieee754` calls `std::frexp` which is not `constexpr` until C++26. This PR adds true-constexpr `convert_signed_integer` / `convert_unsigned_integer` that build the posit encoding directly via `uint64_t` shift/mask, bypassing both `frexp` and the non-constexpr `convert_<>()` / `blockbinary::operator+=` chain.

This is Phase 1 of three. Phases 2 (IEEE-754 float/double `constexpr`) and 3 (`blockbinary` arithmetic operators `constexpr`) are deliberately deferred to separate PRs because they touch foundational building blocks shared by every Universal type and warrant their own focused regression cycle.

## Changes

- `include/sw/universal/number/posit/posit_impl.hpp`
  - promote `check_inward_projection_range` to `constexpr` (5-line pure integer fn)
  - add `encode_positive_uint64` helper (builds the encoding into a `uint64_t` with round-to-nearest-even on discarded fraction bits, saturates via `check_inward_projection_range`)
  - add `convert_unsigned_integer` and `convert_signed_integer` (constexpr for `nbits <= 64`; fall through to existing IEEE-754 path for `nbits > 64`)
  - reroute the integer `operator=` overloads to the new functions
  - signed negation done as two's complement on `uint64_t` (`(~x + 1) & mask`) to avoid the non-constexpr `blockbinary::operator+=` chain that `blockbinary::twosComplement()` ultimately calls
- `static/tapered/posit/api/api.cpp`
  - add `constexpr` smoke tests covering `posit<8,0>`, `posit<16,1>`, `posit<32,2>`, `posit<64,3>`, including saturation and `INT_MIN`; bit-pattern checked against the runtime path

## Local test results (gcc 13 + clang 18, both -std=c++20)

| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| posit_api | OK | PASS (incl. constexpr block) | OK | PASS |
| posit_assignment | OK | PASS | OK | PASS |
| posit_conversion | OK | PASS | OK | PASS |
| posit_addition | OK | PASS | OK | PASS |
| posit_subtraction | OK | PASS | OK | PASS |
| posit_multiplication | OK | PASS | OK | PASS |
| posit_logic | OK | PASS | OK | PASS |
| posito_api | - | - | OK | PASS |
| posit1_api | - | - | OK | PASS |

Plus a 131k-integer enumeration sweep across `posit<8,2>`, `posit<16,1>`, `posit<32,2>` confirmed bit-exact match with the previous runtime path.

## Side effect: improved correctness for wide integer inputs

The previous double-cast route lost precision for 64-bit integer inputs to large posits (e.g., `int64_t` -> `posit<64,3>` was rounded twice: once by the double cast, once by posit conversion). The new direct path preserves all 64 bits and rounds once. For random 64-bit values into `posit<64,3>` this changes results by 1 ULP in some cases. The existing `VerifyIntegerConversion` is robust to this because it only enumerates posit-representable integers (which round-trip exactly through double anyway).

## Out of scope (will be filed as follow-up issues)

- Phase 2: replace `std::frexp` / `std::isnan` / `std::isinf` in `convert_ieee754` with bit-cast extraction via the existing `BIT_CAST_CONSTEXPR extractFields` helper (the same pattern `cfloat` already uses).
- Phase 3: promote `blockbinary::operator+=`, `operator<<=`, `operator|=`, `operator++`, free `truncate`, free `twosComplement` to `constexpr`. This is the gating item for `convert_<>()` to become `constexpr` and unblock Phase 2.

## Test plan

- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit review
- [x] Promote to ready: `gh pr ready`

Resolves #713

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integer-to-posit conversions now evaluate at compile time for common sizes, with a direct constexpr encoding path for up to 64-bit integers; larger sizes use the appropriate conversion route.

* **Bug Fixes**
  * Fixed signed-char handling to ensure correct negative integer encoding across platforms.
  * Improved rounding and saturation for extreme integer inputs and carry-induced overflows.

* **Tests**
  * Added compile-time tests validating integer-to-posit construction and exact bitwise encoding across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->