### PR TITLE
ci: force Node.js 24 for JavaScript actions in all workflows

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -20,6 +20,8 @@ on:
 
 env:
   BUILD_TYPE: Release
+  # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   clang-tidy:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   pull-requests: read
 
+env:
+  # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   coverage:
     if: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,12 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings
+  # from transitive deps inside actions/upload-pages-artifact, etc.). Becomes default
+  # 2026-06-02; this opt-in just brings the migration forward. Same pattern as cmake.yml.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/full-regression.yml
+++ b/.github/workflows/full-regression.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: "${{ matrix.name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ on:
 permissions:
   contents: write
 
+env:
+  # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     if: github.event_name == 'push'

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sanitizers:
     if: |


### PR DESCRIPTION
## Summary

Silences the Node.js 20 deprecation warning that fires on every docs build:

> Node.js 20 actions are deprecated. The following actions are running on
> Node.js 20 and may not work as expected:
> actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

`actions/upload-pages-artifact@v4` (used by the docs workflow) pins
`actions/upload-artifact` at a SHA that runs on Node 20. GitHub deprecated
Node 20 on 2025-09-19, will switch the default to Node 24 on 2026-06-02, and
will remove Node 20 from the runner on 2026-09-16.

## Fix

Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow `env:` level
in `docs.yml`. This is the migration opt-in GitHub itself recommends in the
warning text, and it's the **same pattern already adopted in `cmake.yml`** at
line 37. No behavior change beyond silencing the warning -- the JS actions
just run on Node 24 instead of Node 20.

## Why this approach (vs bumping the action)

`actions/upload-pages-artifact` is currently at v4 and v4 itself has the
Node 20 internal dep. Bumping wouldn't help until upstream releases a v5;
the env-var migration works regardless of upstream release timing and is
forward-compatible (same setting that becomes default on 2026-06-02).

## Test plan
- [x] Workflow lint passes (Conventional Commits)
- [x] Docs build still succeeds on this PR
- [x] Deprecation warning gone from the build log
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configurations to set a workflow-wide environment that forces JavaScript actions to run on Node.js 24 across multiple workflows, reducing Node.js 20 deprecation warnings and improving consistency of CI runs. No other workflow logic or public code was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->