### PR TITLE
feat(integer): full constexpr arithmetic, comparison, shifts, conversions

### DIFF
--- a/include/sw/universal/number/integer/integer_fwd.hpp
+++ b/include/sw/universal/number/integer/integer_fwd.hpp
@@ -13,6 +13,6 @@ template<unsigned nbits, typename BlockType, IntegerNumberType NumberType> class
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType> integer<nbits, BlockType, NumberType> max_int();
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType> integer<nbits, BlockType, NumberType> min_int();
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType> struct idiv_t;
-template<unsigned nbits, typename BlockType, IntegerNumberType NumberType> idiv_t<nbits, BlockType, NumberType> idiv(const integer<nbits, BlockType, NumberType>&, const integer<nbits, BlockType, NumberType>&b);
+template<unsigned nbits, typename BlockType, IntegerNumberType NumberType> constexpr idiv_t<nbits, BlockType, NumberType> idiv(const integer<nbits, BlockType, NumberType>&, const integer<nbits, BlockType, NumberType>&b);
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -381,9 +381,26 @@ public:
 				}
 				clear();
 				if (std::is_constant_evaluated()) {
-					// Portable double-loop (no mul128 intrinsic). For uint64 limbs
-					// we lose the high-half of the mul, but the result is masked
-					// to nbits anyway so any overflow gets discarded.
+					// Constexpr-safe 64x64 -> 128 mul + carry propagation. Uses
+					// __int128 on gcc/clang (where it is constexpr-friendly).
+					// On MSVC (no __int128), constexpr eval of integer<N, uint64_t>
+					// is unsupported -- callers can use uint32_t limbs there.
+#if defined(__SIZEOF_INT128__)
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint128_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint128_t product = static_cast<uint128_t>(base.block(i)) * multiplicant.block(j);
+								uint128_t sum = product + _block[i + j] + carry;
+								_block[i + j] = static_cast<bt>(sum);
+								carry = sum >> 64;
+							}
+						}
+					}
+#else
+					// MSVC fallback (or any platform without __int128): truncating
+					// fallback. Documented limitation: uint64-limb integer<>
+					// constexpr arithmetic loses high-half of partial products.
 					for (unsigned i = 0; i < static_cast<unsigned>(nrBlocks); ++i) {
 						std::uint64_t segment(0);
 						for (unsigned j = 0; j < static_cast<unsigned>(nrBlocks); ++j) {
@@ -391,10 +408,11 @@ public:
 							if (i + j < static_cast<unsigned>(nrBlocks)) {
 								segment += _block[i + j];
 								_block[i + j] = static_cast<bt>(segment);
-								segment = 0;  // uint64 limbs: cannot capture the high half here
+								segment = 0;
 							}
 						}
 					}
+#endif
 				}
 				else {
 					for (unsigned i = 0; i < nrBlocks; ++i) {
@@ -450,6 +468,20 @@ public:
 				integer<nbits, BlockType, NumberType> base(*this), multiplicant(rhs);
 				clear();
 				if (std::is_constant_evaluated()) {
+					// Same __int128 carry propagation as the IntegerNumber branch above
+#if defined(__SIZEOF_INT128__)
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint128_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint128_t product = static_cast<uint128_t>(base.block(i)) * multiplicant.block(j);
+								uint128_t sum = product + _block[i + j] + carry;
+								_block[i + j] = static_cast<bt>(sum);
+								carry = sum >> 64;
+							}
+						}
+					}
+#else
 					for (unsigned i = 0; i < static_cast<unsigned>(nrBlocks); ++i) {
 						std::uint64_t segment(0);
 						for (unsigned j = 0; j < static_cast<unsigned>(nrBlocks); ++j) {
@@ -461,6 +493,7 @@ public:
 							}
 						}
 					}
+#endif
 				}
 				else {
 					for (unsigned i = 0; i < nrBlocks; ++i) {
@@ -503,12 +536,21 @@ public:
 		if constexpr (bitsInBlock == 64) {
 			// uint64_t limbs: same mul128/addcarry dispatch as operator*=
 			if (std::is_constant_evaluated()) {
+#if defined(__SIZEOF_INT128__)
+				uint128_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					uint128_t product = static_cast<uint128_t>(_block[i]) * scale + carry;
+					_block[i] = static_cast<BlockType>(product);
+					carry = product >> 64;
+				}
+#else
 				std::uint64_t scaleFactor(scale), segment(0);
 				for (unsigned i = 0; i < nrBlocks; ++i) {
 					segment += static_cast<std::uint64_t>(_block[i]) * scaleFactor;
 					_block[i] = static_cast<BlockType>(segment);
-					segment = 0;  // uint64 limbs: lose high half
+					segment = 0;
 				}
+#endif
 			}
 			else {
 				uint64_t carry = 0;
@@ -537,9 +579,14 @@ public:
 #if INTEGER_THROW_ARITHMETIC_EXCEPTION
 				throw integer_divide_by_zero{};
 #else
+				// When exceptions are disabled we still must avoid the actual
+				// divide-by-zero below (UB at runtime; constexpr eval would
+				// be ill-formed). Set the result to 0 and bail out.
 				if (!std::is_constant_evaluated()) {
 					std::cerr << "integer_divide_by_zero\n";
 				}
+				clear();
+				return *this;
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 			}
 			if constexpr (NumberType == WholeNumber) {
@@ -550,6 +597,8 @@ public:
 					if (!std::is_constant_evaluated()) {
 						std::cerr << "whole number cannot be zero but division would yield 0\n";
 					}
+					clear();
+					return *this;
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 				}
 			}
@@ -579,9 +628,14 @@ public:
 #if INTEGER_THROW_ARITHMETIC_EXCEPTION
 				throw integer_divide_by_zero{};
 #else
+				// When exceptions are disabled we still must avoid the actual
+				// modulo-by-zero below (UB at runtime; constexpr would be
+				// ill-formed). Set the result to 0 and bail out.
 				if (!std::is_constant_evaluated()) {
 					std::cerr << "integer_divide_by_zero\n";
 				}
+				clear();
+				return *this;
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 			}
 			if constexpr (sizeof(BlockType) == 1) {
@@ -1369,7 +1423,7 @@ private:
 
 	// find the most significant bit set
 	template<unsigned nnbits, typename BBlockType, IntegerNumberType NNumberType>
-	friend signed findMsb(const integer<nnbits, BBlockType, NNumberType>& v);
+	friend constexpr signed findMsb(const integer<nnbits, BBlockType, NNumberType>& v);
 };
 
 ////////////////////////    INTEGER functions   /////////////////////////////////
@@ -1420,41 +1474,48 @@ std::string convert_to_decimal_string(const integer<nbits, BlockType, NumberType
 }
 
 // findMsb takes an integer<nbits, BlockType, NumberType> reference and returns the 0-based position of the most significant bit, -1 if v == 0
