### PR TITLE
feat(lns): Mitchell-style LookupAddSub algorithm (Phase B of #777)

### DIFF
--- a/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
+++ b/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
@@ -71,6 +71,71 @@
 namespace sw { namespace universal {
 
 // ============================================================================
+// Shared log-add dispatcher (used by all sb_add / sb_sub-based policies)
+// ============================================================================
+//
+// Routes special values (NaN, +/-0, +/-inf), then dispatches by sign to either
+// same-sign log-add or mixed-sign magnitude subtraction. The Gauss log-add path
+// only sees finite, non-zero operands. Calls Policy::sb_add(d) for same-sign
+// and Policy::sb_sub(d) for mixed-sign with d <= 0.
+//
+// Policies that build on this dispatcher only need to implement sb_add and
+// sb_sub (per the algorithm contract documented at the top of this file).
+
+namespace detail {
+
+template<typename Policy>
+constexpr double gauss_log_add(double a, double b) {
+	if (a != a || b != b) return a + b;                                   // NaN propagates
+	if (a == 0.0) return b;
+	if (b == 0.0) return a;
+	// Infinities: native double arithmetic gives the correct IEEE result
+	// for all combinations (inf + inf = inf, inf + (-inf) = NaN,
+	// inf + finite = inf). The Gauss log-add path below assumes finite,
+	// non-zero operands; routing inf through log2 would produce inf-inf
+	// in the same-sign branch and a spurious 0 from the La == Lb check in
+	// the mixed-sign branch.
+	{
+		constexpr double dinf = std::numeric_limits<double>::infinity();
+		if (a == dinf || a == -dinf || b == dinf || b == -dinf) return a + b;
+	}
+
+	bool sign_a = a < 0.0;
+	bool sign_b = b < 0.0;
+	double abs_a = sign_a ? -a : a;
+	double abs_b = sign_b ? -b : b;
+
+	if (sign_a == sign_b) {
+		// Same sign: log2(|a + b|) = max(La, Lb) + sb_add(min - max)
+		double La = sw::math::constexpr_math::log2(abs_a);
+		double Lb = sw::math::constexpr_math::log2(abs_b);
+		double Lmax = (La >= Lb) ? La : Lb;
+		double Lmin = (La >= Lb) ? Lb : La;
+		double Lresult = Lmax + Policy::sb_add(Lmin - Lmax);
+		double mag = sw::math::constexpr_math::exp2(Lresult);
+		return sign_a ? -mag : mag;
+	}
+	else {
+		// Mixed sign: magnitude subtraction; result sign follows larger magnitude.
+		double La = sw::math::constexpr_math::log2(abs_a);
+		double Lb = sw::math::constexpr_math::log2(abs_b);
+		if (La == Lb) return 0.0;                                            // exact cancellation
+		bool a_larger = (La > Lb);
+		double Lmax = a_larger ? La : Lb;
+		double Lmin = a_larger ? Lb : La;
+		double Lresult = Lmax + Policy::sb_sub(Lmin - Lmax);
+		// log2 of zero or negative -- happens when the sb_sub argument
+		// rounds to 0; treat as exact cancellation.
+		if (Lresult != Lresult) return 0.0;
+		double mag = sw::math::constexpr_math::exp2(Lresult);
+		bool result_neg = a_larger ? sign_a : sign_b;
+		return result_neg ? -mag : mag;
+	}
+}
+
+}  // namespace detail
+
+// ============================================================================
 // Algorithm 1: DoubleTripAddSub -- the historical placeholder, preserved
 // ============================================================================
 //
@@ -135,9 +200,9 @@ struct DoubleTripAddSub {
 
 template<typename Lns>
 struct DirectEvaluationAddSub {
-private:
 	// log2(1 + 2^d) for d <= 0. As d -> -infinity, correction -> 0.
-	// As d -> 0, correction -> 1.
+	// As d -> 0, correction -> 1. The shared dispatcher in detail::gauss_log_add
+	// only invokes sb_add with finite d <= 0.
 	static constexpr double sb_add(double d) {
 		// 2^d for d <= 0 stays in [0, 1]. The 1 + 2^d sum is exact in
 		// double for any d, and cm::log2 handles the result.
@@ -154,69 +219,14 @@ private:
 		return sw::math::constexpr_math::log2(t);
 	}
 
-	// Compute a + b in the log domain, returning the result as a double in
-	// linear units (caller encodes to Lns).
-	static constexpr double log_add(double a, double b) {
-		// Special values
-		if (a != a || b != b) return a + b;                             // NaN propagates
-		if (a == 0.0) return b;
-		if (b == 0.0) return a;
-		// Infinities: native double arithmetic gives the correct IEEE result
-		// for all combinations (inf + inf = inf, inf + (-inf) = NaN,
-		// inf + finite = inf). The Gauss log-add path below assumes finite,
-		// non-zero operands; routing inf through log2 would produce inf-inf
-		// in the same-sign branch and a spurious 0 from the La==Lb check in
-		// the mixed-sign branch.
-		{
-			constexpr double dinf = std::numeric_limits<double>::infinity();
-			if (a == dinf || a == -dinf || b == dinf || b == -dinf) return a + b;
-		}
-
-		bool sign_a = a < 0.0;
-		bool sign_b = b < 0.0;
-		double abs_a = sign_a ? -a : a;
-		double abs_b = sign_b ? -b : b;
-
-		if (sign_a == sign_b) {
-			// Same sign: pure addition in the log domain.
-			// log2(|a + b|) = max(La, Lb) + sb_add(min - max)
-			double La = sw::math::constexpr_math::log2(abs_a);
-			double Lb = sw::math::constexpr_math::log2(abs_b);
-			double Lmax = (La >= Lb) ? La : Lb;
-			double Lmin = (La >= Lb) ? Lb : La;
-			double Lresult = Lmax + sb_add(Lmin - Lmax);
-			double mag = sw::math::constexpr_math::exp2(Lresult);
-			return sign_a ? -mag : mag;
-		}
-		else {
-			// Mixed sign: a + b = sign(a)*|a| - sign(a)*|b| ... reduces to
-			// magnitude subtraction. The result's sign follows the larger
-			// magnitude.
-			double La = sw::math::constexpr_math::log2(abs_a);
-			double Lb = sw::math::constexpr_math::log2(abs_b);
-			if (La == Lb) return 0.0;                                    // exact cancellation
-			bool a_larger = (La > Lb);
-			double Lmax = a_larger ? La : Lb;
-			double Lmin = a_larger ? Lb : La;
-			double Lresult = Lmax + sb_sub(Lmin - Lmax);
-			// log2 of zero or negative -- happens only when sb_sub argument
-			// rounds to 0; treat as exact cancellation.
-			if (Lresult != Lresult) return 0.0;
-			double mag = sw::math::constexpr_math::exp2(Lresult);
-			bool result_neg = a_larger ? sign_a : sign_b;
-			return result_neg ? -mag : mag;
-		}
-	}
-
-public:
 	static constexpr Lns& add_assign(Lns& lhs, const Lns& rhs) {
-		double result = log_add(double(lhs), double(rhs));
+		double result = detail::gauss_log_add<DirectEvaluationAddSub>(double(lhs), double(rhs));
 		return lhs = result;
 	}
 	static constexpr Lns& sub_assign(Lns& lhs, const Lns& rhs) {
 		// a - b = a + (-b); negate via the lns operator-() which is a single
 		// sign-bit flip.
-		double result = log_add(double(lhs), double(-rhs));
+		double result = detail::gauss_log_add<DirectEvaluationAddSub>(double(lhs), double(-rhs));
 		return lhs = result;
 	}
 };
@@ -258,12 +268,14 @@ public:
 template<typename Lns,
          unsigned IndexBits = ((Lns::rbits + 2u < 10u) ? Lns::rbits + 2u : 10u)>
 struct LookupAddSub {
-	// Shift safety: table_entries = 1 << IndexBits is computed in std::size_t,
-	// so the limit is sizeof(size_t)*8 bits. We cap well below that to keep
-	// table sizes sane (2^30 doubles = 8 GB, far past any realistic budget).
+	// Shift safety: 1 << IndexBits must fit in std::size_t. On narrow ABIs
+	// (e.g., 16-bit embedded targets) std::size_t may be smaller than 30 bits,
+	// so the SRAM cap below is not by itself a sufficient shift-width guard.
+	static_assert(IndexBits < std::numeric_limits<std::size_t>::digits,
+	              "LookupAddSub: IndexBits must be smaller than the bit width of std::size_t");
+	// SRAM cap: 2^30 doubles = 8 GB, far past any realistic embedded budget.
 	static_assert(IndexBits < 30,
-	              "LookupAddSub: IndexBits >= 30 would overflow practical SRAM budgets and "
-	              "approaches the shift width of std::size_t");
+	              "LookupAddSub: IndexBits >= 30 would exceed practical SRAM budgets");
 private:
 	static constexpr std::size_t table_entries = std::size_t(1) << IndexBits;
 	static constexpr double      d_range = double(Lns::rbits) + 2.0;
@@ -298,7 +310,9 @@ private:
 	static constexpr auto add_table = make_add_table();
 	static constexpr auto sub_table = make_sub_table();
 
-	// Linear interp: log2(1 + 2^d) for d <= 0.
+public:
+	// Linear interp: log2(1 + 2^d) for d <= 0. The shared dispatcher in
+	// detail::gauss_log_add only invokes sb_add with finite d <= 0.
 	static constexpr double sb_add(double d) {
 		if (d > 0.0) d = 0.0;
 		double abs_d = -d;
@@ -327,55 +341,12 @@ private:
 		return sub_table[idx] + frac * (sub_table[idx + 1u] - sub_table[idx]);
 	}
 
-	// Same dispatcher as DirectEvaluationAddSub: routes special values, then
-	// dispatches by sign to same-sign add or mixed-sign magnitude subtraction.
-	static constexpr double log_add(double a, double b) {
-		if (a != a || b != b) return a + b;                                 // NaN propagates
-		if (a == 0.0) return b;
-		if (b == 0.0) return a;
-		// Infinities -- delegate to native double for correct IEEE behavior;
-		// see DirectEvaluationAddSub::log_add for the rationale.
-		{
-			constexpr double dinf = std::numeric_limits<double>::infinity();
-			if (a == dinf || a == -dinf || b == dinf || b == -dinf) return a + b;
-		}
-
-		bool sign_a = a < 0.0;
-		bool sign_b = b < 0.0;
-		double abs_a = sign_a ? -a : a;
-		double abs_b = sign_b ? -b : b;
-
-		if (sign_a == sign_b) {
-			double La = sw::math::constexpr_math::log2(abs_a);
-			double Lb = sw::math::constexpr_math::log2(abs_b);
-			double Lmax = (La >= Lb) ? La : Lb;
-			double Lmin = (La >= Lb) ? Lb : La;
-			double Lresult = Lmax + sb_add(Lmin - Lmax);
-			double mag = sw::math::constexpr_math::exp2(Lresult);
-			return sign_a ? -mag : mag;
-		}
-		else {
-			double La = sw::math::constexpr_math::log2(abs_a);
-			double Lb = sw::math::constexpr_math::log2(abs_b);
-			if (La == Lb) return 0.0;
-			bool a_larger = (La > Lb);
-			double Lmax = a_larger ? La : Lb;
-			double Lmin = a_larger ? Lb : La;
-			double Lresult = Lmax + sb_sub(Lmin - Lmax);
-			if (Lresult != Lresult) return 0.0;
-			double mag = sw::math::constexpr_math::exp2(Lresult);
-			bool result_neg = a_larger ? sign_a : sign_b;
-			return result_neg ? -mag : mag;
-		}
-	}
-
-public:
 	static constexpr Lns& add_assign(Lns& lhs, const Lns& rhs) {
-		double result = log_add(double(lhs), double(rhs));
+		double result = detail::gauss_log_add<LookupAddSub>(double(lhs), double(rhs));
 		return lhs = result;
 	}
 	static constexpr Lns& sub_assign(Lns& lhs, const Lns& rhs) {
-		double result = log_add(double(lhs), double(-rhs));
+		double result = detail::gauss_log_add<LookupAddSub>(double(lhs), double(-rhs));
 		return lhs = result;
 	}
 };

--- a/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
+++ b/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
@@ -62,6 +62,8 @@
 // is the responsibility of the algorithm.
 
 #include <array>
+#include <cstddef>
+#include <limits>
 
 #include <math/constexpr_math.hpp>
 #include <universal/number/lns/lns_fwd.hpp>
@@ -159,6 +161,16 @@ private:
 		if (a != a || b != b) return a + b;                             // NaN propagates
 		if (a == 0.0) return b;
 		if (b == 0.0) return a;
+		// Infinities: native double arithmetic gives the correct IEEE result
+		// for all combinations (inf + inf = inf, inf + (-inf) = NaN,
+		// inf + finite = inf). The Gauss log-add path below assumes finite,
+		// non-zero operands; routing inf through log2 would produce inf-inf
+		// in the same-sign branch and a spurious 0 from the La==Lb check in
+		// the mixed-sign branch.
+		{
+			constexpr double dinf = std::numeric_limits<double>::infinity();
+			if (a == dinf || a == -dinf || b == dinf || b == -dinf) return a + b;
+		}
 
 		bool sign_a = a < 0.0;
 		bool sign_b = b < 0.0;
@@ -246,16 +258,22 @@ public:
 template<typename Lns,
          unsigned IndexBits = ((Lns::rbits + 2u < 10u) ? Lns::rbits + 2u : 10u)>
 struct LookupAddSub {
+	// Shift safety: table_entries = 1 << IndexBits is computed in std::size_t,
+	// so the limit is sizeof(size_t)*8 bits. We cap well below that to keep
+	// table sizes sane (2^30 doubles = 8 GB, far past any realistic budget).
+	static_assert(IndexBits < 30,
+	              "LookupAddSub: IndexBits >= 30 would overflow practical SRAM budgets and "
+	              "approaches the shift width of std::size_t");
 private:
-	static constexpr unsigned table_entries = 1u << IndexBits;
-	static constexpr double   d_range = double(Lns::rbits) + 2.0;
-	static constexpr double   step    = d_range / double(table_entries);
+	static constexpr std::size_t table_entries = std::size_t(1) << IndexBits;
+	static constexpr double      d_range = double(Lns::rbits) + 2.0;
+	static constexpr double      step    = d_range / double(table_entries);
 
 	// log2(1 + 2^d) for d = -i*step, i in [0, table_entries].
 	// Endpoint i = table_entries gives the value at d = -d_range.
 	static constexpr std::array<double, table_entries + 1u> make_add_table() {
 		std::array<double, table_entries + 1u> t{};
-		for (unsigned i = 0; i <= table_entries; ++i) {
+		for (std::size_t i = 0; i <= table_entries; ++i) {
 			double d = -double(i) * step;
 			t[i] = sw::math::constexpr_math::log2(
 			           1.0 + sw::math::constexpr_math::exp2(d));
@@ -269,7 +287,7 @@ private:
 	static constexpr std::array<double, table_entries + 1u> make_sub_table() {
 		std::array<double, table_entries + 1u> t{};
 		t[0] = 0.0;
-		for (unsigned i = 1; i <= table_entries; ++i) {
+		for (std::size_t i = 1; i <= table_entries; ++i) {
 			double d = -double(i) * step;
 			double v = 1.0 - sw::math::constexpr_math::exp2(d);
 			t[i] = sw::math::constexpr_math::log2(v);
@@ -286,7 +304,7 @@ private:
 		double abs_d = -d;
 		if (abs_d >= d_range) return 0.0;
 		double idx_f = abs_d / step;
-		unsigned idx = static_cast<unsigned>(idx_f);
+		std::size_t idx = static_cast<std::size_t>(idx_f);
 		double frac = idx_f - double(idx);
 		return add_table[idx] + frac * (add_table[idx + 1u] - add_table[idx]);
 	}
@@ -298,7 +316,7 @@ private:
 		double abs_d = -d;
 		if (abs_d >= d_range) return 0.0;  // 1 - 2^d ~= 1, log2 ~= 0
 		double idx_f = abs_d / step;
-		unsigned idx = static_cast<unsigned>(idx_f);
+		std::size_t idx = static_cast<std::size_t>(idx_f);
 		if (idx == 0) {
 			// Cancellation regime: log2(1 - 2^d) has unbounded slope.
 			// Direct evaluation -- one transcendental pair, only in this band.
@@ -315,6 +333,12 @@ private:
 		if (a != a || b != b) return a + b;                                 // NaN propagates
 		if (a == 0.0) return b;
 		if (b == 0.0) return a;
+		// Infinities -- delegate to native double for correct IEEE behavior;
+		// see DirectEvaluationAddSub::log_add for the rationale.
+		{
+			constexpr double dinf = std::numeric_limits<double>::infinity();
+			if (a == dinf || a == -dinf || b == dinf || b == -dinf) return a + b;
+		}
 
 		bool sign_a = a < 0.0;
 		bool sign_b = b < 0.0;

--- a/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
+++ b/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
@@ -40,12 +40,13 @@
 //         };
 //     }
 //
-// The shipped algorithms (Phase A of #777):
+// The shipped algorithms (Phases A and B of #777):
 //   - DoubleTripAddSub      -- default, preserves current behavior
 //   - DirectEvaluationAddSub -- uses sw::math::constexpr_math::log2/exp2
+//   - LookupAddSub           -- Mitchell-style precomputed table + linear interp
 //
-// Future phases (#780, #781, #783) will add Lookup, Polynomial, ArnoldBailey,
-// and (deferred) CORDIC. All will be drop-in via the same traits specialization.
+// Future phases (#781, #783) will add Polynomial, ArnoldBailey, and (deferred)
+// CORDIC. All will be drop-in via the same traits specialization.
 //
 // -----------------------------------------------------------------------------
 // Algorithm contract
@@ -59,6 +60,8 @@
 // lns Saturating-vs-Modulo Behavior of the Lns instantiation. Special-value
 // handling (NaN propagation, zero, infinity) follows IEEE-754 conventions and
 // is the responsibility of the algorithm.
+
+#include <array>
 
 #include <math/constexpr_math.hpp>
 #include <universal/number/lns/lns_fwd.hpp>
@@ -201,6 +204,153 @@ public:
 	static constexpr Lns& sub_assign(Lns& lhs, const Lns& rhs) {
 		// a - b = a + (-b); negate via the lns operator-() which is a single
 		// sign-bit flip.
+		double result = log_add(double(lhs), double(-rhs));
+		return lhs = result;
+	}
+};
+
+// ============================================================================
+// Algorithm 3: LookupAddSub -- Mitchell-style precomputed table + linear interp
+// ============================================================================
+//
+// The original Mitchell 1962 LNS algorithm: precompute sb_add(d) over a finite
+// d-grid, then index + linearly interpolate at runtime. For ML inference and
+// embedded DSP this is the SRAM-friendly hardware default -- one indexed
+// memory read + one mul-add per operation, no transcendentals at runtime.
+//
+// Table generation runs at compile time via sw::math::constexpr_math::log2/exp2
+// (Epic #763), so no offline tooling is needed and the table follows the
+// instantiation: a different (Lns, IndexBits) pair gets its own table.
+//
+// Parameterization
+// ----------------
+//   IndexBits -- log2 of the number of table entries.
+//                Default: min(Lns::rbits + 2, 10) -- caps at 1024 entries so a
+//                64-bit lns doesn't try to allocate a 4-million-entry table.
+//                Override for higher accuracy or smaller SRAM as needed.
+//
+// d-range
+// -------
+// d = Lb - La with d <= 0. As d -> -infinity, sb_add(d) -> 0; in lns precision
+// (2^-rbits) the correction is below ULP once |d| > rbits + ~2. We pick that
+// as the table cutoff: |d| >= d_range => sb_add returns 0 directly.
+//
+// sb_sub special-case
+// -------------------
+// sb_sub(d) = log2(1 - 2^d) has unbounded slope as d -> 0 (catastrophic
+// cancellation). Linear interpolation in the lowest table cell is not safe;
+// for |d| < step we fall back to direct evaluation via cm::log2/cm::exp2.
+// This preserves accuracy in the cancellation regime at the cost of one
+// transcendental call per sub in that narrow band.
+
+template<typename Lns,
+         unsigned IndexBits = ((Lns::rbits + 2u < 10u) ? Lns::rbits + 2u : 10u)>
+struct LookupAddSub {
+private:
+	static constexpr unsigned table_entries = 1u << IndexBits;
+	static constexpr double   d_range = double(Lns::rbits) + 2.0;
+	static constexpr double   step    = d_range / double(table_entries);
+
+	// log2(1 + 2^d) for d = -i*step, i in [0, table_entries].
+	// Endpoint i = table_entries gives the value at d = -d_range.
+	static constexpr std::array<double, table_entries + 1u> make_add_table() {
+		std::array<double, table_entries + 1u> t{};
+		for (unsigned i = 0; i <= table_entries; ++i) {
+			double d = -double(i) * step;
+			t[i] = sw::math::constexpr_math::log2(
+			           1.0 + sw::math::constexpr_math::exp2(d));
+		}
+		return t;
+	}
+
+	// log2(1 - 2^d) for d = -i*step, i in [1, table_entries].
+	// Index 0 is unused (corresponds to d = 0, where the function is -infinity);
+	// callers route the |d| < step cell through direct evaluation instead.
+	static constexpr std::array<double, table_entries + 1u> make_sub_table() {
+		std::array<double, table_entries + 1u> t{};
+		t[0] = 0.0;
+		for (unsigned i = 1; i <= table_entries; ++i) {
+			double d = -double(i) * step;
+			double v = 1.0 - sw::math::constexpr_math::exp2(d);
+			t[i] = sw::math::constexpr_math::log2(v);
+		}
+		return t;
+	}
+
+	static constexpr auto add_table = make_add_table();
+	static constexpr auto sub_table = make_sub_table();
+
+	// Linear interp: log2(1 + 2^d) for d <= 0.
+	static constexpr double sb_add(double d) {
+		if (d > 0.0) d = 0.0;
+		double abs_d = -d;
+		if (abs_d >= d_range) return 0.0;
+		double idx_f = abs_d / step;
+		unsigned idx = static_cast<unsigned>(idx_f);
+		double frac = idx_f - double(idx);
+		return add_table[idx] + frac * (add_table[idx + 1u] - add_table[idx]);
+	}
+
+	// log2(1 - 2^d) for d < 0. d == 0 is exact-cancellation territory and
+	// must be handled by the caller (we return 0.0 as a safe sentinel).
+	static constexpr double sb_sub(double d) {
+		if (d >= 0.0) return 0.0;
+		double abs_d = -d;
+		if (abs_d >= d_range) return 0.0;  // 1 - 2^d ~= 1, log2 ~= 0
+		double idx_f = abs_d / step;
+		unsigned idx = static_cast<unsigned>(idx_f);
+		if (idx == 0) {
+			// Cancellation regime: log2(1 - 2^d) has unbounded slope.
+			// Direct evaluation -- one transcendental pair, only in this band.
+			double t = 1.0 - sw::math::constexpr_math::exp2(d);
+			return sw::math::constexpr_math::log2(t);
+		}
+		double frac = idx_f - double(idx);
+		return sub_table[idx] + frac * (sub_table[idx + 1u] - sub_table[idx]);
+	}
+
+	// Same dispatcher as DirectEvaluationAddSub: routes special values, then
+	// dispatches by sign to same-sign add or mixed-sign magnitude subtraction.
+	static constexpr double log_add(double a, double b) {
+		if (a != a || b != b) return a + b;                                 // NaN propagates
+		if (a == 0.0) return b;
+		if (b == 0.0) return a;
+
+		bool sign_a = a < 0.0;
+		bool sign_b = b < 0.0;
+		double abs_a = sign_a ? -a : a;
+		double abs_b = sign_b ? -b : b;
+
+		if (sign_a == sign_b) {
+			double La = sw::math::constexpr_math::log2(abs_a);
+			double Lb = sw::math::constexpr_math::log2(abs_b);
+			double Lmax = (La >= Lb) ? La : Lb;
+			double Lmin = (La >= Lb) ? Lb : La;
+			double Lresult = Lmax + sb_add(Lmin - Lmax);
+			double mag = sw::math::constexpr_math::exp2(Lresult);
+			return sign_a ? -mag : mag;
+		}
+		else {
+			double La = sw::math::constexpr_math::log2(abs_a);
+			double Lb = sw::math::constexpr_math::log2(abs_b);
+			if (La == Lb) return 0.0;
+			bool a_larger = (La > Lb);
+			double Lmax = a_larger ? La : Lb;
+			double Lmin = a_larger ? Lb : La;
+			double Lresult = Lmax + sb_sub(Lmin - Lmax);
+			if (Lresult != Lresult) return 0.0;
+			double mag = sw::math::constexpr_math::exp2(Lresult);
+			bool result_neg = a_larger ? sign_a : sign_b;
+			return result_neg ? -mag : mag;
+		}
+	}
+
+public:
+	static constexpr Lns& add_assign(Lns& lhs, const Lns& rhs) {
+		double result = log_add(double(lhs), double(rhs));
+		return lhs = result;
+	}
+	static constexpr Lns& sub_assign(Lns& lhs, const Lns& rhs) {
 		double result = log_add(double(lhs), double(-rhs));
 		return lhs = result;
 	}

--- a/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
+++ b/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
@@ -329,7 +329,7 @@ int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite  = "lns add/sub algorithm cross-validation (issue #777 Phase A)";
+	std::string test_suite  = "lns add/sub algorithm cross-validation (issue #777 Phase A+B)";
 	std::string test_tag    = "log_add_algorithms";
 	bool reportTestCases    = false;
 	int nrOfFailedTestCases = 0;

--- a/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
+++ b/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
@@ -21,6 +21,40 @@
 
 namespace sw { namespace universal {
 
+	// Shared helper for the corner-case / Tier 1 suites: compares an algorithm
+	// output against an expected value, with explicit NaN-mismatch detection
+	// (one-sided NaN fails) and a scaled absolute-difference tolerance.
+	template<typename LnsType>
+	void check_case(const char* algName, const char* name,
+	                double expected, const LnsType& got,
+	                double absTolBase, double tolScale,
+	                bool reportTestCases, int& failed) {
+		double absTol = absTolBase * tolScale;
+		double g = double(got);
+		bool g_nan = (g != g);
+		bool e_nan = (expected != expected);
+		if (g_nan && e_nan) return;
+		if (g_nan != e_nan) {
+			++failed;
+			if (reportTestCases) {
+				std::cout << "FAIL [" << algName << "] " << name
+				          << " NaN mismatch  expected=" << expected
+				          << "  got=" << g << '\n';
+			}
+			return;
+		}
+		double diff = g - expected;
+		if (diff < 0.0) diff = -diff;
+		if (diff > absTol) {
+			++failed;
+			if (reportTestCases) {
+				std::cout << "FAIL [" << algName << "] " << name
+				          << "  expected=" << expected
+				          << "  got=" << g << "  diff=" << diff << '\n';
+			}
+		}
+	}
+
 	// Cross-validate two add/sub policies against each other in the value
 	// domain. Both encode through the same lns instantiation, so the upper
 	// bound on disagreement is dominated by transcendental rounding plus the
@@ -137,32 +171,8 @@ namespace sw { namespace universal {
 	template<typename LnsType, typename Alg>
 	int VerifyAlgorithmCornerCases(bool reportTestCases, const char* algName, double tolScale = 1.0) {
 		int failed = 0;
-
 		auto check = [&](const char* name, double expected, const LnsType& got, double absTolBase) {
-			double absTol = absTolBase * tolScale;
-			double g = double(got);
-			bool g_nan = (g != g);
-			bool e_nan = (expected != expected);
-			if (g_nan && e_nan) return;
-			if (g_nan != e_nan) {
-				++failed;
-				if (reportTestCases) {
-					std::cout << "FAIL [" << algName << "] " << name
-					          << " NaN mismatch  expected=" << expected
-					          << "  got=" << g << '\n';
-				}
-				return;
-			}
-			double diff = g - expected;
-			if (diff < 0.0) diff = -diff;
-			if (diff > absTol) {
-				++failed;
-				if (reportTestCases) {
-					std::cout << "FAIL [" << algName << "] " << name
-					          << "  expected=" << expected
-					          << "  got=" << g << "  diff=" << diff << '\n';
-				}
-			}
+			check_case<LnsType>(algName, name, expected, got, absTolBase, tolScale, reportTestCases, failed);
 		};
 
 		// a + (-a) -> 0 (exact cancellation)
@@ -241,31 +251,8 @@ namespace sw { namespace universal {
 	template<typename LnsType, typename Alg>
 	int VerifyTier1CancellationCases(bool reportTestCases, const char* algName) {
 		int failed = 0;
-
 		auto check = [&](const char* name, double expected, const LnsType& got, double absTol) {
-			double g = double(got);
-			bool g_nan = (g != g);
-			bool e_nan = (expected != expected);
-			if (g_nan && e_nan) return;
-			if (g_nan != e_nan) {
-				++failed;
-				if (reportTestCases) {
-					std::cout << "FAIL [" << algName << "] " << name
-					          << " NaN mismatch  expected=" << expected
-					          << "  got=" << g << '\n';
-				}
-				return;
-			}
-			double diff = g - expected;
-			if (diff < 0.0) diff = -diff;
-			if (diff > absTol) {
-				++failed;
-				if (reportTestCases) {
-					std::cout << "FAIL [" << algName << "] " << name
-					          << "  expected=" << expected
-					          << "  got=" << g << "  diff=" << diff << '\n';
-				}
-			}
+			check_case<LnsType>(algName, name, expected, got, absTol, 1.0, reportTestCases, failed);
 		};
 
 		// Exact cancellation a + (-a): trivial cases

--- a/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
+++ b/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
@@ -5,13 +5,14 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
-// Phase A regression for issue #777: validates that the alternate add/sub
-// algorithm (DirectEvaluationAddSub, using sw::math::constexpr_math::log2/exp2)
-// agrees with the historical DoubleTripAddSub baseline within a small ULP
-// tolerance across representative lns configurations.
+// Phase A and B regression for issue #777: validates that the alternate
+// add/sub algorithms (DirectEvaluationAddSub from Phase A, LookupAddSub from
+// Phase B / issue #780) agree with the historical DoubleTripAddSub baseline
+// and with each other within a small ULP tolerance across representative
+// lns configurations.
 //
-// Direct invocation of both policy classes lets us cross-validate them against
-// the same lns instantiation without specializing the traits.
+// Direct invocation of policy classes lets us cross-validate them against the
+// same lns instantiation without specializing the traits.
 
 #include <universal/utility/directives.hpp>
 #include <universal/number/lns/lns.hpp>
@@ -25,105 +26,209 @@ namespace sw { namespace universal {
 	// bound on disagreement is dominated by transcendental rounding plus the
 	// encode rounding -- in practice a few percent relative error is generous
 	// for small lns sizes where the encoding step itself is coarse.
+	template<typename LnsType, typename AlgA, typename AlgB>
+	int VerifyAddAlgorithmsAgree(bool reportTestCases, double relTol = 0.05) {
+		constexpr unsigned nbits = LnsType::nbits;
+		static_assert(nbits < 64, "exhaustive sweep requires nbits < 64 to avoid shift UB");
+		constexpr size_t NR_ENCODINGS = (1ull << nbits);
+
+		int nrOfFailedTestCases = 0;
+		int reported = 0;
+
+		for (size_t i = 0; i < NR_ENCODINGS; ++i) {
+			LnsType a; a.setbits(i);
+			if (a.isnan()) continue;
+			for (size_t j = 0; j < NR_ENCODINGS; ++j) {
+				LnsType b; b.setbits(j);
+				if (b.isnan()) continue;
+
+				LnsType cA = a; AlgA::add_assign(cA, b);
+				LnsType cB = a; AlgB::add_assign(cB, b);
+
+				if (cA == cB) continue;
+				if (cA.isnan() && cB.isnan()) continue;
+
+				double vA = double(cA);
+				double vB = double(cB);
+				double diff = vA - vB;
+				if (diff < 0.0) diff = -diff;
+				double mag = (vA < 0.0 ? -vA : vA);
+				if (mag < 1.0) mag = 1.0;
+				if (diff / mag <= relTol) continue;
+
+				++nrOfFailedTestCases;
+				if (reportTestCases && reported < 8) {
+					std::cout << "MISMATCH a=" << double(a) << " b=" << double(b)
+					          << " A=" << vA << " B=" << vB
+					          << " relErr=" << (diff / mag) << '\n';
+					++reported;
+				}
+				if (nrOfFailedTestCases > 24) return nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	template<typename LnsType, typename AlgA, typename AlgB>
+	int VerifySubAlgorithmsAgree(bool reportTestCases, double relTol = 0.05) {
+		constexpr unsigned nbits = LnsType::nbits;
+		static_assert(nbits < 64, "exhaustive sweep requires nbits < 64 to avoid shift UB");
+		constexpr size_t NR_ENCODINGS = (1ull << nbits);
+
+		int nrOfFailedTestCases = 0;
+		int reported = 0;
+
+		for (size_t i = 0; i < NR_ENCODINGS; ++i) {
+			LnsType a; a.setbits(i);
+			if (a.isnan()) continue;
+			for (size_t j = 0; j < NR_ENCODINGS; ++j) {
+				LnsType b; b.setbits(j);
+				if (b.isnan()) continue;
+
+				LnsType cA = a; AlgA::sub_assign(cA, b);
+				LnsType cB = a; AlgB::sub_assign(cB, b);
+
+				if (cA == cB) continue;
+				if (cA.isnan() && cB.isnan()) continue;
+
+				double vA = double(cA);
+				double vB = double(cB);
+				double diff = vA - vB;
+				if (diff < 0.0) diff = -diff;
+				double mag = (vA < 0.0 ? -vA : vA);
+				if (mag < 1.0) mag = 1.0;
+				if (diff / mag <= relTol) continue;
+
+				++nrOfFailedTestCases;
+				if (reportTestCases && reported < 8) {
+					std::cout << "MISMATCH a=" << double(a) << " b=" << double(b)
+					          << " A=" << vA << " B=" << vB
+					          << " relErr=" << (diff / mag) << '\n';
+					++reported;
+				}
+				if (nrOfFailedTestCases > 24) return nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	// Convenience wrappers for the original Phase A pairing (Direct vs DoubleTrip)
 	template<typename LnsType>
 	int VerifyAddAlgorithmAgreement(bool reportTestCases, double relTol = 0.05) {
-		constexpr unsigned nbits = LnsType::nbits;
-		static_assert(nbits < 64, "exhaustive sweep requires nbits < 64 to avoid shift UB");
-		constexpr size_t NR_ENCODINGS = (1ull << nbits);
-
-		using Direct = DirectEvaluationAddSub<LnsType>;
-		using DoubleTrip = DoubleTripAddSub<LnsType>;
-
-		int nrOfFailedTestCases = 0;
-		int reported = 0;
-
-		for (size_t i = 0; i < NR_ENCODINGS; ++i) {
-			LnsType a; a.setbits(i);
-			if (a.isnan()) continue;
-			for (size_t j = 0; j < NR_ENCODINGS; ++j) {
-				LnsType b; b.setbits(j);
-				if (b.isnan()) continue;
-
-				LnsType cTrip = a; DoubleTrip::add_assign(cTrip, b);
-				LnsType cDir  = a; Direct::add_assign(cDir, b);
-
-				if (cTrip == cDir) continue;
-				if (cTrip.isnan() && cDir.isnan()) continue;
-
-				double vTrip = double(cTrip);
-				double vDir  = double(cDir);
-				double diff  = vTrip - vDir;
-				if (diff < 0.0) diff = -diff;
-				double mag = (vTrip < 0.0 ? -vTrip : vTrip);
-				if (mag < 1.0) mag = 1.0;
-				if (diff / mag <= relTol) continue;
-
-				++nrOfFailedTestCases;
-				if (reportTestCases && reported < 8) {
-					std::cout << "MISMATCH a=" << double(a) << " b=" << double(b)
-					          << " trip=" << vTrip << " dir=" << vDir
-					          << " relErr=" << (diff / mag) << '\n';
-					++reported;
-				}
-				if (nrOfFailedTestCases > 24) return nrOfFailedTestCases;
-			}
-		}
-		return nrOfFailedTestCases;
+		return VerifyAddAlgorithmsAgree<LnsType,
+		                                DirectEvaluationAddSub<LnsType>,
+		                                DoubleTripAddSub<LnsType>>(reportTestCases, relTol);
 	}
-
 	template<typename LnsType>
 	int VerifySubAlgorithmAgreement(bool reportTestCases, double relTol = 0.05) {
-		constexpr unsigned nbits = LnsType::nbits;
-		static_assert(nbits < 64, "exhaustive sweep requires nbits < 64 to avoid shift UB");
-		constexpr size_t NR_ENCODINGS = (1ull << nbits);
-
-		using Direct = DirectEvaluationAddSub<LnsType>;
-		using DoubleTrip = DoubleTripAddSub<LnsType>;
-
-		int nrOfFailedTestCases = 0;
-		int reported = 0;
-
-		for (size_t i = 0; i < NR_ENCODINGS; ++i) {
-			LnsType a; a.setbits(i);
-			if (a.isnan()) continue;
-			for (size_t j = 0; j < NR_ENCODINGS; ++j) {
-				LnsType b; b.setbits(j);
-				if (b.isnan()) continue;
-
-				LnsType cTrip = a; DoubleTrip::sub_assign(cTrip, b);
-				LnsType cDir  = a; Direct::sub_assign(cDir, b);
-
-				if (cTrip == cDir) continue;
-				if (cTrip.isnan() && cDir.isnan()) continue;
-
-				double vTrip = double(cTrip);
-				double vDir  = double(cDir);
-				double diff  = vTrip - vDir;
-				if (diff < 0.0) diff = -diff;
-				double mag = (vTrip < 0.0 ? -vTrip : vTrip);
-				if (mag < 1.0) mag = 1.0;
-				if (diff / mag <= relTol) continue;
-
-				++nrOfFailedTestCases;
-				if (reportTestCases && reported < 8) {
-					std::cout << "MISMATCH a=" << double(a) << " b=" << double(b)
-					          << " trip=" << vTrip << " dir=" << vDir
-					          << " relErr=" << (diff / mag) << '\n';
-					++reported;
-				}
-				if (nrOfFailedTestCases > 24) return nrOfFailedTestCases;
-			}
-		}
-		return nrOfFailedTestCases;
+		return VerifySubAlgorithmsAgree<LnsType,
+		                                DirectEvaluationAddSub<LnsType>,
+		                                DoubleTripAddSub<LnsType>>(reportTestCases, relTol);
 	}
 
-	// Spot-check the DirectEvaluationAddSub corner cases that the exhaustive
-	// sweep above doesn't exercise (since exhaustive sweeps are restricted to
-	// small lns sizes for runtime reasons). Use a high-precision LnsType so
-	// encoding error doesn't confound the algorithm-correctness check.
+	// Spot-check algorithm corner cases that the exhaustive sweep above doesn't
+	// exercise (sweeps are restricted to small lns sizes for runtime reasons).
+	// Use a high-precision LnsType so encoding error doesn't confound the
+	// algorithm-correctness check. Parameterized on Alg so Phase B's
+	// LookupAddSub can be exercised with the same test bench.
+	// tolScale lets the caller widen tolerances proportionally for less-accurate
+	// algorithms (e.g., LookupAddSub at default IndexBits has ~100x the
+	// per-operation error of DirectEvaluationAddSub for mixed-sign cases).
+	template<typename LnsType, typename Alg>
+	int VerifyAlgorithmCornerCases(bool reportTestCases, const char* algName, double tolScale = 1.0) {
+		int failed = 0;
+
+		auto check = [&](const char* name, double expected, const LnsType& got, double absTolBase) {
+			double absTol = absTolBase * tolScale;
+			double g = double(got);
+			if (g != g && expected != expected) return;
+			double diff = g - expected;
+			if (diff < 0.0) diff = -diff;
+			if (diff > absTol) {
+				++failed;
+				if (reportTestCases) {
+					std::cout << "FAIL [" << algName << "] " << name
+					          << "  expected=" << expected
+					          << "  got=" << g << "  diff=" << diff << '\n';
+				}
+			}
+		};
+
+		// a + (-a) -> 0 (exact cancellation)
+		{
+			LnsType a(2.5);
+			LnsType minus_a = -a;
+			LnsType r = a; Alg::add_assign(r, minus_a);
+			check("2.5 + (-2.5)", 0.0, r, 1e-12);
+		}
+		// a - a -> 0 (exact cancellation)
+		{
+			LnsType a(3.75);
+			LnsType r = a; Alg::sub_assign(r, a);
+			check("3.75 - 3.75", 0.0, r, 1e-12);
+		}
+		// 1 + 1 -> 2
+		{
+			LnsType a(1.0);
+			LnsType b(1.0);
+			LnsType r = a; Alg::add_assign(r, b);
+			check("1 + 1", 2.0, r, 1e-6);
+		}
+		// 1 + 0 -> 1 (zero short-circuit)
+		{
+			LnsType a(1.0);
+			LnsType b(0.0);
+			LnsType r = a; Alg::add_assign(r, b);
+			check("1 + 0", 1.0, r, 1e-12);
+		}
+		// 0 + 2 -> 2 (zero short-circuit on lhs)
+		{
+			LnsType a(0.0);
+			LnsType b(2.0);
+			LnsType r = a; Alg::add_assign(r, b);
+			check("0 + 2", 2.0, r, 1e-6);
+		}
+		// 2 + (-1) -> 1 (mixed sign, magnitude subtraction)
+		{
+			LnsType a(2.0);
+			LnsType b(-1.0);
+			LnsType r = a; Alg::add_assign(r, b);
+			check("2 + (-1)", 1.0, r, 1e-6);
+		}
+		// (-3) + 5 -> 2
+		{
+			LnsType a(-3.0);
+			LnsType b(5.0);
+			LnsType r = a; Alg::add_assign(r, b);
+			check("-3 + 5", 2.0, r, 1e-6);
+		}
+		// large dynamic range: 4 + tiny -> ~4 (Lb - La very negative => sb_add ~ 0)
+		{
+			LnsType a(4.0);
+			LnsType tiny(0.001953125);  // 2^-9, well within lns dynamic range
+			LnsType r = a; Alg::add_assign(r, tiny);
+			// expected ~ 4.001953125; allow lns encoding error
+			double expected = 4.001953125;
+			check("4 + 2^-9", expected, r, 0.05);
+		}
+
+		return failed;
+	}
+
+	// Backward-compat wrapper for the original Phase A direct-eval corner suite
 	template<typename LnsType>
 	int VerifyDirectEvalCornerCases(bool reportTestCases) {
-		using Direct = DirectEvaluationAddSub<LnsType>;
+		return VerifyAlgorithmCornerCases<LnsType, DirectEvaluationAddSub<LnsType>>(
+		    reportTestCases, "DirectEval");
+	}
+
+	// Tier 1 catastrophic-cancellation cases: stress the regions where log-add
+	// algorithms are most likely to diverge -- exact cancellation, near-zero
+	// 1 + epsilon, and large dynamic range in mixed-sign arithmetic. Run these
+	// against any algorithm; the Lookup policy's special-cased near-d=0 fallback
+	// is what makes it agree with DirectEval here within tight tolerance.
+	template<typename LnsType, typename Alg>
+	int VerifyTier1CancellationCases(bool reportTestCases, const char* algName) {
 		int failed = 0;
 
 		auto check = [&](const char* name, double expected, const LnsType& got, double absTol) {
@@ -134,68 +239,63 @@ namespace sw { namespace universal {
 			if (diff > absTol) {
 				++failed;
 				if (reportTestCases) {
-					std::cout << "FAIL " << name << "  expected=" << expected
+					std::cout << "FAIL [" << algName << "] " << name
+					          << "  expected=" << expected
 					          << "  got=" << g << "  diff=" << diff << '\n';
 				}
 			}
 		};
 
-		// a + (-a) -> 0 (exact cancellation)
+		// Exact cancellation a + (-a): trivial cases
 		{
-			LnsType a(2.5);
-			LnsType minus_a = -a;
-			LnsType r = a; Direct::add_assign(r, minus_a);
-			check("2.5 + (-2.5)", 0.0, r, 1e-12);
+			LnsType a(7.0);
+			LnsType b(-7.0);
+			LnsType r = a; Alg::add_assign(r, b);
+			check("Tier1: 7 + (-7) exact cancel", 0.0, r, 1e-12);
 		}
-		// a - a -> 0 (exact cancellation)
+		// 1 + epsilon -> 1 + epsilon (preserves the small addend)
+		// epsilon = 2^-6 = 1/64 = 0.015625 -- representable in lns precision >= 6
 		{
-			LnsType a(3.75);
-			LnsType r = a; Direct::sub_assign(r, a);
-			check("3.75 - 3.75", 0.0, r, 1e-12);
+			LnsType one(1.0);
+			LnsType eps(0.015625);
+			LnsType r = one; Alg::add_assign(r, eps);
+			check("Tier1: 1 + 2^-6", 1.015625, r, 0.01);
 		}
-		// 1 + 1 -> 2
+		// 1 - (1 - epsilon) = epsilon: classic catastrophic cancellation
+		// Use lns-representable values: 1.0 and 0.984375 (= 63/64 = 1 - 2^-6)
 		{
 			LnsType a(1.0);
-			LnsType b(1.0);
-			LnsType r = a; Direct::add_assign(r, b);
-			check("1 + 1", 2.0, r, 1e-6);
+			LnsType b(0.984375);
+			LnsType r = a; Alg::sub_assign(r, b);
+			// Expected ~0.015625; lns encoding rounds. Allow generous tol.
+			check("Tier1: 1 - 0.984375 (cancel)", 0.015625, r, 0.01);
 		}
-		// 1 + 0 -> 1 (zero short-circuit)
+		// Large dynamic range mixed-sign: huge - small_huge = small
+		// 1024 + (-1023) = 1 (both operands are powers-of-2-ish)
+		{
+			LnsType a(1024.0);
+			LnsType b(-1023.0);
+			LnsType r = a; Alg::add_assign(r, b);
+			check("Tier1: 1024 + (-1023)", 1.0, r, 0.05);
+		}
+		// Large dynamic range same-sign: large + tiny -> large
+		// 2^20 + 2^-10 -> 2^20 (the small addend is below useful precision)
+		{
+			LnsType a(1048576.0);   // 2^20
+			LnsType b(0.0009765625); // 2^-10
+			LnsType r = a; Alg::add_assign(r, b);
+			// In high-precision lns, the small addend should still register.
+			// Expected ~= 1048576.0009765625
+			check("Tier1: 2^20 + 2^-10 (large dyn range)", 1048576.0009765625, r, 1.0);
+		}
+		// Mixed signs near equality: 1.0 + (-0.999) = 0.001 (near-zero magnitude
+		// subtraction, the sb_sub catastrophic-cancellation regime)
+		// 0.999 isn't lns-exact; pick 0.9990234375 = 1023/1024 = 1 - 2^-10.
 		{
 			LnsType a(1.0);
-			LnsType b(0.0);
-			LnsType r = a; Direct::add_assign(r, b);
-			check("1 + 0", 1.0, r, 1e-12);
-		}
-		// 0 + 2 -> 2 (zero short-circuit on lhs)
-		{
-			LnsType a(0.0);
-			LnsType b(2.0);
-			LnsType r = a; Direct::add_assign(r, b);
-			check("0 + 2", 2.0, r, 1e-6);
-		}
-		// 2 + (-1) -> 1 (mixed sign, magnitude subtraction)
-		{
-			LnsType a(2.0);
-			LnsType b(-1.0);
-			LnsType r = a; Direct::add_assign(r, b);
-			check("2 + (-1)", 1.0, r, 1e-6);
-		}
-		// (-3) + 5 -> 2
-		{
-			LnsType a(-3.0);
-			LnsType b(5.0);
-			LnsType r = a; Direct::add_assign(r, b);
-			check("-3 + 5", 2.0, r, 1e-6);
-		}
-		// large dynamic range: 4 + tiny -> ~4 (Lb - La very negative => sb_add ~ 0)
-		{
-			LnsType a(4.0);
-			LnsType tiny(0.001953125);  // 2^-9, well within lns dynamic range
-			LnsType r = a; Direct::add_assign(r, tiny);
-			// expected ~ 4.001953125; allow lns encoding error
-			double expected = 4.001953125;
-			check("4 + 2^-9", expected, r, 0.05);
+			LnsType b(-0.9990234375);  // = -(1 - 2^-10)
+			LnsType r = a; Alg::add_assign(r, b);
+			check("Tier1: 1 + (-(1 - 2^-10))", 0.0009765625, r, 0.001);
 		}
 
 		return failed;
@@ -232,7 +332,7 @@ try {
 	using LNS6_2_sat = lns<6, 2, std::uint8_t>;
 	using LNS_HiPrec = lns<32, 24, std::uint32_t>;  // ~7 decimal digits in log domain
 
-	// Algorithm cross-validation: DirectEvaluation vs DoubleTrip
+	// Phase A cross-validation: DirectEvaluation vs DoubleTrip baseline
 	// Allow ~5% relative value-domain tolerance: the two paths use different
 	// transcendental routines and round at different points; for small lns
 	// sizes the encoding step itself is coarser than the algorithm gap.
@@ -243,10 +343,45 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyAddAlgorithmAgreement<LNS6_2_sat>(reportTestCases, 0.05),
 	                                        "lns<6,2,uint8_t> add: Direct vs DoubleTrip", test_tag);
 
-	// Corner cases in DirectEvaluationAddSub: use high-precision lns so
-	// encoding rounding doesn't drown out algorithm-correctness signal.
+	// Phase B cross-validation: LookupAddSub vs DirectEvaluation (the new
+	// table-based algorithm against the constexpr_math reference)
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyAddAlgorithmsAgree<LNS5_2_sat,
+	                              LookupAddSub<LNS5_2_sat>,
+	                              DirectEvaluationAddSub<LNS5_2_sat>>(reportTestCases, 0.05)),
+	    "lns<5,2,uint8_t> add: Lookup vs Direct", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifySubAlgorithmsAgree<LNS5_2_sat,
+	                              LookupAddSub<LNS5_2_sat>,
+	                              DirectEvaluationAddSub<LNS5_2_sat>>(reportTestCases, 0.05)),
+	    "lns<5,2,uint8_t> sub: Lookup vs Direct", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyAddAlgorithmsAgree<LNS6_2_sat,
+	                              LookupAddSub<LNS6_2_sat>,
+	                              DirectEvaluationAddSub<LNS6_2_sat>>(reportTestCases, 0.05)),
+	    "lns<6,2,uint8_t> add: Lookup vs Direct", test_tag);
+
+	// Corner cases: high-precision lns so encoding rounding doesn't drown out
+	// algorithm-correctness signal. Run for both Direct and Lookup variants.
 	nrOfFailedTestCases += ReportTestResult(VerifyDirectEvalCornerCases<LNS_HiPrec>(reportTestCases),
 	                                        "lns<32,24,uint32_t> Direct corner cases", test_tag);
+	// Lookup at default IndexBits has linear-interpolation error ~ step^2
+	// in sb_sub, dominated near d ~ -1 (the "2 + (-1)" / "(-3) + 5" cases).
+	// Scale tolerance up 200x to match -- this still catches algorithm bugs.
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyAlgorithmCornerCases<LNS_HiPrec, LookupAddSub<LNS_HiPrec>>(reportTestCases, "Lookup", 200.0)),
+	    "lns<32,24,uint32_t> Lookup corner cases", test_tag);
+
+	// Tier 1 catastrophic-cancellation suite: stresses sb_sub near d=0,
+	// large dynamic range, and exact-cancellation paths. Both algorithms.
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyTier1CancellationCases<LNS_HiPrec,
+	                                  DirectEvaluationAddSub<LNS_HiPrec>>(reportTestCases, "DirectEval")),
+	    "lns<32,24,uint32_t> Direct Tier 1 cancellation", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyTier1CancellationCases<LNS_HiPrec,
+	                                  LookupAddSub<LNS_HiPrec>>(reportTestCases, "Lookup")),
+	    "lns<32,24,uint32_t> Lookup Tier 1 cancellation", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2
@@ -255,6 +390,16 @@ try {
 	                                        "lns<8,3,uint8_t> add: Direct vs DoubleTrip", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifySubAlgorithmAgreement<LNS8_3_sat_l2>(reportTestCases, 0.05),
 	                                        "lns<8,3,uint8_t> sub: Direct vs DoubleTrip", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyAddAlgorithmsAgree<LNS8_3_sat_l2,
+	                              LookupAddSub<LNS8_3_sat_l2>,
+	                              DirectEvaluationAddSub<LNS8_3_sat_l2>>(reportTestCases, 0.05)),
+	    "lns<8,3,uint8_t> add: Lookup vs Direct", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifySubAlgorithmsAgree<LNS8_3_sat_l2,
+	                              LookupAddSub<LNS8_3_sat_l2>,
+	                              DirectEvaluationAddSub<LNS8_3_sat_l2>>(reportTestCases, 0.05)),
+	    "lns<8,3,uint8_t> sub: Lookup vs Direct", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3
@@ -262,8 +407,16 @@ try {
 	using LNS16_8 = lns<16, 8, std::uint16_t>;
 	nrOfFailedTestCases += ReportTestResult(VerifyAddAlgorithmAgreement<LNS9_4_sat>(reportTestCases, 0.05),
 	                                        "lns<9,4,uint8_t> add: Direct vs DoubleTrip", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyAddAlgorithmsAgree<LNS9_4_sat,
+	                              LookupAddSub<LNS9_4_sat>,
+	                              DirectEvaluationAddSub<LNS9_4_sat>>(reportTestCases, 0.05)),
+	    "lns<9,4,uint8_t> add: Lookup vs Direct", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifyDirectEvalCornerCases<LNS16_8>(reportTestCases),
 	                                        "lns<16,8,uint16_t> Direct corner cases", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyAlgorithmCornerCases<LNS16_8, LookupAddSub<LNS16_8>>(reportTestCases, "Lookup", 200.0)),
+	    "lns<16,8,uint16_t> Lookup corner cases", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_4
@@ -272,6 +425,16 @@ try {
 	                                        "lns<10,4,uint8_t> add: Direct vs DoubleTrip", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifySubAlgorithmAgreement<LNS10_4_sat>(reportTestCases, 0.05),
 	                                        "lns<10,4,uint8_t> sub: Direct vs DoubleTrip", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifyAddAlgorithmsAgree<LNS10_4_sat,
+	                              LookupAddSub<LNS10_4_sat>,
+	                              DirectEvaluationAddSub<LNS10_4_sat>>(reportTestCases, 0.05)),
+	    "lns<10,4,uint8_t> add: Lookup vs Direct", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+	    (VerifySubAlgorithmsAgree<LNS10_4_sat,
+	                              LookupAddSub<LNS10_4_sat>,
+	                              DirectEvaluationAddSub<LNS10_4_sat>>(reportTestCases, 0.05)),
+	    "lns<10,4,uint8_t> sub: Lookup vs Direct", test_tag);
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
+++ b/static/logarithmic/lns/arithmetic/log_add_algorithms.cpp
@@ -141,7 +141,18 @@ namespace sw { namespace universal {
 		auto check = [&](const char* name, double expected, const LnsType& got, double absTolBase) {
 			double absTol = absTolBase * tolScale;
 			double g = double(got);
-			if (g != g && expected != expected) return;
+			bool g_nan = (g != g);
+			bool e_nan = (expected != expected);
+			if (g_nan && e_nan) return;
+			if (g_nan != e_nan) {
+				++failed;
+				if (reportTestCases) {
+					std::cout << "FAIL [" << algName << "] " << name
+					          << " NaN mismatch  expected=" << expected
+					          << "  got=" << g << '\n';
+				}
+				return;
+			}
 			double diff = g - expected;
 			if (diff < 0.0) diff = -diff;
 			if (diff > absTol) {
@@ -233,7 +244,18 @@ namespace sw { namespace universal {
 
 		auto check = [&](const char* name, double expected, const LnsType& got, double absTol) {
 			double g = double(got);
-			if (g != g && expected != expected) return;
+			bool g_nan = (g != g);
+			bool e_nan = (expected != expected);
+			if (g_nan && e_nan) return;
+			if (g_nan != e_nan) {
+				++failed;
+				if (reportTestCases) {
+					std::cout << "FAIL [" << algName << "] " << name
+					          << " NaN mismatch  expected=" << expected
+					          << "  got=" << g << '\n';
+				}
+				return;
+			}
 			double diff = g - expected;
 			if (diff < 0.0) diff = -diff;
 			if (diff > absTol) {


### PR DESCRIPTION
## Summary

Phase B of issue #777 (lns native operator+/-). Implements the Mitchell-style
**lookup-table** algorithm as the third policy in the configurable add/sub
framework introduced in Phase A (#784, merged).

For ML inference accelerators and embedded DSP, this is the SRAM-friendly
hardware default: one indexed memory read + one mul-add per operation,
no transcendentals at runtime.

## Algorithm

Given the Gauss log-add formulation \`log2(a + b) = La + sb_add(d), d = Lb - La <= 0\`:

- Precompute \`sb_add(d) = log2(1 + 2^d)\` over a finite d-grid at compile time
  via \`sw::math::constexpr_math::log2/exp2\` (Epic #763).
- Linearly interpolate at runtime.
- \`sb_sub(d) = log2(1 - 2^d)\` analogously, with one special case: the
  cell containing \`|d| < step\` falls back to direct evaluation because
  the function has unbounded slope as d -> 0 (catastrophic cancellation
  regime where linear interpolation is unsafe).

## Parameterization

\`\`\`cpp
template<typename Lns,
         unsigned IndexBits = ((Lns::rbits + 2 < 10) ? Lns::rbits + 2 : 10)>
struct LookupAddSub { ... };
\`\`\`

\`IndexBits\` (log2 of table entries) defaults to \`min(rbits + 2, 10)\` so a
64-bit lns doesn't try to allocate millions of entries. Users override per
instantiation for higher accuracy or smaller SRAM:

\`\`\`cpp
template<>
struct lns_addsub_traits<lns<16, 8, std::uint16_t>> {
    using type = LookupAddSub<lns<16, 8, std::uint16_t>, 12>;  // 4096 entries
};
\`\`\`

## Changes

- \`include/sw/universal/number/lns/lns_addsub_algorithms.hpp\` — adds
  \`LookupAddSub<Lns, IndexBits>\` between \`DirectEvaluationAddSub\` and
  the traits class.
- \`static/logarithmic/lns/arithmetic/log_add_algorithms.cpp\` — generalizes
  \`Verify*AlgorithmsAgree\` to take two policy types; preserves the Phase A
  1-arg form as a wrapper. Adds Lookup cross-validation cases at all four
  regression levels. Adds new \`VerifyTier1CancellationCases\` suite covering
  exact cancellation, \`1 + epsilon\`, \`1 - (1 - epsilon)\` catastrophic
  cancellation, and large dynamic range -- run for both Direct and Lookup.

## Acceptance criteria (from #780)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | \`LookupAddSub\` policy with sb_add/sb_sub via compile-time table | met |
| 2 | Table size + interpolation parameterized for accuracy/SRAM trade-off | met (IndexBits) |
| 3 | Cross-validates against \`DirectEvaluationAddSub\` within ~1-2 ULP | met for small lns at default; tolerance scaled for high-precision lns where default IndexBits is undersized (documented in code) |
| 4 | Regression test extended for Lookup variant | met |
| 5 | Tier 1 catastrophic-cancellation tests | met (\`VerifyTier1CancellationCases\`) |

Note on (3): for \`lns<32, 24>\`, hitting 1-2 ULP with linear interp would
need ~100K table entries. The default 1024-entry cap is the SRAM-vs-accuracy
trade-off the issue explicitly calls out. The corner-case suite uses
tolScale=200 for Lookup to document this difference; users targeting
high-precision lns should override IndexBits.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| \`lns_log_add_algorithms\` | OK | PASS (10/10) | OK | PASS (10/10) |
| \`lns_addition\` | OK | PASS | OK | PASS |
| \`lns_subtraction\` | OK | PASS | OK | PASS |
| \`lns_multiplication\` | OK | PASS | OK | PASS |
| \`lns_division\` | OK | PASS | OK | PASS |

## Roadmap

- **Phase A** (#784, merged): scaffolding + DoubleTrip baseline + DirectEvaluation
- **Phase B** (this PR): Lookup table (Mitchell)
- **Phase C** (#781): polynomial (minimax) + Arnold-Bailey closed-form
- **Phase D** (#782): benchmark suite + design documentation
- **Phase E** (#783): CORDIC (deferred)

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <NNN>\`

Resolves #780
Relates to #777

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lookup-based addition/subtraction algorithm for logarithmic numbers as an alternative, faster evaluation path.

* **Bug Fixes**
  * Centralized special-value routing so NaN and ±infinity preserve native floating-point behavior across add/sub.

* **Refactor**
  * Direct evaluation add/sub now routes through a shared dispatcher for consistent sign and special-value handling.

* **Tests**
  * Expanded regression suite with exhaustive algorithm comparisons, Phase B coverage, enhanced corner-case checks, and a new catastrophic-cancellation test set.

* **Documentation**
  * Updated comments to reflect revised phase naming and future-phase notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->