### PR TITLE
feat(posit): full constexpr arithmetic, comparison, and conversion-out

### DIFF
--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -879,7 +879,7 @@ public:
 		}
 		return ll;
 	}
-	uint64_t to_ull() const {
+	constexpr uint64_t to_ull() const {
 		uint64_t ull{ 0 };
 		uint64_t mask{ 1 };
 		uint32_t msb = nbits < 64 ? nbits : 64;
@@ -996,22 +996,22 @@ constexpr bool operator>=(const blockbinary<N, B, T>& lhs, const blockbinary<N, 
 // binary operators
 
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<N, B, T> operator+(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr blockbinary<N, B, T> operator+(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N, B, T> c(a);
 	return c += b;
 }
 template<unsigned N, typename B, BinaryNumberType T >
-blockbinary<N, B, T> operator-(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr blockbinary<N, B, T> operator-(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N, B, T> c(a);
 	return c -= b;
 }
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<N, B, T> operator*(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+inline blockbinary<N, B, T> operator*(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N, B, T> c(a);
 	return c *= b;
 }
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<N, B, T> operator/(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+inline blockbinary<N, B, T> operator/(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N, B, T> c(a);
 	return c /= b;
 }

--- a/include/sw/universal/number/posit/posit_exponent.hpp
+++ b/include/sw/universal/number/posit/posit_exponent.hpp
@@ -20,36 +20,37 @@ template<unsigned nbits, unsigned es, typename bt>
 class positExponent {
 	constexpr static std::uint32_t MASK = (0xFFFF'FFFFul >> (31ul - es)) >> 1ul;
 public:
-	positExponent() : _expBits{ 0 }, _nrExpBits{ es } {}
-	
-	positExponent(const positExponent& r) = default;
-	positExponent(positExponent&& r) = default;
+	constexpr positExponent() : _expBits{ 0 }, _nrExpBits{ es } {}
 
-	positExponent& operator=(const positExponent& r) = default;
-	positExponent& operator=(positExponent&& r) = default;
-	
-	void reset() {
+	constexpr positExponent(const positExponent& r) = default;
+	constexpr positExponent(positExponent&& r) = default;
+
+	constexpr positExponent& operator=(const positExponent& r) = default;
+	constexpr positExponent& operator=(positExponent&& r) = default;
+
+	constexpr void reset() {
 		_nrExpBits = 0;
 		_expBits = 0;
 	}
-	void setzero() { reset(); }
-	unsigned nrBits() const noexcept {
+	constexpr void setzero() { reset(); }
+	constexpr unsigned nrBits() const noexcept {
 		return _nrExpBits;
 	}
-	int scale() const noexcept {
+	constexpr int scale() const noexcept {
 		return int(_expBits);
 	}
-	long double value() const noexcept {
+	constexpr long double value() const noexcept {
+		// pure integer shift -- constexpr-clean (unlike positRegime::value which uses std::ldexp)
 		return (long double)(std::uint64_t(1) << _expBits);
 	}
-	std::uint32_t bits() const noexcept {
+	constexpr std::uint32_t bits() const noexcept {
 		return _expBits;
 	}
-	void set(const std::uint32_t& raw, unsigned nrExponentBits) {
+	constexpr void set(const std::uint32_t& raw, unsigned nrExponentBits) {
 		_expBits = raw & MASK;
 		_nrExpBits = nrExponentBits;
 	}
-	void setNrBits(unsigned nrExpBits) noexcept {
+	constexpr void setNrBits(unsigned nrExpBits) noexcept {
 		_nrExpBits = nrExpBits;
 	}
 	constexpr void setbit(unsigned i, bool v = true) noexcept {
@@ -70,7 +71,7 @@ public:
 		return false; // nop if out of range
 	}
 	// extract the exponent bits given a pattern and the location of the starting point
-	void extract_exponent_bits(const blockbinary<nbits, bt, BinaryNumberType::Signed>& rawPositBits, unsigned nrRegimeBits) {
+	constexpr void extract_exponent_bits(const blockbinary<nbits, bt, BinaryNumberType::Signed>& rawPositBits, unsigned nrRegimeBits) {
 		reset();
 		// start of positExponent is nbits - (sign_bit + regime_bits)
 		int msb = static_cast<int>(nbits - 1ull - (1ull + nrRegimeBits));

--- a/include/sw/universal/number/posit/posit_exponent.hpp
+++ b/include/sw/universal/number/posit/posit_exponent.hpp
@@ -40,8 +40,17 @@ public:
 		return int(_expBits);
 	}
 	constexpr long double value() const noexcept {
-		// pure integer shift -- constexpr-clean (unlike positRegime::value which uses std::ldexp)
-		return (long double)(std::uint64_t(1) << _expBits);
+		// Compute 2^_expBits via repeated multiplication. Earlier code used
+		// `std::uint64_t(1) << _expBits` but that is undefined behavior when
+		// _expBits >= 64 -- which happens for valid posit configurations with
+		// es >= 7 (e.g. posit<N,8> can hold _expBits up to 255 per the MASK).
+		// The multiply-by-2 loop is constexpr-clean and well-defined for any
+		// _expBits up to long double's exponent range (~16384 for x86-80).
+		long double v = 1.0l;
+		for (std::uint32_t i = 0; i < _expBits; ++i) {
+			v *= 2.0l;
+		}
+		return v;
 	}
 	constexpr std::uint32_t bits() const noexcept {
 		return _expBits;

--- a/include/sw/universal/number/posit/posit_fraction.hpp
+++ b/include/sw/universal/number/posit/posit_fraction.hpp
@@ -19,21 +19,21 @@ class positFraction {
 	using UnsignedFraction = blockbinary<fbits, bt, BinaryNumberType::Unsigned>;
 	using UnsignedSignificant = blockbinary<fbits+1, bt, BinaryNumberType::Unsigned>;
 public:
-	positFraction() : _block{}, _nrBits{} {}
+	constexpr positFraction() : _block{}, _nrBits{} {}
 
-	positFraction(const positFraction& f) = default;
-	positFraction(positFraction&& f) = default;
-	
-	positFraction& operator=(const positFraction& f) = default;
-	positFraction& operator=(positFraction&& f) = default;
-	
+	constexpr positFraction(const positFraction& f) = default;
+	constexpr positFraction(positFraction&& f) = default;
+
+	constexpr positFraction& operator=(const positFraction& f) = default;
+	constexpr positFraction& operator=(positFraction&& f) = default;
+
 	// selectors
-	bool none() const {	return _block.none(); }
-	UnsignedFraction bits() const noexcept { return _block; }
-	unsigned nrBits() const noexcept { return _nrBits;	}
+	constexpr bool none() const {	return _block.none(); }
+	constexpr UnsignedFraction bits() const noexcept { return _block; }
+	constexpr unsigned nrBits() const noexcept { return _nrBits;	}
 	// positFractions are assumed to have a hidden bit, the case where they do not must be managed by the container of the positFraction
 	// calculate the value of the positFraction ignoring the hidden bit. So a positFraction of 1010 has the value 0.5+0.125=5/8
-	long double value() const { 
+	constexpr long double value() const {
 		long double v = 0.0l;
 		if (_block.none()) return v;
 		if constexpr (fbits > 0) {
@@ -48,13 +48,13 @@ public:
 	}
 
 	// modifiers
-	void reset() {
+	constexpr void reset() {
 		_nrBits = 0;
 		_block.clear();
 	}
-	void setzero() { reset(); }
+	constexpr void setzero() { reset(); }
 
-	void set(const UnsignedFraction& raw, unsigned nrOfFractionBits = fbits) {
+	constexpr void set(const UnsignedFraction& raw, unsigned nrOfFractionBits = fbits) {
 		_block = raw;
 		_nrBits = (fbits < nrOfFractionBits ? fbits : nrOfFractionBits);
 	}

--- a/include/sw/universal/number/posit/posit_fwd.hpp
+++ b/include/sw/universal/number/posit/posit_fwd.hpp
@@ -23,8 +23,8 @@ template<unsigned nbits, unsigned es, typename bt>
 bool parse(const std::string& number, posit<nbits, es, bt>& v);
 
 // helpers
-template<unsigned nbits, unsigned es, typename bt, unsigned fbits, BlockTripleOperator op> posit<nbits, es, bt>& convert(const blocktriple<fbits, op, bt>&, posit<nbits, es, bt>&);
+template<unsigned nbits, unsigned es, typename bt, unsigned fbits, BlockTripleOperator op> constexpr posit<nbits, es, bt>& convert(const blocktriple<fbits, op, bt>&, posit<nbits, es, bt>&);
 
-template<unsigned nbits, typename bt> int decode_regime(const blockbinary<nbits, bt>&);
+template<unsigned nbits, typename bt> constexpr int decode_regime(const blockbinary<nbits, bt>&);
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -100,9 +100,9 @@ constexpr bool check_inward_projection_range(int scale) {
 // decode_regime measures the run-length of the regime and returns the k value associated with that run-length
 // how many shifts represent the regime?
 // regime = useed ^ k = (2 ^ (2 ^ es)) ^ k = 2 ^ (k*(2 ^ es))
-// scale  = useed ^ k * 2^e = k*(2 ^ es) + e 
+// scale  = useed ^ k * 2^e = k*(2 ^ es) + e
 template<unsigned nbits, typename bt>
-int decode_regime(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits) {
+constexpr int decode_regime(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits) {
 	// let m be the number of identical bits in the regime
 	int m = 0;   // regime runlength counter
 	int k = 0;   // converted regime scale
@@ -141,7 +141,7 @@ int decode_regime(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bi
 
 // extract_fields takes a raw posit encoding and extracts the sign, regime, exponent, and fraction components
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits>
-void extract_fields(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits, bool& _sign, positRegime<nbits, es, bt>& _regime, positExponent<nbits, es, bt>& _exponent, positFraction<fbits, bt>& _fraction) {
+constexpr void extract_fields(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits, bool& _sign, positRegime<nbits, es, bt>& _regime, positExponent<nbits, es, bt>& _exponent, positFraction<fbits, bt>& _fraction) {
 	using TwosComplementNumber = blockbinary<nbits, bt, BinaryNumberType::Signed>;
 	// check special case: zero
 	if (raw_bits.iszero()) {
@@ -213,7 +213,7 @@ void extract_fields(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_
 // and decodes the sign, regime, the exponent, and the fraction.
 // This function has the functionality of the posit register-file load.
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits>
-void decode(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits, bool& _sign, positRegime<nbits, es, bt>& _regime, positExponent<nbits, es, bt>& _exponent, positFraction<fbits, bt>& _fraction) {
+constexpr void decode(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits, bool& _sign, positRegime<nbits, es, bt>& _regime, positExponent<nbits, es, bt>& _exponent, positFraction<fbits, bt>& _fraction) {
 	//_block = raw_bits;	// store the raw bits for reference
 	// check special cases
 	_sign = raw_bits.test(nbits - 1);
@@ -242,8 +242,7 @@ void decode(const blockbinary<nbits, bt, BinaryNumberType::Signed>& raw_bits, bo
 			extract_fields(raw_bits, _sign, _regime, _exponent, _fraction);
 		}
 	}
-	//if (_trace_decode) std::cout << "raw bits: " << raw_bits << " posit bits: " << (_sign ? "1|" : "0|") << _regime << "|" << _exponent << "|" << _fraction << " posit value: " << *this << std::endl;
-	if (_trace_decode) std::cout << "raw bits: " << raw_bits << " posit bits: " << (_sign ? "1|" : "0|") << _regime << "|" << _exponent << "|" << _fraction << std::endl;
+	if constexpr (_trace_decode) std::cout << "raw bits: " << raw_bits << " posit bits: " << (_sign ? "1|" : "0|") << _regime << "|" << _exponent << "|" << _fraction << std::endl;
 }
 
 #ifdef TBD
@@ -396,7 +395,7 @@ constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const bl
 
 // convert a floating point value to a specific posit configuration. Semantically, p = v, return reference to p
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits, BlockTripleOperator op>
-inline posit<nbits, es, bt>& convert(const blocktriple<fbits, op, bt>& v, posit<nbits, es, bt>& p) {
+constexpr inline posit<nbits, es, bt>& convert(const blocktriple<fbits, op, bt>& v, posit<nbits, es, bt>& p) {
 	if constexpr (_trace_conversion) std::cout << "------------------- CONVERT ------------------" << '\n';
 	if constexpr (_trace_conversion) std::cout << to_triple(v) << " : " << v << '\n';
 
@@ -632,7 +631,7 @@ public:
 	}
 	
 	// negation operator
-	posit operator-() const {
+	constexpr posit operator-() const {
 		if (iszero()) {
 			return *this;
 		}
@@ -644,31 +643,31 @@ public:
 		return negated;
 	}
 	// prefix increment operator
-	posit& operator++() {
+	constexpr posit& operator++() {
 		++_block;
 		return *this;
 	}
 	// postfix increment operator
-	posit operator++(int) {
+	constexpr posit operator++(int) {
 		posit tmp(*this);
 		operator++();
 		return tmp;
 	}
 	// prefix decrement operator
-	posit& operator--() {
+	constexpr posit& operator--() {
 		--_block;
 		return *this;
 	}
 	// postfix decrement operator
-	posit operator--(int) {
+	constexpr posit operator--(int) {
 		posit tmp(*this);
 		operator--();
 		return tmp;
 	}
 
 	// we model a hw pipeline with register assignments, functional block, and conversion
-	posit& operator+=(const posit& rhs) {
-		if (_trace_add) std::cout << "---------------------- ADD -------------------" << std::endl;
+	constexpr posit& operator+=(const posit& rhs) {
+		if constexpr (_trace_add) std::cout << "---------------------- ADD -------------------" << std::endl;
 		// special case handling of the inputs
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
 		if (isnar() || rhs.isnar()) {
@@ -707,18 +706,18 @@ public:
 		}
 		return *this;                
 	}
-	posit& operator+=(double rhs) {
+	constexpr posit& operator+=(double rhs) {
 		return *this += posit<nbits, es, bt>(rhs);
 	}
-	posit& operator-=(const posit& rhs) {
+	constexpr posit& operator-=(const posit& rhs) {
 		return *this += (-rhs);
 	}
-	posit& operator-=(double rhs) {
+	constexpr posit& operator-=(double rhs) {
 		return *this -= posit<nbits, es, bt>(rhs);
 	}
-	posit& operator*=(const posit& rhs) {
+	constexpr posit& operator*=(const posit& rhs) {
 		static_assert(fhbits > 0, "posit configuration does not support multiplication");
-		if (_trace_mul) std::cout << "---------------------- MUL -------------------" << std::endl;
+		if constexpr (_trace_mul) std::cout << "---------------------- MUL -------------------" << std::endl;
 		// special case handling of the inputs
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
 		if (isnar() || rhs.isnar()) {
@@ -755,11 +754,11 @@ public:
 		}
 		return *this;
 	}
-	posit& operator*=(double rhs) {
+	constexpr posit& operator*=(double rhs) {
 		return *this *= posit<nbits, es, bt>(rhs);
 	}
-	posit& operator/=(const posit& rhs) {
-		if (_trace_div) std::cout << "---------------------- DIV -------------------" << std::endl;
+	constexpr posit& operator/=(const posit& rhs) {
+		if constexpr (_trace_div) std::cout << "---------------------- DIV -------------------" << std::endl;
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
 		if (rhs.iszero()) {
 			throw posit_divide_by_zero{};    // not throwing is a quiet signalling NaR
@@ -820,7 +819,7 @@ public:
 
 		return *this;
 	}
-	posit& operator/=(double rhs) {
+	constexpr posit& operator/=(double rhs) {
 		return *this /= posit<nbits, es, bt>(rhs);
 	}
 	
@@ -1477,19 +1476,19 @@ private:
 	template<unsigned nnbits, unsigned ees, typename bbt>
 	friend std::istream& operator>> (std::istream& istr, posit<nnbits, ees, bbt>& p);
 
-	// posit - posit logic functions
+	// posit - posit logic functions (constexpr to match implementations)
 	template<unsigned nnbits, unsigned ees, typename bbt>
-	friend bool operator==(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
+	friend constexpr bool operator==(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
 	template<unsigned nnbits, unsigned ees, typename bbt>
-	friend bool operator!=(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
+	friend constexpr bool operator!=(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
 	template<unsigned nnbits, unsigned ees, typename bbt>
-	friend bool operator< (const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
+	friend constexpr bool operator< (const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
 	template<unsigned nnbits, unsigned ees, typename bbt>
-	friend bool operator> (const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
+	friend constexpr bool operator> (const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
 	template<unsigned nnbits, unsigned ees, typename bbt>
-	friend bool operator<=(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
+	friend constexpr bool operator<=(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
 	template<unsigned nnbits, unsigned ees, typename bbt>
-	friend bool operator>=(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
+	friend constexpr bool operator>=(const posit<nnbits, ees, bbt>& lhs, const posit<nnbits, ees, bbt>& rhs);
 
 #if POSIT_ENABLE_LITERALS
 	// posit - literal logic functions
@@ -2145,52 +2144,52 @@ inline std::string to_base2_scientific(const posit<nbits, es, bt>& number) {
 // posit - posit binary logic operators
 
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator==(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline bool operator==(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	return lhs._block == rhs._block;
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator!=(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline bool operator!=(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	return !operator==(lhs, rhs);
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator< (const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline bool operator< (const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	return operator<(lhs._block, rhs._block);
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator> (const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline bool operator> (const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	return operator< (rhs, lhs);
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator<=(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline bool operator<=(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator>=(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline bool operator>=(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	return !operator< (lhs, rhs);
 }
 
 // posit - posit binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, unsigned es, typename bt>
-inline posit<nbits, es, bt> operator+(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline posit<nbits, es, bt> operator+(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	posit<nbits, es, bt> sum = lhs;
 	return sum += rhs;
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned es, typename bt>
-inline posit<nbits, es, bt> operator-(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline posit<nbits, es, bt> operator-(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	posit<nbits, es, bt> diff = lhs;
 	return diff -= rhs;
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned es, typename bt>
-inline posit<nbits, es, bt> operator*(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline posit<nbits, es, bt> operator*(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	posit<nbits, es, bt> mul = lhs;
 	return mul *= rhs;
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned es, typename bt>
-inline posit<nbits, es, bt> operator/(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
+constexpr inline posit<nbits, es, bt> operator/(const posit<nbits, es, bt>& lhs, const posit<nbits, es, bt>& rhs) {
 	posit<nbits, es, bt> ratio(lhs);
 	return ratio /= rhs;
 }

--- a/include/sw/universal/number/posit/posit_regime.hpp
+++ b/include/sw/universal/number/posit/posit_regime.hpp
@@ -18,72 +18,73 @@ template<unsigned nbits, unsigned es, typename bt>
 class positRegime {
 	using RegimeBits = blockbinary<nbits - 1, bt, BinaryNumberType::Unsigned>;
 public:
-	positRegime() : _block(), _k(0), _run(0), _nrRegimeBits(0) {}
-	
-	positRegime(const positRegime& r) = default;
-	positRegime(positRegime&& r) = default;
+	constexpr positRegime() : _block(), _k(0), _run(0), _nrRegimeBits(0) {}
 
-	positRegime& operator=(const positRegime& r) = default;
-	positRegime& operator=(positRegime&& r) = default;
-	
-	inline void reset() {
+	constexpr positRegime(const positRegime& r) = default;
+	constexpr positRegime(positRegime&& r) = default;
+
+	constexpr positRegime& operator=(const positRegime& r) = default;
+	constexpr positRegime& operator=(positRegime&& r) = default;
+
+	constexpr void reset() {
 		_k = 0;
 		_nrRegimeBits = 0;
 		_block.clear();
 	}
-	inline size_t nrBits() const { return _nrRegimeBits;	}
-	int scale() const {
+	constexpr size_t nrBits() const { return _nrRegimeBits;	}
+	constexpr int scale() const {
 		return _k > 0 ? int(_k) * (1 << es) : -(int(-_k) * (1 << es));
 	}
 
 	// return the k-value of the positRegime: useed ^ k
-	inline int positRegime_k() const {
+	constexpr int positRegime_k() const {
 		return _k;
 	}
 	// the length of the run of the positRegime
-	inline int positRegime_run() const {
+	constexpr int positRegime_run() const {
 		return _run;
 	}
+	// uses std::ldexp -- not constexpr until C++26
 	long double value() const {
 		int e2 = (1 << es) * _k;
 		return std::ldexp(1.0l, e2);
 	}
-	inline bool iszero() const { return _block.none(); }
-	inline blockbinary<nbits - 1, bt, BinaryNumberType::Unsigned> bits() const { return _block; }
-	void set(const blockbinary<nbits - 1, bt>& raw, unsigned nrOfRegimeBits) {
+	constexpr bool iszero() const { return _block.none(); }
+	constexpr blockbinary<nbits - 1, bt, BinaryNumberType::Unsigned> bits() const { return _block; }
+	constexpr void set(const blockbinary<nbits - 1, bt>& raw, unsigned nrOfRegimeBits) {
 		_block = raw;
 		_nrRegimeBits = nrOfRegimeBits;
 	}
-	void setzero() {
+	constexpr void setzero() {
 		_block.clear();
 		_nrRegimeBits = nbits - 1;
 		_k = 1 - static_cast<int>(nbits);   // by design: this simplifies increment/decrement
 	}
-	void setinf() {
+	constexpr void setinf() {
 		_block.clear();
 		_nrRegimeBits = nbits - 1;
 		_k = static_cast<int>(nbits) - 1;   // by design: this simplifies increment/decrement
 	}
 	// return the size of a regime encoding for a particular k value
-	int regime_size(int k) const {
+	constexpr int regime_size(int k) const {
 		if (k < 0) k = -k - 1;
 		return (k < static_cast<int>(nbits) - 2 ? k + 2 : nbits - 1);
 	}
-	size_t assign(int scale) {
+	constexpr size_t assign(int scale) {
 		bool r = scale > 0;
 		_k = calculate_k<nbits,es,bt>(scale);
 		_run = static_cast<unsigned>(r ? 1 + (scale >> es) : -scale >> es);
 		r ? _block.set() : _block.clear();
-		_block.set(nbits - 1 - _run - 1, 1 ^ r); // termination bit		
+		_block.set(nbits - 1 - _run - 1, 1 ^ r); // termination bit
 		_nrRegimeBits = _run + 1;
 		return _nrRegimeBits;
 	}
 	// construct the regime bit pattern given a number's useed scale, that is, k represents the useed factors of the number
 	// k is the unifying abstraction between decoding a posit and converting a float value.
-	// Return the number of regime bits. 
+	// Return the number of regime bits.
 	// Usage example: say value is 1024 -> sign = false (not negative), scale is 10: assign_regime_pattern(scale >> es)
 	// because useed = 2^es and thus a value of scale 'scale' will contain (scale >> es) number of useed factors
-	unsigned assign_regime_pattern(int k) {
+	constexpr unsigned assign_regime_pattern(int k) {
 		// The stored regime always includes the terminating opposite bit unless the run saturates all payload bits.
 		// That makes _nrRegimeBits a layout property, not just a run-length: downstream exponent extraction can
 		// skip exactly that many bits regardless of whether the regime came from decoding or from reconstruction.

--- a/static/tapered/posit/api/api.cpp
+++ b/static/tapered/posit/api/api.cpp
@@ -175,6 +175,57 @@ try {
 	}
 #endif  // BIT_CAST_IS_CONSTEXPR
 
+	std::cout << "+-----------------   constexpr arithmetic + comparison (issue #718)\n";
+#if BIT_CAST_IS_CONSTEXPR
+	{
+		// The #718 acceptance form: constexpr posit<32,2>(2.0) * posit<32,2>(3.0) etc.
+		// Promotion of the entire decode/normalize/blocktriple chain to constexpr
+		// makes posit a true plug-in for native float in constexpr contexts.
+		constexpr posit<32, 2> a(2.0);
+		constexpr posit<32, 2> b(3.0);
+		constexpr auto cx_sum  = a + b;
+		constexpr auto cx_diff = a - b;
+		constexpr auto cx_prod = a * b;
+		constexpr auto cx_quot = b / a;
+		constexpr auto cx_neg  = -a;
+
+		// Compound forms via lambda
+		constexpr posit<32, 2> cx_addeq = []() { posit<32, 2> t(2.0); t += posit<32, 2>(3.0); return t; }();
+		constexpr posit<32, 2> cx_muleq = []() { posit<32, 2> t(2.0); t *= posit<32, 2>(3.0); return t; }();
+
+		// Constexpr comparisons
+		constexpr bool eq = (a == b);
+		constexpr bool lt = (a < b);
+		constexpr bool ge = (b >= a);
+		static_assert(!eq, "constexpr a == b is false for 2 vs 3");
+		static_assert(lt,  "constexpr a < b is true for 2 < 3");
+		static_assert(ge,  "constexpr b >= a is true for 3 >= 2");
+
+		// Cross-check constexpr-evaluated values match runtime-computed values bit-for-bit
+		posit<32, 2> ra(2.0), rb(3.0);
+		posit<32, 2> rsum  = ra + rb;
+		posit<32, 2> rprod = ra * rb;
+
+		int start = nrOfFailedTestCases;
+		if (!posit_same_bits(cx_sum,   rsum))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit + matches runtime\n"; }
+		if (!posit_same_bits(cx_prod,  rprod)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit * matches runtime\n"; }
+		if (!posit_same_bits(cx_addeq, rsum))  { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit += matches runtime +\n"; }
+		if (!posit_same_bits(cx_muleq, rprod)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr posit *= matches runtime *\n"; }
+
+		// Exact arithmetic checks (these values fit posit<32,2> exactly)
+		posit<32, 2> r5(5.0), r6(6.0);
+		if (!posit_same_bits(cx_sum,  r5)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 2+3 == 5 exactly\n"; }
+		if (!posit_same_bits(cx_prod, r6)) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 2*3 == 6 exactly\n"; }
+
+		(void)cx_diff; (void)cx_quot; (void)cx_neg;  // suppress unused -- the constexpr eval IS the test
+		if (nrOfFailedTestCases - start == 0) std::cout << "PASS constexpr arithmetic + comparison\n";
+	}
+#else
+	{
+		std::cout << "SKIP constexpr arithmetic + comparison (compiler lacks constexpr bit_cast support)\n";
+	}
+#endif
+
 	// Runtime smoke test for the nbits > 64 IEEE-754 path. This branch routes
 	// through convert_<>() with a blocksignificand and exists as a fallback
 	// because uint64_t cannot accommodate the wider posit encoding. The path


### PR DESCRIPTION
## Summary

Resolves **#718**. Builds on #714, #716, #717, #725, #752 and completes the posit constexpr surface. After this PR:

```cpp
constexpr posit<32, 2> a(2.0), b(3.0);
constexpr auto sum  = a + b;     // works
constexpr auto prod = a * b;     // works
constexpr auto neg  = -a;        // works
static_assert(a < b);            // works
```

posit is now the **first Universal number system fully constexpr from construction through arithmetic**. The proven playbook from this work (PRs #714 + #716 + #717 + #752 + this one) is the template for the remaining Tier-2 sub-issues of Epic #723.

## Why this PR is bigger than originally scoped

The audit revealed the chain ran deeper than the original #718 scoping suggested. `posit::operator*=` calls `normalizeMultiplication`, which calls `decode`, which calls `extract_fields`, which manipulates `positRegime`/`positExponent`/`positFraction` — and **none** of those types had any of their member functions marked `constexpr`. The work was mechanical (~25 method signatures + 6 free functions) but had to land all-or-nothing because partial promotion produces "decorated but not actually constexpr" lies.

## Changes

### Internal primitives (small)
- `blockbinary::to_ull()` — constexpr (pure bit-loop reading)
- Free `blockbinary operator+`, `operator-` — constexpr (delegate to constexpr `operator+=`/`operator-=`)
- Note: `blockbinary operator*`, `operator/`, `operator%` left non-constexpr — they delegate to `*=`/`/=`/`%=` which are still non-constexpr (that's #720 territory)

### Posit value-extraction internals
- `decode_regime`, `extract_fields`, `decode` (free template helpers in posit_impl.hpp): constexpr
- `convert(blocktriple, posit)` free function: constexpr (body was already constexpr-clean)
- `if (_trace_decode) std::cout` -> `if constexpr (_trace_decode) std::cout`

### Posit field-component classes
- `positRegime`: ctors, `reset`, `scale`, `set`, `setzero`, `setinf`, `regime_size`, `assign`, `assign_regime_pattern`, `iszero`, `bits`, `nrBits`, `positRegime_k`, `positRegime_run` — all constexpr. Left `value()` (uses `std::ldexp`) and `increment()` (uses `std::cout`) non-constexpr; neither is on the arithmetic critical path.
- `positExponent`: all member functions including `extract_exponent_bits`. `value()` is constexpr because it uses pure integer shift (unlike positRegime's ldexp).
- `positFraction`: all member functions including `value()` (pure long-double accumulation, constexpr-clean).

### Posit operators
- `posit::operator-()`, `++`, `--`, `+=`, `-=`, `*=`, `/=` (and double overloads): constexpr
- Four `if (_trace_X)` -> `if constexpr (_trace_X)` conversions in `+=`, `*=`, `/=`
- Free `posit operator+`, `-`, `*`, `/`: constexpr (delegate to compound)
- Free `posit operator==`, `!=`, `<`, `>`, `<=`, `>=` plus matching friend declarations: constexpr

### Tests
`static/tapered/posit/api/api.cpp` gets a third `#if BIT_CAST_IS_CONSTEXPR`-guarded block (after the integer #714 and IEEE-754 #717 ones) exercising:
- `constexpr auto sum = a + b;` and the other 5 binary operator forms
- Compound forms via lambda (`+=`, `*=`)
- `static_assert` on comparison results (`==`, `<`, `>=`)
- Bit-equivalent cross-check vs runtime construction
- Exact arithmetic on representable values: `2+3 == 5` and `2*3 == 6` exactly

## Local validation (gcc 13 + clang 18, -std=c++20)

| Suite | Targets | gcc | clang |
|-------|---------|-----|-------|
| posit | `posit_api` (incl. 3 constexpr blocks), `posit_assignment`, `posit_conversion`, `posit_addition`, `posit_subtraction`, `posit_multiplication`, `posit_division` | PASS | PASS |
| cfloat | `cfloat_api` | PASS | PASS |
| lns | `lns_api` | PASS | PASS |
| fixpnt | `fixpnt_api` | PASS | PASS |
| bfloat16 | `bfloat16_api` | PASS | PASS |
| internal | `bb_constexpr` | PASS | PASS |

12/12 PASS each compiler. Plus an off-tree harness:
```cpp
constexpr posit<32,2> a(2.0), b(3.0);
constexpr auto prod = a * b;
static_assert(prod == posit<32,2>(6.0), "exact");
```
...compiles and runs on both compilers.

## Risk

Low-medium. The internal primitive changes (`blockbinary::to_ull`, free `+`/`-`) affect every type that consumes blockbinary, but they're additive (no behavior change). The posit-internal changes are isolated to posit_*.hpp files and exercised by the full posit regression suite which passes.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #718
Relates to #723 (Epic)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader constexpr support across numeric types so arithmetic, comparisons, and related operations can be evaluated at compile time, improving performance and compile-time guarantees.
  * Safer constant-evaluation of exponent/fraction computations for posit types.

* **Tests**
  * Added compile-time tests validating constexpr arithmetic, comparisons, unary ops, and bit-exact equivalence for posit numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->