+// Index-based loop (constexpr-clean; pointer arithmetic on stack arrays is forbidden in constexpr).
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline signed findMsb(const integer<nbits, BlockType, NumberType>& v) {
-	BlockType const* pV = v._block + v.nrBlocks - 1;
-	BlockType const* pLast = v._block;
-	BlockType BlockMsb = BlockType(BlockType(1u) << (v.bitsInBlock - 1));
-	signed msb = static_cast<signed>(v.nbits - 1ull); // the case for an aligned MSB
-	unsigned rem = nbits % v.bitsInBlock;
-	// we are organized little-endian
+constexpr signed findMsb(const integer<nbits, BlockType, NumberType>& v) {
+	using IntegerT = integer<nbits, BlockType, NumberType>;
+	// Access static members via the type (clang requires this in constexpr context).
+	constexpr unsigned bitsInBlk = IntegerT::bitsInBlock;
+	constexpr unsigned nBlks = IntegerT::nrBlocks;
+	constexpr BlockType BlockMsb = BlockType(BlockType(1u) << (bitsInBlk - 1));
+	signed msb = static_cast<signed>(IntegerT::nbits - 1ull); // the case for an aligned MSB
+	constexpr unsigned rem = nbits % bitsInBlk;
+
+	// little-endian: most significant block is at index nBlks - 1
+	unsigned blockIdx = nBlks - 1;
+
 	// check if the blocks are aligned with the representation
-	if (rem > 0) {
+	if constexpr (rem > 0) {
 		// the top bits are unaligned: construct the right mask
 		BlockType mask = BlockType(BlockType(1u) << (rem - 1u));
 		while (mask != 0) {
-			if (*pV & mask) return msb;
+			if (v._block[blockIdx] & mask) return msb;
 			--msb;
 			mask >>= 1;
 		}
 		if (msb < 0) return msb;
-		--pV;
+		if (blockIdx == 0) return msb;
+		--blockIdx;
 	}
 	// invariant: msb is now aligned with the blocks
-	// std::cout << "invariant msb : " << msb << '\n';
-	while (pV >= pLast) {
-		if (*pV != 0) {
+	while (true) {
+		if (v._block[blockIdx] != 0) {
 			BlockType mask = BlockMsb;
 			while (mask != 0) {
-				if (*pV & mask) return msb;
+				if (v._block[blockIdx] & mask) return msb;
 				--msb;
 				mask >>= 1;
 			}
 		}
 		else {
-			msb -= v.bitsInBlock;
+			msb -= static_cast<signed>(bitsInBlk);
 		}
-		--pV;
+		if (blockIdx == 0) break;
+		--blockIdx;
 	}
 	return msb; // == -1 if no significant bit found
 }
@@ -1482,9 +1543,14 @@ constexpr idiv_t<nbits, BlockType, NumberType> idiv(const integer<nbits, BlockTy
 #if INTEGER_THROW_ARITHMETIC_EXCEPTION
 		throw integer_divide_by_zero{};
 #else
+		// When exceptions are disabled we still must avoid the actual
+		// long-division below (UB on integer div-by-zero; constexpr would
+		// be ill-formed). Return zeroed quot/rem and bail out.
 		if (!std::is_constant_evaluated()) {
 			std::cerr << "integer_divide_by_zero\n";
 		}
+		idiv_t<nbits, BlockType, NumberType> zeroed;
+		return zeroed;
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 	}
 

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <regex>
+#include <type_traits>  // for std::is_constant_evaluated() dispatch around mul128/addcarry
 #include <vector>
 #include <map>
 
@@ -77,7 +78,7 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& v);
 // idiv_t for integer<nbits, BlockType, NumberType> to capture quotient and remainder during long division
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
 struct idiv_t {
-	idiv_t() : quot{ 0 }, rem{ 0 } {};
+	constexpr idiv_t() : quot{ 0 }, rem{ 0 } {};
 	integer<nbits, BlockType, NumberType> quot; // quotient
 	integer<nbits, BlockType, NumberType> rem;  // remainder
 };
@@ -130,7 +131,7 @@ public:
 
 	/// Construct a new integer from another, sign extend when necessary, BlockTypes must be the same
 	template<unsigned srcbits>
-	integer(const integer<srcbits, BlockType, NumberType>& a) {
+	constexpr integer(const integer<srcbits, BlockType, NumberType>& a) {
 //		static_assert(srcbits > nbits, "Source integer is bigger than target: potential loss of precision"); // TODO: do we want this?
 		bitcopy(a);
 		if constexpr (srcbits < nbits && NumberType == IntegerNumberType::IntegerNumber) {
@@ -274,39 +275,52 @@ public:
 #endif
 
 	// arithmetic operators
-	integer& operator+=(const integer& rhs) {
+	constexpr integer& operator+=(const integer& rhs) {
 		if constexpr (nrBlocks == 1) {
 			_block[0] = static_cast<bt>(_block[0] + rhs.block(0));
 			// null any leading bits that fall outside of nbits
 			_block[MSU] = static_cast<bt>(MSU_MASK & _block[MSU]);
 		}
 		else if constexpr (bitsInBlock == 64) {
-			// uint64_t limbs: use carry-detection intrinsics
+			// uint64_t limbs: addcarry uses platform intrinsics (not constexpr on MSVC).
+			// Dispatch to a portable carry path in constant-evaluated context.
 			integer<nbits, BlockType, NumberType> sum;
-			uint64_t carry = 0;
-			for (unsigned i = 0; i < nrBlocks; ++i) {
-				sum._block[i] = addcarry(_block[i], rhs._block[i], carry, carry);
+			if (std::is_constant_evaluated()) {
+				uint64_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					uint64_t a = _block[i];
+					uint64_t b = rhs._block[i];
+					uint64_t s1 = a + carry;
+					uint64_t c1 = (s1 < a) ? 1ull : 0ull;
+					uint64_t r  = s1 + b;
+					uint64_t c2 = (r < s1) ? 1ull : 0ull;
+					sum._block[i] = r;
+					carry = c1 + c2;
+				}
+			}
+			else {
+				uint64_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					sum._block[i] = addcarry(_block[i], rhs._block[i], carry, carry);
+				}
 			}
 			// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
 			sum._block[MSU] = static_cast<bt>(MSU_MASK & sum._block[MSU]);
 			*this = sum;
 		}
 		else {
+			// Multi-limb path for bt = uint8_t/uint16_t/uint32_t.
+			// Index-based loop (constexpr-friendly; pointer arithmetic on stack
+			// arrays is forbidden in constexpr).
 			integer<nbits, BlockType, NumberType> sum;
 			std::uint64_t carry = 0;
-			BlockType* pA = _block;
-			BlockType const* pB = rhs._block;
-			BlockType* pC = sum._block;
-			BlockType* pEnd = pC + nrBlocks;
-			while (pC != pEnd) {
-				carry += static_cast<std::uint64_t>(*pA) + static_cast<std::uint64_t>(*pB);
-				*pC = static_cast<bt>(carry);
+			for (unsigned i = 0; i < nrBlocks; ++i) {
+				carry += static_cast<std::uint64_t>(_block[i]) + static_cast<std::uint64_t>(rhs._block[i]);
+				sum._block[i] = static_cast<bt>(carry);
 				carry >>= bitsInBlock;
-				++pA; ++pB; ++pC;
 			}
 			// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
-			BlockType* pLast = pEnd - 1;
-			*pLast = static_cast<bt>(MSU_MASK & *pLast);
+			sum._block[MSU] = static_cast<bt>(MSU_MASK & sum._block[MSU]);
 	#if INTEGER_THROW_ARITHMETIC_EXCEPTION
 			// TODO: what is the real overflow condition?
 			// it is not carry == 1 as  say 1 + -1 sets the carry but is 0
@@ -316,7 +330,7 @@ public:
 		}
 		return *this;
 	}
-	integer& operator-=(const integer& rhs) {
+	constexpr integer& operator-=(const integer& rhs) {
 		if constexpr (NumberType == WholeNumber) {
 			if (*this < rhs) {
 				throw integer_wholenumber_cannot_be_negative{};
@@ -324,13 +338,20 @@ public:
 			if (*this == rhs) {
 				throw integer_wholenumber_cannot_be_zero{};
 			}
-			std::cerr << "subtractor for WholeNumbers TBD\n";
+			// std::cerr is not constexpr-callable; gate the diagnostic on
+			// runtime context only. The WholeNumber subtractor is TBD anyway,
+			// so this is just a placeholder warning.
+			if (!std::is_constant_evaluated()) {
+				std::cerr << "subtractor for WholeNumbers TBD\n";
+			}
 		}
 		else if constexpr (NumberType == NaturalNumber) {
 			if (*this < rhs) {
 				throw integer_wholenumber_cannot_be_negative{};
 			}
-			std::cerr << "subtractor for NaturalNumbers TBD\n";
+			if (!std::is_constant_evaluated()) {
+				std::cerr << "subtractor for NaturalNumbers TBD\n";
+			}
 		}
 		else {
 			integer twos(rhs);
@@ -338,13 +359,17 @@ public:
 		}
 		return *this;
 	}
-	integer& operator*=(const integer& rhs) {
+	constexpr integer& operator*=(const integer& rhs) {
 		if constexpr (NumberType == IntegerNumberType::IntegerNumber) {
 			if constexpr (nrBlocks == 1) {
 				_block[0] = static_cast<bt>(_block[0] * rhs.block(0));
 			}
 			else if constexpr (bitsInBlock == 64) {
-				// uint64_t limbs: use mul128/addcarry intrinsics
+				// uint64_t limbs: mul128/addcarry use platform intrinsics that are
+				// not constexpr on MSVC. In constant-evaluated context, fall back
+				// to a portable double-loop using the index-loop formulation
+				// (same as the bt < 64 branch below). At runtime we keep the
+				// intrinsic path for performance.
 				integer<nbits + 1, BlockType, NumberType> base(*this);
 				integer<nbits + 1, BlockType, NumberType> multiplicant(rhs);
 				bool resultIsNeg = (base.isneg() ^ multiplicant.isneg());
@@ -355,16 +380,34 @@ public:
 					multiplicant.twosComplement();
 				}
 				clear();
-				for (unsigned i = 0; i < nrBlocks; ++i) {
-					uint64_t carry = 0;
-					for (unsigned j = 0; j < nrBlocks; ++j) {
-						if (i + j < nrBlocks) {
-							uint64_t lo, hi;
-							mul128(base.block(i), multiplicant.block(j), lo, hi);
-							uint64_t c1 = 0;
-							uint64_t sum = addcarry(_block[i + j], lo, carry, c1);
-							_block[i + j] = sum;
-							carry = hi + c1;
+				if (std::is_constant_evaluated()) {
+					// Portable double-loop (no mul128 intrinsic). For uint64 limbs
+					// we lose the high-half of the mul, but the result is masked
+					// to nbits anyway so any overflow gets discarded.
+					for (unsigned i = 0; i < static_cast<unsigned>(nrBlocks); ++i) {
+						std::uint64_t segment(0);
+						for (unsigned j = 0; j < static_cast<unsigned>(nrBlocks); ++j) {
+							segment += static_cast<std::uint64_t>(base.block(i)) * static_cast<std::uint64_t>(multiplicant.block(j));
+							if (i + j < static_cast<unsigned>(nrBlocks)) {
+								segment += _block[i + j];
+								_block[i + j] = static_cast<bt>(segment);
+								segment = 0;  // uint64 limbs: cannot capture the high half here
+							}
+						}
+					}
+				}
+				else {
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint64_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint64_t lo, hi;
+								mul128(base.block(i), multiplicant.block(j), lo, hi);
+								uint64_t c1 = 0;
+								uint64_t sum = addcarry(_block[i + j], lo, carry, c1);
+								_block[i + j] = sum;
+								carry = hi + c1;
+							}
 						}
 					}
 				}
@@ -402,19 +445,35 @@ public:
 				_block[0] = static_cast<bt>(_block[0] * rhs.block(0));
 			}
 			else if constexpr (bitsInBlock == 64) {
-				// uint64_t limbs: use mul128/addcarry intrinsics
+				// Same is_constant_evaluated dispatch as the IntegerNumber branch
+				// above to keep mul128/addcarry intrinsics out of constexpr context.
 				integer<nbits, BlockType, NumberType> base(*this), multiplicant(rhs);
 				clear();
-				for (unsigned i = 0; i < nrBlocks; ++i) {
-					uint64_t carry = 0;
-					for (unsigned j = 0; j < nrBlocks; ++j) {
-						if (i + j < nrBlocks) {
-							uint64_t lo, hi;
-							mul128(base.block(i), multiplicant.block(j), lo, hi);
-							uint64_t c1 = 0;
-							uint64_t sum = addcarry(_block[i + j], lo, carry, c1);
-							_block[i + j] = sum;
-							carry = hi + c1;
+				if (std::is_constant_evaluated()) {
+					for (unsigned i = 0; i < static_cast<unsigned>(nrBlocks); ++i) {
+						std::uint64_t segment(0);
+						for (unsigned j = 0; j < static_cast<unsigned>(nrBlocks); ++j) {
+							segment += static_cast<std::uint64_t>(base.block(i)) * static_cast<std::uint64_t>(multiplicant.block(j));
+							if (i + j < static_cast<unsigned>(nrBlocks)) {
+								segment += _block[i + j];
+								_block[i + j] = static_cast<bt>(segment);
+								segment = 0;
+							}
+						}
+					}
+				}
+				else {
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint64_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint64_t lo, hi;
+								mul128(base.block(i), multiplicant.block(j), lo, hi);
+								uint64_t c1 = 0;
+								uint64_t sum = addcarry(_block[i + j], lo, carry, c1);
+								_block[i + j] = sum;
+								carry = hi + c1;
+							}
 						}
 					}
 				}
@@ -440,16 +499,26 @@ public:
 		_block[MSU] = static_cast<bt>(MSU_MASK & _block[MSU]);
 		return *this;
 	}
-	integer& operator*=(const BlockType& scale) noexcept {
+	constexpr integer& operator*=(const BlockType& scale) noexcept {
 		if constexpr (bitsInBlock == 64) {
-			// uint64_t limbs: use mul128/addcarry intrinsics
-			uint64_t carry = 0;
-			for (unsigned i = 0; i < nrBlocks; ++i) {
-				uint64_t lo, hi;
-				mul128(_block[i], static_cast<uint64_t>(scale), lo, hi);
-				uint64_t c1 = 0;
-				_block[i] = addcarry(lo, carry, uint64_t(0), c1);
-				carry = hi + c1;
+			// uint64_t limbs: same mul128/addcarry dispatch as operator*=
+			if (std::is_constant_evaluated()) {
+				std::uint64_t scaleFactor(scale), segment(0);
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					segment += static_cast<std::uint64_t>(_block[i]) * scaleFactor;
+					_block[i] = static_cast<BlockType>(segment);
+					segment = 0;  // uint64 limbs: lose high half
+				}
+			}
+			else {
+				uint64_t carry = 0;
+				for (unsigned i = 0; i < nrBlocks; ++i) {
+					uint64_t lo, hi;
+					mul128(_block[i], static_cast<uint64_t>(scale), lo, hi);
+					uint64_t c1 = 0;
+					_block[i] = addcarry(lo, carry, uint64_t(0), c1);
+					carry = hi + c1;
+				}
 			}
 		}
 		else {
@@ -462,13 +531,15 @@ public:
 		}
 		return *this;
 	}
-	integer& operator/=(const integer& rhs) {
+	constexpr integer& operator/=(const integer& rhs) {
 		if constexpr (EXACT_FIT && 1 == nrBlocks) {
 			if (rhs._block[0] == 0) {
 #if INTEGER_THROW_ARITHMETIC_EXCEPTION
 				throw integer_divide_by_zero{};
 #else
-				std::cerr << "integer_divide_by_zero\n";
+				if (!std::is_constant_evaluated()) {
+					std::cerr << "integer_divide_by_zero\n";
+				}
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 			}
 			if constexpr (NumberType == WholeNumber) {
@@ -476,7 +547,9 @@ public:
 #if INTEGER_THROW_ARITHMETIC_EXCEPTION
 					throw integer_wholenumber_cannot_be_zero{};
 #else
-					std::cerr << "whole number cannot be zero but division would yield 0\n";
+					if (!std::is_constant_evaluated()) {
+						std::cerr << "whole number cannot be zero but division would yield 0\n";
+					}
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 				}
 			}
@@ -500,13 +573,15 @@ public:
 		}
 		return *this;
 	}
-	integer& operator%=(const integer& rhs) {
+	constexpr integer& operator%=(const integer& rhs) {
 		if constexpr (nbits == (sizeof(BlockType) * 8)) {
 			if (rhs._block[0] == 0) {
 #if INTEGER_THROW_ARITHMETIC_EXCEPTION
 				throw integer_divide_by_zero{};
 #else
-				std::cerr << "integer_divide_by_zero\n";
+				if (!std::is_constant_evaluated()) {
+					std::cerr << "integer_divide_by_zero\n";
+				}
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 			}
 			if constexpr (sizeof(BlockType) == 1) {
@@ -532,7 +607,7 @@ public:
 	}
 
 	// arithmetic shift right operator
-	integer& operator<<=(int bitsToShift) {
+	constexpr integer& operator<<=(int bitsToShift) {
 		if (bitsToShift == 0) return *this;
 		if (bitsToShift < 0) return operator>>=(-bitsToShift);
 		if (bitsToShift > static_cast<int>(nbits)) {
@@ -568,7 +643,7 @@ public:
 		_block[MSU] &= MSU_MASK; // null any leading bits that fall outside of nbits
 		return *this;
 	}
-	integer& operator>>=(int bitsToShift) {
+	constexpr integer& operator>>=(int bitsToShift) {
 		if (bitsToShift == 0) return *this;
 		if (bitsToShift < 0) return operator<<=(-bitsToShift);
 		if (bitsToShift >= static_cast<int>(nbits)) {
@@ -638,7 +713,7 @@ public:
 		_block[MSU] &= MSU_MASK;
 		return *this;
 	}
-	integer& logicShiftRight(int shift) {
+	constexpr integer& logicShiftRight(int shift) {
 		if (shift == 0) return *this;
 		if (shift < 0) {
 			return operator<<=(-shift);
@@ -654,21 +729,21 @@ public:
 		*this = target;
 		return *this;
 	}
-	integer& operator&=(const integer& rhs) {
+	constexpr integer& operator&=(const integer& rhs) {
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			_block[i] &= rhs._block[i];
 		}
 		_block[MSU] &= MSU_MASK;
 		return *this;
 	}
-	integer& operator|=(const integer& rhs) {
+	constexpr integer& operator|=(const integer& rhs) {
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			_block[i] |= rhs._block[i];
 		}
 		_block[MSU] &= MSU_MASK;
 		return *this;
 	}
-	integer& operator^=(const integer& rhs) {
+	constexpr integer& operator^=(const integer& rhs) {
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			_block[i] ^= rhs._block[i];
 		}
@@ -1290,7 +1365,7 @@ private:
 
 	// integer - integer logic comparisons
 	template<unsigned nnbits, typename BBlockType, IntegerNumberType NNumberType>
-	friend bool operator==(const integer<nnbits, BBlockType, NNumberType>& lhs, const integer<nnbits, BBlockType, NNumberType>& rhs);
+	friend constexpr bool operator==(const integer<nnbits, BBlockType, NNumberType>& lhs, const integer<nnbits, BBlockType, NNumberType>& rhs);
 
 	// find the most significant bit set
 	template<unsigned nnbits, typename BBlockType, IntegerNumberType NNumberType>
@@ -1300,20 +1375,20 @@ private:
 ////////////////////////    INTEGER functions   /////////////////////////////////
 
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> abs(const integer<nbits, BlockType, NumberType>& a) {
+constexpr inline integer<nbits, BlockType, NumberType> abs(const integer<nbits, BlockType, NumberType>& a) {
 	integer<nbits, BlockType, NumberType> b(a);
 	return (a >= 0 ? b : b.twosComplement());
 }
 
 // free function to create a 1's complement copy of an integer
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> onesComplement(const integer<nbits, BlockType, NumberType>& value) {
+constexpr inline integer<nbits, BlockType, NumberType> onesComplement(const integer<nbits, BlockType, NumberType>& value) {
 	integer<nbits, BlockType, NumberType> ones(value);
 	return ones.flip();
 }
 // free function to create the 2's complement of an integer
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> twosComplement(const integer<nbits, BlockType, NumberType>& value) {
+constexpr inline integer<nbits, BlockType, NumberType> twosComplement(const integer<nbits, BlockType, NumberType>& value) {
 	integer<nbits, BlockType, NumberType> twos(value);
 	return twos.twosComplement();;
 }
@@ -1402,12 +1477,14 @@ void remainder(integer<nbits, BlockType, NumberType>& c, const integer<nbits, Bl
 
 // divide integer<nbits, BlockType, NumberType> a and b and return result argument
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-idiv_t<nbits, BlockType, NumberType> idiv(const integer<nbits, BlockType, NumberType>& _a, const integer<nbits, BlockType, NumberType>& _b) {
+constexpr idiv_t<nbits, BlockType, NumberType> idiv(const integer<nbits, BlockType, NumberType>& _a, const integer<nbits, BlockType, NumberType>& _b) {
 	if (_b.iszero()) {
 #if INTEGER_THROW_ARITHMETIC_EXCEPTION
 		throw integer_divide_by_zero{};
 #else
-		std::cerr << "integer_divide_by_zero\n";
+		if (!std::is_constant_evaluated()) {
+			std::cerr << "integer_divide_by_zero\n";
+		}
 #endif // INTEGER_THROW_ARITHMETIC_EXCEPTION
 	}
 
@@ -1781,18 +1858,18 @@ inline std::string to_native(const integer<nbits, BlockType, NumberType>& number
 
 // equal: precondition is that the storage is properly nulled in all arithmetic paths
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator==(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator==(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	for (unsigned i = 0; i < lhs.nrBlocks; ++i) {
 		if (lhs._block[i] != rhs._block[i]) return false;
 	}
 	return true;
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator!=(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator!=(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return !operator==(lhs, rhs);
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator< (const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator< (const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	if constexpr (NumberType == WholeNumber || NumberType == NaturalNumber) {
 		for (int i = static_cast<int>(lhs.nrBlocks) - 1; i >= 0; --i) {
 			if (lhs.block(static_cast<unsigned>(i)) == rhs.block(static_cast<unsigned>(i))) continue;
@@ -1824,15 +1901,15 @@ inline bool operator< (const integer<nbits, BlockType, NumberType>& lhs, const i
 	}
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator> (const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator> (const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator< (rhs, lhs);
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator<=(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator<=(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return !operator> (lhs, rhs);
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator>=(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator>=(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return !operator< (lhs, rhs);
 }
 
@@ -1840,27 +1917,27 @@ inline bool operator>=(const integer<nbits, BlockType, NumberType>& lhs, const i
 // integer - literal binary logic operators
 // equal: precondition is that the byte-storage is properly nulled in all arithmetic paths
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType, typename IntType>
-inline bool operator==(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
+constexpr inline bool operator==(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
 	return operator==(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType, typename IntType>
-inline bool operator!=(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
+constexpr inline bool operator!=(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
 	return !operator==(lhs, rhs);
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType, typename IntType>
-inline bool operator< (const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
+constexpr inline bool operator< (const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
 	return operator<(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType, typename IntType>
-inline bool operator> (const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
+constexpr inline bool operator> (const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
 	return operator< (integer<nbits, BlockType, NumberType>(rhs), lhs);
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType, typename IntType>
-inline bool operator<=(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
+constexpr inline bool operator<=(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType, typename IntType>
-inline bool operator>=(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
+constexpr inline bool operator>=(const integer<nbits, BlockType, NumberType>& lhs, IntType rhs) {
 	return !operator< (lhs, rhs);
 }
 
@@ -1869,40 +1946,40 @@ inline bool operator>=(const integer<nbits, BlockType, NumberType>& lhs, IntType
 // precondition is that the byte-storage is properly nulled in all arithmetic paths
 
 template<typename IntType, unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator==(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator==(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator==(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 template<typename IntType, unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator!=(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator!=(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return !operator==(lhs, rhs);
 }
 template<typename IntType, unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator< (IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator< (IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator<(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 template<typename IntType, unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator> (IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator> (IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator< (rhs, lhs);
 }
 template<typename IntType, unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator<=(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator<=(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<typename IntType, unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline bool operator>=(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline bool operator>=(IntType lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return !operator< (lhs, rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator<<(const integer<nbits, BlockType, NumberType>& lhs, int shift) {
+constexpr inline integer<nbits, BlockType, NumberType> operator<<(const integer<nbits, BlockType, NumberType>& lhs, int shift) {
 	integer<nbits, BlockType, NumberType> shifted(lhs);
 	return (shifted <<= shift);
 }
 
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator>>(const integer<nbits, BlockType, NumberType>& lhs, int shift) {
+constexpr inline integer<nbits, BlockType, NumberType> operator>>(const integer<nbits, BlockType, NumberType>& lhs, int shift) {
 	integer<nbits, BlockType, NumberType> shifted(lhs);
 	return (shifted >>= shift);
 }
@@ -1911,56 +1988,56 @@ inline integer<nbits, BlockType, NumberType> operator>>(const integer<nbits, Blo
 // integer - integer binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator+(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator+(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> sum(lhs);
 	sum += rhs;
 	return sum;
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator-(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator-(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> diff(lhs);
 	diff -= rhs;
 	return diff;
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator*(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator*(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> mul(lhs);
 	mul *= rhs;
 	return mul;
 }
 // BINARY DIVISION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator/(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator/(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> ratio(lhs);
 	ratio /= rhs;
 	return ratio;
 }
 // BINARY REMAINDER
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator%(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator%(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> ratio(lhs);
 	ratio %= rhs;
 	return ratio;
 }
 // BINARY BIT-WISE AND
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator&(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator&(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> bitwise(lhs);
 	bitwise &= rhs;
 	return bitwise;
 }
 // BINARY BIT-WISE OR
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator|(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator|(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> bitwise(lhs);
 	bitwise |= rhs;
 	return bitwise;
 }
 // BINARY BIT-WISE XOR
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator^(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator^(const integer<nbits, BlockType, NumberType>& lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	integer<nbits, BlockType, NumberType> bitwise(lhs);
 	bitwise ^= rhs;
 	return bitwise;
@@ -1970,84 +2047,84 @@ inline integer<nbits, BlockType, NumberType> operator^(const integer<nbits, Bloc
 // integer - literal binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator+(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator+(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator+(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator-(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator-(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator-(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator*(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator*(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator*(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator/(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator/(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator/(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator%(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator%(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator%(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 // BINARY BIT-WISE AND
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator&(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator&(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator&(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 // BINARY BIT-WISE OR
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator|(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator|(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator|(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 // BINARY BIT-WISE XOR
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator^(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator^(const integer<nbits, BlockType, NumberType>& lhs, long long rhs) {
 	return operator^(lhs, integer<nbits, BlockType, NumberType>(rhs));
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - integer binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator+(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator+(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator+(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator-(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator-(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator-(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator*(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator*(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator*(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator/(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator/(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator/(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator%(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator%(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator%(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 // BINARY BIT-WISE AND
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator&(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator&(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator&(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 // BINARY BIT-WISE OR
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator|(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator|(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator|(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 // BINARY BIT-WISE XOR
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
-inline integer<nbits, BlockType, NumberType> operator^(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
+constexpr inline integer<nbits, BlockType, NumberType> operator^(long long lhs, const integer<nbits, BlockType, NumberType>& rhs) {
 	return operator^(integer<nbits, BlockType, NumberType>(lhs), rhs);
 }
 

--- a/static/integer/binary/api/api.cpp
+++ b/static/integer/binary/api/api.cpp
@@ -24,59 +24,6 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	std::cout << "+-----------------   constexpr arithmetic + comparison (issue #720)\n";
-	{
-		// The #720 acceptance form: constexpr integer arithmetic in a constant
-		// expression. Joins posit (#718), cfloat (#719), bfloat16 (#725) as a
-		// fully constexpr type.
-		using I32 = integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>;
-		constexpr I32 a(42);
-		constexpr I32 b(7);
-		constexpr auto cx_sum  = a + b;
-		constexpr auto cx_diff = a - b;
-		constexpr auto cx_prod = a * b;
-		constexpr auto cx_quot = a / b;
-		constexpr auto cx_rem  = a % b;
-		constexpr auto cx_neg  = -a;
-		constexpr auto cx_and  = a & b;
-		constexpr auto cx_or   = a | b;
-		constexpr auto cx_xor  = a ^ b;
-		constexpr auto cx_shl  = a << 2;
-		constexpr auto cx_shr  = a >> 2;
-
-		// Compound forms via lambda
-		constexpr I32 cx_addeq = []() { I32 t(42); t += I32(7); return t; }();
-		constexpr I32 cx_muleq = []() { I32 t(42); t *= I32(7); return t; }();
-
-		// Constexpr comparisons
-		static_assert(!(a == b), "constexpr 42 != 7");
-		static_assert(b < a,     "constexpr 7 < 42");
-		static_assert(a >= b,    "constexpr 42 >= 7");
-
-		int start = nrOfFailedTestCases;
-		I32 r49(49), r294(294), r6(6), r0(0), r_neg42(-42);
-		I32 r168(168), r10(10);  // 42<<2=168, 42>>2=10
-		if (cx_sum  != r49)     { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42+7\n"; }
-		if (cx_prod != r294)    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42*7\n"; }
-		if (cx_quot != r6)      { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42/7\n"; }
-		if (cx_rem  != r0)      { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42%7\n"; }
-		if (cx_neg  != r_neg42) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr -42\n"; }
-		if (cx_shl  != r168)    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42<<2\n"; }
-		if (cx_shr  != r10)     { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42>>2\n"; }
-		if (cx_addeq != r49)    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr += matches +\n"; }
-		if (cx_muleq != r294)   { ++nrOfFailedTestCases; std::cout << "FAIL constexpr *= matches *\n"; }
-		(void)cx_diff; (void)cx_and; (void)cx_or; (void)cx_xor;
-
-		// Multi-limb constexpr
-		using I128 = integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>;
-		constexpr I128 ma(1000000), mb(1000);
-		constexpr auto cx_m_prod = ma * mb;
-		I128 r_billion(1000000000ll);
-		if (cx_m_prod != r_billion) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 1M * 1k == 1B (multi-limb)\n"; }
-
-		if (nrOfFailedTestCases - start == 0) std::cout << "PASS constexpr arithmetic + comparison\n";
-	}
-
 	/////////////////////////////////////////////////////////////////////////////////////
 	//// MODULAR integers
 

--- a/static/integer/binary/api/api.cpp
+++ b/static/integer/binary/api/api.cpp
@@ -24,6 +24,59 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
+	std::cout << "+-----------------   constexpr arithmetic + comparison (issue #720)\n";
+	{
+		// The #720 acceptance form: constexpr integer arithmetic in a constant
+		// expression. Joins posit (#718), cfloat (#719), bfloat16 (#725) as a
+		// fully constexpr type.
+		using I32 = integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>;
+		constexpr I32 a(42);
+		constexpr I32 b(7);
+		constexpr auto cx_sum  = a + b;
+		constexpr auto cx_diff = a - b;
+		constexpr auto cx_prod = a * b;
+		constexpr auto cx_quot = a / b;
+		constexpr auto cx_rem  = a % b;
+		constexpr auto cx_neg  = -a;
+		constexpr auto cx_and  = a & b;
+		constexpr auto cx_or   = a | b;
+		constexpr auto cx_xor  = a ^ b;
+		constexpr auto cx_shl  = a << 2;
+		constexpr auto cx_shr  = a >> 2;
+
+		// Compound forms via lambda
+		constexpr I32 cx_addeq = []() { I32 t(42); t += I32(7); return t; }();
+		constexpr I32 cx_muleq = []() { I32 t(42); t *= I32(7); return t; }();
+
+		// Constexpr comparisons
+		static_assert(!(a == b), "constexpr 42 != 7");
+		static_assert(b < a,     "constexpr 7 < 42");
+		static_assert(a >= b,    "constexpr 42 >= 7");
+
+		int start = nrOfFailedTestCases;
+		I32 r49(49), r294(294), r6(6), r0(0), r_neg42(-42);
+		I32 r168(168), r10(10);  // 42<<2=168, 42>>2=10
+		if (cx_sum  != r49)     { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42+7\n"; }
+		if (cx_prod != r294)    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42*7\n"; }
+		if (cx_quot != r6)      { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42/7\n"; }
+		if (cx_rem  != r0)      { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42%7\n"; }
+		if (cx_neg  != r_neg42) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr -42\n"; }
+		if (cx_shl  != r168)    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42<<2\n"; }
+		if (cx_shr  != r10)     { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 42>>2\n"; }
+		if (cx_addeq != r49)    { ++nrOfFailedTestCases; std::cout << "FAIL constexpr += matches +\n"; }
+		if (cx_muleq != r294)   { ++nrOfFailedTestCases; std::cout << "FAIL constexpr *= matches *\n"; }
+		(void)cx_diff; (void)cx_and; (void)cx_or; (void)cx_xor;
+
+		// Multi-limb constexpr
+		using I128 = integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>;
+		constexpr I128 ma(1000000), mb(1000);
+		constexpr auto cx_m_prod = ma * mb;
+		I128 r_billion(1000000000ll);
+		if (cx_m_prod != r_billion) { ++nrOfFailedTestCases; std::cout << "FAIL constexpr 1M * 1k == 1B (multi-limb)\n"; }
+
+		if (nrOfFailedTestCases - start == 0) std::cout << "PASS constexpr arithmetic + comparison\n";
+	}
+
 	/////////////////////////////////////////////////////////////////////////////////////
 	//// MODULAR integers
 

--- a/static/integer/binary/api/constexpr.cpp
+++ b/static/integer/binary/api/constexpr.cpp
@@ -1,0 +1,360 @@
+// constexpr.cpp: compile-time tests for constexpr support of the integer<> type
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// This regression test exercises the full constexpr API surface of integer<>:
+//   - construction from native int types
+//   - cross-template copy construction (integer<n+1> from integer<n>)
+//   - all arithmetic operators (+, -, *, /, %, +=, -=, *=, /=, %=, ++, --, unary -)
+//   - all bitwise operators (&, |, ^, ~, <<, >>, &=, |=, ^=, <<=, >>=)
+//   - all comparison operators (==, !=, <, >, <=, >=)
+//   - signed and unsigned (IntegerNumber, NaturalNumber) configurations
+//   - single-limb (nrBlocks==1) and multi-limb (nrBlocks>1) configurations
+//   - uint8_t / uint16_t / uint32_t / uint64_t block types
+//   - findMsb() free function (constexpr after PR for issue #720)
+//   - idiv() free function (constexpr after PR for issue #720)
+//   - edge cases: signed overflow saturation, divide-by-zero defined behavior
+
+#include <universal/utility/directives.hpp>
+// disable arithmetic exceptions so constexpr-throw paths don't fail to compile
+#define INTEGER_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/integer/integer.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace sw { namespace universal {
+
+// ----------------------------------------------------------------------------
+// Construction tests
+// ----------------------------------------------------------------------------
+
+template<typename Integer>
+void TestConstexprConstruction() {
+	{ constexpr Integer a{};           (void)a; }                  // value-init (default ctor is trivial / no zeroing)
+	{ constexpr Integer a(static_cast<signed char>(-3));   (void)a; }
+	{ constexpr Integer a(static_cast<short>(-300));        (void)a; }
+	{ constexpr Integer a(-30000);                          (void)a; }
+	{ constexpr Integer a(0L);                              (void)a; }
+	{ constexpr Integer a(123456789LL);                     (void)a; }
+	{ constexpr Integer a(static_cast<unsigned char>(255)); (void)a; }
+	{ constexpr Integer a(static_cast<unsigned short>(65535)); (void)a; }
+	{ constexpr Integer a(4000000000u);                     (void)a; }
+	{ constexpr Integer a(0UL);                             (void)a; }
+	{ constexpr Integer a(static_cast<unsigned long long>(18446744073709551615ull)); (void)a; }
+}
+
+// Cross-template copy construction (integer<n>(integer<srcbits>))
+// This is exercised internally by multi-limb mul (constructs integer<nbits+1>)
+// so it must be constexpr for the multi-limb path to be constexpr-callable.
+template<unsigned dstBits, unsigned srcBits, typename BlockType, IntegerNumberType NumberType>
+void TestConstexprCrossTemplateCopy() {
+	using Src = integer<srcBits, BlockType, NumberType>;
+	using Dst = integer<dstBits, BlockType, NumberType>;
+	constexpr Src s(42);
+	constexpr Dst d(s);
+	(void)d;
+}
+
+// ----------------------------------------------------------------------------
+// Arithmetic operators (binary + compound assignment + unary)
+// ----------------------------------------------------------------------------
+
+template<typename Integer>
+int TestConstexprArithmetic() {
+	int errors = 0;
+	constexpr Integer a(42);
+	constexpr Integer b(7);
+
+	// Binary operators
+	constexpr auto sum  = a + b;
+	constexpr auto diff = a - b;
+	constexpr auto prod = a * b;
+	constexpr auto quot = a / b;
+	constexpr auto rem  = a % b;
+	constexpr auto neg  = -a;
+
+	// Compound assignment via lambda (so the test can be in constexpr context)
+	constexpr Integer addeq = []() { Integer t(42); t += Integer(7); return t; }();
+	constexpr Integer subeq = []() { Integer t(42); t -= Integer(7); return t; }();
+	constexpr Integer muleq = []() { Integer t(42); t *= Integer(7); return t; }();
+	constexpr Integer diveq = []() { Integer t(42); t /= Integer(7); return t; }();
+	constexpr Integer modeq = []() { Integer t(42); t %= Integer(7); return t; }();
+	constexpr Integer scleq = []() { Integer t(42); t *= typename Integer::BlockType(2); return t; }();
+
+	// Increment / decrement
+	constexpr Integer inc_pre  = []() { Integer t(0); ++t; return t; }();
+	constexpr Integer dec_pre  = []() { Integer t(0); --t; return t; }();
+	constexpr Integer inc_post = []() { Integer t(0); t++; return t; }();
+	constexpr Integer dec_post = []() { Integer t(0); t--; return t; }();
+
+	// Reference values for cross-check
+	const Integer r49(49), r35(35), r294(294), r6(6), r0(0), r_neg42(-42), r_neg1(-1), r1(1), r84(84);
+
+	if (sum  != r49)     { ++errors; std::cout << "FAIL constexpr 42 + 7 == 49\n"; }
+	if (diff != r35)     { ++errors; std::cout << "FAIL constexpr 42 - 7 == 35\n"; }
+	if (prod != r294)    { ++errors; std::cout << "FAIL constexpr 42 * 7 == 294\n"; }
+	if (quot != r6)      { ++errors; std::cout << "FAIL constexpr 42 / 7 == 6\n"; }
+	if (rem  != r0)      { ++errors; std::cout << "FAIL constexpr 42 % 7 == 0\n"; }
+	if (neg  != r_neg42) { ++errors; std::cout << "FAIL constexpr -42\n"; }
+	if (addeq != r49)    { ++errors; std::cout << "FAIL constexpr += equals binary +\n"; }
+	if (subeq != r35)    { ++errors; std::cout << "FAIL constexpr -= equals binary -\n"; }
+	if (muleq != r294)   { ++errors; std::cout << "FAIL constexpr *= equals binary *\n"; }
+	if (diveq != r6)     { ++errors; std::cout << "FAIL constexpr /= equals binary /\n"; }
+	if (modeq != r0)     { ++errors; std::cout << "FAIL constexpr %= equals binary %\n"; }
+	if (scleq != r84)    { ++errors; std::cout << "FAIL constexpr *=(BlockType) (42 * 2 == 84)\n"; }
+	if (inc_pre  != r1)  { ++errors; std::cout << "FAIL constexpr ++t starting from 0\n"; }
+	if (dec_pre  != r_neg1) { ++errors; std::cout << "FAIL constexpr --t starting from 0\n"; }
+	if (inc_post != r1)  { ++errors; std::cout << "FAIL constexpr t++ starting from 0\n"; }
+	if (dec_post != r_neg1) { ++errors; std::cout << "FAIL constexpr t-- starting from 0\n"; }
+	return errors;
+}
+
+// ----------------------------------------------------------------------------
+// Bitwise + shift operators
+// ----------------------------------------------------------------------------
+
+template<typename Integer>
+int TestConstexprBitwise() {
+	int errors = 0;
+	constexpr Integer a(42);   // ...0010 1010
+	constexpr Integer b(7);    // ...0000 0111
+
+	constexpr auto bw_and = a & b;   // 2
+	constexpr auto bw_or  = a | b;   // 47
+	constexpr auto bw_xor = a ^ b;   // 45
+	constexpr auto bw_not = ~a;      // -43 (signed two's complement) but we'll just check it's not == a
+	constexpr auto shl    = a << 2;  // 168
+	constexpr auto shr    = a >> 2;  // 10
+
+	// Compound forms
+	constexpr Integer andeq = []() { Integer t(42); t &= Integer(7);  return t; }();
+	constexpr Integer oreq  = []() { Integer t(42); t |= Integer(7);  return t; }();
+	constexpr Integer xoreq = []() { Integer t(42); t ^= Integer(7);  return t; }();
+	constexpr Integer shleq = []() { Integer t(42); t <<= 2;          return t; }();
+	constexpr Integer shreq = []() { Integer t(42); t >>= 2;          return t; }();
+
+	const Integer r2(2), r47(47), r45(45), r168(168), r10(10);
+	if (bw_and != r2)   { ++errors; std::cout << "FAIL constexpr 42 & 7 == 2\n"; }
+	if (bw_or  != r47)  { ++errors; std::cout << "FAIL constexpr 42 | 7 == 47\n"; }
+	if (bw_xor != r45)  { ++errors; std::cout << "FAIL constexpr 42 ^ 7 == 45\n"; }
+	if (bw_not == a)    { ++errors; std::cout << "FAIL constexpr ~a should differ from a\n"; }
+	if (shl    != r168) { ++errors; std::cout << "FAIL constexpr 42 << 2 == 168\n"; }
+	if (shr    != r10)  { ++errors; std::cout << "FAIL constexpr 42 >> 2 == 10\n"; }
+	if (andeq  != r2)   { ++errors; std::cout << "FAIL constexpr &= equals &\n"; }
+	if (oreq   != r47)  { ++errors; std::cout << "FAIL constexpr |= equals |\n"; }
+	if (xoreq  != r45)  { ++errors; std::cout << "FAIL constexpr ^= equals ^\n"; }
+	if (shleq  != r168) { ++errors; std::cout << "FAIL constexpr <<= equals <<\n"; }
+	if (shreq  != r10)  { ++errors; std::cout << "FAIL constexpr >>= equals >>\n"; }
+	return errors;
+}
+
+// ----------------------------------------------------------------------------
+// Comparison operators
+// ----------------------------------------------------------------------------
+
+template<typename Integer>
+void TestConstexprComparisons() {
+	constexpr Integer a(42);
+	constexpr Integer b(7);
+	constexpr Integer c(42);
+
+	// integer-integer
+	static_assert( (a == c), "constexpr 42 == 42");
+	static_assert(!(a == b), "constexpr 42 != 7");
+	static_assert( (a != b), "constexpr 42 != 7");
+	static_assert( (b <  a), "constexpr 7 < 42");
+	static_assert( (a >  b), "constexpr 42 > 7");
+	static_assert( (a <= c), "constexpr 42 <= 42");
+	static_assert( (a >= b), "constexpr 42 >= 7");
+
+	// integer-IntType (using the literal-comparison overloads)
+	static_assert( (a == 42),  "constexpr a == 42");
+	static_assert(!(a == 7),   "constexpr !(a == 7)");
+	static_assert( (a >  7),   "constexpr a > 7");
+	static_assert( (7  <  a),  "constexpr 7 < a");
+	static_assert( (42 == a),  "constexpr 42 == a");
+}
+
+// ----------------------------------------------------------------------------
+// Multi-limb + uint64-limb tests (the hard cases that exercise the
+// is_constant_evaluated() carry-propagation dispatch and constexpr findMsb)
+// ----------------------------------------------------------------------------
+
+int TestConstexprMultiLimb() {
+	int errors = 0;
+
+	// Multi-limb mul with uint32_t limbs (4 limbs of 32 bits = 128 bits).
+	// 1_000_000 * 1_000 = 1_000_000_000 (fits in uint32, so this is a basic
+	// smoke that the multi-limb code path is constexpr-callable).
+	using I128_32 = integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>;
+	constexpr I128_32 ma(1000000), mb(1000);
+	constexpr auto cx_m_prod = ma * mb;
+	constexpr I128_32 r_billion(1000000000ll);
+	if (cx_m_prod != r_billion) { ++errors; std::cout << "FAIL constexpr 1M * 1k == 1B (uint32 multi-limb mul)\n"; }
+
+	// Multi-limb division (exercises constexpr findMsb in idiv).
+	// 1_000_000_000 / 1_000 = 1_000_000.
+	constexpr auto cx_m_quot = r_billion / mb;
+	constexpr I128_32 r_million(1000000);
+	if (cx_m_quot != r_million) { ++errors; std::cout << "FAIL constexpr 1B / 1k == 1M (uint32 multi-limb div)\n"; }
+
+	// Multi-limb modulo (also via idiv).
+	constexpr auto cx_m_rem = (r_billion + I128_32(7)) % I128_32(13);
+	constexpr I128_32 r_expected_rem((1000000000ll + 7) % 13);
+	if (cx_m_rem != r_expected_rem) { ++errors; std::cout << "FAIL constexpr (1B+7) % 13 (uint32 multi-limb mod)\n"; }
+
+#if defined(__SIZEOF_INT128__)
+	// uint64-limb mul: exercises the __int128-based constexpr fallback that
+	// preserves the upper 64 bits of each partial product.
+	// (1 << 62) * 4 == (1 << 64) which spans both limbs of integer<128, uint64>.
+	using I128_64 = integer<128, std::uint64_t, IntegerNumberType::IntegerNumber>;
+	constexpr I128_64 huge_a(1ll << 62);
+	constexpr I128_64 huge_b(4);
+	constexpr auto cx_huge = huge_a * huge_b;
+	const I128_64 rt_huge = I128_64(1ll << 62) * I128_64(4);
+	if (cx_huge != rt_huge) { ++errors; std::cout << "FAIL constexpr uint64-limb mul carry preservation\n"; }
+#endif
+	return errors;
+}
+
+// ----------------------------------------------------------------------------
+// Edge cases: divide-by-zero with exceptions disabled, signed/unsigned, etc.
+// ----------------------------------------------------------------------------
+
+int TestConstexprEdgeCases() {
+	int errors = 0;
+	using I32 = integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>;
+
+	// Divide-by-zero with INTEGER_THROW_ARITHMETIC_EXCEPTION=0 returns 0
+	// instead of UB. Exercise at runtime; constexpr eval would short-circuit
+	// before the actual divide.
+	I32 a(10), b(0);
+	a /= b;
+	if (!a.iszero()) { ++errors; std::cout << "FAIL div-by-zero with exceptions disabled should yield 0\n"; }
+
+	I32 c(10), d(0);
+	c %= d;
+	if (!c.iszero()) { ++errors; std::cout << "FAIL mod-by-zero with exceptions disabled should yield 0\n"; }
+
+	// Signed arithmetic produces correct negative results
+	constexpr I32 neg(-5), pos(3);
+	constexpr auto sum_neg = neg + pos;
+	const I32 r_minus2(-2);
+	if (sum_neg != r_minus2) { ++errors; std::cout << "FAIL constexpr signed -5 + 3 == -2\n"; }
+
+	// Unsigned (NaturalNumber) saturating modular behavior — currently TBD per
+	// the std::cerr placeholder in operator-=, so we just check construction
+	// works in constexpr context.
+	using N32 = integer<32, std::uint32_t, IntegerNumberType::NaturalNumber>;
+	constexpr N32 nat_a(42), nat_b(7);
+	constexpr auto nat_sum = nat_a + nat_b;
+	const N32 r49(49);
+	if (nat_sum != r49) { ++errors; std::cout << "FAIL constexpr NaturalNumber addition\n"; }
+
+	return errors;
+}
+
+// ----------------------------------------------------------------------------
+// findMsb (free function used by idiv long division)
+// ----------------------------------------------------------------------------
+
+int TestConstexprFindMsb() {
+	int errors = 0;
+	using I64_32 = integer<64, std::uint32_t, IntegerNumberType::IntegerNumber>;
+
+	// findMsb returns the 0-based position of the most significant bit, or -1
+	// if v == 0. Cross-checked against runtime evaluation.
+	constexpr I64_32 v0(0);
+	constexpr I64_32 v1(1);
+	constexpr I64_32 v_pow12(1ll << 12);
+	constexpr I64_32 v_pow32(1ll << 32);
+
+	constexpr signed cx_msb_zero  = findMsb(v0);
+	constexpr signed cx_msb_one   = findMsb(v1);
+	constexpr signed cx_msb_pow12 = findMsb(v_pow12);
+	constexpr signed cx_msb_pow32 = findMsb(v_pow32);
+
+	if (cx_msb_zero  != -1) { ++errors; std::cout << "FAIL constexpr findMsb(0) == -1\n"; }
+	if (cx_msb_one   !=  0) { ++errors; std::cout << "FAIL constexpr findMsb(1) == 0\n"; }
+	if (cx_msb_pow12 != 12) { ++errors; std::cout << "FAIL constexpr findMsb(1<<12) == 12\n"; }
+	if (cx_msb_pow32 != 32) { ++errors; std::cout << "FAIL constexpr findMsb(1<<32) == 32 (multi-limb)\n"; }
+	return errors;
+}
+
+}}  // namespace sw::universal
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "integer<> constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = true;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// Construction across block types and number-type policies
+	std::cout << "+----- construction\n";
+	TestConstexprConstruction<integer<32, std::uint8_t,  IntegerNumberType::IntegerNumber>>();
+	TestConstexprConstruction<integer<32, std::uint16_t, IntegerNumberType::IntegerNumber>>();
+	TestConstexprConstruction<integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>>();
+	TestConstexprConstruction<integer<64, std::uint64_t, IntegerNumberType::IntegerNumber>>();
+	TestConstexprConstruction<integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>>();
+
+	// Cross-template copy is exercised internally by multi-limb mul; ensure
+	// it works in constexpr context for the configurations that need it.
+	std::cout << "+----- cross-template copy construction\n";
+	TestConstexprCrossTemplateCopy<33,  32,  std::uint32_t, IntegerNumberType::IntegerNumber>();
+	TestConstexprCrossTemplateCopy<129, 128, std::uint32_t, IntegerNumberType::IntegerNumber>();
+
+	// Arithmetic: single-limb and multi-limb, multiple block types, signed and unsigned
+	std::cout << "+----- arithmetic\n";
+	nrOfFailedTestCases += TestConstexprArithmetic<integer<32,  std::uint8_t,  IntegerNumberType::IntegerNumber>>();
+	nrOfFailedTestCases += TestConstexprArithmetic<integer<32,  std::uint16_t, IntegerNumberType::IntegerNumber>>();
+	nrOfFailedTestCases += TestConstexprArithmetic<integer<32,  std::uint32_t, IntegerNumberType::IntegerNumber>>();
+	nrOfFailedTestCases += TestConstexprArithmetic<integer<64,  std::uint64_t, IntegerNumberType::IntegerNumber>>();
+	nrOfFailedTestCases += TestConstexprArithmetic<integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>>();
+
+	// Bitwise + shifts
+	std::cout << "+----- bitwise and shifts\n";
+	nrOfFailedTestCases += TestConstexprBitwise<integer<32,  std::uint8_t,  IntegerNumberType::IntegerNumber>>();
+	nrOfFailedTestCases += TestConstexprBitwise<integer<32,  std::uint32_t, IntegerNumberType::IntegerNumber>>();
+	nrOfFailedTestCases += TestConstexprBitwise<integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>>();
+
+	// Comparisons (static_assert based -- compile-time failures show up as
+	// build errors, not runtime test failures)
+	std::cout << "+----- comparisons (static_assert)\n";
+	TestConstexprComparisons<integer<32, std::uint8_t,  IntegerNumberType::IntegerNumber>>();
+	TestConstexprComparisons<integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>>();
+	TestConstexprComparisons<integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>>();
+
+	// Multi-limb (mul, div, mod) and uint64-limb (carry preservation)
+	std::cout << "+----- multi-limb + uint64-limb\n";
+	nrOfFailedTestCases += TestConstexprMultiLimb();
+
+	// Edge cases
+	std::cout << "+----- edge cases (divide-by-zero, signed, unsigned)\n";
+	nrOfFailedTestCases += TestConstexprEdgeCases();
+
+	// findMsb free function (used by idiv long division)
+	std::cout << "+----- findMsb\n";
+	nrOfFailedTestCases += TestConstexprFindMsb();
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/integer/binary/api/constexpr.cpp
+++ b/static/integer/binary/api/constexpr.cpp
@@ -244,7 +244,7 @@ int TestConstexprEdgeCases() {
 	const I32 r_minus2(-2);
 	if (sum_neg != r_minus2) { ++errors; std::cout << "FAIL constexpr signed -5 + 3 == -2\n"; }
 
-	// Unsigned (NaturalNumber) saturating modular behavior — currently TBD per
+	// Unsigned (NaturalNumber) saturating modular behavior -- currently TBD per
 	// the std::cerr placeholder in operator-=, so we just check construction
 	// works in constexpr context.
 	using N32 = integer<32, std::uint32_t, IntegerNumberType::NaturalNumber>;


### PR DESCRIPTION
## Summary

Resolves **#720**. integer joins posit (#718), cfloat (#719), bfloat16 (#725) as a fully constexpr arithmetic type.

```cpp
using I32 = integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>;
constexpr I32 a(42), b(7);
constexpr auto sum  = a + b;     // works
constexpr auto prod = a * b;     // works
constexpr auto quot = a / b;     // works (idiv free function constexpr)
constexpr auto rem  = a % b;     // works
static_assert(b < a);            // works

// Multi-limb works too (uses uint64-limb mul128 path with is_constant_evaluated dispatch)
using I128 = integer<128, std::uint32_t, IntegerNumberType::IntegerNumber>;
constexpr I128 m_prod = I128(1000000) * I128(1000);  // == 1 billion
```

## Scope

Larger PR than cfloat #719 because integer has its own arithmetic implementation (not a thin blockbinary wrapper). Same playbook as PR #716 (blockbinary) and #752 (blocktriple).

### Class members promoted to constexpr
- `operator+=` — uint64-limb path uses `std::is_constant_evaluated()` dispatch around `addcarry` intrinsic; multi-limb path converted from pointer-arithmetic loop to index-loop
- `operator-=` — `std::cerr` in WholeNumber/NaturalNumber TBD branches guarded with `!std::is_constant_evaluated()`
- `operator*=` — uint64-limb path: same `is_constant_evaluated` dispatch around `mul128`/`addcarry`; both signed and whole/natural branches promoted
- `operator*=(BlockType)` — same dispatch
- `operator/=`, `operator%=` — `std::cerr` in divide-by-zero branches guarded
- `operator<<=`, `operator>>=`, `operator&=`, `operator|=`, `operator^=`
- `logicShiftRight`
- Cross-template `integer<n>(integer<srcbits>)` copy ctor — needed because multi-limb mul constructs `integer<nbits+1>` internally

### Free helpers promoted
- `idiv_t` default ctor
- `idiv()` free function (`std::cerr` guarded)
- All free comparison operators (`==`, `!=`, `<`, `>`, `<=`, `>=`) for integer-integer and integer-IntType, both directions (18 total)
- All free binary operators (`+`, `-`, `*`, `/`, `%`) for integer-integer and integer-IntType, both directions (29 total)
- Matching `friend` declaration

## Local validation (gcc 13 + clang 18, -std=c++20)

| Suite | Targets | gcc | clang |
|-------|---------|-----|-------|
| integer | `bint_api` (incl. new constexpr block), `bint_conversion`, `bint_misc`, `bint_bit_manipulation`, `bint_exceptions` | PASS | PASS |
| posit | `posit_api` | PASS | PASS |
| cfloat | `cfloat_api` | PASS | PASS |
| lns | `lns_api` | PASS | PASS |
| fixpnt | `fixpnt_api` | PASS | PASS |
| bfloat16 | `bfloat16_api` | PASS | PASS |
| internal | `bb_constexpr` | PASS | PASS |

11/11 PASS each compiler.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #720
Relates to #723 (Epic). With #718, #719, #720, #725 closed, four foundational types are fully constexpr.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled compile-time evaluation (`constexpr`) for integer arithmetic, bitwise, and comparison operations, allowing more computations to occur at compile-time.
  * Integer construction and standard operations now support constant evaluation contexts.

* **Tests**
  * Added regression tests to validate compile-time evaluation capabilities of the integer type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->