### PR TITLE
feat(fixpnt): full constexpr arithmetic, comparison, shifts, conversions

### DIFF
--- a/include/sw/universal/number/fixpnt/fixpnt_fwd.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_fwd.hpp
@@ -10,7 +10,7 @@ namespace sw { namespace universal {
 
 	// forward references
 	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt> class fixpnt;
-	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt> fixpnt<nbits, rbits, arithmetic, bt> abs(const fixpnt<nbits, rbits, arithmetic, bt>&);
+	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt> constexpr fixpnt<nbits, rbits, arithmetic, bt> abs(const fixpnt<nbits, rbits, arithmetic, bt>&);
 
 	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt> struct fixpntdiv_t;
 	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt> fixpntdiv_t<nbits, rbits, arithmetic, bt> fixpntdiv(const fixpnt<nbits, rbits, arithmetic, bt>&, const fixpnt<nbits, rbits, arithmetic, bt>&);
@@ -23,10 +23,10 @@ namespace sw { namespace universal {
 
 	// free function generator to create a 1's complement copy of a fixpnt
 	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-	inline fixpnt<nbits, rbits, arithmetic, bt> onesComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value);
+	constexpr inline fixpnt<nbits, rbits, arithmetic, bt> onesComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value);
 	// free function generator to create the 2's complement of a fixpnt
 	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-	inline fixpnt<nbits, rbits, arithmetic, bt> twosComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value);
+	constexpr inline fixpnt<nbits, rbits, arithmetic, bt> twosComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value);
 
 	// The free function scale calculates the power of 2 exponent that would capture an approximation of a normalized real value
 	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>

--- a/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
@@ -71,7 +71,7 @@ constexpr inline fixpnt<nbits, rbits, arithmetic, bt> onesComplement(const fixpn
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
 constexpr inline fixpnt<nbits, rbits, arithmetic, bt> twosComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value) {
 	fixpnt<nbits, rbits, arithmetic, bt> twos(value);
-	return twos.twosComplement();;
+	return twos.twosComplement();
 }
 
 // The free function scale calculates the power of 2 exponent that would capture an approximation of a normalized real value

--- a/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
@@ -63,13 +63,13 @@ struct fixpntdiv_t {
 
 // free function generator to create a 1's complement copy of a fixpnt
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> onesComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> onesComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value) {
 	fixpnt<nbits, rbits, arithmetic, bt> ones(value);
 	return ones.flip();
 }
 // free function generator to create the 2's complement of a fixpnt
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> twosComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> twosComplement(const fixpnt<nbits, rbits, arithmetic, bt>& value) {
 	fixpnt<nbits, rbits, arithmetic, bt> twos(value);
 	return twos.twosComplement();;
 }
@@ -127,7 +127,7 @@ public:
 	fixpnt(fixpnt&&) noexcept = default;
 
 	constexpr fixpnt& operator=(const fixpnt&) noexcept = default;
-	fixpnt& operator=(fixpnt&&) noexcept = default;
+	constexpr fixpnt& operator=(fixpnt&&) noexcept = default;
 
 	// decorated/converting constructors
 
@@ -137,7 +137,7 @@ public:
 	/// </summary>
 	/// <param name="a">source fixpnt</param>
 	template<unsigned src_nbits, unsigned src_rbits>
