### PR TITLE
feat(blockbinary): promote arithmetic operators to constexpr (PR 2 of #713)

### DIFF
--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <string>
 #include <sstream>
+#include <type_traits>
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/internal/blocktype/carry.hpp>
 
@@ -22,7 +23,7 @@ enum class BinaryNumberType {
 
 // forward references
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> class blockbinary;
-template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> blockbinary<nbits, BlockType, NumberType> twosComplement(const blockbinary<nbits, BlockType, NumberType>&);
+template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> constexpr blockbinary<nbits, BlockType, NumberType> twosComplement(const blockbinary<nbits, BlockType, NumberType>&);
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> struct quorem;
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> quorem<nbits, BlockType, NumberType> longdivision(const blockbinary<nbits, BlockType, NumberType>&, const blockbinary<nbits, BlockType, NumberType>&);
 
@@ -57,7 +58,7 @@ constexpr blockbinary<nbits, BlockType, NumberType>& maxneg(blockbinary<nbits, B
 
 // generate the 2's complement of the block binary number
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
-blockbinary<nbits, BlockType, NumberType> twosComplement(const blockbinary<nbits, BlockType, NumberType>& orig) {
+constexpr blockbinary<nbits, BlockType, NumberType> twosComplement(const blockbinary<nbits, BlockType, NumberType>& orig) {
 	blockbinary<nbits, BlockType, NumberType> twosC(orig);
 	blockbinary<nbits, BlockType, NumberType> plusOne(1);
 	twosC.flip();
@@ -67,7 +68,7 @@ blockbinary<nbits, BlockType, NumberType> twosComplement(const blockbinary<nbits
 
 // Truncate a bigger posit to fit in a smaller
 template<unsigned srcbits, unsigned tgtbits, typename bt, BinaryNumberType nt>
-void truncate(const blockbinary<srcbits, bt, nt>& src, blockbinary<tgtbits, bt, nt>& tgt) {
+constexpr void truncate(const blockbinary<srcbits, bt, nt>& src, blockbinary<tgtbits, bt, nt>& tgt) {
 	static_assert(tgtbits < srcbits, "truncate requires source posit to be bigger than target posit");
 	constexpr unsigned diff = srcbits - tgtbits;
 	for (unsigned i = 0; i < tgtbits; ++i) { // TODO: optimize for limbs
@@ -202,23 +203,23 @@ public:
 		return complement;
 	}
 	// increment/decrement
-	blockbinary operator++(int) {
+	constexpr blockbinary operator++(int) {
 		blockbinary tmp(*this);
 		operator++();
 		return tmp;
 	}
-	blockbinary& operator++() {
+	constexpr blockbinary& operator++() {
 		blockbinary increment;
 		increment.setbits(0x1);
 		*this += increment;
 		return *this;
 	}
-	blockbinary operator--(int) {
+	constexpr blockbinary operator--(int) {
 		blockbinary tmp(*this);
 		operator--();
 		return tmp;
 	}
-	blockbinary& operator--() {
+	constexpr blockbinary& operator--() {
 		blockbinary decrement;
 		decrement.setbits(0x1);
 		return *this -= decrement;
@@ -230,44 +231,56 @@ public:
 		return complement;
 	}
 	// arithmetic operators
-	blockbinary& operator+=(const blockbinary& rhs) {
+	constexpr blockbinary& operator+=(const blockbinary& rhs) {
 		if constexpr (nrBlocks == 1) {
 			_block[0] = static_cast<bt>(_block[0] + rhs.block(0));
 			// null any leading bits that fall outside of nbits
 			_block[MSU] = static_cast<bt>(MSU_MASK & _block[MSU]);
 		}
 		else if constexpr (bitsInBlock == 64) {
-			// uint64_t limbs: use carry-detection intrinsics
+			// uint64_t limbs: addcarry uses platform intrinsics (not constexpr on MSVC).
+			// In a constant-evaluated context, fall back to portable carry detection.
 			blockbinary sum;
-			uint64_t carry = 0;
-			for (unsigned i = 0; i < nrBlocks; ++i) {
-				sum._block[i] = addcarry(_block[i], rhs._block[i], carry, carry);
+			if (std::is_constant_evaluated()) {
+				uint64_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					uint64_t a = _block[i];
+					uint64_t b = rhs._block[i];
+					uint64_t s1 = a + carry;
+					uint64_t c1 = (s1 < a) ? 1ull : 0ull;
+					uint64_t r  = s1 + b;
+					uint64_t c2 = (r < s1) ? 1ull : 0ull;
+					sum._block[i] = r;
+					carry = c1 + c2;
+				}
+			}
+			else {
+				uint64_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					sum._block[i] = addcarry(_block[i], rhs._block[i], carry, carry);
+				}
 			}
 			// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
 			sum._block[MSU] = static_cast<bt>(MSU_MASK & sum._block[MSU]);
 			*this = sum;
 		}
 		else {
+			// Multi-limb path for bt = uint8_t/uint16_t/uint32_t.
+			// Index-based loop (constexpr-friendly).
 			blockbinary sum;
-			BlockType* pA = _block;
-			BlockType const* pB = rhs._block;
-			BlockType* pC = sum._block;
-			BlockType* pEnd = pC + nrBlocks;
 			std::uint64_t carry = 0;
-			while (pC != pEnd) {
-				carry += static_cast<std::uint64_t>(*pA) + static_cast<std::uint64_t>(*pB);
-				*pC = static_cast<bt>(carry);
+			for (unsigned i = 0; i < nrBlocks; ++i) {
+				carry += static_cast<std::uint64_t>(_block[i]) + static_cast<std::uint64_t>(rhs._block[i]);
+				sum._block[i] = static_cast<bt>(carry);
 				carry >>= bitsInBlock;
-				++pA; ++pB; ++pC;
 			}
 			// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
-			BlockType* pLast = pEnd - 1;
-			*pLast = static_cast<bt>(MSU_MASK & *pLast);
+			sum._block[MSU] = static_cast<bt>(MSU_MASK & sum._block[MSU]);
 			*this = sum;
 		}
 		return *this;
 	}
-	blockbinary& operator-=(const blockbinary& rhs) {
+	constexpr blockbinary& operator-=(const blockbinary& rhs) {
 		return operator+=(sw::universal::twosComplement(rhs));
 	}
 #define BLOCKBINARY_FAST_MUL
@@ -458,21 +471,21 @@ public:
 	///////////////////////////////////////////////////////////////////
 	///              logic operators
 
-	blockbinary& operator|=(const blockbinary& rhs) noexcept {
+	constexpr blockbinary& operator|=(const blockbinary& rhs) noexcept {
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			_block[i] |= rhs._block[i];
 		}
 		_block[MSU] &= MSU_MASK; // assert precondition of properly nulled leading non-bits
 		return *this;
 	}
-	blockbinary& operator&=(const blockbinary& rhs) noexcept {
+	constexpr blockbinary& operator&=(const blockbinary& rhs) noexcept {
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			_block[i] &= rhs._block[i];
 		}
 		_block[MSU] &= MSU_MASK; // assert precondition of properly nulled leading non-bits
 		return *this;
 	}
-	blockbinary& operator^=(const blockbinary& rhs) noexcept {
+	constexpr blockbinary& operator^=(const blockbinary& rhs) noexcept {
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			_block[i] ^= rhs._block[i];
 		}
@@ -481,7 +494,7 @@ public:
 	}
 
 	// shift left operator
-	blockbinary& operator<<=(int bitsToShift) {
+	constexpr blockbinary& operator<<=(int bitsToShift) {
 		if (bitsToShift == 0) return *this;
 		if (bitsToShift < 0) return operator>>=(-bitsToShift);
 		if (bitsToShift > static_cast<int>(nbits)) {
@@ -514,7 +527,7 @@ public:
 		return *this;
 	}
 	// arithmetic shift right operator
-	blockbinary& operator>>=(int bitsToShift) {
+	constexpr blockbinary& operator>>=(int bitsToShift) {
 		if (bitsToShift == 0) return *this;
 		if (bitsToShift < 0) return operator<<=(-bitsToShift);
 		if (bitsToShift >= static_cast<int>(nbits)) {

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -321,7 +321,7 @@ inline blockbinary<nbits, bt, BinaryNumberType::Signed>& convert_to_bb(bool _sig
 
 // needed to avoid double rounding situations during arithmetic: TODO: does that mean the condensed version below should be removed?
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits>
-inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const blocksignificand<fbits, bt>& fraction_in, posit<nbits, es, bt>& p) {
+constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const blocksignificand<fbits, bt>& fraction_in, posit<nbits, es, bt>& p) {
 	if constexpr (_trace_conversion) std::cout << "------------------- CONVERT ------------------" << std::endl;
 	if constexpr (_trace_conversion) std::cout << "sign " << (_sign ? "-1 " : " 1 ") << "scale " << std::setw(3) << _scale << " fraction " << fraction_in << std::endl;
 
@@ -329,12 +329,12 @@ inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const blocksignifi
 	// construct the posit
 	// interpolation rule checks
 	if (check_inward_projection_range<nbits, es, bt>(_scale)) {    // regime dominated
-		if (_trace_conversion) std::cout << "inward projection" << std::endl;
+		if constexpr (_trace_conversion) std::cout << "inward projection" << std::endl;
 		// we are projecting to minpos/maxpos or minneg/maxneg
 		int k = calculate_unconstrained_k<nbits, es>(_scale);
 		k < 0 ? (_sign ? p.minneg() : p.minpos()) : (_sign ? p.maxneg() : p.maxpos());
 		// we are done
-		if (_trace_rounding) std::cout << "projection  rounding ";
+		if constexpr (_trace_rounding) std::cout << "projection  rounding ";
 	}
 	else {
 		constexpr unsigned pt_len = nbits + 3 + es;

--- a/internal/blockbinary/api/constexpr.cpp
+++ b/internal/blockbinary/api/constexpr.cpp
@@ -38,6 +38,46 @@ try {
 		std::cout << b16_1 << '\n' << b16_2 << '\n' << b16_4b << '\n';
 	}
 
+	// constexpr arithmetic (issue #715)
+	{
+		using BB = blockbinary<32, std::uint8_t, BinaryNumberType::Signed>;
+
+		// constexpr operator+= via lambda
+		constexpr BB sum = []() { BB t(5); t += BB(7); return t; }();
+		static_assert(sum.block(0) == 12, "constexpr blockbinary<32,uint8>(5) += 7 == 12");
+
+		// constexpr operator++
+		constexpr BB inc = []() { BB t(0); ++t; ++t; ++t; return t; }();
+		static_assert(inc.block(0) == 3, "constexpr blockbinary<32,uint8> ++x3 == 3");
+
+		// constexpr operator<<=
+		constexpr BB shl = []() { BB t(1); t <<= 5; return t; }();
+		static_assert(shl.block(0) == 32, "constexpr blockbinary<32,uint8>(1) <<= 5 == 32");
+
+		// constexpr operator|=
+		constexpr BB orResult = []() { BB t(0xF); t |= BB(0xF0); return t; }();
+		static_assert(orResult.block(0) == 0xFF, "constexpr blockbinary<32,uint8>(0xF) |= 0xF0 == 0xFF");
+
+		// constexpr free twosComplement (negation)
+		constexpr BB neg = twosComplement(BB(5));
+		static_assert(neg.block(0) == 0xFB, "constexpr twosComplement(blockbinary<32,uint8>(5)) low byte == 0xFB");
+
+		// multi-block uint8 carry across limbs
+		using BB64u8 = blockbinary<64, std::uint8_t, BinaryNumberType::Signed>;
+		constexpr BB64u8 carryAcross = []() { BB64u8 t(123); t += BB64u8(456); return t; }();
+		// 123 + 456 = 579 = 0x243
+		static_assert(carryAcross.block(0) == 0x43, "constexpr 123+456 low byte");
+		static_assert(carryAcross.block(1) == 0x02, "constexpr 123+456 high byte (carry)");
+
+		// uint64 limb arithmetic via std::is_constant_evaluated portable carry path
+		using BB128u64 = blockbinary<128, std::uint64_t, BinaryNumberType::Signed>;
+		constexpr BB128u64 u128inc = []() { BB128u64 t(0); ++t; return t; }();
+		static_assert(u128inc.block(0) == 1, "constexpr 2-limb uint64 ++ low limb");
+		static_assert(u128inc.block(1) == 0, "constexpr 2-limb uint64 ++ high limb");
+
+		std::cout << "constexpr arithmetic smoke tests PASS (compile-time)\n";
+	}
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/internal/blockbinary/api/constexpr.cpp
+++ b/internal/blockbinary/api/constexpr.cpp
@@ -62,6 +62,10 @@ try {
 		constexpr BB neg = twosComplement(BB(5));
 		static_assert(neg.block(0) == 0xFB, "constexpr twosComplement(blockbinary<32,uint8>(5)) low byte == 0xFB");
 
+		// constexpr operator-= (exercises the twosComplement + operator+= delegation chain)
+		constexpr BB sub = []() { BB t(10); t -= BB(3); return t; }();
+		static_assert(sub.block(0) == 7, "constexpr blockbinary<32,uint8>(10) -= 3 == 7");
+
 		// multi-block uint8 carry across limbs
 		using BB64u8 = blockbinary<64, std::uint8_t, BinaryNumberType::Signed>;
 		constexpr BB64u8 carryAcross = []() { BB64u8 t(123); t += BB64u8(456); return t; }();

--- a/internal/blockbinary/api/constexpr.cpp
+++ b/internal/blockbinary/api/constexpr.cpp
@@ -73,11 +73,18 @@ try {
 		static_assert(carryAcross.block(0) == 0x43, "constexpr 123+456 low byte");
 		static_assert(carryAcross.block(1) == 0x02, "constexpr 123+456 high byte (carry)");
 
-		// uint64 limb arithmetic via std::is_constant_evaluated portable carry path
+		// uint64 limb arithmetic via std::is_constant_evaluated portable carry path.
+		// To actually validate cross-limb carry propagation, set low limb to
+		// UINT64_MAX and add 1 -- correct propagation gives (low=0, high=1).
 		using BB128u64 = blockbinary<128, std::uint64_t, BinaryNumberType::Signed>;
-		constexpr BB128u64 u128inc = []() { BB128u64 t(0); ++t; return t; }();
-		static_assert(u128inc.block(0) == 1, "constexpr 2-limb uint64 ++ low limb");
-		static_assert(u128inc.block(1) == 0, "constexpr 2-limb uint64 ++ high limb");
+		constexpr BB128u64 u128carry = []() {
+			BB128u64 t;
+			t.setbits(static_cast<uint64_t>(-1));  // low limb = UINT64_MAX, high limb = 0
+			t += BB128u64(1);
+			return t;
+		}();
+		static_assert(u128carry.block(0) == 0, "constexpr 2-limb uint64 add: low limb wraps to 0");
+		static_assert(u128carry.block(1) == 1, "constexpr 2-limb uint64 add: carry propagates to high limb");
 
 		std::cout << "constexpr arithmetic smoke tests PASS (compile-time)\n";
 	}


### PR DESCRIPTION
## Summary

Make `blockbinary` arithmetic and bitwise operators `constexpr` so the `convert_<>()` chain in `posit_impl.hpp` (and any future Universal code) can do compile-time blockbinary arithmetic.

This is **PR 2 of 3** for issue #713 (constexpr posit construction). It is the foundational prerequisite for Phase 2 (IEEE-754 literal constexpr) and is independently valuable for any code wanting compile-time blockbinary work.

## Changes

### `include/sw/universal/internal/blockbinary/blockbinary.hpp`
Operators promoted to `constexpr`:
- `operator+=`, `operator-=`, `operator++`, `operator--`
- `operator<<=`, `operator>>=`
- `operator|=`, `operator&=`, `operator^=`
- free `truncate(...)`, free `twosComplement(...)`

Implementation challenges:
- The `bitsInBlock == 64` path of `operator+=` calls `addcarry()`, which uses platform intrinsics (`_addcarry_u64` on MSVC, `__int128` on gcc/clang). MSVC's `_addcarry_u64` is **not** constexpr. Solution: dispatch via `std::is_constant_evaluated()` to a portable carry-detection path in constexpr context, while keeping the intrinsic for runtime perf.
- The general multi-block path used pointer-arithmetic loops (forbidden in constexpr). Rewritten as index-based loops.

Out of scope (separate intrinsic dependencies, not needed by `convert_<>()`):
- `operator*=` (uses `mul128`)
- `operator/=`, `operator%=`

### `include/sw/universal/number/posit/posit_impl.hpp`
- Mark `convert_<>()` (line 324) `constexpr`.
- Convert two `if (_trace_conversion)` runtime branches to `if constexpr (_trace_conversion)` (the trace constant is already constexpr `false`; the `if constexpr` form is needed so `std::cout` calls are not seen by the constexpr evaluator).

### `internal/blockbinary/api/constexpr.cpp`
Add `static_assert` smoke tests covering:
- `operator+=`, `++`, `<<=`, `|=`, free `twosComplement`
- single-block uint8, multi-block uint8 (limb-carry path)
- multi-block uint64 (the `is_constant_evaluated` portable-carry path)

## Local validation (gcc 13 + clang 18, both -std=c++20)

Cross-type regression sweep — blockbinary is shared by every Universal type, so we tested broadly:

| Suite | Targets | gcc | clang |
|-------|---------|-----|-------|
| blockbinary | `bb_constexpr` `bb_api` `bb_conversion` | PASS | PASS |
| posit | `posit_api` `posit_assignment` `posit_conversion` `posit_addition` `posit_subtraction` `posit_multiplication` | PASS | PASS |
| cfloat | `cfloat_api` `cfloat_assignment` `cfloat_constexpr` `cfloat_traits` | PASS | PASS |
| lns | `lns_api` `lns_assignment` | PASS | PASS |
| fixpnt | `fixpnt_api` `fixpnt_assignment` `fixpnt_constexpr` | PASS | PASS |

15 / 15 PASS each compiler.

A standalone test verified `convert_<>()` is constexpr-callable and produces bit-identical encoding to a runtime invocation.

## Risk

Medium. blockbinary is a shared building block. Mitigations:
- The `is_constant_evaluated()` dispatch leaves the runtime intrinsic path completely unchanged.
- Pointer-loop -> index-loop conversion was a transcription, not a redesign.
- Cross-type regression sweep covers every consumer of these operators.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready for full CI (sanitizers + 11 platforms + clang-tidy + coverage)
- [ ] Verify on MinGW (`-fno-ipa-icf` toolchain) since MEMORY.md documents an ICF interaction with multiple template instantiations

Resolves #715
Relates to #713

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many arithmetic and bitwise in-place operations (inc/dec, add/sub, shifts, bitwise assigns, negation) are usable in compile-time (constexpr) contexts, enabling constant-evaluated arithmetic.

* **Refactor**
  * Conversion routines and debug logging paths changed to compile-time branches to eliminate unnecessary runtime logging.

* **Tests**
  * Added compile-time validation covering in-place ops, carry propagation and multi-limb correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->