### PR TITLE
feat(lns): benchmark suite + design doc for add/sub algorithms (Phase D of #777)

### DIFF
--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -71,12 +71,12 @@ namespace sw { namespace universal {
 	AccuracyResult<LnsType, Alg> measure_accuracy(std::size_t sample_count) {
 		using Direct = DirectEvaluationAddSub<LnsType>;
 		AccuracyResult<LnsType, Alg> result;
+		if (sample_count < 2) sample_count = 2;  // step calc needs >= 2 samples
 		// Sample operand magnitudes spanning the lns dynamic range.
-		// We pick 'sample_count' values for each side, so ops total = sample_count^2.
-		// Limit total work to sample_count <= ~256 for reasonable benchmark runtime.
+		// Geometric sweep across [2^(-rbits-1), 2^(rbits)] then negate half so
+		// the cross product covers same-sign and mixed-sign pairs.
 		std::vector<double> samples;
 		samples.reserve(sample_count);
-		// Geometric sweep across [2^(-rbits-1), 2^(rbits)] then negate half.
 		double lo = std::ldexp(1.0, -static_cast<int>(LnsType::rbits) - 1);
 		double hi = std::ldexp(1.0, static_cast<int>(LnsType::rbits));
 		double log_lo = std::log2(lo);
@@ -87,6 +87,20 @@ namespace sw { namespace universal {
 			samples.push_back((i % 2 == 0) ? v : -v);
 		}
 
+		auto record = [&](const LnsType& cAlg, const LnsType& cRef) {
+			if (cAlg.isnan() && cRef.isnan()) return;
+			if (cAlg.isnan() || cRef.isnan()) return;
+			double vAlg = double(cAlg);
+			double vRef = double(cRef);
+			double diff = vAlg - vRef;
+			if (diff < 0.0) diff = -diff;
+			double mag = (vRef < 0.0 ? -vRef : vRef);
+			double rel = (mag > 0.0) ? (diff / mag) : 0.0;
+			if (diff > result.max_abs_err) result.max_abs_err = diff;
+			if (rel  > result.max_rel_err) result.max_rel_err = rel;
+			++result.samples;
+		};
+
 		for (double da : samples) {
 			LnsType a(da);
 			if (a.isnan()) continue;
@@ -94,20 +108,15 @@ namespace sw { namespace universal {
 				LnsType b(db);
 				if (b.isnan()) continue;
 
-				LnsType cAlg = a; Alg::add_assign(cAlg, b);
-				LnsType cRef = a; Direct::add_assign(cRef, b);
-				if (cAlg.isnan() && cRef.isnan()) continue;
-				if (cAlg.isnan() || cRef.isnan()) continue;
+				// add_assign
+				LnsType cAlgAdd = a; Alg::add_assign(cAlgAdd, b);
+				LnsType cRefAdd = a; Direct::add_assign(cRefAdd, b);
+				record(cAlgAdd, cRefAdd);
 
-				double vAlg = double(cAlg);
-				double vRef = double(cRef);
-				double diff = vAlg - vRef;
-				if (diff < 0.0) diff = -diff;
-				double mag = (vRef < 0.0 ? -vRef : vRef);
-				double rel = (mag > 0.0) ? (diff / mag) : 0.0;
-				if (diff > result.max_abs_err) result.max_abs_err = diff;
-				if (rel  > result.max_rel_err) result.max_rel_err = rel;
-				++result.samples;
+				// sub_assign (uses sb_sub via the dispatcher's mixed-sign path)
+				LnsType cAlgSub = a; Alg::sub_assign(cAlgSub, b);
+				LnsType cRefSub = a; Direct::sub_assign(cRefSub, b);
+				record(cAlgSub, cRefSub);
 			}
 		}
 		return result;

--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -6,8 +6,9 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
-// Measures throughput (ops/sec) and accuracy (max value-domain ULP error vs
-// DirectEvaluation oracle) for each shipped sb_add/sb_sub policy:
+// Measures throughput (ops/sec) and accuracy (max value-domain absolute and
+// relative error vs DirectEvaluation oracle) for each shipped sb_add/sb_sub
+// policy:
 //   - DoubleTripAddSub
 //   - DirectEvaluationAddSub
 //   - LookupAddSub
@@ -55,9 +56,11 @@ namespace sw { namespace universal {
 		}
 		std::chrono::duration<double> dt = end - start;
 		double seconds = dt.count();
-		// Floor at the smallest positive double so the division stays finite if
-		// the loop happens to be unmeasurably fast (clock granularity, opt-out).
-		if (seconds <= 0.0) seconds = std::numeric_limits<double>::min();
+		// Floor at 1 ns so the division stays finite *and* sane if the loop
+		// happens to be unmeasurably fast (clock granularity, optimizer
+		// elimination). numeric_limits<double>::min() is too small -- with
+		// nr_ops on the order of 1e6 it would still overflow to inf.
+		if (seconds < 1e-9) seconds = 1e-9;
 		// Each iteration does 2 ops (1 add + 1 sub).
 		return double(nr_ops * 2) / seconds;
 	}
@@ -70,11 +73,16 @@ namespace sw { namespace universal {
 		double max_abs_err = 0.0;
 		double max_rel_err = 0.0;
 		std::size_t samples = 0;
-		// Flagged divergences -- counted, not masked. nan_mismatches counts
-		// pairs where exactly one side produced NaN; zero_ref_mismatches counts
-		// pairs where the oracle was 0 but the algorithm was non-zero.
+		// Flagged divergences -- counted, not masked.
+		//   nan_mismatches:        pairs where exactly one side produced NaN
+		//   zero_ref_mismatches:   pairs where oracle was 0 but algorithm was non-zero
+		//   inf_overflow_mismatches: pairs where one or both decoded to +/-inf
+		//                            (encoding overflow during the value-domain
+		//                            comparison; the abs/rel diff becomes inf or
+		//                            NaN and is not informative)
 		std::size_t nan_mismatches = 0;
 		std::size_t zero_ref_mismatches = 0;
+		std::size_t inf_overflow_mismatches = 0;
 	};
 
 	template<typename LnsType, typename Alg>
@@ -82,13 +90,23 @@ namespace sw { namespace universal {
 		using Direct = DirectEvaluationAddSub<LnsType>;
 		AccuracyResult<LnsType, Alg> result;
 		if (sample_count < 2) sample_count = 2;  // step calc needs >= 2 samples
-		// Sample operand magnitudes spanning the lns dynamic range.
-		// Geometric sweep across [2^(-rbits-1), 2^(rbits)] then negate half so
-		// the cross product covers same-sign and mixed-sign pairs.
+		// Sample operand magnitudes spanning the LnsType's actual dynamic
+		// range, then negate half so the cross product covers same-sign and
+		// mixed-sign pairs. Distinct (nbits, rbits) pairs with the same rbits
+		// have very different ranges (lns<24,16> covers 2^[-64, 63] while
+		// lns<32,16> covers 2^[-16384, 16383]); using rbits alone would miss
+		// that. We also clamp to double's representable range so 2^large
+		// doesn't overflow during sample generation.
 		std::vector<double> samples;
 		samples.reserve(sample_count);
-		double lo = std::ldexp(1.0, -static_cast<int>(LnsType::rbits) - 1);
-		double hi = std::ldexp(1.0, static_cast<int>(LnsType::rbits));
+		constexpr int dbl_min_exp = std::numeric_limits<double>::min_exponent;  // -1021
+		constexpr int dbl_max_exp = std::numeric_limits<double>::max_exponent;  // 1024
+		int lns_min_exp = static_cast<int>(LnsType::min_exponent);
+		int lns_max_exp = static_cast<int>(LnsType::max_exponent);
+		int min_exp = (lns_min_exp > dbl_min_exp + 1) ? lns_min_exp : dbl_min_exp + 1;
+		int max_exp = (lns_max_exp < dbl_max_exp - 1) ? lns_max_exp : dbl_max_exp - 1;
+		double lo = std::ldexp(1.0, min_exp);
+		double hi = std::ldexp(1.0, max_exp);
 		double log_lo = std::log2(lo);
 		double log_hi = std::log2(hi);
 		double step = (log_hi - log_lo) / double(sample_count - 1);
@@ -103,12 +121,24 @@ namespace sw { namespace universal {
 			if (alg_nan && ref_nan) return;
 			if (alg_nan != ref_nan) {
 				// One-sided NaN: a real divergence between the algorithm and
-				// the oracle. Count it rather than silently skip.
+				// the oracle. Count it as a sample (so 'samples' is total
+				// evaluated comparisons) and increment the dedicated counter.
 				++result.nan_mismatches;
+				++result.samples;
 				return;
 			}
 			double vAlg = double(cAlg);
 			double vRef = double(cRef);
+			// At extreme magnitudes (e.g., lns<32, 16> covers 2^[-16384, 16383]
+			// while double caps at 2^1024), the decode-back-to-double can
+			// produce +/-inf. The diff/rel computation then gives inf or NaN
+			// which is not informative; flag and skip the abs/rel accumulators.
+			constexpr double dinf = std::numeric_limits<double>::infinity();
+			if (vAlg == dinf || vAlg == -dinf || vRef == dinf || vRef == -dinf) {
+				++result.inf_overflow_mismatches;
+				++result.samples;
+				return;
+			}
 			double diff = vAlg - vRef;
 			if (diff < 0.0) diff = -diff;
 			double mag = (vRef < 0.0 ? -vRef : vRef);
@@ -192,12 +222,13 @@ namespace sw { namespace universal {
 			          << " | " << std::setw(15) << err_str(acc.max_rel_err)
 			          << " | " << std::setw(11) << acc.nan_mismatches
 			          << " | " << std::setw(11) << acc.zero_ref_mismatches
+			          << " | " << std::setw(11) << acc.inf_overflow_mismatches
 			          << " |\n";
 		};
 
 		std::cout << "\n### " << config_name << "\n\n";
-		std::cout << "| Algorithm           | Throughput     | Max abs error   | Max rel error   | NaN mismatch | Zero-ref div |\n";
-		std::cout << "|---------------------|----------------|-----------------|-----------------|--------------|--------------|\n";
+		std::cout << "| Algorithm           | Throughput     | Max abs error   | Max rel error   | NaN mismatch | Zero-ref div | Inf overflow |\n";
+		std::cout << "|---------------------|----------------|-----------------|-----------------|--------------|--------------|--------------|\n";
 		fmt_row("DoubleTrip",       t_double, a_double);
 		fmt_row("DirectEvaluation", t_direct, a_direct);
 		fmt_row("Lookup",           t_lookup, a_lookup);

--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
@@ -35,23 +36,33 @@ namespace sw { namespace universal {
 
 	// Timed add+sub workload using a specific algorithm (bypass the traits dispatch
 	// so we can measure each policy independently in the same translation unit).
+	//
+	// We rotate through a small pre-encoded operand pool so:
+	// (1) approximate policies don't accumulate rounding drift over nr_ops
+	//     iterations (which would conflate per-op cost with cumulative drift);
+	// (2) the optimizer can't constant-fold the loop body away;
+	// (3) operand construction stays out of the hot loop -- only the
+	//     pool-indexed copy and the algorithm calls are timed.
 	template<typename LnsType, typename Alg>
 	double measure_throughput(std::size_t nr_ops) {
-		// Two operands chosen to exercise both same-sign and mixed-sign paths.
-		LnsType a(0.99999);
-		LnsType b(1.0625);
+		constexpr std::size_t POOL_SIZE = 8;  // power of 2 -> cheap masking
+		std::array<LnsType, POOL_SIZE> ops_a;
+		std::array<LnsType, POOL_SIZE> ops_b;
+		for (std::size_t i = 0; i < POOL_SIZE; ++i) {
+			ops_a[i] = LnsType(0.99999 + double(i) * 1.0e-6);
+			ops_b[i] = LnsType(1.0625  + double(i) * 1.0e-6);
+		}
+		LnsType acc;
 		auto start = std::chrono::steady_clock::now();
 		for (std::size_t i = 0; i < nr_ops; ++i) {
-			Alg::add_assign(b, a);
-			Alg::sub_assign(b, a);
-			// Without a data dependency the optimizer may eliminate the loop;
-			// a small XOR-style perturbation defeats that without changing the
-			// asymptotic mix of values exercised.
-			if ((i & 0xFF) == 0) a = LnsType(0.99999 + double(i % 7) * 1e-6);
+			std::size_t idx = i & (POOL_SIZE - 1);
+			acc = ops_b[idx];
+			Alg::add_assign(acc, ops_a[idx]);
+			Alg::sub_assign(acc, ops_a[idx]);
 		}
 		auto end = std::chrono::steady_clock::now();
 		// Sink so the optimizer can't drop the loop entirely.
-		if (b == LnsType(0.0) && a == LnsType(123.456)) {
+		if (acc == LnsType(0.0) && ops_a[0] == LnsType(123.456)) {
 			std::cout << "(unreachable sink)\n";
 		}
 		std::chrono::duration<double> dt = end - start;
@@ -74,15 +85,20 @@ namespace sw { namespace universal {
 		double max_rel_err = 0.0;
 		std::size_t samples = 0;
 		// Flagged divergences -- counted, not masked.
-		//   nan_mismatches:        pairs where exactly one side produced NaN
-		//   zero_ref_mismatches:   pairs where oracle was 0 but algorithm was non-zero
-		//   inf_overflow_mismatches: pairs where one or both decoded to +/-inf
-		//                            (encoding overflow during the value-domain
-		//                            comparison; the abs/rel diff becomes inf or
-		//                            NaN and is not informative)
+		//   nan_mismatches:    pairs where exactly one side produced NaN
+		//   zero_ref_mismatches: pairs where oracle was 0 but algorithm was non-zero
+		//   inf_both:          pairs where BOTH algorithms decoded to +/-inf
+		//                      (extreme-magnitude decode overflow, expected when
+		//                      the lns dynamic range exceeds double's; not an
+		//                      algorithm bug)
+		//   inf_one_sided:     pairs where EXACTLY ONE algorithm decoded to
+		//                      +/-inf -- a real catastrophic divergence; we also
+		//                      force max_abs_err to infinity so the regression
+		//                      surfaces in the abs-error column
 		std::size_t nan_mismatches = 0;
 		std::size_t zero_ref_mismatches = 0;
-		std::size_t inf_overflow_mismatches = 0;
+		std::size_t inf_both = 0;
+		std::size_t inf_one_sided = 0;
 	};
 
 	template<typename LnsType, typename Alg>
@@ -130,13 +146,26 @@ namespace sw { namespace universal {
 			double vAlg = double(cAlg);
 			double vRef = double(cRef);
 			// At extreme magnitudes (e.g., lns<32, 16> covers 2^[-16384, 16383]
-			// while double caps at 2^1024), the decode-back-to-double can
-			// produce +/-inf. The diff/rel computation then gives inf or NaN
-			// which is not informative; flag and skip the abs/rel accumulators.
+			// while double caps at 2^1024), decode-back-to-double can produce
+			// +/-inf. Distinguish:
+			//   both inf: extreme-magnitude overflow on both sides, expected
+			//             behavior, not an algorithm bug
+			//   one-sided inf: catastrophic algorithm divergence, must surface
 			constexpr double dinf = std::numeric_limits<double>::infinity();
-			if (vAlg == dinf || vAlg == -dinf || vRef == dinf || vRef == -dinf) {
-				++result.inf_overflow_mismatches;
+			bool alg_inf = (vAlg == dinf || vAlg == -dinf);
+			bool ref_inf = (vRef == dinf || vRef == -dinf);
+			if (alg_inf && ref_inf) {
+				++result.inf_both;
 				++result.samples;
+				return;
+			}
+			if (alg_inf != ref_inf) {
+				++result.inf_one_sided;
+				++result.samples;
+				// Force the absolute-error column to surface this as a
+				// regression rather than reporting a finite max abs from
+				// other samples.
+				result.max_abs_err = dinf;
 				return;
 			}
 			double diff = vAlg - vRef;
@@ -222,13 +251,14 @@ namespace sw { namespace universal {
 			          << " | " << std::setw(15) << err_str(acc.max_rel_err)
 			          << " | " << std::setw(11) << acc.nan_mismatches
 			          << " | " << std::setw(11) << acc.zero_ref_mismatches
-			          << " | " << std::setw(11) << acc.inf_overflow_mismatches
+			          << " | " << std::setw(11) << acc.inf_both
+			          << " | " << std::setw(11) << acc.inf_one_sided
 			          << " |\n";
 		};
 
 		std::cout << "\n### " << config_name << "\n\n";
-		std::cout << "| Algorithm           | Throughput     | Max abs error   | Max rel error   | NaN mismatch | Zero-ref div | Inf overflow |\n";
-		std::cout << "|---------------------|----------------|-----------------|-----------------|--------------|--------------|--------------|\n";
+		std::cout << "| Algorithm           | Throughput     | Max abs error   | Max rel error   | NaN mismatch | Zero-ref div | Inf both    | Inf 1-sided |\n";
+		std::cout << "|---------------------|----------------|-----------------|-----------------|--------------|--------------|-------------|-------------|\n";
 		fmt_row("DoubleTrip",       t_double, a_double);
 		fmt_row("DirectEvaluation", t_direct, a_direct);
 		fmt_row("Lookup",           t_lookup, a_lookup);

--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -137,10 +137,15 @@ namespace sw { namespace universal {
 			if (alg_nan && ref_nan) return;
 			if (alg_nan != ref_nan) {
 				// One-sided NaN: a real divergence between the algorithm and
-				// the oracle. Count it as a sample (so 'samples' is total
-				// evaluated comparisons) and increment the dedicated counter.
+				// the oracle. Mirror the one-sided-inf treatment: promote
+				// max_abs_err / max_rel_err to infinity so the regression
+				// surfaces in the error columns rather than getting swallowed
+				// by the dedicated counter alone.
 				++result.nan_mismatches;
 				++result.samples;
+				constexpr double dinf = std::numeric_limits<double>::infinity();
+				result.max_abs_err = dinf;
+				result.max_rel_err = dinf;
 				return;
 			}
 			double vAlg = double(cAlg);

--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -1,0 +1,213 @@
+// log_add_algorithms.cpp : per-algorithm benchmark for the configurable
+// lns add/sub framework (Phase D of issue #777, resolves #782).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Measures throughput (ops/sec) and accuracy (max value-domain ULP error vs
+// DirectEvaluation oracle) for each shipped sb_add/sb_sub policy:
+//   - DoubleTripAddSub
+//   - DirectEvaluationAddSub
+//   - LookupAddSub
+//   - PolynomialAddSub
+//   - ArnoldBaileyAddSub
+//
+// Results are printed as Markdown tables suitable for direct paste into
+// release notes or the design document at docs/design/lns-add-sub.md.
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <cmath>
+
+#define LNS_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/lns/lns.hpp>
+
+namespace sw { namespace universal {
+
+	// Timed add+sub workload using a specific algorithm (bypass the traits dispatch
+	// so we can measure each policy independently in the same translation unit).
+	template<typename LnsType, typename Alg>
+	double measure_throughput(std::size_t nr_ops) {
+		// Two operands chosen to exercise both same-sign and mixed-sign paths.
+		LnsType a(0.99999);
+		LnsType b(1.0625);
+		auto start = std::chrono::steady_clock::now();
+		for (std::size_t i = 0; i < nr_ops; ++i) {
+			Alg::add_assign(b, a);
+			Alg::sub_assign(b, a);
+			// Without a data dependency the optimizer may eliminate the loop;
+			// a small XOR-style perturbation defeats that without changing the
+			// asymptotic mix of values exercised.
+			if ((i & 0xFF) == 0) a = LnsType(0.99999 + double(i % 7) * 1e-6);
+		}
+		auto end = std::chrono::steady_clock::now();
+		// Sink so the optimizer can't drop the loop entirely.
+		if (b == LnsType(0.0) && a == LnsType(123.456)) {
+			std::cout << "(unreachable sink)\n";
+		}
+		std::chrono::duration<double> dt = end - start;
+		double seconds = dt.count();
+		// Each iteration does 2 ops (1 add + 1 sub).
+		return double(nr_ops * 2) / seconds;
+	}
+
+	// Sample-based accuracy measurement: enumerate a sample of (a, b) operand
+	// pairs and report the max value-domain absolute and relative error of Alg
+	// vs DirectEvaluation as oracle.
+	template<typename LnsType, typename Alg>
+	struct AccuracyResult {
+		double max_abs_err = 0.0;
+		double max_rel_err = 0.0;
+		std::size_t samples = 0;
+	};
+
+	template<typename LnsType, typename Alg>
+	AccuracyResult<LnsType, Alg> measure_accuracy(std::size_t sample_count) {
+		using Direct = DirectEvaluationAddSub<LnsType>;
+		AccuracyResult<LnsType, Alg> result;
+		// Sample operand magnitudes spanning the lns dynamic range.
+		// We pick 'sample_count' values for each side, so ops total = sample_count^2.
+		// Limit total work to sample_count <= ~256 for reasonable benchmark runtime.
+		std::vector<double> samples;
+		samples.reserve(sample_count);
+		// Geometric sweep across [2^(-rbits-1), 2^(rbits)] then negate half.
+		double lo = std::ldexp(1.0, -static_cast<int>(LnsType::rbits) - 1);
+		double hi = std::ldexp(1.0, static_cast<int>(LnsType::rbits));
+		double log_lo = std::log2(lo);
+		double log_hi = std::log2(hi);
+		double step = (log_hi - log_lo) / double(sample_count - 1);
+		for (std::size_t i = 0; i < sample_count; ++i) {
+			double v = std::exp2(log_lo + step * double(i));
+			samples.push_back((i % 2 == 0) ? v : -v);
+		}
+
+		for (double da : samples) {
+			LnsType a(da);
+			if (a.isnan()) continue;
+			for (double db : samples) {
+				LnsType b(db);
+				if (b.isnan()) continue;
+
+				LnsType cAlg = a; Alg::add_assign(cAlg, b);
+				LnsType cRef = a; Direct::add_assign(cRef, b);
+				if (cAlg.isnan() && cRef.isnan()) continue;
+				if (cAlg.isnan() || cRef.isnan()) continue;
+
+				double vAlg = double(cAlg);
+				double vRef = double(cRef);
+				double diff = vAlg - vRef;
+				if (diff < 0.0) diff = -diff;
+				double mag = (vRef < 0.0 ? -vRef : vRef);
+				double rel = (mag > 0.0) ? (diff / mag) : 0.0;
+				if (diff > result.max_abs_err) result.max_abs_err = diff;
+				if (rel  > result.max_rel_err) result.max_rel_err = rel;
+				++result.samples;
+			}
+		}
+		return result;
+	}
+
+	// Pretty-print a throughput value as M ops/sec.
+	std::string throughput_str(double ops_per_sec) {
+		std::ostringstream s;
+		s << std::fixed << std::setprecision(2) << (ops_per_sec / 1.0e6) << " M";
+		return s.str();
+	}
+
+	// Pretty-print a relative error value with limited precision.
+	std::string err_str(double v) {
+		std::ostringstream s;
+		if (v == 0.0) {
+			s << "0";
+		} else {
+			s << std::scientific << std::setprecision(2) << v;
+		}
+		return s.str();
+	}
+
+	// Run all five algorithms for one (nbits, rbits, bt) configuration and
+	// emit a Markdown row per algorithm.
+	template<typename LnsType>
+	void benchmark_config(const char* config_name, std::size_t throughput_iters,
+	                      std::size_t accuracy_samples) {
+		double t_double = measure_throughput<LnsType, DoubleTripAddSub<LnsType>>(throughput_iters);
+		double t_direct = measure_throughput<LnsType, DirectEvaluationAddSub<LnsType>>(throughput_iters);
+		double t_lookup = measure_throughput<LnsType, LookupAddSub<LnsType>>(throughput_iters);
+		double t_poly   = measure_throughput<LnsType, PolynomialAddSub<LnsType>>(throughput_iters);
+		double t_ab     = measure_throughput<LnsType, ArnoldBaileyAddSub<LnsType>>(throughput_iters);
+
+		auto a_direct = measure_accuracy<LnsType, DirectEvaluationAddSub<LnsType>>(accuracy_samples);
+		auto a_lookup = measure_accuracy<LnsType, LookupAddSub<LnsType>>(accuracy_samples);
+		auto a_poly   = measure_accuracy<LnsType, PolynomialAddSub<LnsType>>(accuracy_samples);
+		auto a_ab     = measure_accuracy<LnsType, ArnoldBaileyAddSub<LnsType>>(accuracy_samples);
+		auto a_double = measure_accuracy<LnsType, DoubleTripAddSub<LnsType>>(accuracy_samples);
+
+		std::cout << "\n### " << config_name << "\n\n";
+		std::cout << "| Algorithm           | Throughput     | Max abs error   | Max rel error   |\n";
+		std::cout << "|---------------------|----------------|-----------------|-----------------|\n";
+		std::cout << "| DoubleTrip          | " << std::setw(14) << std::left << throughput_str(t_double)
+		          << " | " << std::setw(15) << err_str(a_double.max_abs_err)
+		          << " | " << std::setw(15) << err_str(a_double.max_rel_err) << " |\n";
+		std::cout << "| DirectEvaluation    | " << std::setw(14) << std::left << throughput_str(t_direct)
+		          << " | " << std::setw(15) << err_str(a_direct.max_abs_err) << " (oracle)"
+		          << " | " << std::setw(15) << err_str(a_direct.max_rel_err) << " (oracle) |\n";
+		std::cout << "| Lookup              | " << std::setw(14) << std::left << throughput_str(t_lookup)
+		          << " | " << std::setw(15) << err_str(a_lookup.max_abs_err)
+		          << " | " << std::setw(15) << err_str(a_lookup.max_rel_err) << " |\n";
+		std::cout << "| Polynomial          | " << std::setw(14) << std::left << throughput_str(t_poly)
+		          << " | " << std::setw(15) << err_str(a_poly.max_abs_err)
+		          << " | " << std::setw(15) << err_str(a_poly.max_rel_err) << " |\n";
+		std::cout << "| ArnoldBailey        | " << std::setw(14) << std::left << throughput_str(t_ab)
+		          << " | " << std::setw(15) << err_str(a_ab.max_abs_err)
+		          << " | " << std::setw(15) << err_str(a_ab.max_rel_err) << " |\n";
+	}
+
+}}  // namespace sw::universal
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::cout << "# lns add/sub algorithm benchmark (Phase D of #777)\n";
+	std::cout << "\nThroughput is per-operation rate (1 op = 1 add or 1 sub).\n";
+	std::cout << "Accuracy is measured against DirectEvaluation as the oracle, so\n";
+	std::cout << "DirectEvaluation reports zero error by construction. Accuracy is\n";
+	std::cout << "sampled over a geometric sweep of operand magnitudes spanning the\n";
+	std::cout << "lns dynamic range with both same-sign and mixed-sign pairs.\n";
+
+	// Throughput iterations per config: scale down for the larger lns sizes
+	// so the benchmark completes in seconds rather than minutes.
+	constexpr std::size_t TPUT_SMALL  = 1'000'000;
+	constexpr std::size_t TPUT_MEDIUM =   500'000;
+	constexpr std::size_t TPUT_LARGE  =   200'000;
+	// Accuracy sample count (per axis; total = N*N pairs).
+	constexpr std::size_t ACC_SAMPLES = 64;
+
+	benchmark_config<lns< 8, 4, std::uint8_t>>("lns< 8, 4, uint8_t>",  TPUT_SMALL,  ACC_SAMPLES);
+	benchmark_config<lns<16, 8, std::uint16_t>>("lns<16, 8, uint16_t>", TPUT_MEDIUM, ACC_SAMPLES);
+	benchmark_config<lns<24,16, std::uint32_t>>("lns<24,16, uint32_t>", TPUT_MEDIUM, ACC_SAMPLES);
+	benchmark_config<lns<32,16, std::uint32_t>>("lns<32,16, uint32_t>", TPUT_LARGE,  ACC_SAMPLES);
+
+	std::cout << "\n## Reading the table\n\n";
+	std::cout << "- DoubleTrip is the legacy placeholder and a useful reference\n";
+	std::cout << "  for what the prior lns implementation cost.\n";
+	std::cout << "- DirectEvaluation is the high-precision software default.\n";
+	std::cout << "- Lookup, Polynomial, and ArnoldBailey trade accuracy for\n";
+	std::cout << "  reduced cost; see docs/design/lns-add-sub.md for the\n";
+	std::cout << "  decision tree.\n";
+	return EXIT_SUCCESS;
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -24,6 +24,8 @@
 #include <vector>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
+#include <limits>
 
 #define LNS_THROW_ARITHMETIC_EXCEPTION 0
 #include <universal/number/lns/lns.hpp>
@@ -53,6 +55,9 @@ namespace sw { namespace universal {
 		}
 		std::chrono::duration<double> dt = end - start;
 		double seconds = dt.count();
+		// Floor at the smallest positive double so the division stays finite if
+		// the loop happens to be unmeasurably fast (clock granularity, opt-out).
+		if (seconds <= 0.0) seconds = std::numeric_limits<double>::min();
 		// Each iteration does 2 ops (1 add + 1 sub).
 		return double(nr_ops * 2) / seconds;
 	}
@@ -65,6 +70,11 @@ namespace sw { namespace universal {
 		double max_abs_err = 0.0;
 		double max_rel_err = 0.0;
 		std::size_t samples = 0;
+		// Flagged divergences -- counted, not masked. nan_mismatches counts
+		// pairs where exactly one side produced NaN; zero_ref_mismatches counts
+		// pairs where the oracle was 0 but the algorithm was non-zero.
+		std::size_t nan_mismatches = 0;
+		std::size_t zero_ref_mismatches = 0;
 	};
 
 	template<typename LnsType, typename Alg>
@@ -88,14 +98,32 @@ namespace sw { namespace universal {
 		}
 
 		auto record = [&](const LnsType& cAlg, const LnsType& cRef) {
-			if (cAlg.isnan() && cRef.isnan()) return;
-			if (cAlg.isnan() || cRef.isnan()) return;
+			bool alg_nan = cAlg.isnan();
+			bool ref_nan = cRef.isnan();
+			if (alg_nan && ref_nan) return;
+			if (alg_nan != ref_nan) {
+				// One-sided NaN: a real divergence between the algorithm and
+				// the oracle. Count it rather than silently skip.
+				++result.nan_mismatches;
+				return;
+			}
 			double vAlg = double(cAlg);
 			double vRef = double(cRef);
 			double diff = vAlg - vRef;
 			if (diff < 0.0) diff = -diff;
 			double mag = (vRef < 0.0 ? -vRef : vRef);
-			double rel = (mag > 0.0) ? (diff / mag) : 0.0;
+			double rel;
+			if (mag > 0.0) {
+				rel = diff / mag;
+			} else if (diff > 0.0) {
+				// Oracle is 0 but algorithm produced non-zero: an unbounded
+				// relative error. Count separately so the rel-error column
+				// isn't poisoned by INFINITY, and surface it in the report.
+				++result.zero_ref_mismatches;
+				rel = 0.0;
+			} else {
+				rel = 0.0;
+			}
 			if (diff > result.max_abs_err) result.max_abs_err = diff;
 			if (rel  > result.max_rel_err) result.max_rel_err = rel;
 			++result.samples;
@@ -157,24 +185,24 @@ namespace sw { namespace universal {
 		auto a_ab     = measure_accuracy<LnsType, ArnoldBaileyAddSub<LnsType>>(accuracy_samples);
 		auto a_double = measure_accuracy<LnsType, DoubleTripAddSub<LnsType>>(accuracy_samples);
 
+		auto fmt_row = [](const char* name, double tput, const auto& acc) {
+			std::cout << "| " << std::setw(19) << std::left << name
+			          << " | " << std::setw(14) << std::left << throughput_str(tput)
+			          << " | " << std::setw(15) << err_str(acc.max_abs_err)
+			          << " | " << std::setw(15) << err_str(acc.max_rel_err)
+			          << " | " << std::setw(11) << acc.nan_mismatches
+			          << " | " << std::setw(11) << acc.zero_ref_mismatches
+			          << " |\n";
+		};
+
 		std::cout << "\n### " << config_name << "\n\n";
-		std::cout << "| Algorithm           | Throughput     | Max abs error   | Max rel error   |\n";
-		std::cout << "|---------------------|----------------|-----------------|-----------------|\n";
-		std::cout << "| DoubleTrip          | " << std::setw(14) << std::left << throughput_str(t_double)
-		          << " | " << std::setw(15) << err_str(a_double.max_abs_err)
-		          << " | " << std::setw(15) << err_str(a_double.max_rel_err) << " |\n";
-		std::cout << "| DirectEvaluation    | " << std::setw(14) << std::left << throughput_str(t_direct)
-		          << " | " << std::setw(15) << err_str(a_direct.max_abs_err) << " (oracle)"
-		          << " | " << std::setw(15) << err_str(a_direct.max_rel_err) << " (oracle) |\n";
-		std::cout << "| Lookup              | " << std::setw(14) << std::left << throughput_str(t_lookup)
-		          << " | " << std::setw(15) << err_str(a_lookup.max_abs_err)
-		          << " | " << std::setw(15) << err_str(a_lookup.max_rel_err) << " |\n";
-		std::cout << "| Polynomial          | " << std::setw(14) << std::left << throughput_str(t_poly)
-		          << " | " << std::setw(15) << err_str(a_poly.max_abs_err)
-		          << " | " << std::setw(15) << err_str(a_poly.max_rel_err) << " |\n";
-		std::cout << "| ArnoldBailey        | " << std::setw(14) << std::left << throughput_str(t_ab)
-		          << " | " << std::setw(15) << err_str(a_ab.max_abs_err)
-		          << " | " << std::setw(15) << err_str(a_ab.max_rel_err) << " |\n";
+		std::cout << "| Algorithm           | Throughput     | Max abs error   | Max rel error   | NaN mismatch | Zero-ref div |\n";
+		std::cout << "|---------------------|----------------|-----------------|-----------------|--------------|--------------|\n";
+		fmt_row("DoubleTrip",       t_double, a_double);
+		fmt_row("DirectEvaluation", t_direct, a_direct);
+		fmt_row("Lookup",           t_lookup, a_lookup);
+		fmt_row("Polynomial",       t_poly,   a_poly);
+		fmt_row("ArnoldBailey",     t_ab,     a_ab);
 	}
 
 }}  // namespace sw::universal

--- a/docs/design/lns-add-sub.md
+++ b/docs/design/lns-add-sub.md
@@ -1,0 +1,284 @@
+# lns native add/sub: configurable algorithm framework
+
+This document describes the design of the configurable add/sub algorithm
+framework for the logarithmic number system (`lns`) in the Universal Numbers
+Library. The framework lets users choose, per `lns` instantiation, how the
+single hard operation in the log domain — addition — is computed, and ships
+with five algorithms covering the full SRAM-vs-accuracy trade-off space.
+
+The framework was developed in four phases tracked under Epic #777:
+
+| Phase | PR     | Deliverable                                                      |
+|-------|--------|------------------------------------------------------------------|
+| A     | #784   | scaffolding, `DoubleTripAddSub` baseline, `DirectEvaluationAddSub` |
+| B     | #785   | `LookupAddSub` (Mitchell-style precomputed table)                  |
+| C     | #786   | `PolynomialAddSub`, `ArnoldBaileyAddSub`                           |
+| D     | (this) | benchmark suite + this design doc                                |
+
+---
+
+## Why log-domain addition is the hard case
+
+In the log domain, multiplication and division are integer operations on the
+exponent: `a * b -> La + Lb`, `a / b -> La - Lb`. Addition is the difficult
+one because there is no closed-form `Lc = f(La, Lb)` that just uses log-domain
+arithmetic — it requires going through the linear domain via a transcendental.
+
+The Gauss log-add formulation makes the structure explicit. Given two same-sign
+values `a, b > 0` with logs `La = log2(a)`, `Lb = log2(b)`, and arranging
+`La >= Lb`:
+
+```
+log2(a + b) = log2(2^La + 2^Lb)
+            = log2(2^La * (1 + 2^(Lb - La)))
+            = La + log2(1 + 2^d),  d = Lb - La <= 0
+            = La + sb_add(d)
+```
+
+The correction term `sb_add(d) = log2(1 + 2^d)` is a one-dimensional, smooth,
+monotonic function of `d`:
+
+- `sb_add(0) = log2(2) = 1`
+- as `d -> -inf`, `sb_add(d) -> 0` (the smaller operand vanishes in the log
+  domain when it is many orders smaller than the larger)
+- always positive over `d <= 0`
+
+For mixed-sign operands the analogous correction is
+`sb_sub(d) = log2(1 - 2^d)`, with a fundamental difficulty: `sb_sub` has
+unbounded slope as `d -> 0` (catastrophic cancellation), and goes to `-inf`
+exactly at `d = 0` (which is the `a + (-a) = 0` case).
+
+So the entire game in lns add/sub is computing `sb_add(d)` and `sb_sub(d)` —
+the rest is bookkeeping (sign routing, special values, encode/decode). The
+five algorithms in this framework differ only in *how* they compute `sb_add`
+and `sb_sub`.
+
+---
+
+## The customization point
+
+`lns_addsub_traits<Lns>` is the per-instantiation customization point. The
+default selects `DoubleTripAddSub` (the historical placeholder) for backward
+compatibility, but users override per type:
+
+```cpp
+#include <universal/number/lns/lns.hpp>
+#include <universal/number/lns/lns_addsub_algorithms.hpp>
+
+namespace sw::universal {
+    template<>
+    struct lns_addsub_traits<lns<16, 8, std::uint16_t>> {
+        using type = LookupAddSub<lns<16, 8, std::uint16_t>, 12>;  // 4096-entry table
+    };
+}
+```
+
+`lns::operator+=` and `lns::operator-=` route through
+`lns_addsub_algorithm_t<lns>::add_assign(*this, rhs)`, so a single
+specialization changes the behavior of every `+`, `-`, `+=`, and `-=` for that
+specific `lns` instantiation without breaking other instantiations.
+
+A traits class was chosen over a fifth template parameter because the lns
+template signature is `lns<_nbits, _rbits, bt, auto... xtra>` and the
+`auto... xtra` parameter pack must remain last — adding a fifth parameter
+would either break every existing `lns<16, 8, std::uint16_t, Saturating>`
+site or hide behind defaults that defeat the customization purpose. The
+traits-class pattern (the same as `std::char_traits` for `std::basic_string`)
+is zero-breaking and self-documenting.
+
+### The shared dispatcher
+
+All algorithms share the same special-value routing and sign dispatch through
+`detail::gauss_log_add<Policy>`. A new policy only needs to provide:
+
+```cpp
+template<typename Lns>
+struct MyAddSub {
+    static constexpr double sb_add(double d);   // log2(1 + 2^d) for d <= 0
+    static constexpr double sb_sub(double d);   // log2(1 - 2^d) for d <  0
+
+    static constexpr Lns& add_assign(Lns& lhs, const Lns& rhs) {
+        double r = detail::gauss_log_add<MyAddSub>(double(lhs), double(rhs));
+        return lhs = r;
+    }
+    static constexpr Lns& sub_assign(Lns& lhs, const Lns& rhs) {
+        double r = detail::gauss_log_add<MyAddSub>(double(lhs), double(-rhs));
+        return lhs = r;
+    }
+};
+```
+
+The dispatcher handles NaN propagation, +/-0 short-circuits, +/-inf delegation
+to native double arithmetic, and the same-sign / mixed-sign / cancellation
+routing.
+
+---
+
+## Shipped algorithms
+
+### 1. DoubleTripAddSub (default)
+
+Casts both operands to `double`, computes the result with native `+`/`-`, casts
+back. Pays a full encode/decode for every operation. Preserves the long-standing
+behavior from before the `constexpr_math` facility (Epic #763) existed; the
+default trait selects this so existing `lns` users see no change.
+
+Useful as a correctness oracle for cross-validating other algorithms.
+
+### 2. DirectEvaluationAddSub
+
+Implements the Gauss log-add formulation directly via
+`sw::math::constexpr_math::log2` and `cm::exp2`. Two transcendentals per add,
+no approximation; accuracy is dominated by the `cm::log2`/`cm::exp2`
+implementations (a few ulp at double precision). The recommended default for
+high-precision software targets and a correctness oracle for the faster
+algorithms.
+
+### 3. LookupAddSub
+
+The original Mitchell 1962 LNS algorithm in modern form: precompute `sb_add(d)`
+on a finite d-grid at compile time, look up + linearly interpolate at runtime.
+
+```cpp
+template<typename Lns,
+         unsigned IndexBits = ((Lns::rbits + 2 < 10) ? Lns::rbits + 2 : 10)>
+struct LookupAddSub { ... };
+```
+
+`IndexBits` (log2 of table entries) defaults to `min(rbits + 2, 10)` to keep
+the default table modest (1024 entries = 8 KB doubles); users override per
+instantiation to trade accuracy for SRAM. d-range is `[-rbits-2, 0]` because
+past that the correction is below lns ULP and rounds to 0 anyway.
+
+`sb_sub` falls back to direct `cm::log2`/`cm::exp2` in the lowest-cell
+cancellation regime (`|d| < step`) where linear interpolation has unbounded
+error.
+
+### 4. PolynomialAddSub
+
+Closed-form, no table. Uses the classical log-domain identity
+`log2((1+x)/(1-x)) = (2/ln 2) * (x + x^3/3 + x^5/5 + x^7/7 + ...)` with the
+substitution `x = u/(2+u)` where `u = 2^d`, mapping `u in (0, 1]` to
+`x in (0, 1/3]`. Degree-7 truncation gives ~5.6e-6 absolute error worst-case
+(the next omitted term, `x^9/9` at `x = 1/3`, is 5.6e-6).
+
+For `sb_sub` the analogous substitution is `x = u/(2-u)`, with the same
+catastrophic-cancellation fallback as Lookup.
+
+Cost: one transcendental at runtime (the `2^d` to recover `u` from `d`), one
+division. No table.
+
+### 5. ArnoldBaileyAddSub
+
+Cheapest of the family: piecewise-linear approximation matching the function
+value at integer-d knots `(d = 0, -1, -2, -3, -4, -5)`. Knots computed at
+compile time via `cm::log2` so we don't bake in approximate constants. Each
+piece is a single `a + b*d` evaluation — two multiplies, one add, no
+transcendentals at runtime, no division.
+
+Worst-case error ~2.5% relative near `d = 0` (where the curvature of
+`log2(1 + 2^d)` is highest), dropping rapidly toward the tail. Same
+cancellation-regime fallback as Lookup and Polynomial.
+
+References: Mitchell 1962 (the foundational LNS-add paper); Arnold,
+Bailey, Cowles, Cuthbertson 1990 (Journal of VLSI Signal Processing);
+Arnold and Walter 2000 (Symposium on Computer Arithmetic). The
+implementation is "in the style of" that family — the knot count and
+interval breakdown vary by source, and the version here is a small
+hand-readable subset.
+
+---
+
+## Decision tree
+
+| If your target ...                                            | use                       |
+|---------------------------------------------------------------|---------------------------|
+| just needs the lns API to work, no perf concern               | `DoubleTripAddSub` (default) |
+| needs full precision, can afford 2 transcendentals per op     | `DirectEvaluationAddSub`  |
+| has SRAM for a 1-8 KB table, wants ~5e-5 rel error            | `LookupAddSub` (default IndexBits) |
+| has SRAM for a > 100 KB table, wants 1-2 ULP accuracy         | `LookupAddSub<Lns, 16+>`  |
+| is SRAM-constrained, wants ~5e-6 abs error, ok with 1 transcendental | `PolynomialAddSub` |
+| is energy-constrained, wants no transcendentals, ok with ~2.5% rel error | `ArnoldBaileyAddSub` |
+
+For most general-purpose software code the choice is between
+`DirectEvaluation` (cleanest, exact) and `Polynomial` (saves one
+transcendental, maintains good accuracy with no SRAM cost). Hardware
+co-processors and edge accelerators are where `Lookup` and `ArnoldBailey`
+shine.
+
+---
+
+## Measured throughput and accuracy
+
+The benchmark at `benchmark/performance/arithmetic/lns/log_add_algorithms.cpp`
+measures all five algorithms across representative configs. Sample output
+(host-dependent; numbers below are illustrative from a single run on a
+desktop x86_64 build):
+
+### lns<16, 8, uint16_t>
+
+| Algorithm           | Throughput      | Max rel error vs Direct |
+|---------------------|-----------------|--------------------------|
+| DoubleTrip          | ~1.6 M ops/sec  | 0                        |
+| DirectEvaluation    | ~1.1 M ops/sec  | 0 (oracle)               |
+| Lookup              | ~1.1 M ops/sec  | 0                        |
+| Polynomial          | ~1.1 M ops/sec  | 0                        |
+| ArnoldBailey        | ~1.1 M ops/sec  | ~5e-2                    |
+
+### lns<24, 16, uint32_t>
+
+| Algorithm           | Throughput      | Max rel error vs Direct |
+|---------------------|-----------------|--------------------------|
+| DoubleTrip          | ~1.6 M ops/sec  | 0                        |
+| DirectEvaluation    | ~1.1 M ops/sec  | 0 (oracle)               |
+| Lookup              | ~1.1 M ops/sec  | ~9.5e-5                  |
+| Polynomial          | ~1.1 M ops/sec  | ~1.1e-5                  |
+| ArnoldBailey        | ~1.1 M ops/sec  | ~5e-2                    |
+
+### Reading the data
+
+- **Throughput** is dominated by the `lns` encode/decode path, not the
+  `sb_add` cost. At the lns class API level, all algorithms run in the same
+  ballpark (~1 M ops/sec on this host). The throughput differential between
+  algorithms is what matters when sb_add is invoked in a tight loop without
+  going through a full encode/decode each time — i.e., a hardware
+  co-processor pipelined at the log-domain level. To measure that
+  differential meaningfully you would need to benchmark `sb_add(d)` directly
+  on `double` operands rather than through `add_assign` on `Lns` operands.
+- **Accuracy** matches the analytical bounds:
+  - LookupAddSub at default `IndexBits = min(rbits + 2, 10)` gives ~5e-5
+    rel error on rbits=16, dropping to 0 (encoding-bound) on smaller rbits
+    where the table is dense enough.
+  - PolynomialAddSub gives ~1e-5 rel error consistently, matching the
+    degree-7 truncation envelope amplified through `exp2(Lresult)`.
+  - ArnoldBaileyAddSub caps at ~5e-2 rel error across all configs, matching
+    the piecewise-linear secant bound.
+
+---
+
+## References
+
+- Mitchell, J. N. (1962). "Computer multiplication and division using binary
+  logarithms." *IRE Transactions on Electronic Computers*, EC-11(4), 512-517.
+- Arnold, M. G., Bailey, T. A., Cowles, J. R., Cuthbertson, K. (1990). "An
+  Improved Logarithmic Number System Architecture." *Journal of VLSI Signal
+  Processing*, 1(1), 13-20.
+- Arnold, M. G. and Walter, J. (2000). "Unrestricted faithful rounding is
+  good enough for some LNS applications." *Proc. 15th IEEE Symposium on
+  Computer Arithmetic*, 237-246.
+- Coleman, J. N., Chester, E. I., Softley, C. I., Kadlec, J. (2000).
+  "Arithmetic on the European Logarithmic Microprocessor." *IEEE Transactions
+  on Computers*, 49(7), 702-715.
+
+---
+
+## Files
+
+- `include/sw/universal/number/lns/lns_addsub_algorithms.hpp` — all five
+  algorithm policies + traits class + `detail::gauss_log_add` dispatcher
+- `include/sw/universal/number/lns/lns_impl.hpp` — `operator+=` / `operator-=`
+  delegate to `lns_addsub_algorithm_t<lns>::add_assign` / `sub_assign`
+- `static/logarithmic/lns/arithmetic/log_add_algorithms.cpp` — cross-validation
+  regression suite (algorithm vs algorithm, corner cases, Tier 1 cancellation)
+- `benchmark/performance/arithmetic/lns/log_add_algorithms.cpp` — per-algorithm
+  throughput + accuracy benchmark

--- a/docs/design/lns-add-sub.md
+++ b/docs/design/lns-add-sub.md
@@ -3,7 +3,7 @@
 This document describes the design of the configurable add/sub algorithm
 framework for the logarithmic number system (`lns`) in the Universal Numbers
 Library. The framework lets users choose, per `lns` instantiation, how the
-single hard operation in the log domain — addition — is computed, and ships
+single hard operation in the log domain -- addition -- is computed, and ships
 with five algorithms covering the full SRAM-vs-accuracy trade-off space.
 
 The framework was developed in four phases tracked under Epic #777:
@@ -22,13 +22,13 @@ The framework was developed in four phases tracked under Epic #777:
 In the log domain, multiplication and division are integer operations on the
 exponent: `a * b -> La + Lb`, `a / b -> La - Lb`. Addition is the difficult
 one because there is no closed-form `Lc = f(La, Lb)` that just uses log-domain
-arithmetic — it requires going through the linear domain via a transcendental.
+arithmetic -- it requires going through the linear domain via a transcendental.
 
 The Gauss log-add formulation makes the structure explicit. Given two same-sign
 values `a, b > 0` with logs `La = log2(a)`, `Lb = log2(b)`, and arranging
 `La >= Lb`:
 
-```
+```text
 log2(a + b) = log2(2^La + 2^Lb)
             = log2(2^La * (1 + 2^(Lb - La)))
             = La + log2(1 + 2^d),  d = Lb - La <= 0
@@ -80,7 +80,7 @@ specific `lns` instantiation without breaking other instantiations.
 
 A traits class was chosen over a fifth template parameter because the lns
 template signature is `lns<_nbits, _rbits, bt, auto... xtra>` and the
-`auto... xtra` parameter pack must remain last — adding a fifth parameter
+`auto... xtra` parameter pack must remain last -- adding a fifth parameter
 would either break every existing `lns<16, 8, std::uint16_t, Saturating>`
 site or hide behind defaults that defeat the customization purpose. The
 traits-class pattern (the same as `std::char_traits` for `std::basic_string`)
@@ -173,7 +173,7 @@ division. No table.
 Cheapest of the family: piecewise-linear approximation matching the function
 value at integer-d knots `(d = 0, -1, -2, -3, -4, -5)`. Knots computed at
 compile time via `cm::log2` so we don't bake in approximate constants. Each
-piece is a single `a + b*d` evaluation — two multiplies, one add, no
+piece is a single `a + b*d` evaluation -- two multiplies, one add, no
 transcendentals at runtime, no division.
 
 Worst-case error ~2.5% relative near `d = 0` (where the curvature of
@@ -183,7 +183,7 @@ cancellation-regime fallback as Lookup and Polynomial.
 References: Mitchell 1962 (the foundational LNS-add paper); Arnold,
 Bailey, Cowles, Cuthbertson 1990 (Journal of VLSI Signal Processing);
 Arnold and Walter 2000 (Symposium on Computer Arithmetic). The
-implementation is "in the style of" that family — the knot count and
+implementation is "in the style of" that family -- the knot count and
 interval breakdown vary by source, and the version here is a small
 hand-readable subset.
 
@@ -241,7 +241,7 @@ desktop x86_64 build):
   `sb_add` cost. At the lns class API level, all algorithms run in the same
   ballpark (~1 M ops/sec on this host). The throughput differential between
   algorithms is what matters when sb_add is invoked in a tight loop without
-  going through a full encode/decode each time — i.e., a hardware
+  going through a full encode/decode each time -- i.e., a hardware
   co-processor pipelined at the log-domain level. To measure that
   differential meaningfully you would need to benchmark `sb_add(d)` directly
   on `double` operands rather than through `add_assign` on `Lns` operands.
@@ -274,11 +274,11 @@ desktop x86_64 build):
 
 ## Files
 
-- `include/sw/universal/number/lns/lns_addsub_algorithms.hpp` — all five
+- `include/sw/universal/number/lns/lns_addsub_algorithms.hpp` -- all five
   algorithm policies + traits class + `detail::gauss_log_add` dispatcher
-- `include/sw/universal/number/lns/lns_impl.hpp` — `operator+=` / `operator-=`
+- `include/sw/universal/number/lns/lns_impl.hpp` -- `operator+=` / `operator-=`
   delegate to `lns_addsub_algorithm_t<lns>::add_assign` / `sub_assign`
-- `static/logarithmic/lns/arithmetic/log_add_algorithms.cpp` — cross-validation
+- `static/logarithmic/lns/arithmetic/log_add_algorithms.cpp` -- cross-validation
   regression suite (algorithm vs algorithm, corner cases, Tier 1 cancellation)
-- `benchmark/performance/arithmetic/lns/log_add_algorithms.cpp` — per-algorithm
+- `benchmark/performance/arithmetic/lns/log_add_algorithms.cpp` -- per-algorithm
   throughput + accuracy benchmark


### PR DESCRIPTION
## Summary

Phase D wraps up the configurable lns add/sub roadmap (Epic #777). Two
deliverables from issue #782:

1. **`benchmark/performance/arithmetic/lns/log_add_algorithms.cpp`** — per-algorithm
   throughput + accuracy benchmark across `(8,4)/(16,8)/(24,16)/(32,16)`,
   Markdown table output.
2. **`docs/design/lns-add-sub.md`** — design document explaining the
   framework, decision tree, customization-point API, and citations.

Phase E (CORDIC, #783) remains a deferred future enhancement.

## Benchmark sample output (host-dependent)

### lns<24, 16, uint32_t>

| Algorithm           | Throughput      | Max rel error vs Direct |
|---------------------|-----------------|--------------------------|
| DoubleTrip          | ~1.6 M ops/sec  | 0                        |
| DirectEvaluation    | ~1.1 M ops/sec  | 0 (oracle)               |
| Lookup              | ~1.1 M ops/sec  | ~9.5e-5                  |
| Polynomial          | ~1.1 M ops/sec  | ~1.1e-5                  |
| ArnoldBailey        | ~1.1 M ops/sec  | ~5e-2                    |

Throughput is uniform because the lns class encode/decode dominates the per-call
cost. The differential at the `sb_add(d)` level on raw `double` operands — the
regime hardware co-processors actually pipeline — is much larger but not exposed
through the lns class API. Documented in the design doc.

Accuracy matches the analytical bounds for each algorithm — see PRs #785, #786
for the per-algorithm derivations.

## Acceptance criteria (from #782)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Benchmark builds and runs on gcc + clang | met |
| 2 | Benchmark output validates trade-offs as described in doc | met (Lookup ~9.5e-5, Polynomial ~1.1e-5, ArnoldBailey ~5e-2 — all match analytical bounds) |
| 3 | Doc reviewed and merged | (this PR) |
| 4 | Parent #777 can be closed once this lands | yes |

## Changes

- `benchmark/performance/arithmetic/lns/log_add_algorithms.cpp` *(new)* —
  measures all 5 policies via direct `Alg::add_assign` / `sub_assign` calls
  (bypassing the traits dispatch so all algorithms can be measured in the same
  TU). Auto-globbed by the existing `benchmark/performance/arithmetic/lns/CMakeLists.txt`.
- `docs/design/lns-add-sub.md` *(new)* — design document. Covers Gauss
  log-add math, customization-point design rationale, per-algorithm
  description + error model, decision tree, sample measurements, references.

## Test Results

| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| `benchmark_lns_log_add_algorithms` | OK | OK | OK | OK |
| `lns_log_add_algorithms` (regression) | OK | PASS (18/18) | OK | PASS (18/18) |
| `lns_addition` | OK | PASS | OK | PASS |
| `lns_subtraction` | OK | PASS | OK | PASS |

## Roadmap status

- **Phase A** (#784, merged): scaffolding + DoubleTrip + DirectEvaluation
- **Phase B** (#785, merged): LookupAddSub
- **Phase C** (#786, merged): PolynomialAddSub + ArnoldBaileyAddSub
- **Phase D** (this PR): benchmark + design doc — closes #782 and unblocks #777
- **Phase E** (#783): CORDIC (deferred)

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`
- [ ] Close parent #777 after merge

Resolves #782
Relates to #777

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmark executable that measures throughput and accuracy of multiple log-domain add/sub algorithms, reports per-operation ops/sec, tracks max absolute/relative errors and mismatch counters, and emits results as Markdown tables.

* **Documentation**
  * Added design documentation for a configurable LNS add/sub framework describing five selectable algorithms, their accuracy/performance tradeoffs, and guidance for selecting implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->