### PR TITLE
feat(bfloat16): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
@@ -5,12 +5,14 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <iostream>
 #include <iomanip>
 #include <regex>
 
+#include <universal/utility/bit_cast.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/shared/infinite_encoding.hpp>
@@ -27,53 +29,49 @@ namespace sw { namespace universal {
 // bfloat16 is Google's Brain Float type
 class bfloat16 {
 		// HELPER methods
+	// bfloat16 is the upper 16 bits of an IEEE-754 float; conversion is pure
+	// bit-shuffle via sw::bit_cast (constexpr where __builtin_bit_cast is
+	// constexpr - i.e. on gcc, clang, MSVC modern). This replaces the previous
+	// std::memcpy-based punning, which was decorated constexpr but is not
+	// actually constexpr until C++26.
 	template<typename SignedInt,
 		typename = typename std::enable_if< std::is_integral<SignedInt>::value, SignedInt >::type>
-	constexpr bfloat16& convert_signed(SignedInt v) noexcept {
+	BIT_CAST_CONSTEXPR bfloat16& convert_signed(SignedInt v) noexcept {
 		if (0 == v) {
 			setzero();
 		}
 		else {
-			float f = float(v);
-			uint16_t pun[2];
-			std::memcpy(pun, &f, 4);
-			_bits = pun[1];
+			return convert_ieee754(static_cast<float>(v));
 		}
 		return *this;
 	}
 	template<typename UnsignedInt,
 		typename = typename std::enable_if< std::is_integral<UnsignedInt>::value, UnsignedInt >::type>
-	constexpr bfloat16& convert_unsigned(UnsignedInt v) noexcept {
+	BIT_CAST_CONSTEXPR bfloat16& convert_unsigned(UnsignedInt v) noexcept {
 		if (0 == v) {
 			setzero();
 		}
 		else {
-			float f = float(v);
-			uint16_t pun[2];
-			std::memcpy(pun, &f, 4);
-			_bits = pun[1];
+			return convert_ieee754(static_cast<float>(v));
 		}
 		return *this;
 	}
 	template<typename Real,
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
-	constexpr bfloat16& convert_ieee754(Real rhs) noexcept {
-
-		float f = float(rhs);
-		uint16_t pun[2];
-		std::memcpy(pun, &f, 4);
-		_bits = pun[1];
+	BIT_CAST_CONSTEXPR bfloat16& convert_ieee754(Real rhs) noexcept {
+		// Down-cast wider floats to single precision first; bfloat16 is
+		// defined relative to the 32-bit IEEE-754 layout.
+		float f = static_cast<float>(rhs);
+		uint32_t bits = sw::bit_cast<uint32_t>(f);
+		_bits = static_cast<uint16_t>(bits >> 16);
 		return *this;
 	}
 	template<typename Real,
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
-	constexpr Real convert_to_ieee754() const noexcept {
-		float f;
-		uint16_t pun[2];
-		pun[1] = _bits;
-		pun[0] = 0;
-		std::memcpy(&f, pun, 4);
-		return Real(f);
+	BIT_CAST_CONSTEXPR Real convert_to_ieee754() const noexcept {
+		uint32_t bits = static_cast<uint32_t>(_bits) << 16;
+		float f = sw::bit_cast<float>(bits);
+		return static_cast<Real>(f);
 	}
 public:
 	static constexpr unsigned nbits = 16;
@@ -122,62 +120,74 @@ public:
 		}
 	}
 
-	// initializers for native types
-	constexpr bfloat16(signed char iv)                    noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(short iv)                          noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(int iv)                            noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(long iv)                           noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(long long iv)                      noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(char iv)                           noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(unsigned short iv)                 noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(unsigned int iv)                   noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(unsigned long iv)                  noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16(unsigned long long iv)             noexcept : _bits{} { *this = iv; }
-	explicit constexpr bfloat16(float iv)                 noexcept : _bits{} { *this = iv; }
-	explicit constexpr bfloat16(double iv)                noexcept : _bits{} { *this = iv; }
+	// initializers for native types. Integer ctors are BIT_CAST_CONSTEXPR
+	// because they route through convert_ieee754 (via convert_signed /
+	// convert_unsigned), which is BIT_CAST_CONSTEXPR.
+	BIT_CAST_CONSTEXPR bfloat16(signed char iv)                    noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(short iv)                          noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(int iv)                            noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(long iv)                           noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(long long iv)                      noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(char iv)                           noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(unsigned short iv)                 noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(unsigned int iv)                   noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(unsigned long iv)                  noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16(unsigned long long iv)             noexcept : _bits{} { *this = iv; }
+	explicit BIT_CAST_CONSTEXPR bfloat16(float iv)                 noexcept : _bits{} { *this = iv; }
+	explicit BIT_CAST_CONSTEXPR bfloat16(double iv)                noexcept : _bits{} { *this = iv; }
 
 	// assignment operators for native types
-	constexpr bfloat16& operator=(signed char rhs)        noexcept { return convert_signed(rhs); }
-	constexpr bfloat16& operator=(short rhs)              noexcept { return convert_signed(rhs); }
-	constexpr bfloat16& operator=(int rhs)                noexcept { return convert_signed(rhs); }
-	constexpr bfloat16& operator=(long rhs)               noexcept { return convert_signed(rhs); }
-	constexpr bfloat16& operator=(long long rhs)          noexcept { return convert_signed(rhs); }
-	constexpr bfloat16& operator=(char rhs)               noexcept { return convert_unsigned(rhs); }
-	constexpr bfloat16& operator=(unsigned short rhs)     noexcept { return convert_unsigned(rhs); }
-	constexpr bfloat16& operator=(unsigned int rhs)       noexcept { return convert_unsigned(rhs); }
-	constexpr bfloat16& operator=(unsigned long rhs)      noexcept { return convert_unsigned(rhs); }
-	constexpr bfloat16& operator=(unsigned long long rhs) noexcept { return convert_unsigned(rhs); }
-	constexpr bfloat16& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
-	constexpr bfloat16& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(signed char rhs)        noexcept { return convert_signed(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(short rhs)              noexcept { return convert_signed(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(int rhs)                noexcept { return convert_signed(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(long rhs)               noexcept { return convert_signed(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(long long rhs)          noexcept { return convert_signed(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(char rhs)               noexcept {
+		// Plain char is implementation-defined as either signed or unsigned;
+		// dispatch on its signedness so negative values on signed-char
+		// platforms (the common case) sign-extend correctly.
+		if constexpr (std::is_signed_v<char>) {
+			return convert_signed(rhs);
+		}
+		else {
+			return convert_unsigned(static_cast<unsigned char>(rhs));
+		}
+	}
+	BIT_CAST_CONSTEXPR bfloat16& operator=(unsigned short rhs)     noexcept { return convert_unsigned(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(unsigned int rhs)       noexcept { return convert_unsigned(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(unsigned long rhs)      noexcept { return convert_unsigned(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(unsigned long long rhs) noexcept { return convert_unsigned(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
 
-	// conversion operators
-	explicit operator signed char()                 const noexcept { return (signed char)(float(*this)); }
-	explicit operator short()                       const noexcept { return short(float(*this)); }
-	explicit operator int()                         const noexcept { return int(float(*this)); }
-	explicit operator long()                        const noexcept { return long(float(*this)); }
-	explicit operator long long()                   const noexcept { return (long long)(float(*this)); }
-	explicit operator char()                        const noexcept { return (char)(float(*this)); }
-	explicit operator unsigned short()              const noexcept { return (unsigned short)(float(*this)); }
-	explicit operator unsigned int()                const noexcept { return (unsigned int)(float(*this)); }
-	explicit operator unsigned long()               const noexcept { return (unsigned long)(float(*this)); }
-	explicit operator unsigned long long()          const noexcept { return (unsigned long long)(float(*this)); }
-	explicit operator float()                       const noexcept { return convert_to_ieee754<float>(); }
-	explicit operator double()                      const noexcept { return convert_to_ieee754<double>(); }
+	// conversion operators (BIT_CAST_CONSTEXPR via convert_to_ieee754)
+	explicit BIT_CAST_CONSTEXPR operator signed char()        const noexcept { return (signed char)(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator short()              const noexcept { return short(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator int()                const noexcept { return int(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator long()               const noexcept { return long(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator long long()          const noexcept { return (long long)(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator char()               const noexcept { return (char)(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator unsigned short()     const noexcept { return (unsigned short)(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator unsigned int()       const noexcept { return (unsigned int)(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator unsigned long()      const noexcept { return (unsigned long)(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator unsigned long long() const noexcept { return (unsigned long long)(float(*this)); }
+	explicit BIT_CAST_CONSTEXPR operator float()              const noexcept { return convert_to_ieee754<float>(); }
+	explicit BIT_CAST_CONSTEXPR operator double()             const noexcept { return convert_to_ieee754<double>(); }
 
 #if LONG_DOUBLE_SUPPORT
-	explicit constexpr bfloat16(long double iv)           noexcept : _bits{} { *this = iv; }
-	constexpr bfloat16& operator=(long double rhs)        noexcept { return convert_ieee754(rhs); }
-	explicit operator long double()                 const noexcept { return convert_to_ieee754<long double>(); }
-#endif 
+	explicit BIT_CAST_CONSTEXPR bfloat16(long double iv)           noexcept : _bits{} { *this = iv; }
+	BIT_CAST_CONSTEXPR bfloat16& operator=(long double rhs)        noexcept { return convert_ieee754(rhs); }
+	explicit BIT_CAST_CONSTEXPR operator long double()        const noexcept { return convert_to_ieee754<long double>(); }
+#endif
 
 	// prefix operators
-	bfloat16 operator-() const noexcept {
+	constexpr bfloat16 operator-() const noexcept {
 		bfloat16 tmp;
 		tmp.setbits(_bits ^ 0x8000u);
 		return tmp;
 	}
 
-	bfloat16& operator++() noexcept {
+	constexpr bfloat16& operator++() noexcept {
 		if (isneg()) {
 			if (_bits == 0x8001u) { // pattern 1.00.001 == minneg
 				_bits = 0;
@@ -196,12 +206,12 @@ public:
 		}
 		return *this;
 	}
-	bfloat16 operator++(int) noexcept {
+	constexpr bfloat16 operator++(int) noexcept {
 		bfloat16 tmp(*this);
 		operator++();
 		return tmp;
 	}
-	bfloat16& operator--() noexcept {
+	constexpr bfloat16& operator--() noexcept {
 		if (sign()) {
 			++_bits;
 		}
@@ -215,26 +225,28 @@ public:
 		}
 		return *this;
 	}
-	bfloat16 operator--(int) noexcept {
+	constexpr bfloat16 operator--(int) noexcept {
 		bfloat16 tmp(*this);
 		operator--();
 		return tmp;
 	}
 
-	// arithmetic operators
-	bfloat16& operator+=(const bfloat16& rhs) {
+	// arithmetic operators - cast to float, compute, cast back. Both legs use
+	// BIT_CAST_CONSTEXPR conversions, and IEEE-754 float arithmetic itself is
+	// constexpr in C++20, so the compound is BIT_CAST_CONSTEXPR overall.
+	BIT_CAST_CONSTEXPR bfloat16& operator+=(const bfloat16& rhs) {
 		*this = float(*this) + float(rhs);
 		return *this;
 	}
-	bfloat16& operator-=(const bfloat16& rhs) {
+	BIT_CAST_CONSTEXPR bfloat16& operator-=(const bfloat16& rhs) {
 		*this = float(*this) - float(rhs);
 		return *this;
 	}
-	bfloat16& operator*=(const bfloat16& rhs) {
+	BIT_CAST_CONSTEXPR bfloat16& operator*=(const bfloat16& rhs) {
 		*this = float(*this) * float(rhs);
 		return *this;
 	}
-	bfloat16& operator/=(const bfloat16& rhs) {
+	BIT_CAST_CONSTEXPR bfloat16& operator/=(const bfloat16& rhs) {
 		*this = float(*this) / float(rhs);
 		return *this;
 	}
@@ -425,13 +437,13 @@ protected:
 private:
 
 	// bfloat16 - bfloat16 logic comparisons
-	friend bool operator==(bfloat16 lhs, bfloat16 rhs);
+	friend constexpr bool operator==(bfloat16 lhs, bfloat16 rhs);
 
-	// bfloat16 - literal logic comparisons
-	friend bool operator==(bfloat16 lhs, float rhs);
+	// bfloat16 - literal logic comparisons (BIT_CAST_CONSTEXPR via bfloat16(float))
+	friend BIT_CAST_CONSTEXPR bool operator==(bfloat16 lhs, float rhs);
 
-	// literal - bfloat16 logic comparisons
-	friend bool operator==(float lhs, bfloat16 rhs);
+	// literal - bfloat16 logic comparisons (BIT_CAST_CONSTEXPR via bfloat16(float))
+	friend BIT_CAST_CONSTEXPR bool operator==(float lhs, bfloat16 rhs);
 };
 
 ////////////////////////    functions   /////////////////////////////////
@@ -502,29 +514,30 @@ inline std::string to_native(bfloat16 v, bool nibbleMarker = false) {
 // bfloat16 - bfloat16 binary logic operators
 
 // equal: precondition is that the storage is properly nulled in all arithmetic paths
-inline bool operator==(bfloat16 lhs, bfloat16 rhs) {
+constexpr inline bool operator==(bfloat16 lhs, bfloat16 rhs) {
 	// NaN != NaN
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return lhs._bits == rhs._bits;
 }
 
-inline bool operator!=(bfloat16 lhs, bfloat16 rhs) {
+constexpr inline bool operator!=(bfloat16 lhs, bfloat16 rhs) {
 	return !operator==(lhs, rhs);
 }
 
-inline bool operator< (bfloat16 lhs, bfloat16 rhs) {
+// operator< is BIT_CAST_CONSTEXPR (depends on the float() conversion)
+BIT_CAST_CONSTEXPR inline bool operator< (bfloat16 lhs, bfloat16 rhs) {
 	return (float(lhs) - float(rhs)) < 0;
 }
 
-inline bool operator> (bfloat16 lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bool operator> (bfloat16 lhs, bfloat16 rhs) {
 	return operator< (rhs, lhs);
 }
 
-inline bool operator<=(bfloat16 lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bool operator<=(bfloat16 lhs, bfloat16 rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 
-inline bool operator>=(bfloat16 lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bool operator>=(bfloat16 lhs, bfloat16 rhs) {
 	return !operator< (lhs, rhs);
 }
 

--- a/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
@@ -517,6 +517,10 @@ inline std::string to_native(bfloat16 v, bool nibbleMarker = false) {
 constexpr inline bool operator==(bfloat16 lhs, bfloat16 rhs) {
 	// NaN != NaN
 	if (lhs.isnan() || rhs.isnan()) return false;
+	// IEEE-754 signed zero: +0 and -0 compare equal even though their bit
+	// patterns differ (0x0000 vs 0x8000). operator-(bfloat16(0)) produces
+	// the 0x8000 pattern directly, so this case is observable in practice.
+	if (lhs.iszero() && rhs.iszero()) return true;
 	return lhs._bits == rhs._bits;
 }
 
@@ -601,30 +605,29 @@ BIT_CAST_CONSTEXPR inline bool operator>=(float lhs, bfloat16 rhs) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // bfloat16 - bfloat16 binary arithmetic operators
-// BINARY ADDITION
+// BIT_CAST_CONSTEXPR via the compound-assignment operators (which are themselves
+// BIT_CAST_CONSTEXPR via float()). This is the #725 public-API acceptance form:
+// `constexpr auto c = a + b;` works once these are decorated.
 
-inline bfloat16 operator+(bfloat16 lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator+(bfloat16 lhs, bfloat16 rhs) {
 	bfloat16 sum = lhs;
 	sum += rhs;
 	return sum;
 }
-// BINARY SUBTRACTION
 
-inline bfloat16 operator-(bfloat16 lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator-(bfloat16 lhs, bfloat16 rhs) {
 	bfloat16 diff = lhs;
 	diff -= rhs;
 	return diff;
 }
-// BINARY MULTIPLICATION
 
-inline bfloat16 operator*(bfloat16 lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator*(bfloat16 lhs, bfloat16 rhs) {
 	bfloat16 mul = lhs;
 	mul *= rhs;
 	return mul;
 }
-// BINARY DIVISION
 
-inline bfloat16 operator/(bfloat16 lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator/(bfloat16 lhs, bfloat16 rhs) {
 	bfloat16 ratio = lhs;
 	ratio /= rhs;
 	return ratio;
@@ -632,47 +635,39 @@ inline bfloat16 operator/(bfloat16 lhs, bfloat16 rhs) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // bfloat16 - literal binary arithmetic operators
-// BINARY ADDITION
 
-inline bfloat16 operator+(bfloat16 lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator+(bfloat16 lhs, float rhs) {
 	return operator+(lhs, bfloat16(rhs));
 }
-// BINARY SUBTRACTION
 
-inline bfloat16 operator-(bfloat16 lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator-(bfloat16 lhs, float rhs) {
 	return operator-(lhs, bfloat16(rhs));
 }
-// BINARY MULTIPLICATION
 
-inline bfloat16 operator*(bfloat16 lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator*(bfloat16 lhs, float rhs) {
 	return operator*(lhs, bfloat16(rhs));
 }
-// BINARY DIVISION
 
-inline bfloat16 operator/(bfloat16 lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator/(bfloat16 lhs, float rhs) {
 	return operator/(lhs, bfloat16(rhs));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - bfloat16 binary arithmetic operators
-// BINARY ADDITION
 
-inline bfloat16 operator+(float lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator+(float lhs, bfloat16 rhs) {
 	return operator+(bfloat16(lhs), rhs);
 }
-// BINARY SUBTRACTION
 
-inline bfloat16 operator-(float lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator-(float lhs, bfloat16 rhs) {
 	return operator-(bfloat16(lhs), rhs);
 }
-// BINARY MULTIPLICATION
 
-inline bfloat16 operator*(float lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator*(float lhs, bfloat16 rhs) {
 	return operator*(bfloat16(lhs), rhs);
 }
-// BINARY DIVISION
 
-inline bfloat16 operator/(float lhs, bfloat16 rhs) {
+BIT_CAST_CONSTEXPR inline bfloat16 operator/(float lhs, bfloat16 rhs) {
 	return operator/(bfloat16(lhs), rhs);
 }
 

--- a/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
@@ -543,58 +543,57 @@ BIT_CAST_CONSTEXPR inline bool operator>=(bfloat16 lhs, bfloat16 rhs) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // bfloat16 - literal binary logic operators
-// equal: precondition is that the byte-storage is properly nulled in all arithmetic paths
+// All take bfloat16 by value to match the friend declarations and to enable
+// BIT_CAST_CONSTEXPR (the bfloat16(float) ctor is BIT_CAST_CONSTEXPR).
 
-inline bool operator==(const bfloat16& lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bool operator==(bfloat16 lhs, float rhs) {
 	return operator==(lhs, bfloat16(rhs));
 }
 
-inline bool operator!=(const bfloat16& lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bool operator!=(bfloat16 lhs, float rhs) {
 	return !operator==(lhs, bfloat16(rhs));
 }
 
-inline bool operator< (const bfloat16& lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bool operator< (bfloat16 lhs, float rhs) {
 	return operator<(lhs, bfloat16(rhs));
 }
 
-inline bool operator> (const bfloat16& lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bool operator> (bfloat16 lhs, float rhs) {
 	return operator< (bfloat16(rhs), lhs);
 }
 
-inline bool operator<=(const bfloat16& lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bool operator<=(bfloat16 lhs, float rhs) {
 	return operator< (lhs, bfloat16(rhs)) || operator==(lhs, bfloat16(rhs));
 }
 
-inline bool operator>=(const bfloat16& lhs, float rhs) {
+BIT_CAST_CONSTEXPR inline bool operator>=(bfloat16 lhs, float rhs) {
 	return !operator< (lhs, bfloat16(rhs));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - bfloat16 binary logic operators
-// precondition is that the byte-storage is properly nulled in all arithmetic paths
 
-
-inline bool operator==(float lhs, const bfloat16& rhs) {
+BIT_CAST_CONSTEXPR inline bool operator==(float lhs, bfloat16 rhs) {
 	return operator==(bfloat16(lhs), rhs);
 }
 
-inline bool operator!=(float lhs, const bfloat16& rhs) {
+BIT_CAST_CONSTEXPR inline bool operator!=(float lhs, bfloat16 rhs) {
 	return !operator==(bfloat16(lhs), rhs);
 }
 
-inline bool operator< (float lhs, const bfloat16& rhs) {
+BIT_CAST_CONSTEXPR inline bool operator< (float lhs, bfloat16 rhs) {
 	return operator<(bfloat16(lhs), rhs);
 }
 
-inline bool operator> (float lhs, const bfloat16& rhs) {
+BIT_CAST_CONSTEXPR inline bool operator> (float lhs, bfloat16 rhs) {
 	return operator< (rhs, bfloat16(lhs));
 }
 
-inline bool operator<=(float lhs, const bfloat16& rhs) {
+BIT_CAST_CONSTEXPR inline bool operator<=(float lhs, bfloat16 rhs) {
 	return operator< (bfloat16(lhs), rhs) || operator==(bfloat16(lhs), rhs);
 }
 
-inline bool operator>=(float lhs, const bfloat16& rhs) {
+BIT_CAST_CONSTEXPR inline bool operator>=(float lhs, bfloat16 rhs) {
 	return !operator< (bfloat16(lhs), rhs);
 }
 

--- a/static/float/bfloat16/api/api.cpp
+++ b/static/float/bfloat16/api/api.cpp
@@ -21,6 +21,60 @@ try {
 	std::string test_suite = "bfloat16 API tests";
 	int nrOfFailedTestCases = 0;
 
+	std::cout << "+-----------------   constexpr support (issue #725 / Epic #723)\n";
+#if BIT_CAST_IS_CONSTEXPR
+	{
+		// bfloat16 is the upper 16 bits of an IEEE-754 float; conversion is
+		// pure bit-shuffle via sw::bit_cast. After issue #725, all
+		// constructors, operator=, conversion-out, increment/decrement, and
+		// arithmetic operators are BIT_CAST_CONSTEXPR.
+		// These checks fail to compile if the constexpr decoration is wrong.
+		constexpr bfloat16 cx_pi   (3.14f);
+		constexpr bfloat16 cx_npi  (-3.14f);
+		constexpr bfloat16 cx_zero (0.0f);
+		constexpr bfloat16 cx_one  (1.0f);
+		constexpr bfloat16 cx_two  (2.0f);
+		constexpr bfloat16 cx_d_pi (3.14);   // double source
+		constexpr bfloat16 cx_int42(42);     // int source
+		constexpr bfloat16 cx_neg42(-42);    // negative int
+
+		// Constexpr arithmetic via lambda
+		constexpr bfloat16 cx_sum  = []() { bfloat16 t(2.0f); t += bfloat16(3.0f); return t; }();
+		constexpr bfloat16 cx_prod = []() { bfloat16 t(2.0f); t *= bfloat16(3.0f); return t; }();
+		constexpr bfloat16 cx_diff = []() { bfloat16 t(5.0f); t -= bfloat16(2.0f); return t; }();
+		constexpr bfloat16 cx_quot = []() { bfloat16 t(6.0f); t /= bfloat16(2.0f); return t; }();
+		constexpr bfloat16 cx_neg  = -cx_pi;
+		constexpr bfloat16 cx_inc  = []() { bfloat16 t(0.0f); ++t; return t; }();
+		// suppress unused-variable warnings -- the constexpr evaluation IS the test
+		(void)cx_npi; (void)cx_one; (void)cx_zero; (void)cx_neg; (void)cx_inc;
+
+		// Constexpr conversion-out
+		constexpr float two_back  = float(cx_two);
+		constexpr int   int_back  = int(cx_neg42);
+
+		static_assert(float(cx_sum)  == 5.0f, "constexpr 2+3 == 5");
+		static_assert(float(cx_prod) == 6.0f, "constexpr 2*3 == 6");
+		static_assert(float(cx_diff) == 3.0f, "constexpr 5-2 == 3");
+		static_assert(float(cx_quot) == 3.0f, "constexpr 6/2 == 3");
+		static_assert(two_back == 2.0f,        "constexpr conversion-out");
+		static_assert(int_back == -42,         "constexpr int conversion");
+		static_assert(cx_zero != cx_one,       "constexpr comparison");
+
+		// Cross-check constexpr value matches runtime value bit-for-bit
+		bfloat16 rt_pi  (3.14f);
+		bfloat16 rt_int42(42);
+		bfloat16 rt_d_pi (3.14);
+		if (float(cx_pi)    != float(rt_pi))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr bfloat16(3.14f)\n"; }
+		if (float(cx_int42) != float(rt_int42)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr bfloat16(42)\n"; }
+		if (float(cx_d_pi)  != float(rt_d_pi))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr bfloat16(3.14)\n"; }
+		std::cout << "PASS constexpr support\n";
+	}
+#else
+	{
+		std::cout << "SKIP constexpr support (compiler lacks constexpr bit_cast support)\n";
+	}
+#endif
+
 	{
 		bfloat16 a;
 		a = 1.0f;

--- a/static/float/bfloat16/api/api.cpp
+++ b/static/float/bfloat16/api/api.cpp
@@ -64,10 +64,11 @@ try {
 		bfloat16 rt_pi  (3.14f);
 		bfloat16 rt_int42(42);
 		bfloat16 rt_d_pi (3.14);
+		int blockStart = nrOfFailedTestCases;
 		if (float(cx_pi)    != float(rt_pi))    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr bfloat16(3.14f)\n"; }
 		if (float(cx_int42) != float(rt_int42)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr bfloat16(42)\n"; }
 		if (float(cx_d_pi)  != float(rt_d_pi))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr bfloat16(3.14)\n"; }
-		std::cout << "PASS constexpr support\n";
+		if (nrOfFailedTestCases == blockStart) std::cout << "PASS constexpr support\n";
 	}
 #else
 	{

--- a/static/float/bfloat16/api/api.cpp
+++ b/static/float/bfloat16/api/api.cpp
@@ -38,15 +38,38 @@ try {
 		constexpr bfloat16 cx_int42(42);     // int source
 		constexpr bfloat16 cx_neg42(-42);    // negative int
 
-		// Constexpr arithmetic via lambda
+		// Constexpr arithmetic via lambda (compound assignment)
 		constexpr bfloat16 cx_sum  = []() { bfloat16 t(2.0f); t += bfloat16(3.0f); return t; }();
 		constexpr bfloat16 cx_prod = []() { bfloat16 t(2.0f); t *= bfloat16(3.0f); return t; }();
 		constexpr bfloat16 cx_diff = []() { bfloat16 t(5.0f); t -= bfloat16(2.0f); return t; }();
 		constexpr bfloat16 cx_quot = []() { bfloat16 t(6.0f); t /= bfloat16(2.0f); return t; }();
 		constexpr bfloat16 cx_neg  = -cx_pi;
 		constexpr bfloat16 cx_inc  = []() { bfloat16 t(0.0f); ++t; return t; }();
+
+		// Constexpr arithmetic via the public binary operators (the primary
+		// #725 acceptance form: constexpr auto c = a + b)
+		constexpr auto cx_sum2  = bfloat16(2.0f) + bfloat16(3.0f);
+		constexpr auto cx_diff2 = bfloat16(5.0f) - bfloat16(2.0f);
+		constexpr auto cx_prod2 = bfloat16(2.0f) * bfloat16(3.0f);
+		constexpr auto cx_quot2 = bfloat16(6.0f) / bfloat16(2.0f);
+		// Mixed bfloat16/float overloads
+		constexpr auto cx_mix1  = bfloat16(2.0f) + 3.0f;
+		constexpr auto cx_mix2  = 4.0f * bfloat16(2.5f);
+		static_assert(float(cx_sum2)  == 5.0f, "constexpr a + b");
+		static_assert(float(cx_diff2) == 3.0f, "constexpr a - b");
+		static_assert(float(cx_prod2) == 6.0f, "constexpr a * b");
+		static_assert(float(cx_quot2) == 3.0f, "constexpr a / b");
+		static_assert(float(cx_mix1)  == 5.0f,  "constexpr bfloat16 + float");
+		static_assert(float(cx_mix2)  == 10.0f, "constexpr float * bfloat16");
+
+		// Signed zero: +0 and -0 must compare equal (IEEE-754 semantics)
+		constexpr bfloat16 cx_pos_zero(0.0f);
+		constexpr bfloat16 cx_neg_zero = -cx_pos_zero;
+		static_assert(cx_pos_zero == cx_neg_zero, "constexpr +0 == -0");
+		static_assert(!(cx_pos_zero != cx_neg_zero), "constexpr !(+0 != -0)");
 		// suppress unused-variable warnings -- the constexpr evaluation IS the test
 		(void)cx_npi; (void)cx_one; (void)cx_zero; (void)cx_neg; (void)cx_inc;
+		(void)cx_sum2; (void)cx_diff2; (void)cx_prod2; (void)cx_quot2; (void)cx_mix1; (void)cx_mix2;
 
 		// Constexpr conversion-out
 		constexpr float two_back  = float(cx_two);


### PR DESCRIPTION
## Summary

Resolves **#725** (sub-issue of Epic #723). Bring `bfloat16` to fully constexpr — construction, operator=, arithmetic, increment/decrement, comparison, and conversion-out — by replacing the misleading `std::memcpy`-based punning with `sw::bit_cast`.

```cpp
constexpr bfloat16 pi(3.14f);     // works
constexpr bfloat16 sum = []() { bfloat16 t(2.0f); t += bfloat16(3.0f); return t; }();  // works
static_assert(float(sum) == 5.0f);  // works
```

## Why this was almost-but-not-quite-constexpr before

The existing code decorates `convert_signed` / `convert_unsigned` / `convert_ieee754` / `convert_to_ieee754` with `constexpr`, but each of them calls `std::memcpy` for the `float` <-> `uint32_t` punning. **`std::memcpy` is not constexpr until C++26** (LWG 4035). The decoration was a hidden lie — the type would compile fine in non-constexpr contexts, but any user attempt at `constexpr bfloat16 x(3.14f);` would fail.

This PR follows the proven posit playbook from #717: replace `memcpy` with `sw::bit_cast` (constexpr today on gcc, clang, MSVC modern via `__builtin_bit_cast`) and propagate `BIT_CAST_CONSTEXPR` through transitive callers.

## Changes

### `include/sw/universal/number/bfloat16/bfloat16_impl.hpp`

- Add `#include <universal/utility/bit_cast.hpp>` for direct dependency
- `convert_ieee754<Real>(rhs)`: `_bits = sw::bit_cast<uint32_t>(float(rhs)) >> 16` -- `BIT_CAST_CONSTEXPR`
- `convert_to_ieee754<Real>()`: `sw::bit_cast<float>(uint32_t(_bits) << 16)` -- `BIT_CAST_CONSTEXPR`
- `convert_signed` / `convert_unsigned`: now route through `convert_ieee754(static_cast<float>(v))` -- `BIT_CAST_CONSTEXPR`
- All native-type ctors: `BIT_CAST_CONSTEXPR`
- All `operator=` overloads: `BIT_CAST_CONSTEXPR`
- `operator=(char)` gets `if constexpr (std::is_signed_v<char>)` dispatch (same signedness fix from PR #714's CodeRabbit feedback)
- `operator+=`, `-=`, `*=`, `/=`: `BIT_CAST_CONSTEXPR` (cast through float, IEEE-754 float arithmetic is constexpr in C++20)
- `operator++`, `--`, prefix unary `-`: `constexpr` (pure bit operations)
- All conversion-out operators (`operator float`, `double`, etc.): `BIT_CAST_CONSTEXPR`
- Free comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`): `constexpr` for bit-only ops, `BIT_CAST_CONSTEXPR` for those that compare via float

### `static/float/bfloat16/api/api.cpp`

`#if BIT_CAST_IS_CONSTEXPR`-guarded block exercising the constexpr contract via `static_assert` over `+=`, `*=`, `-=`, `/=`, conversion-out, comparison. Plus runtime cross-check that constexpr-constructed values match runtime construction bit-for-bit.

## Local validation (gcc 13 + clang 18, -std=c++20)

| Target | gcc | clang |
|--------|-----|-------|
| bfloat16_api (incl. constexpr block) | PASS | PASS |
| bfloat16_attributes | PASS | PASS |
| bfloat16_constants | PASS | PASS |
| bfloat16_traits | PASS | PASS |
| bfloat16_arithmetic | PASS | PASS |

5/5 PASS each compiler. Plus an off-tree harness verified bit-equivalence between constexpr and runtime construction across float, double, int, neg-int sources.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #725
Relates to #723 (Epic: constexpr support across Universal number systems)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced compile-time support for bfloat16: conversions, constructors, assignments, unary ops, compound arithmetic, binary operators, and comparisons are now usable in constant evaluation.
  * Corrected character-to-bfloat16 conversions to respect platform char signedness and ensured +0/-0 equality behaves as expected.

* **Tests**
  * Added a compile-time gated test validating constexpr construction, arithmetic, comparisons, and conversions for bfloat16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->