-	fixpnt(const fixpnt<src_nbits, src_rbits, arithmetic, bt>& a) noexcept { *this = a; }
+	constexpr fixpnt(const fixpnt<src_nbits, src_rbits, arithmetic, bt>& a) noexcept { *this = a; }
 
 	// specific value constructor
 	constexpr fixpnt(const SpecificValue code) : _block{ 0 } {
@@ -177,7 +177,7 @@ public:
 	// fixpnt size adapter: convert fixpnt<src_nbits, src_rbits> -> fixpnt<nbits, rbits>
 	// The radix point must be aligned by shifting bits before copying.
 	template<unsigned src_nbits, unsigned src_rbits>
-	fixpnt& operator=(const fixpnt<src_nbits, src_rbits, arithmetic, bt>& a) noexcept {
+	constexpr fixpnt& operator=(const fixpnt<src_nbits, src_rbits, arithmetic, bt>& a) noexcept {
 		if constexpr (src_rbits == rbits) {
 			// radix points are aligned: blockbinary assign handles
 			// sign extension (src_nbits < nbits) or truncation (src_nbits > nbits)
@@ -425,7 +425,7 @@ public:
 	explicit constexpr operator double()             const noexcept { return to_native<double>(); }
 
 	// arithmetic operators
-	fixpnt& operator+=(const fixpnt& rhs) {
+	constexpr fixpnt& operator+=(const fixpnt& rhs) {
 		if constexpr (arithmetic == Modulo) {
 			_block += rhs._block;
 		}
@@ -447,7 +447,7 @@ public:
 		}
 		return *this;
 	}
-	fixpnt& operator-=(const fixpnt& rhs) {
+	constexpr fixpnt& operator-=(const fixpnt& rhs) {
 		if constexpr (arithmetic == Modulo) {
 			operator+=(sw::universal::twosComplement(rhs));
 		}
@@ -469,7 +469,7 @@ public:
 		}
 		return *this;
 	}
-	fixpnt& operator*=(const fixpnt& rhs) {
+	constexpr fixpnt& operator*=(const fixpnt& rhs) {
 		if constexpr (arithmetic == Modulo) {
 //			blockbinary<2 * nbits, bt> c = urmul(_block, rhs._block);
 			blockbinary<2 * nbits, bt> c = urmul2(_block, rhs._block);
@@ -501,12 +501,14 @@ public:
 	/// Divide this fixpnt by rhs in-place.
 	/// In Modulo mode, the result wraps on overflow.
 	/// In Saturate mode, the result clamps to maxpos or maxneg on overflow.
-	fixpnt& operator/=(const fixpnt& rhs) {
+	constexpr fixpnt& operator/=(const fixpnt& rhs) {
 #if FIXPNT_THROW_ARITHMETIC_EXCEPTION
 		if (rhs.iszero()) throw fixpnt_divide_by_zero();
 #else
 		if (rhs.iszero()) {
-			std::cerr << "fixpnt_divide_by_zero" << std::endl;
+			if (!std::is_constant_evaluated()) {
+				std::cerr << "fixpnt_divide_by_zero" << std::endl;
+			}
 			if constexpr (arithmetic == Saturate) {
 				// saturate to maxpos or maxneg based on sign of dividend
 				if (isneg())
@@ -598,15 +600,15 @@ public:
 		}
 		return *this;
 	}
-	fixpnt& operator%=(const fixpnt& rhs) {
+	constexpr fixpnt& operator%=(const fixpnt& rhs) {
 		_block %= rhs._block;
 		return *this;
 	}
-	fixpnt& operator<<=(const signed shift) {
+	constexpr fixpnt& operator<<=(const signed shift) {
 		_block <<= shift;
 		return *this;
 	}
-	fixpnt& operator>>=(const signed shift) {
+	constexpr fixpnt& operator>>=(const signed shift) {
 		_block >>= shift;
 		return *this;
 	}
@@ -690,7 +692,7 @@ public:
 	constexpr uint8_t nibble(unsigned n)      const noexcept { return _block.nibble(n); }
 
 	// collect a copy of the underlying bit representation
-	blockbinary<nbits, bt, BinaryNumberType::Signed> bits() const noexcept { return _block; }
+	constexpr blockbinary<nbits, bt, BinaryNumberType::Signed> bits() const noexcept { return _block; }
 
 	// normalize: decompose fixpnt value into a blocktriple<rbits, REP> for quire accumulation
 	template<typename TargetBlockType = bt>
@@ -854,7 +856,7 @@ protected:
 
 	// from fixed-point to native signed integer
 	template<typename NativeInt>
-	typename std::enable_if< std::is_integral_v<NativeInt> && std::is_signed_v<NativeInt>,
+	constexpr typename std::enable_if< std::is_integral_v<NativeInt> && std::is_signed_v<NativeInt>,
 		NativeInt>::type to_signed() const {
 		if constexpr (nbits <= rbits) return 0;
 		constexpr unsigned sizeOfInteger = 8 * sizeof(NativeInt);
@@ -876,13 +878,13 @@ protected:
 	
 	// from fixed-point to native unsigned integer
 	template<typename NativeInt>
-	typename std::enable_if< std::is_unsigned_v<NativeInt>,
+	constexpr typename std::enable_if< std::is_unsigned_v<NativeInt>,
 		NativeInt>::type to_unsigned() const {
 		return NativeInt(_block.to_sll());
 	}
 
 	template<typename TargetFloat>
-	TargetFloat to_native() const {
+	constexpr TargetFloat to_native() const {
 		// pick up the absolute value of the minimum normal and subnormal exponents 
 		constexpr unsigned minNormalExponent = static_cast<unsigned>(-ieee754_parameter<TargetFloat > ::minNormalExp);
 		constexpr unsigned minSubnormalExponent = static_cast<unsigned>(-ieee754_parameter<TargetFloat>::minSubnormalExp);
@@ -921,15 +923,15 @@ private:
 
 	// fixpnt - fixpnt logic comparisons
 	template<unsigned nnbits, unsigned rrbits, bool aarithmetic, typename Bbt>
-	friend bool operator==(const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& lhs, const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& rhs);
+	friend constexpr bool operator==(const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& lhs, const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& rhs);
 	template<unsigned nnbits, unsigned rrbits, bool aarithmetic, typename Bbt>
-	friend bool operator< (const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& lhs, const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& rhs);
+	friend constexpr bool operator< (const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& lhs, const fixpnt<nnbits, rrbits, aarithmetic, Bbt>& rhs);
 };
 
 
 /// Magnitude of a fixpnt. Expensive as fixpnts are encoded as 2's complement, so we need to test, copy, complement, and return.
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-fixpnt<nbits, rbits, arithmetic, bt> abs(const fixpnt<nbits, rbits, arithmetic, bt>& v) {
+constexpr fixpnt<nbits, rbits, arithmetic, bt> abs(const fixpnt<nbits, rbits, arithmetic, bt>& v) {
 	fixpnt<nbits, rbits, arithmetic, bt> tmp(v);
 	if (v.isneg()) tmp.twosComplement();
 	return tmp;
@@ -944,27 +946,27 @@ fixpnt<nbits, rbits, arithmetic, bt> abs(const fixpnt<nbits, rbits, arithmetic, 
 
 // equal: precondition is that the block-storage is properly nulled in all arithmetic paths
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return (lhs._block == rhs._block);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(lhs, rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return (lhs._block < rhs._block);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (lhs, rhs);
 }
 
@@ -974,372 +976,372 @@ inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fi
 
 // equal: precondition is that the byte-storage is properly nulled in all arithmetic paths
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - fixpnt binary logic operators
 // precondition is that the byte-storage is properly nulled in all arithmetic paths
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // fixpnt - literal float/double binary logic operators
 // equal: precondition is that the byte-storage is properly nulled in all arithmetic paths
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
  
 #if LONG_DOUBLE_SUPPORT
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline bool operator==(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline bool operator!=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return !operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline bool operator< (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator<(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline bool operator> (const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(rhs), lhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline bool operator<=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs)) || operator==(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return !operator< (lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 #endif
@@ -1349,77 +1351,77 @@ inline bool operator>=(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long dou
 // precondition is that the byte-storage is properly nulled in all arithmetic paths
 
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
 #if LONG_DOUBLE_SUPPORT
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator==(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator==(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator!=(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator!=(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator< (long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator< (long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator<(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator> (long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator> (long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (rhs, fixpnt<nbits, rbits, arithmetic, bt>(lhs));
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator<=(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator<=(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs) || operator==(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline bool operator>=(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline bool operator>=(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return !operator< (fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 #endif
@@ -1431,35 +1433,35 @@ inline bool operator>=(long double lhs, const fixpnt<nbits, rbits, arithmetic, b
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	fixpnt<nbits, rbits, arithmetic, bt> sum = lhs;
 	sum += rhs;
 	return sum;
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	fixpnt<nbits, rbits, arithmetic, bt> diff = lhs;
 	diff -= rhs;
 	return diff;
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	fixpnt<nbits, rbits, arithmetic, bt> mul = lhs;
 	mul *= rhs;
 	return mul;
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	fixpnt<nbits, rbits, arithmetic, bt> ratio = lhs;
 	ratio /= rhs;
 	return ratio;
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	fixpnt<nbits, rbits, arithmetic, bt> ratio = lhs;
 	ratio %= rhs;
 	return ratio;
@@ -1472,167 +1474,167 @@ inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits,
 
 // BINARY left shift
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator<<(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator<<(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	fixpnt<nbits, rbits, arithmetic, bt> tmp = lhs;
 	return tmp <<= rhs;
 }
 // BINARY right shift
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator>>(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator>>(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	fixpnt<nbits, rbits, arithmetic, bt> tmp = lhs;
 	return tmp >>= rhs;
 }
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, int rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 /////////////////  long
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 /////////////  long long
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long long rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 
 ///////////////////// unsigned int
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned int rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 /////////////////  unsigned long
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 /////////////  unsigned long long
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, unsigned long long rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 
@@ -1641,157 +1643,157 @@ inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits,
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
 // // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(unsigned int lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
 // // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(unsigned long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(unsigned long long lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
@@ -1801,79 +1803,79 @@ inline fixpnt<nbits, rbits, arithmetic, bt> operator%(unsigned long long lhs, co
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, float rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, double rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator+(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator-(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator*(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator/(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits, arithmetic, bt>& lhs, long double rhs) {
 	return operator%(lhs, fixpnt<nbits, rbits, arithmetic, bt>(rhs));
 }
 
@@ -1881,27 +1883,27 @@ inline fixpnt<nbits, rbits, arithmetic, bt> operator%(const fixpnt<nbits, rbits,
 // literal double - fixpnt binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(float lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
@@ -1909,27 +1911,27 @@ inline fixpnt<nbits, rbits, arithmetic, bt> operator%(float lhs, const fixpnt<nb
 // literal double - fixpnt binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 
@@ -1937,27 +1939,27 @@ inline fixpnt<nbits, rbits, arithmetic, bt> operator%(double lhs, const fixpnt<n
 // literal double - fixpnt binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator+(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator+(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator+(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator-(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator-(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator-(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator*(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator*(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator*(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator/(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator/(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator/(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 // BINARY REMAINDER
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-inline fixpnt<nbits, rbits, arithmetic, bt> operator%(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
+constexpr inline fixpnt<nbits, rbits, arithmetic, bt> operator%(long double lhs, const fixpnt<nbits, rbits, arithmetic, bt>& rhs) {
 	return operator%(fixpnt<nbits, rbits, arithmetic, bt>(lhs), rhs);
 }
 

--- a/static/fixpnt/binary/api/constexpr.cpp
+++ b/static/fixpnt/binary/api/constexpr.cpp
@@ -157,6 +157,96 @@ try {
 #if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(DecoratedConstructors<Fixpnt>(), test_tag, "constructors");
 	nrOfFailedTestCases += ReportTestResult(AssignmentOperators<Fixpnt>(), test_tag, "assignment");
+
+	// ----------------------------------------------------------------------
+	// Comprehensive constexpr arithmetic / comparison / shift / bitwise
+	// (issue #721) -- joins integer (#720), posit (#718), cfloat (#719),
+	// bfloat16 (#725) as a fully constexpr-compliant Universal type.
+	// ----------------------------------------------------------------------
+	{
+		std::cout << "+----- constexpr arithmetic + comparison (issue #721)\n";
+
+		// Acceptance form: Q16.16 multiply 2.5 * 1.5 produces 3.75 at compile time.
+		using Q16_16 = fixpnt<32, 16, Modulo, std::uint32_t>;
+		BIT_CAST_CONSTEXPR Q16_16 q_a(2.5);
+		BIT_CAST_CONSTEXPR Q16_16 q_b(1.5);
+		constexpr auto q_prod = q_a * q_b;  // 2.5 * 1.5 = 3.75
+		// raw bit pattern of 3.75 in Q16.16 = 3 << 16 | 0xC000 = 0x0003C000
+		// uint32 block: low 32 bits hold the whole representation.
+		constexpr auto q_prod_bits = q_prod.bits();
+		static_assert(q_prod_bits.block(0) == 0x0003C000u, "Q16.16 2.5 * 1.5 == 3.75 raw bits 0x0003C000");
+
+		// Pure integer arithmetic on Modulo Q-format
+		using Q32 = fixpnt<32, 0, Modulo, std::uint32_t>;
+		constexpr Q32 a(42), b(7);
+		constexpr auto cx_sum  = a + b;
+		constexpr auto cx_diff = a - b;
+		constexpr auto cx_prod = a * b;
+		constexpr auto cx_quot = a / b;
+		constexpr auto cx_rem  = a % b;
+		constexpr auto cx_neg  = -a;
+		constexpr auto cx_shl  = a << 2;
+		constexpr auto cx_shr  = a >> 2;
+
+		// Compound assignment via lambda
+		constexpr Q32 cx_addeq = []() { Q32 t(42); t += Q32(7); return t; }();
+		constexpr Q32 cx_muleq = []() { Q32 t(42); t *= Q32(7); return t; }();
+
+		// Constexpr comparisons
+		static_assert(!(a == b), "constexpr 42 != 7");
+		static_assert(b < a,     "constexpr 7 < 42");
+		static_assert(a >= b,    "constexpr 42 >= 7");
+
+		// Cross-check via runtime; use to_long() for value comparison
+		Q32 ra(42), rb(7);
+		Q32 r49(49), r294(294), r6(6), r0(0), r_neg42(-42), r168(168), r10(10);
+		auto check = [&](const char* name, bool ok) {
+			if (!ok) { ++nrOfFailedTestCases; std::cout << "FAIL " << name << '\n'; }
+		};
+		check("constexpr 42+7  == 49",  cx_sum  == r49);
+		check("constexpr 42*7  == 294", cx_prod == r294);
+		check("constexpr 42/7  == 6",   cx_quot == r6);
+		check("constexpr 42%7  == 0",   cx_rem  == r0);
+		check("constexpr -42",          cx_neg  == r_neg42);
+		check("constexpr 42<<2 == 168", cx_shl  == r168);
+		check("constexpr 42>>2 == 10",  cx_shr  == r10);
+		check("constexpr += matches +", cx_addeq == r49);
+		check("constexpr *= matches *", cx_muleq == r294);
+		(void)cx_diff;
+
+		// Multi-limb constexpr: fixpnt<128, 64> via uint32 limbs.
+		using Q128_64 = fixpnt<128, 64, Modulo, std::uint32_t>;
+		BIT_CAST_CONSTEXPR Q128_64 ml_a(1000.0);
+		BIT_CAST_CONSTEXPR Q128_64 ml_b(1000.0);
+		constexpr auto ml_prod = ml_a * ml_b;
+		BIT_CAST_CONSTEXPR Q128_64 r_million(1000000.0);
+		check("constexpr Q128.64 1000 * 1000 == 1_000_000 (multi-limb mul)", ml_prod == r_million);
+
+		// Saturating variant: maxpos clamping under * overflow at compile time.
+		using Sat8_4 = fixpnt<8, 4, Saturate, std::uint8_t>;
+		constexpr Sat8_4 sat_a(7);   // close to maxpos
+		constexpr Sat8_4 sat_b(2);
+		constexpr auto sat_prod = sat_a * sat_b;  // 7*2 = 14, would overflow -> clamp
+		constexpr Sat8_4 sat_maxpos(SpecificValue::maxpos);
+		check("constexpr Saturate 7*2 clamps to maxpos", sat_prod == sat_maxpos);
+
+		// Saturating addition that should NOT overflow (in-range result).
+		constexpr Sat8_4 sat_add = []() { Sat8_4 t(3); t += Sat8_4(1); return t; }();  // 3+1=4 in range
+		constexpr Sat8_4 r4(4);
+		check("constexpr Saturate 3+1 == 4 (no clamping)", sat_add == r4);
+
+		// Edge case: divide-by-zero defined behavior under
+		// FIXPNT_THROW_ARITHMETIC_EXCEPTION=0 (set above for this TU).
+		// Modulo: result is 0 (setzero).
+		constexpr Q32 div_zero_mod = []() { Q32 t(42); t /= Q32(0); return t; }();
+		check("constexpr Modulo div-by-zero returns 0", div_zero_mod == r0);
+
+		// Saturating: clamps to maxpos for positive dividend.
+		constexpr Sat8_4 div_zero_sat = []() { Sat8_4 t(2); t /= Sat8_4(0); return t; }();
+		check("constexpr Saturate div-by-zero (pos) clamps to maxpos", div_zero_sat == sat_maxpos);
+
+		std::cout << "constexpr arithmetic regression: PASS\n";
+	}
 #endif
 
 #if REGRESSION_LEVEL_2


### PR DESCRIPTION
## Summary

Promotes \`fixpnt<nbits, rbits, arithmetic, BlockType>\` to fully constexpr across all user-facing operators. Joins integer (#720), posit (#718), cfloat (#719), and bfloat16 (#725) as a fully constexpr-compliant Universal type.

Built on top of the blockbinary mul/div/mod constexpr foundation that just landed in **#759** (PR #760, merged as 651a0ba2). fixpnt arithmetic decomposes to blockbinary arithmetic, so this PR is mostly bulk \`constexpr\` decoration once the substrate is in place.

## Changes

| File | Change |
|------|--------|
| \`include/sw/universal/number/fixpnt/fixpnt_impl.hpp\` | Method promotions: \`to_signed\`, \`to_unsigned\`, \`to_native\`, \`bits()\`, all 7 compound assignments, cross-template copy ctor + assignment + move assignment. Bulk: 114 free comparison operators + 99 free arithmetic operators (\`fixpnt-fixpnt\` and ~108 mixed \`fixpnt-int/long/unsigned/float/double/long double\` overloads). \`abs\`, \`onesComplement\`, \`twosComplement\` free helpers. \`std::cerr\` div-by-zero diagnostic gated on \`!is_constant_evaluated\`; defined-behavior return paths preserved (Modulo: setzero; Saturate: clamp by sign). |
| \`include/sw/universal/number/fixpnt/fixpnt_fwd.hpp\` | Forward declarations of \`abs\`, \`onesComplement\`, \`twosComplement\` gain \`constexpr\` to match implementations |
| \`static/fixpnt/binary/api/constexpr.cpp\` | Added 90-line \"constexpr arithmetic + comparison (issue #721)\" section after the existing pi tests |

## Acceptance form

\`\`\`cpp
using Q16_16 = fixpnt<32, 16, Modulo, std::uint32_t>;
BIT_CAST_CONSTEXPR Q16_16 a(2.5);
BIT_CAST_CONSTEXPR Q16_16 b(1.5);
constexpr auto prod = a * b;  // 2.5 * 1.5 = 3.75
constexpr auto bits = prod.bits();
static_assert(bits.block(0) == 0x0003C000u);  // raw Q16.16 of 3.75
\`\`\`

Plus comprehensive coverage: all arithmetic and comparison operators, multi-limb (\`fixpnt<128, 64, Modulo, uint32>\` 1000 * 1000 = 1_000_000), Saturating clamp on overflow (\`Sat8.4\` 7 * 2 -> maxpos), divide-by-zero defined behavior in both Modulo and Saturate modes.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| fixpnt_api | OK | PASS | OK | PASS |
| fixpnt_constexpr | OK | PASS | OK | PASS |
| fixpnt_assignment | OK | PASS | (full suite spot-check) | - |
| fixpnt_attributes | OK | PASS | - | - |
| fixpnt_classify | OK | PASS | - | - |
| fixpnt_logic | OK | PASS | - | - |
| fixpnt_mod_addition | OK | PASS | OK | PASS |
| fixpnt_mod_subtraction | OK | PASS | - | - |
| fixpnt_mod_multiplication | OK | PASS | OK | PASS |
| fixpnt_mod_division | OK | PASS | OK | PASS |
| fixpnt_sat_addition | OK | PASS | OK | PASS |
| fixpnt_sat_multiplication | OK | PASS | OK | PASS |
| fixpnt_mod_conversion | OK | PASS | - | - |
| fixpnt_sat_conversion | OK | PASS | - | - |

14/14 PASS on gcc full sweep, 7/7 spot-check on clang.

## Test plan

- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit review
- [x] Promote to ready when satisfied: \`gh pr ready NNN\`

Resolves #721
Relates to #723

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widened compile-time (constexpr) support across the fixed-point API: arithmetic, comparisons, bit access, shifts, conversions, complements and unary helpers now evaluate at compile time.

* **Bug Fixes**
  * Suppress runtime diagnostics during compile-time evaluation for divide-by-zero paths to avoid spurious output.

* **Tests**
  * Added comprehensive constexpr regression tests covering arithmetic, comparisons, shifts, edge cases and cross-checks with runtime results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->