### PR TITLE
feat(internal): blockbinary mul/div/mod constexpr foundation

### DIFF
--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -25,7 +25,7 @@ enum class BinaryNumberType {
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> class blockbinary;
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> constexpr blockbinary<nbits, BlockType, NumberType> twosComplement(const blockbinary<nbits, BlockType, NumberType>&);
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> struct quorem;
-template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> quorem<nbits, BlockType, NumberType> longdivision(const blockbinary<nbits, BlockType, NumberType>&, const blockbinary<nbits, BlockType, NumberType>&);
+template<unsigned nbits, typename BlockType, BinaryNumberType NumberType> constexpr quorem<nbits, BlockType, NumberType> longdivision(const blockbinary<nbits, BlockType, NumberType>&, const blockbinary<nbits, BlockType, NumberType>&);
 
 // idiv_t for blockbinary<nbits> to capture quotient and remainder during long division
 template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
@@ -114,7 +114,7 @@ public:
 
 	/// construct a blockbinary from another: bt must be the same
 	template<unsigned nnbits>
-	blockbinary(const blockbinary<nnbits, BlockType, NumberType>& rhs) : _block{} { this->assign(rhs); }
+	constexpr blockbinary(const blockbinary<nnbits, BlockType, NumberType>& rhs) : _block{} { this->assign(rhs); }
 
 	// initializer for long long
 	constexpr blockbinary(long long initial_value) noexcept : _block{} { *this = initial_value; }
@@ -189,7 +189,7 @@ public:
 	constexpr BlockType operator[](unsigned index) const { return _block[index]; }
 
 	// prefix operators
-	blockbinary operator-() const {
+	constexpr blockbinary operator-() const {
 		blockbinary negated(*this);
 		blockbinary plusOne(1);
 		negated.flip();
@@ -197,7 +197,7 @@ public:
 		return negated;
 	}
 	// one's complement
-	blockbinary operator~() const {
+	constexpr blockbinary operator~() const {
 		blockbinary complement(*this);
 		complement.flip();
 		return complement;
@@ -225,7 +225,7 @@ public:
 		return *this -= decrement;
 	}
 	// logic operators
-	blockbinary  operator~() {
+	constexpr blockbinary  operator~() {
 		blockbinary<nbits, bt> complement(*this);
 		complement.flip();
 		return complement;
@@ -285,13 +285,15 @@ public:
 	}
 #define BLOCKBINARY_FAST_MUL
 #ifdef BLOCKBINARY_FAST_MUL
-	blockbinary& operator*=(const blockbinary& rhs) {
+	constexpr blockbinary& operator*=(const blockbinary& rhs) {
 		if constexpr (NumberType == BinaryNumberType::Signed) {
 			if constexpr (nrBlocks == 1) {
 				_block[0] = static_cast<bt>(static_cast<std::uint64_t>(_block[0]) * static_cast<std::uint64_t>(rhs.block(0)));
 			}
 			else if constexpr (bitsInBlock == 64) {
-				// uint64_t limbs: use mul128/addcarry intrinsics
+				// uint64_t limbs: mul128/addcarry use platform intrinsics that are not
+				// constexpr on MSVC. In a constant-evaluated context, fall back to a
+				// portable __uint128_t-based carry-propagation loop (gcc/clang only).
 				blockbinary<nbits + 1, BlockType, NumberType> base(*this);
 				blockbinary<nbits + 1, BlockType, NumberType> multiplicant(rhs);
 				bool resultIsNeg = (base.isneg() ^ multiplicant.isneg());
@@ -302,21 +304,42 @@ public:
 					multiplicant.twosComplement();
 				}
 				clear();
-				for (unsigned i = 0; i < nrBlocks; ++i) {
-					uint64_t carry = 0;
-					for (unsigned j = 0; j < nrBlocks; ++j) {
-						if (i + j < nrBlocks) {
-							uint64_t lo, hi;
-							mul128(base.block(i), multiplicant.block(j), lo, hi);
-							// accumulate: _block[i+j] += lo + carry
-							// use two separate additions to avoid passing multi-bit carry
-							// to addcarry (MSVC _addcarry_u64 only accepts 0/1 carry_in)
-							uint64_t c1 = 0;
-							uint64_t sum = addcarry(_block[i + j], lo, 0, c1);
-							uint64_t c2 = 0;
-							sum = addcarry(sum, carry, 0, c2);
-							_block[i + j] = sum;
-							carry = hi + c1 + c2;
+				if (std::is_constant_evaluated()) {
+#if defined(__SIZEOF_INT128__)
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint128_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint128_t product = static_cast<uint128_t>(base.block(i)) * multiplicant.block(j);
+								uint128_t sum = product + _block[i + j] + carry;
+								_block[i + j] = static_cast<bt>(sum);
+								carry = sum >> 64;
+							}
+						}
+					}
+#else
+					// Constexpr eval of uint64-limb mul without __int128 is unsupported.
+					// Users on MSVC: use uint32_t limbs for compile-time evaluation.
+					// At runtime the intrinsic path below is used.
+#endif
+				}
+				else {
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint64_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint64_t lo, hi;
+								mul128(base.block(i), multiplicant.block(j), lo, hi);
+								// accumulate: _block[i+j] += lo + carry
+								// use two separate additions to avoid passing multi-bit carry
+								// to addcarry (MSVC _addcarry_u64 only accepts 0/1 carry_in)
+								uint64_t c1 = 0;
+								uint64_t sum = addcarry(_block[i + j], lo, 0, c1);
+								uint64_t c2 = 0;
+								sum = addcarry(sum, carry, 0, c2);
+								_block[i + j] = sum;
+								carry = hi + c1 + c2;
+							}
 						}
 					}
 				}
@@ -354,25 +377,42 @@ public:
 				_block[0] = static_cast<bt>(static_cast<std::uint64_t>(_block[0]) * static_cast<std::uint64_t>(rhs.block(0)));
 			}
 			else if constexpr (bitsInBlock == 64) {
-				// uint64_t limbs: use mul128/addcarry intrinsics
+				// uint64_t limbs: same is_constant_evaluated dispatch as the signed path.
 				blockbinary base(*this);
 				blockbinary multiplicant(rhs);
 				clear();
-				for (unsigned i = 0; i < nrBlocks; ++i) {
-					uint64_t carry = 0;
-					for (unsigned j = 0; j < nrBlocks; ++j) {
-						if (i + j < nrBlocks) {
-							uint64_t lo, hi;
-							mul128(base.block(i), multiplicant.block(j), lo, hi);
-							// accumulate: _block[i+j] += lo + carry
-							// use two separate additions to avoid passing multi-bit carry
-							// to addcarry (MSVC _addcarry_u64 only accepts 0/1 carry_in)
-							uint64_t c1 = 0;
-							uint64_t sum = addcarry(_block[i + j], lo, 0, c1);
-							uint64_t c2 = 0;
-							sum = addcarry(sum, carry, 0, c2);
-							_block[i + j] = sum;
-							carry = hi + c1 + c2;
+				if (std::is_constant_evaluated()) {
+#if defined(__SIZEOF_INT128__)
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint128_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint128_t product = static_cast<uint128_t>(base.block(i)) * multiplicant.block(j);
+								uint128_t sum = product + _block[i + j] + carry;
+								_block[i + j] = static_cast<bt>(sum);
+								carry = sum >> 64;
+							}
+						}
+					}
+#endif
+				}
+				else {
+					for (unsigned i = 0; i < nrBlocks; ++i) {
+						uint64_t carry = 0;
+						for (unsigned j = 0; j < nrBlocks; ++j) {
+							if (i + j < nrBlocks) {
+								uint64_t lo, hi;
+								mul128(base.block(i), multiplicant.block(j), lo, hi);
+								// accumulate: _block[i+j] += lo + carry
+								// use two separate additions to avoid passing multi-bit carry
+								// to addcarry (MSVC _addcarry_u64 only accepts 0/1 carry_in)
+								uint64_t c1 = 0;
+								uint64_t sum = addcarry(_block[i + j], lo, 0, c1);
+								uint64_t c2 = 0;
+								sum = addcarry(sum, carry, 0, c2);
+								_block[i + j] = sum;
+								carry = hi + c1 + c2;
+							}
 						}
 					}
 				}
@@ -400,7 +440,7 @@ public:
 		return *this;
 	}
 #else
-	blockbinary& operator*=(const blockbinary& rhs) { // modulo in-place
+	constexpr blockbinary& operator*=(const blockbinary& rhs) { // modulo in-place
 		blockbinary base(*this);
 		blockbinary multiplicant(rhs);
 		clear();
@@ -415,7 +455,7 @@ public:
 		return *this;
 	}
 #endif
-	blockbinary& operator/=(const blockbinary& rhs) {
+	constexpr blockbinary& operator/=(const blockbinary& rhs) {
 		if constexpr (nbits == (sizeof(BlockType) * 8)) {
 			if (rhs.iszero()) {
 				*this = 0;
@@ -441,7 +481,7 @@ public:
 		}
 		return *this;
 	}
-	blockbinary& operator%=(const blockbinary& rhs) {
+	constexpr blockbinary& operator%=(const blockbinary& rhs) {
 		if constexpr (nbits == (sizeof(BlockType) * 8)) {
 			if (rhs.iszero()) {
 				*this = 0;
@@ -811,7 +851,7 @@ public:
 	// copy a value over from one blockbinary to this blockbinary
 	// blockbinary is a 2's complement encoding, so we sign-extend by default
 	template<unsigned srcbits>
-	blockbinary<nbits, bt, NumberType>& assign(const blockbinary<srcbits, bt, NumberType>& rhs) {
+	constexpr blockbinary<nbits, bt, NumberType>& assign(const blockbinary<srcbits, bt, NumberType>& rhs) {
 		clear();
 		// since bt is the same, we can simply copy the blocks in
 		unsigned minNrBlocks = (this->nrBlocks < rhs.nrBlocks) ? this->nrBlocks : rhs.nrBlocks;
@@ -834,7 +874,7 @@ public:
 	// blockbinary is a 2's complement encoding, so we sign-extend by default
 	// for fraction/significent encodings, we need to turn off sign-extending.
 	template<unsigned srcbits>
-	blockbinary<nbits, bt, NumberType>& assignWithoutSignExtend(const blockbinary<srcbits, bt, NumberType>& rhs) {
+	constexpr blockbinary<nbits, bt, NumberType>& assignWithoutSignExtend(const blockbinary<srcbits, bt, NumberType>& rhs) {
 		clear();
 		// since bt is the same, we can simply copy the blocks in
 		unsigned minNrBlocks = (this->nrBlocks < rhs.nrBlocks) ? this->nrBlocks : rhs.nrBlocks;
@@ -847,7 +887,7 @@ public:
 	}
 
 	// return the position of the most significant bit, -1 if v == 0
-	int msb() const noexcept {
+	constexpr int msb() const noexcept {
 		for (int i = int(MSU); i >= 0; --i) {
 			if (_block[i] != 0) {
 				bt mask = (bt(1u) << (bitsInBlock-1));
@@ -862,7 +902,7 @@ public:
 		return -1; // no significant bit found, all bits are zero
 	}
 	// conversion to native types
-	int64_t to_sll() const {
+	constexpr int64_t to_sll() const {
 		constexpr unsigned sizeoflonglong = 8 * sizeof(long long);
 		int64_t ll{ 0 };
 		int64_t mask{ 1 };
@@ -902,7 +942,7 @@ public:
 		return (isneg() ? -v : v);
 	}
 	// determine the rounding mode: result needs to be rounded up if true
-	bool roundingMode(unsigned targetLsb) const {
+	constexpr bool roundingMode(unsigned targetLsb) const {
 		bool lsb = at(targetLsb);
 		bool guard = (targetLsb == 0 ? false : at(targetLsb - 1));
 		bool round = (targetLsb > 1 ? at(targetLsb - 2) : false);
@@ -910,7 +950,7 @@ public:
 		bool tie = guard && !round && !sticky;
 		return (lsb && tie) || (guard && !tie);
 	}
-	bool any(unsigned msb) const {
+	constexpr bool any(unsigned msb) const {
 		msb = (msb > nbits - 1 ? nbits - 1 : msb);
 		unsigned topBlock = msb / bitsInBlock;
 		bt mask = bt(ALL_ONES >> (bitsInBlock - 1 - (msb % bitsInBlock)));
@@ -1006,17 +1046,17 @@ constexpr blockbinary<N, B, T> operator-(const blockbinary<N, B, T>& a, const bl
 	return c -= b;
 }
 template<unsigned N, typename B, BinaryNumberType T>
-inline blockbinary<N, B, T> operator*(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr inline blockbinary<N, B, T> operator*(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N, B, T> c(a);
 	return c *= b;
 }
 template<unsigned N, typename B, BinaryNumberType T>
-inline blockbinary<N, B, T> operator/(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr inline blockbinary<N, B, T> operator/(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N, B, T> c(a);
 	return c /= b;
 }
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<N, B, T> operator%(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr blockbinary<N, B, T> operator%(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N, B, T> c(a);
 	return c %= b;
 }
@@ -1034,7 +1074,7 @@ blockbinary<N, B, T> operator>>(const blockbinary<N, B, T>& a, long b) {
 
 // divide a by b and return both quotient and remainder
 template<unsigned N, typename B, BinaryNumberType T>
-quorem<N, B, T> longdivision(const blockbinary<N, B, T>& dividend, const blockbinary<N, B, T>& divisor) {
+constexpr quorem<N, B, T> longdivision(const blockbinary<N, B, T>& dividend, const blockbinary<N, B, T>& divisor) {
 	static_assert(T == BinaryNumberType::Signed, "longdivision requires signed blockbinary types");
 	using BlockBinary = blockbinary<N + 1, B, T>;
 	quorem<N, B, T> result = { 0, 0, 0 };
@@ -1094,14 +1134,14 @@ quorem<N, B, T> longdivision(const blockbinary<N, B, T>& dividend, const blockbi
 
 // unrounded addition, returns a blockbinary that is of size nbits+1
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<N + 1, B, T> uradd(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr blockbinary<N + 1, B, T> uradd(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N + 1, B, T> result(a);
 	return result += blockbinary<N + 1, B, T>(b);
 }
 
 // unrounded subtraction, returns a blockbinary that is of size nbits+1
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<N + 1, B, T> ursub(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr blockbinary<N + 1, B, T> ursub(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<N + 1, B, T> result(a);
 	return result -= blockbinary<N + 1, B, T>(b);
 }
@@ -1110,7 +1150,7 @@ blockbinary<N + 1, B, T> ursub(const blockbinary<N, B, T>& a, const blockbinary<
 // unrounded multiplication, returns a blockbinary that is of size 2*nbits
 // using brute-force sign-extending of operands to yield correct sign-extended result for 2*nbits 2's complement.
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<2*N, B, T> urmul(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr blockbinary<2*N, B, T> urmul(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	using BlockBinary = blockbinary<2 * N, B, T>;
 	BlockBinary result(0);
 	if (a.iszero() || b.iszero()) return result;
@@ -1144,7 +1184,7 @@ blockbinary<2*N, B, T> urmul(const blockbinary<N, B, T>& a, const blockbinary<N,
 // unrounded multiplication, returns a blockbinary that is of size 2*nbits
 // using nbits modulo arithmetic with final sign
 template<unsigned N, typename B, BinaryNumberType T>
-blockbinary<2 * N, B, T> urmul2(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
+constexpr blockbinary<2 * N, B, T> urmul2(const blockbinary<N, B, T>& a, const blockbinary<N, B, T>& b) {
 	blockbinary<2 * N, B, T> result(0);
 	if (a.iszero() || b.iszero()) return result;
 

--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -851,7 +851,9 @@ public:
 	}
 
 	// copy a value over from one blockbinary to this blockbinary
-	// blockbinary is a 2's complement encoding, so we sign-extend by default
+	// blockbinary is a 2's complement encoding when Signed, so we sign-extend
+	// by default for Signed; for Unsigned, the high bit is just data and must
+	// be zero-extended on widening (clear() above already zeroed the storage).
 	template<unsigned srcbits>
 	constexpr blockbinary<nbits, bt, NumberType>& assign(const blockbinary<srcbits, bt, NumberType>& rhs) {
 		clear();
@@ -860,7 +862,7 @@ public:
 		for (unsigned i = 0; i < minNrBlocks; ++i) {
 			_block[i] = rhs.block(i);
 		}
-		if constexpr (nbits > srcbits) { // check if we need to sign extend
+		if constexpr (nbits > srcbits && NumberType == BinaryNumberType::Signed) {
 			if (rhs.sign()) {
 				for (unsigned i = srcbits; i < nbits; ++i) { // TODO: replace bit-oriented sequence with block
 					setbit(i);

--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -224,12 +224,6 @@ public:
 		decrement.setbits(0x1);
 		return *this -= decrement;
 	}
-	// logic operators
-	constexpr blockbinary  operator~() {
-		blockbinary<nbits, bt> complement(*this);
-		complement.flip();
-		return complement;
-	}
 	// arithmetic operators
 	constexpr blockbinary& operator+=(const blockbinary& rhs) {
 		if constexpr (nrBlocks == 1) {

--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -318,9 +318,13 @@ public:
 						}
 					}
 #else
-					// Constexpr eval of uint64-limb mul without __int128 is unsupported.
-					// Users on MSVC: use uint32_t limbs for compile-time evaluation.
-					// At runtime the intrinsic path below is used.
+					// Constexpr eval of uint64-limb mul without __int128 is unsupported
+					// (MSVC). Forcing a throw in the constant-evaluated branch turns this
+					// into a compile error rather than a silent zero-result. The branch
+					// is unreachable at runtime because is_constant_evaluated() is false
+					// there; the runtime intrinsic path below handles all execution.
+					// Users on MSVC needing compile-time eval should use uint32_t limbs.
+					throw "blockbinary<N, uint64_t> constexpr multiply requires __int128 support (gcc/clang); on MSVC use uint32_t limbs for compile-time evaluation";
 #endif
 				}
 				else {
@@ -394,6 +398,10 @@ public:
 							}
 						}
 					}
+#else
+					// See the signed branch: forcing a throw turns silent zero-result
+					// into a compile error on platforms without __int128 (MSVC).
+					throw "blockbinary<N, uint64_t> constexpr multiply requires __int128 support (gcc/clang); on MSVC use uint32_t limbs for compile-time evaluation";
 #endif
 				}
 				else {

--- a/internal/blockbinary/api/constexpr.cpp
+++ b/internal/blockbinary/api/constexpr.cpp
@@ -175,6 +175,24 @@ try {
 		constexpr BB32u8 notZero = ~BB32u8(0);
 		static_assert(notZero.to_sll() == -1LL, "constexpr unary ~ on zero is all-ones");
 
+		// Unsigned widening must zero-extend, not sign-extend (CodeRabbit fix).
+		// 0x80 widened from 8 -> 16 bits should be 0x0080 (=128), NOT 0xFF80 (=65408).
+		using U8  = blockbinary<8,  std::uint8_t, BinaryNumberType::Unsigned>;
+		using U16 = blockbinary<16, std::uint8_t, BinaryNumberType::Unsigned>;
+		constexpr U16 widened = U16(U8(0x80));  // exercises constexpr cross-template ctor + assign()
+		static_assert(widened.block(0) == 0x80, "constexpr Unsigned widen low byte preserved");
+		static_assert(widened.block(1) == 0x00, "constexpr Unsigned widen high byte zero-extended (NOT 0xFF)");
+
+		// Signed widening must still sign-extend (regression guard).
+		using S8  = blockbinary<8,  std::uint8_t, BinaryNumberType::Signed>;
+		using S16 = blockbinary<16, std::uint8_t, BinaryNumberType::Signed>;
+		constexpr S16 sx_neg = S16(S8(-1));      // 0xFF -> 0xFFFF
+		static_assert(sx_neg.block(0) == 0xFF, "constexpr Signed widen low byte preserved");
+		static_assert(sx_neg.block(1) == 0xFF, "constexpr Signed widen sign-extends to 0xFF");
+		constexpr S16 sx_pos = S16(S8(0x7F));    // 0x7F -> 0x007F (positive, no extension)
+		static_assert(sx_pos.block(0) == 0x7F, "constexpr Signed widen positive low byte");
+		static_assert(sx_pos.block(1) == 0x00, "constexpr Signed widen positive: high byte stays zero");
+
 		std::cout << "constexpr mul/div/mod smoke tests PASS (compile-time)\n";
 	}
 

--- a/internal/blockbinary/api/constexpr.cpp
+++ b/internal/blockbinary/api/constexpr.cpp
@@ -89,6 +89,95 @@ try {
 		std::cout << "constexpr arithmetic smoke tests PASS (compile-time)\n";
 	}
 
+	// constexpr mul/div/mod (issue #759)
+	{
+		std::cout << "+----- mul/div/mod (issue #759)\n";
+
+		// Single-block constexpr mul (uint8 limb).
+		using BB32u8 = blockbinary<32, std::uint8_t, BinaryNumberType::Signed>;
+		constexpr BB32u8 prod32u8 = []() { BB32u8 t(7); t *= BB32u8(11); return t; }();
+		static_assert(prod32u8.block(0) == 77, "constexpr blockbinary<32,uint8>(7) *= 11 == 77");
+
+		// Multi-limb constexpr mul (uint8 limbs spanning more than one block).
+		using BB64u8 = blockbinary<64, std::uint8_t, BinaryNumberType::Signed>;
+		constexpr BB64u8 mlMul = []() { BB64u8 t(1000); t *= BB64u8(1000); return t; }();  // 1_000_000 = 0x0F4240
+		static_assert(mlMul.to_sll() == 1000000LL, "constexpr 1000*1000 == 1_000_000 (uint8 multi-limb)");
+
+		// Multi-limb constexpr mul (uint32 limbs).
+		using BB128u32 = blockbinary<128, std::uint32_t, BinaryNumberType::Signed>;
+		constexpr BB128u32 milProd = []() { BB128u32 t(1000000); t *= BB128u32(1000); return t; }();
+		static_assert(milProd.to_sll() == 1000000000LL, "constexpr 1M * 1k == 1B (uint32 multi-limb)");
+
+#if defined(__SIZEOF_INT128__)
+		// uint64-limb constexpr mul exercises the __int128-based portable carry path.
+		using BB128u64 = blockbinary<128, std::uint64_t, BinaryNumberType::Signed>;
+		constexpr BB128u64 u64Prod = []() { BB128u64 t(1ll << 30); t *= BB128u64(1ll << 30); return t; }();
+		// 2^30 * 2^30 = 2^60 -- still fits in low 64-bit limb
+		static_assert(u64Prod.block(0) == (uint64_t(1) << 60), "constexpr 2^30 * 2^30 == 2^60 (uint64 limb low)");
+		static_assert(u64Prod.block(1) == 0,                    "constexpr 2^30 * 2^30 high limb is zero");
+
+		// Force a cross-limb carry: 2^32 * 2^32 = 2^64 -> low=0, high=1.
+		constexpr BB128u64 u64CrossCarry = []() { BB128u64 t(1ll << 32); t *= BB128u64(1ll << 32); return t; }();
+		static_assert(u64CrossCarry.block(0) == 0, "constexpr 2^32 * 2^32 low limb wraps to 0");
+		static_assert(u64CrossCarry.block(1) == 1, "constexpr 2^32 * 2^32 high limb captures 2^64 carry");
+#endif
+
+		// Single-block constexpr div (uint8 limb -- the nbits == sizeof(bt)*8 fast path).
+		using BB8u8 = blockbinary<8, std::uint8_t, BinaryNumberType::Signed>;
+		constexpr BB8u8 quot8u8 = []() { BB8u8 t(77); t /= BB8u8(11); return t; }();
+		static_assert(quot8u8.block(0) == 7, "constexpr blockbinary<8,uint8>(77) /= 11 == 7");
+
+		// Single-block constexpr mod.
+		constexpr BB8u8 rem8u8 = []() { BB8u8 t(77); t %= BB8u8(13); return t; }();
+		static_assert(rem8u8.block(0) == (77 % 13), "constexpr 77 %% 13 == 12");
+
+		// Multi-limb constexpr div via longdivision.
+		constexpr BB128u32 mlQuot = []() { BB128u32 t(1000000000LL); t /= BB128u32(1000); return t; }();
+		static_assert(mlQuot.to_sll() == 1000000LL, "constexpr 1B / 1k == 1M (uint32 longdivision)");
+
+		// Multi-limb constexpr mod via longdivision.
+		constexpr BB128u32 mlRem = []() { BB128u32 t(1000000007LL); t %= BB128u32(13); return t; }();
+		static_assert(mlRem.to_sll() == (1000000007LL % 13), "constexpr 1000000007 %% 13");
+
+		// Free operator* / operator/ / operator% (verify the constexpr wrappers).
+		constexpr BB32u8 freeProd = BB32u8(6) * BB32u8(7);
+		static_assert(freeProd.block(0) == 42, "constexpr free operator* (single-block)");
+		constexpr BB32u8 freeQuot = BB32u8(42) / BB32u8(6);
+		static_assert(freeQuot.block(0) == 7, "constexpr free operator/ (single-block)");
+		constexpr BB32u8 freeRem  = BB32u8(43) % BB32u8(6);
+		static_assert(freeRem.block(0) == 1, "constexpr free operator%% (single-block)");
+
+		// Divide-by-zero defined behavior: returns zero, no UB.
+		constexpr BB8u8 divZero = []() { BB8u8 t(42); t /= BB8u8(0); return t; }();
+		static_assert(divZero.iszero(), "constexpr divide-by-zero returns zero (single-block fast path)");
+		constexpr BB128u32 divZeroMl = []() { BB128u32 t(42); t /= BB128u32(0); return t; }();
+		static_assert(divZeroMl.iszero(), "constexpr divide-by-zero returns zero (longdivision path)");
+
+		// uradd / ursub / urmul2 wrappers.
+		constexpr blockbinary<33, std::uint8_t, BinaryNumberType::Signed> ua = uradd(BB32u8(100), BB32u8(200));
+		static_assert(ua.to_sll() == 300LL, "constexpr uradd(100, 200) == 300");
+		constexpr blockbinary<33, std::uint8_t, BinaryNumberType::Signed> us = ursub(BB32u8(200), BB32u8(75));
+		static_assert(us.to_sll() == 125LL, "constexpr ursub(200, 75) == 125");
+		constexpr blockbinary<64, std::uint8_t, BinaryNumberType::Signed> um = urmul2(BB32u8(1234), BB32u8(5678));
+		static_assert(um.to_sll() == (1234LL * 5678LL), "constexpr urmul2(1234, 5678) == 7006652");
+
+		// Helpers: msb, any, to_sll, roundingMode.
+		constexpr int m = BB32u8(0x10).msb();
+		static_assert(m == 4, "constexpr msb(0x10) == 4");
+		constexpr int64_t s = BB32u8(-7).to_sll();
+		static_assert(s == -7LL, "constexpr to_sll preserves sign");
+		constexpr bool anyHi = BB64u8(0x100).any(15);  // bit 8 set, asking about bits[0..15]
+		static_assert(anyHi, "constexpr any(15) sees bit 8");
+
+		// Unary - and ~ are now constexpr too.
+		constexpr BB32u8 negFive = -BB32u8(5);
+		static_assert(negFive.to_sll() == -5LL, "constexpr unary - returns -5");
+		constexpr BB32u8 notZero = ~BB32u8(0);
+		static_assert(notZero.to_sll() == -1LL, "constexpr unary ~ on zero is all-ones");
+
+		std::cout << "constexpr mul/div/mod smoke tests PASS (compile-time)\n";
+	}
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/internal/blockbinary/api/conversion.cpp
+++ b/internal/blockbinary/api/conversion.cpp
@@ -45,6 +45,7 @@ try {
 	{
 		std::cout << "+----- cross-template widening (Signed sign-extend, Unsigned zero-extend)\n";
 
+		const int failures_before = nrOfFailedTestCases;
 		auto check = [&](const char* name, bool ok) {
 			if (!ok) { ++nrOfFailedTestCases; std::cout << "FAIL " << name << '\n'; }
 		};
@@ -100,7 +101,9 @@ try {
 			check("Unsigned 64->128 widen UINT64_MAX: high limb is zero",     widened.block(1) == 0);
 		}
 
-		std::cout << "+----- cross-template widening regression: PASS\n";
+		if (nrOfFailedTestCases == failures_before) {
+			std::cout << "+----- cross-template widening regression: PASS\n";
+		}
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/internal/blockbinary/api/conversion.cpp
+++ b/internal/blockbinary/api/conversion.cpp
@@ -81,6 +81,17 @@ try {
 
 		// Multi-block widening (uint16 limbs, 32 -> 64 bits): same Signed/Unsigned semantics
 		{
+			// Signed: -1 widens with sign-extension across all four 16-bit limbs
+			using S32 = blockbinary<32, std::uint16_t, BinaryNumberType::Signed>;
+			using S64 = blockbinary<64, std::uint16_t, BinaryNumberType::Signed>;
+			S32 signed_src(-1);
+			S64 signed_widened(signed_src);
+			check("Signed 32->64 widen -1: limb 0",         signed_widened.block(0) == 0xFFFF);
+			check("Signed 32->64 widen -1: limb 1",         signed_widened.block(1) == 0xFFFF);
+			check("Signed 32->64 widen -1: limb 2 sign-ext",signed_widened.block(2) == 0xFFFF);
+			check("Signed 32->64 widen -1: limb 3 sign-ext",signed_widened.block(3) == 0xFFFF);
+
+			// Unsigned: same bit pattern, but high limbs MUST stay zero
 			using U32 = blockbinary<32, std::uint16_t, BinaryNumberType::Unsigned>;
 			using U64 = blockbinary<64, std::uint16_t, BinaryNumberType::Unsigned>;
 			U32 src; src.setbits(0xFFFFFFFFull);

--- a/internal/blockbinary/api/conversion.cpp
+++ b/internal/blockbinary/api/conversion.cpp
@@ -39,6 +39,70 @@ try {
 		}
 	}
 
+	// Cross-template (widening) copy ctor: Signed must sign-extend, Unsigned must
+	// zero-extend. Regression for the assign() bug surfaced on PR #760: widening
+	// 0x80 (Unsigned 8-bit) was sign-extending to 0xFF80 instead of 0x0080.
+	{
+		std::cout << "+----- cross-template widening (Signed sign-extend, Unsigned zero-extend)\n";
+
+		auto check = [&](const char* name, bool ok) {
+			if (!ok) { ++nrOfFailedTestCases; std::cout << "FAIL " << name << '\n'; }
+		};
+
+		// Signed: negative widens by sign-extension
+		{
+			using S8  = blockbinary<8,  std::uint8_t, BinaryNumberType::Signed>;
+			using S16 = blockbinary<16, std::uint8_t, BinaryNumberType::Signed>;
+			S16 sx_neg(S8(-1));
+			check("Signed widen -1: low byte == 0xFF",  sx_neg.block(0) == 0xFF);
+			check("Signed widen -1: high byte == 0xFF (sign-ext)", sx_neg.block(1) == 0xFF);
+			check("Signed widen -1: to_sll() == -1",    sx_neg.to_sll() == -1LL);
+
+			// Signed: positive (high bit clear) -- no extension, high bytes are zero
+			S16 sx_pos(S8(0x7F));
+			check("Signed widen 0x7F: low byte == 0x7F", sx_pos.block(0) == 0x7F);
+			check("Signed widen 0x7F: high byte == 0x00", sx_pos.block(1) == 0x00);
+			check("Signed widen 0x7F: to_sll() == 127",   sx_pos.to_sll() == 127LL);
+		}
+
+		// Unsigned: high bit is data, MUST zero-extend (regression: was sign-extending)
+		{
+			using U8  = blockbinary<8,  std::uint8_t, BinaryNumberType::Unsigned>;
+			using U16 = blockbinary<16, std::uint8_t, BinaryNumberType::Unsigned>;
+			U16 zx_msb(U8(0x80));
+			check("Unsigned widen 0x80: low byte == 0x80",  zx_msb.block(0) == 0x80);
+			check("Unsigned widen 0x80: high byte == 0x00 (zero-ext, NOT 0xFF)", zx_msb.block(1) == 0x00);
+
+			U16 zx_all(U8(0xFF));
+			check("Unsigned widen 0xFF: low byte == 0xFF",  zx_all.block(0) == 0xFF);
+			check("Unsigned widen 0xFF: high byte == 0x00 (zero-ext, NOT 0xFF)", zx_all.block(1) == 0x00);
+		}
+
+		// Multi-block widening (uint16 limbs, 32 -> 64 bits): same Signed/Unsigned semantics
+		{
+			using U32 = blockbinary<32, std::uint16_t, BinaryNumberType::Unsigned>;
+			using U64 = blockbinary<64, std::uint16_t, BinaryNumberType::Unsigned>;
+			U32 src; src.setbits(0xFFFFFFFFull);
+			U64 widened(src);
+			check("Unsigned 32->64 widen 0xFFFFFFFF: low limb",        widened.block(0) == 0xFFFF);
+			check("Unsigned 32->64 widen 0xFFFFFFFF: limb 1",          widened.block(1) == 0xFFFF);
+			check("Unsigned 32->64 widen 0xFFFFFFFF: limb 2 zero",     widened.block(2) == 0x0000);
+			check("Unsigned 32->64 widen 0xFFFFFFFF: limb 3 zero",     widened.block(3) == 0x0000);
+		}
+
+		// Sanity: blockdecimal-flavored use (blockbinary<N, bt, Unsigned> via uint64 limbs)
+		{
+			using U64u64 = blockbinary<64,  std::uint64_t, BinaryNumberType::Unsigned>;
+			using U128u64 = blockbinary<128, std::uint64_t, BinaryNumberType::Unsigned>;
+			U64u64 src; src.setbits(static_cast<uint64_t>(-1));  // all 64 bits set
+			U128u64 widened(src);
+			check("Unsigned 64->128 widen UINT64_MAX: low limb is all-ones",  widened.block(0) == static_cast<uint64_t>(-1));
+			check("Unsigned 64->128 widen UINT64_MAX: high limb is zero",     widened.block(1) == 0);
+		}
+
+		std::cout << "+----- cross-template widening regression: PASS\n";
+	}
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }


### PR DESCRIPTION
## Summary

Closes the constexpr surface on \`blockbinary\` by promoting \`operator*=\`, \`operator/=\`, \`operator%=\`, \`longdivision\`, and the \`urmul\`/\`urmul2\`/\`uradd\`/\`ursub\` free helpers, along with their supporting members (\`msb\`, \`to_sll\`, \`roundingMode\`, \`any\`, unary \`-\`, \`~\`, cross-template copy ctor, \`assign\`).

PR #716 covered add/sub/shift/bitwise. The mul/div/mod path was deferred because the multi-limb \`uint64_t\`-block fast-mul uses platform intrinsics (\`mul128\`, \`addcarry\`) that are not \`constexpr\` on MSVC. This PR uses the same \`std::is_constant_evaluated()\` dispatch pattern that just landed for \`integer<>\` in PR #757: a portable \`__uint128_t\`-based carry-propagation fallback for compile-time evaluation, with the intrinsic path retained for runtime performance.

This unblocks #721 (fixpnt full constexpr) and transitively #722 (lns).

## Changes

| File | Change |
|------|--------|
| \`include/sw/universal/internal/blockbinary/blockbinary.hpp\` | All listed members and free helpers promoted to \`constexpr\`; \`operator*=\` uint64-limb path gets \`is_constant_evaluated\` dispatch with \`__uint128_t\` fallback (gated on \`__SIZEOF_INT128__\`) |
| \`internal/blockbinary/api/constexpr.cpp\` | Added \"mul/div/mod (issue #759)\" section: single-block + multi-limb mul/div/mod, uint64 \`__int128\` cross-limb carry test, free-operator wrappers, divide-by-zero defined-behavior, \`uradd\`/\`ursub\`/\`urmul2\`, helper smoke (\`msb\`, \`to_sll\`, \`any\`), unary \`-\` / \`~\` |

Existing div-by-zero behavior was already constexpr-friendly: single-block fast path returns \`*this = 0\` silently, \`longdivision\` sets \`result.exceptionId = 1\` as a return code. No exception infrastructure needed.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| bb_constexpr | OK | PASS | OK | PASS |
| bb_api | OK | PASS | OK | PASS |
| bb_multiplication | OK | PASS | OK | PASS |
| bb_division | OK | PASS | OK | PASS |
| bb_remainder | OK | PASS | OK | PASS |
| bb_addition | OK | PASS | OK | PASS |
| bb_subtraction | OK | PASS | OK | PASS |
| bb_shift_left | OK | PASS | OK | PASS |
| bb_shift_right | OK | PASS | OK | PASS |
| bb_logic | OK | PASS | OK | PASS |
| bb_uint64_limbs | OK | PASS | OK | PASS |
| bb_urmul | OK | PASS | OK | PASS |

Downstream sanity (consumers of \`blockbinary\`):
| Target | gcc | clang |
|--------|-----|-------|
| fixpnt_api | PASS | (not retested - same code path) |
| fixpnt_constexpr | PASS | (not retested) |
| bint_api | PASS | (not retested) |
| bint_constexpr | PASS | (not retested) |

## Test plan

- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] CodeRabbit review
- [ ] Promote to ready when satisfied: \`gh pr ready NNN\`
- [ ] After merge: pivot to #721 (fixpnt constexpr) and use blockbinary mul/div as substrate

Resolves #759
Relates to #723

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded compile-time (constexpr) support for many arithmetic ops, compound assignments, unary ops and helper methods.

* **Tests**
  * Added comprehensive constexpr validation for multiply/divide/modulo, carry propagation, helpers/unary ops, widening semantics and defined divide-by-zero behavior.

* **Refactor / Behavior**
  * Tightened constexpr fast-path handling; removed non-const bitwise-complement overload; unsigned widening now zero-extends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->