### PR TITLE
feat(internal): promote blocktriple and blocksignificand arithmetic to constexpr

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -61,9 +61,10 @@ jobs:
             erational
             efloat
             ereal
+            internal
             blockbinary
             blockdecimal
-            blocksignificant
+            blocksignificand
             blocktriple
             microfloat
             e8m0

--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -934,9 +934,9 @@ private:
 
 	// integer - integer logic comparisons
 	template<unsigned N, typename B, BinaryNumberType T>
-	friend bool operator==(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs);
+	friend constexpr bool operator==(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs);
 	template<unsigned N, typename B, BinaryNumberType T>
-	friend bool operator!=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs);
+	friend constexpr bool operator!=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs);
 	// the other logic operators are defined in terms of arithmetic terms
 
 	template<unsigned N, typename B, BinaryNumberType T>
@@ -958,7 +958,7 @@ std::string type_tag(const blockbinary<N, B, T>& = {}) {
 // logic operators
 
 template<unsigned N, typename B, BinaryNumberType T>
-bool operator==(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
+constexpr bool operator==(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
 	for (unsigned i = 0; i < lhs.nrBlocks; ++i) {
 		if (lhs._block[i] != rhs._block[i]) {
 			return false;
@@ -967,11 +967,11 @@ bool operator==(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs
 	return true;
 }
 template<unsigned N, typename B, BinaryNumberType T>
-bool operator!=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
+constexpr bool operator!=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
 	return !operator==(lhs, rhs);
 }
 template<unsigned N, typename B, BinaryNumberType T>
-bool operator<(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
+constexpr bool operator<(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
 	if (lhs.ispos() && rhs.isneg()) return false; // need to filter out possible overflow conditions
 	if (lhs.isneg() && rhs.ispos()) return true;  // need to filter out possible underflow conditions
 	if (lhs == rhs) return false; // so the maxneg logic works
@@ -981,15 +981,15 @@ bool operator<(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs)
 	return diff.isneg();
 }
 template<unsigned N, typename B, BinaryNumberType T>
-bool operator<=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
+constexpr bool operator<=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
 	return (lhs < rhs || lhs == rhs);
 }
 template<unsigned N, typename B, BinaryNumberType T>
-bool operator>(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
+constexpr bool operator>(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
 	return !(lhs <= rhs);
 }
 template<unsigned N, typename B, BinaryNumberType T>
-bool operator>=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
+constexpr bool operator>=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs) {
 	return !(lhs < rhs);
 }
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
+++ b/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <sstream>
 #include <limits>
+#include <type_traits>  // for std::is_constant_evaluated() in constexpr arithmetic dispatch
 
 #include <universal/internal/blocksignificand/blocksignificand_fwd.hpp>
 #include <universal/internal/blocktype/carry.hpp>
@@ -231,12 +232,28 @@ public:
 	/// </summary>
 	/// <param name="lhs">nbits of fraction in the form 00h.ffff</param>
 	/// <param name="rhs">nbits of fraction in the form 00h.ffff</param>
-	void add(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
+	constexpr void add(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
 		if constexpr (bitsInBlock == 64) {
-			// uint64_t limbs: use carry-detection intrinsics
-			uint64_t carry = 0;
-			for (unsigned i = 0; i < nrBlocks; ++i) {
-				_block[i] = addcarry(lhs._block[i], rhs._block[i], carry, carry);
+			// uint64_t limbs: addcarry uses platform intrinsics (not constexpr on MSVC).
+			// Dispatch to a portable carry path in constant-evaluated context.
+			if (std::is_constant_evaluated()) {
+				uint64_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					uint64_t a = lhs._block[i];
+					uint64_t b = rhs._block[i];
+					uint64_t s1 = a + carry;
+					uint64_t c1 = (s1 < a) ? 1ull : 0ull;
+					uint64_t r  = s1 + b;
+					uint64_t c2 = (r < s1) ? 1ull : 0ull;
+					_block[i] = r;
+					carry = c1 + c2;
+				}
+			}
+			else {
+				uint64_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					_block[i] = addcarry(lhs._block[i], rhs._block[i], carry, carry);
+				}
 			}
 		}
 		else {
@@ -253,11 +270,11 @@ public:
 		// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
 		_block[MSU] &= MSU_MASK;
 	}
-	void sub(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
-		blocksignificand<nbits, bt> b(twosComplementFree(rhs)); 
+	constexpr void sub(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
+		blocksignificand<nbits, bt> b(twosComplementFree(rhs));
 		add(lhs, b);
 	}
-	void mul(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
+	constexpr void mul(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
 		blocksignificand<nbits, bt> base(lhs);
 		blocksignificand<nbits, bt> multiplicand(rhs);
 		clear();
@@ -270,7 +287,7 @@ public:
 		// since we used operator+=, which enforces the nulling of leading bits
 		// we don't need to null here
 	}
-	void div(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
+	constexpr void div(const blocksignificand& lhs, const blocksignificand& rhs) noexcept {
 		blocksignificand<nbits, bt> base(lhs);
 		blocksignificand<nbits, bt> divider(rhs);
 		clear();

--- a/include/sw/universal/internal/blocktriple/blocktriple.hpp
+++ b/include/sw/universal/internal/blocktriple/blocktriple.hpp
@@ -463,7 +463,7 @@ public:
 	/// <param name="lhs">ephemeral blocktriple that may get modified</param>
 	/// <param name="rhs">ephemeral blocktriple that may get modified</param>
 	/// <param name="result">unrounded sum</param>
-	void add(blocktriple& lhs, blocktriple& rhs) {
+	constexpr void add(blocktriple& lhs, blocktriple& rhs) {
 		int lhs_scale = lhs.scale();
 		int rhs_scale = rhs.scale();
 		int scale_of_result = std::max(lhs_scale, rhs_scale);
@@ -532,7 +532,7 @@ public:
 		}
 	}
 
-	void sub(blocktriple& lhs, blocktriple& rhs) {
+	constexpr void sub(blocktriple& lhs, blocktriple& rhs) {
 		add(lhs, rhs.twosComplement());
 	}
 
@@ -553,7 +553,7 @@ public:
 	/// <param name="lhs">ephemeral blocktriple that may get modified</param>
 	/// <param name="rhs">ephemeral blocktriple that may get modified</param>
 	/// <param name="result">unrounded sum</param>
-	void mul(blocktriple& lhs, blocktriple& rhs) {
+	constexpr void mul(blocktriple& lhs, blocktriple& rhs) {
 		int lhs_scale = lhs.scale();
 		int rhs_scale = rhs.scale();
 		int scale_of_result = lhs_scale + rhs_scale;
@@ -601,7 +601,7 @@ public:
 		}
 	}
 
-	void div(blocktriple& lhs, blocktriple& rhs) {
+	constexpr void div(blocktriple& lhs, blocktriple& rhs) {
 		int lhs_scale = lhs.scale();
 		int rhs_scale = rhs.scale();
 		int scale_of_result = lhs_scale - rhs_scale;


### PR DESCRIPTION
## Summary

Resolves **#752** (sub-issue of Epic #723). Foundational prerequisite for posit/cfloat/lns/etc. constexpr arithmetic. Mirrors PR #716 (which promoted blockbinary arithmetic).

After this PR, the following are `constexpr`:

- `blocksignificand::add`, `sub`, `mul`, `div`
- `blocktriple::add`, `sub`, `mul`, `div`
- Free `blockbinary` `operator==`, `!=`, `<`, `<=`, `>`, `>=`

This unblocks #718 (posit constexpr arithmetic) and #719 (cfloat constexpr arithmetic), and most other Tier-2 Epic #723 sub-issues that depend on the blocktriple/blocksignificand chain.

## Changes

### `include/sw/universal/internal/blocksignificand/blocksignificand.hpp`
- Add `#include <type_traits>` for `std::is_constant_evaluated()`
- `add(lhs, rhs)`: marked `constexpr`. The `bitsInBlock == 64` path uses `addcarry` (non-constexpr on MSVC). Dispatch via `std::is_constant_evaluated()` to a portable carry-detection path in constant-evaluated context, keeping the intrinsic for runtime perf. Same pattern as PR #716.
- `sub`, `mul`, `div`: `constexpr` (delegate to `add` which is now constexpr)

### `include/sw/universal/internal/blocktriple/blocktriple.hpp`
- `add`, `sub`, `mul`, `div`: `constexpr`. Bodies were already constexpr-clean — they used `if constexpr (_trace_btriple_X)` for tracing and only delegated to `_significand` methods that are constexpr (now including the four arithmetic ones above).

### `include/sw/universal/internal/blockbinary/blockbinary.hpp`
- Free `operator==`, `!=`, `<`, `<=`, `>`, `>=`: `constexpr`. Pure bit-loop comparisons; trivial promote. The friend declarations within the class are also updated to match.

## Local validation (gcc-13 + clang-18, -std=c++20)

| Suite | Targets | gcc | clang |
|-------|---------|-----|-------|
| blockbinary | `bb_constexpr` `bb_api` `bb_conversion` | PASS | PASS |
| posit | `posit_api` `posit_assignment` `posit_conversion` `posit_addition` `posit_subtraction` `posit_multiplication` `posit_division` | PASS | PASS |
| cfloat | `cfloat_api` `cfloat_assignment` `cfloat_constexpr` | PASS | PASS |
| lns | `lns_api` `lns_assignment` | PASS | PASS |
| fixpnt | `fixpnt_api` `fixpnt_assignment` `fixpnt_constexpr` | PASS | PASS |
| bfloat16 | `bfloat16_api` `bfloat16_arithmetic` | PASS | PASS |

20/20 PASS each compiler.

An off-tree harness verified that `constexpr` evaluation of `blocksignificand::add`, `blocktriple::add`, and `blocktriple::mul` works end-to-end on both compilers.

## Risk

Medium. blocksignificand and blocktriple are shared by every Universal floating-point type. Mitigations:
- The `is_constant_evaluated()` dispatch leaves the runtime intrinsic path completely unchanged (zero perf regression at runtime).
- Cross-type regression sweep covers every type that consumes these primitives.
- Comparison operator changes are pure-promotion (no behavior change).

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #752
Relates to #723 (Epic), unblocks #718 and #719

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Comparison operators now support compile-time evaluation.
  * Core arithmetic routines (add, sub, mul, div) are now usable in constant expressions, enabling more compile-time validation and optimization while remaining backward compatible.
* **Chore**
  * CI conventional-commit configuration expanded/renamed to accept the updated internal scope naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->