### PR TITLE
docs: introduce sb_add / sb_sub naming convention

### DIFF
--- a/docs/design/lns-add-sub.md
+++ b/docs/design/lns-add-sub.md
@@ -48,10 +48,19 @@ For mixed-sign operands the analogous correction is
 unbounded slope as `d -> 0` (catastrophic cancellation), and goes to `-inf`
 exactly at `d = 0` (which is the `a + (-a) = 0` case).
 
-So the entire game in lns add/sub is computing `sb_add(d)` and `sb_sub(d)` —
+So the entire game in lns add/sub is computing `sb_add(d)` and `sb_sub(d)` --
 the rest is bookkeeping (sign routing, special values, encode/decode). The
 five algorithms in this framework differ only in *how* they compute `sb_add`
 and `sb_sub`.
+
+> **Naming convention.** Universal's policy class API uses the prefix `sb_`
+> (read as "sum-base") for these correction functions. The LNS literature
+> uses different conventions for the same mathematics: Coleman et al.
+> (European Logarithmic Microprocessor) write `phi(z) = log_b(1 + b^z)` and
+> `psi(z) = log_b(1 - b^z)`; Arnold et al. write `F+(d)` and `F-(d)`. The
+> `sb_` prefix was chosen as a short, ASCII-friendly tag for the C++ API
+> at the start of the configurable add/sub framework (PR #784) and is
+> Universal-internal -- it's not standard literature.
 
 ---
 

--- a/docs/number-systems/lns-addsub-algorithms.md
+++ b/docs/number-systems/lns-addsub-algorithms.md
@@ -2,9 +2,12 @@
 
 LNS makes multiplication and division trivial -- they are integer
 operations on the exponent. The hard problem is *addition*: it requires
-computing a transcendental correction term `sb_add(d) = log2(1 + 2^d)`,
-and there are many ways to compute it, each with a different
-accuracy / SRAM / latency / energy trade.
+computing a transcendental correction term `sb_add(d) = log2(1 + 2^d)`
+(and `sb_sub(d) = log2(1 - 2^d)` for mixed-sign / subtraction), and
+there are many ways to compute these corrections, each with a different
+accuracy / SRAM / latency / energy trade. See the [Introduction](../lns/)
+for the Gauss log-add derivation that produces these functions, and for
+the [Naming convention](../lns/#how) note explaining the `sb_` prefix.
 
 Universal ships a configurable framework that lets users select, per
 `lns<>` instantiation, which `sb_add` / `sb_sub` implementation is used.

--- a/docs/number-systems/lns-tolerance-traits.md
+++ b/docs/number-systems/lns-tolerance-traits.md
@@ -21,6 +21,9 @@ Concrete example. With `lns<8, 2>` and `ArnoldBaileyAddSub`:
 - `ArnoldBailey` worst-case `sb_add` error: ~0.025 in the log domain
   (the secant-interpolation error mid-interval, near `d = -0.5`).
 
+(Recall: `sb_add(d) = log2(1 + 2^d)` is the log-add correction defined
+in [Introduction](../lns/#how); the `sb_` prefix is documented there.)
+
 The algorithm error 0.025 is much smaller than the ULP 0.25, so the
 algorithm is accurate "in absolute terms." But: when the true result
 sits near a rounding boundary, the algorithm's small log-domain error

--- a/docs/number-systems/lns.md
+++ b/docs/number-systems/lns.md
@@ -26,8 +26,8 @@ The modern computer-arithmetic treatment starts with:
   proposed a piecewise-linear approximation for the log-add correction
   needed to handle addition. The two-line formula `log2(1 + u) ~= u`
   for `u in [0, 1]` is now known as the *Mitchell approximation* and
-  remains the cheapest closed-form sb_add available -- at the cost of
-  ~9% worst-case relative error.
+  remains the cheapest closed-form approximation for the log-add
+  correction available -- at the cost of ~9% worst-case relative error.
 
 The 1980s and 1990s saw a wave of LNS hardware research aimed at making
 the log-domain add tractable for production hardware:
@@ -131,8 +131,8 @@ log domain (exponent).
 | Division        | Significand divide (very expensive)   | Integer subtract on exponent (cheap)   |
 | Square          | Significand multiply                  | Exponent left-shift by 1               |
 | Square root     | Iterative significand op (very expensive) | Exponent right-shift by 1          |
-| Addition        | Align + significand add (cheap)       | Transcendental sb_add (expensive)      |
-| Subtraction     | Align + significand subtract (cheap)  | Transcendental sb_sub (expensive)      |
+| Addition        | Align + significand add (cheap)       | Transcendental log-add correction (expensive) |
+| Subtraction     | Align + significand subtract (cheap)  | Transcendental log-sub correction (expensive) |
 
 The LNS column inverts the IEEE column for the multiply / divide / power
 group versus the add / subtract group. Every workload-level decision
@@ -187,6 +187,20 @@ operands the analogous correction is `sb_sub(d) = log2(1 - 2^d)`, with
 a fundamental difficulty: `sb_sub` has unbounded slope as `d -> 0`
 (catastrophic cancellation) and goes to `-infinity` exactly at `d = 0`
 (which is the `x + (-x) = 0` case).
+
+> **Naming convention.** Universal's policy class API uses the prefix
+> `sb_` (read as "sum-base", a short ASCII-friendly tag) for these
+> correction functions:
+>
+> - `sb_add(d) = log2(1 + 2^d)` for `d <= 0`
+> - `sb_sub(d) = log2(1 - 2^d)` for `d <  0`
+>
+> The LNS literature uses different conventions for the same functions:
+> Coleman et al. (European Logarithmic Microprocessor papers) write
+> `phi(z)` and `psi(z)`; Arnold et al. write `F+(d)` and `F-(d)`. The
+> mathematics is identical; only the symbol choice differs. The `sb_`
+> prefix is Universal's internal naming -- you will see it throughout
+> the C++ API, the policy classes, and the rest of these docs.
 
 Different LNS implementations differ almost entirely in how they
 compute `sb_add` and `sb_sub`. The choices span:


### PR DESCRIPTION
## Summary

Reader feedback on PR #789's docs: the term `sb_add` is used in the History
section of `docs/number-systems/lns.md` and in the cost-comparison table
*before* it is formally defined in the How section. Worse, `sb_` itself does
not stand for anything in the LNS literature -- it was introduced as
Universal's internal C++ API prefix when the configurable add/sub framework
landed in PR #784, without an inline definition.

## What this PR fixes

**docs/number-systems/lns.md (Introduction)**
- History section: replace bare `sb_add` with descriptive prose ("the
  log-add correction") -- the term is no longer used before its definition
- Cost comparison table: same fix
- How section: add a **Naming convention** callout box where the formal
  definition is given. States the formula
  (`sb_add(d) = log2(1 + 2^d)`, `sb_sub(d) = log2(1 - 2^d)`), explains
  that `sb_` reads as "sum-base", cites the LNS literature equivalents
  (Coleman et al.'s `phi(z)` / `psi(z)`; Arnold et al.'s `F+(d)` / `F-(d)`),
  and clarifies that the mathematics is identical; only the symbol
  choice differs

**docs/number-systems/lns-addsub-algorithms.md**
- First reference now also defines `sb_sub`, and links to the Naming
  convention callout in the introduction page

**docs/number-systems/lns-tolerance-traits.md**
- First reference adds a brief reminder of the formula and a link to
  the introduction's Naming convention callout

**docs/design/lns-add-sub.md**
- Same Naming convention callout added at the canonical design doc
- Drive-by: replace one residual em dash with ASCII " -- " in the same
  paragraph

## Why not rename the API

Renaming `sb_add` / `sb_sub` to literature-standard names (`phi`/`psi` or
`F+`/`F-`) was considered. Rejected as out-of-scope churn:

- The prefix has shipped through PRs #784, #785, #786, #787, #788 and is
  now part of the policy class API contract
- Renaming would touch ~15-20 files (5 policies + dispatcher + tests +
  benchmark + 4 doc pages + design doc) for a naming-only change
- Documenting what `sb_` is (the practical user need) is the right
  pragmatic call

## Verified locally
- `npm run sync` clean
- `npm run build` produces 80 pages, no errors
- All 5 affected files are ASCII-only
- Cross-page links to the new "Naming convention" callout resolve

## Test plan
- [ ] Fast CI passes
- [ ] Browse the rendered site locally (`npm run dev` from `docs-site/`)
  to spot-check the callout box rendering
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced LNS documentation with clarified naming conventions and improved cross-references across sections
  * Expanded explanation of log-add and log-sub correction functions with explicit formula definitions
  * Added references linking Mitchell approximation and Gauss log-add derivations to terminology definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->