### PR TITLE
feat(areal): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -2175,8 +2175,11 @@ inline std::istream& operator>>(std::istream& istr, const areal<nnbits,nes,nbt>&
 
 // areal-specific equality: bit-pattern equality, intentionally diverging
 // from IEEE-754 in two cases:
-//   - NaN == NaN returns true if the encodings match (areal has a unique
-//     NaN encoding, so this is meaningful and useful for testing)
+//   - NaN == NaN returns true when the encodings match (areal models both
+//     quiet and signalling NaN via setnan(NAN_TYPE_QUIET)/setnan(NAN_TYPE_SIGNALLING)
+//     and the corresponding isnan() variants; bit-pattern equality lets
+//     regression suites distinguish qNaN from sNaN). Two NaNs with different
+//     encodings (e.g., qNaN vs sNaN) compare unequal.
 //   - +0 != -0 (different bit patterns)
 // The ordering operators (<, <=, >, >=) below use IEEE-style semantics
 // (NaN ordering returns false). This mixed convention is intentional and

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -774,13 +774,13 @@ public:
 
 	// arithmetic operators
 	// prefix operator
-	inline areal operator-() const {
+	constexpr areal operator-() const noexcept {
 		areal tmp(*this);
 		tmp._block[MSU] ^= SIGN_BIT_MASK;
 		return tmp;
 	}
 
-	areal& operator+=(const areal& rhs) {
+	constexpr areal& operator+=(const areal& rhs) {
 		// special case handling of NaN
 		if (isnan() || rhs.isnan()) {
 			setnan();
@@ -823,10 +823,10 @@ public:
 
 		return *this;
 	}
-	areal& operator+=(double rhs) {
+	constexpr areal& operator+=(double rhs) {
 		return *this += areal(rhs);
 	}
-	areal& operator-=(const areal& rhs) {
+	constexpr areal& operator-=(const areal& rhs) {
 		// subtraction is addition with negated rhs
 		// but we need to handle NaN specially
 		if (rhs.isnan()) {
@@ -834,10 +834,10 @@ public:
 		}
 		return *this += -rhs;
 	}
-	areal& operator-=(double rhs) {
+	constexpr areal& operator-=(double rhs) {
 		return *this -= areal<nbits, es>(rhs);
 	}
-	areal& operator*=(const areal& rhs) {
+	constexpr areal& operator*=(const areal& rhs) {
 		// special case handling of NaN
 		if (isnan() || rhs.isnan()) {
 			setnan();
@@ -887,10 +887,10 @@ public:
 
 		return *this;
 	}
-	areal& operator*=(double rhs) {
+	constexpr areal& operator*=(double rhs) {
 		return *this *= areal<nbits, es>(rhs);
 	}
-	areal& operator/=(const areal& rhs) {
+	constexpr areal& operator/=(const areal& rhs) {
 		// special case handling of NaN
 		if (isnan() || rhs.isnan()) {
 			setnan();
@@ -950,14 +950,14 @@ public:
 
 		return *this;
 	}
-	areal& operator/=(double rhs) {
+	constexpr areal& operator/=(double rhs) {
 		return *this /= areal<nbits, es>(rhs);
 	}
 	/// <summary>
 	/// move to the next bit encoding modulo 2^nbits
 	/// </summary>
 	/// <typeparam name="bt"></typeparam>
-	inline areal& operator++() {
+	constexpr areal& operator++() {
 		if constexpr (0 == nrBlocks) {
 			return *this;
 		}
@@ -994,16 +994,53 @@ public:
 		}
 		return *this;
 	}
-	inline areal operator++(int) {
+	constexpr areal operator++(int) {
 		areal tmp(*this);
 		operator++();
 		return tmp;
 	}
-	inline areal& operator--() {
-
+	/// <summary>
+	/// move to the previous bit encoding modulo 2^nbits (the symmetric
+	/// inverse of operator++). 000...000 wraps to 111...111.
+	/// </summary>
+	constexpr areal& operator--() {
+		if constexpr (0 == nrBlocks) {
+			return *this;
+		}
+		else if constexpr (1 == nrBlocks) {
+			// special case: 000...000 wraps to 111...111
+			if ((_block[MSU] & MSU_MASK) == 0) {
+				_block[MSU] = MSU_MASK;
+			}
+			else {
+				--_block[MSU];
+			}
+		}
+		else {
+			bool borrow = true;
+			for (unsigned i = 0; i < MSU; ++i) {
+				if ((_block[i] & storageMask) == 0) { // block will underflow
+					_block[i] = static_cast<bt>(storageMask);
+				}
+				else {
+					--_block[i];
+					borrow = false;
+					break;
+				}
+			}
+			if (borrow) {
+				// encoding behaves like a 2's complement modulo wise
+				if ((_block[MSU] & MSU_MASK) == 0) {
+					_block[MSU] = MSU_MASK;
+				}
+				else {
+					--_block[MSU];
+				}
+			}
+		}
 		return *this;
 	}
-	inline areal operator--(int) {
+	constexpr areal operator--(int) {
 		areal tmp(*this);
 		operator--();
 		return tmp;
@@ -1948,17 +1985,17 @@ private:
 	friend std::istream& operator>> (std::istream& istr, areal<nnbits,nes,nbt>& r);
 
 	template<unsigned nnbits, unsigned nes, typename nbt>
-	friend bool operator==(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
+	friend constexpr bool operator==(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
 	template<unsigned nnbits, unsigned nes, typename nbt>
-	friend bool operator!=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
+	friend constexpr bool operator!=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
 	template<unsigned nnbits, unsigned nes, typename nbt>
-	friend bool operator< (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
+	friend constexpr bool operator< (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
 	template<unsigned nnbits, unsigned nes, typename nbt>
-	friend bool operator> (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
+	friend constexpr bool operator> (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
 	template<unsigned nnbits, unsigned nes, typename nbt>
-	friend bool operator<=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
+	friend constexpr bool operator<=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
 	template<unsigned nnbits, unsigned nes, typename nbt>
-	friend bool operator>=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
+	friend constexpr bool operator>=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs);
 };
 
 /// <summary>
@@ -1974,7 +2011,7 @@ private:
 /// <param name="tgt">the areal to convert to</param>
 /// <param name="inputUncertain">whether any input was uncertain (ubit was set)</param>
 template<unsigned srcbits, BlockTripleOperator op, unsigned nbits, unsigned es, typename bt>
-inline void convert(const blocktriple<srcbits, op, bt>& src, areal<nbits, es, bt>& tgt, bool inputUncertain = false) {
+constexpr void convert(const blocktriple<srcbits, op, bt>& src, areal<nbits, es, bt>& tgt, bool inputUncertain = false) {
 	using ArealType = areal<nbits, es, bt>;
 	// test special cases
 	if (src.isnan()) {
@@ -2137,7 +2174,7 @@ inline std::istream& operator>>(std::istream& istr, const areal<nnbits,nes,nbt>&
 }
 
 template<unsigned nnbits, unsigned nes, typename nbt>
-inline bool operator==(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { 
+constexpr bool operator==(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) {
 	for (unsigned i = 0; i < lhs.nrBlocks; ++i) {
 		if (lhs._block[i] != rhs._block[i]) {
 			return false;
@@ -2146,15 +2183,54 @@ inline bool operator==(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,
 	return true;
 }
 template<unsigned nnbits, unsigned nes, typename nbt>
-inline bool operator!=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator==(lhs, rhs); }
+constexpr bool operator!=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator==(lhs, rhs); }
+
+// Sign-magnitude comparison: directly compares the bit encoding rather than
+// going through arithmetic subtraction. This is constexpr-clean (the prior
+// (lhs - rhs).isneg() approach would require arithmetic to be constexpr in
+// every path, including the special-value handling inside operator-=, which
+// is fragile). Semantics:
+//   - NaN comparisons return false (IEEE-754)
+//   - +0 == -0 (so neither is less than the other)
+//   - Different signs: negative is less than positive
+//   - Same sign: compare magnitude bits (everything except sign bit).
+//     For positives: larger magnitude bits == larger value.
+//     For negatives: larger magnitude bits == smaller value (more negative).
 template<unsigned nnbits, unsigned nes, typename nbt>
-inline bool operator< (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return (lhs - rhs).isneg(); }
+constexpr bool operator< (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) {
+	if (lhs.isnan() || rhs.isnan()) return false;
+	bool lhsNeg = lhs.sign();
+	bool rhsNeg = rhs.sign();
+	if (lhsNeg != rhsNeg) {
+		// +0 == -0 in IEEE-754; neither is strictly less than the other.
+		if (lhs.iszero() && rhs.iszero()) return false;
+		return lhsNeg;
+	}
+	// Same sign: compare magnitude bits (sign masked off in the MSU).
+	using ArealType = areal<nnbits, nes, nbt>;
+	constexpr nbt MAGNITUDE_MSU_MASK =
+		static_cast<nbt>(ArealType::MSU_MASK & static_cast<nbt>(~ArealType::SIGN_BIT_MASK));
+	for (int i = static_cast<int>(ArealType::MSU); i >= 0; --i) {
+		nbt l = lhs._block[i];
+		nbt r = rhs._block[i];
+		if (i == static_cast<int>(ArealType::MSU)) {
+			l = static_cast<nbt>(l & MAGNITUDE_MSU_MASK);
+			r = static_cast<nbt>(r & MAGNITUDE_MSU_MASK);
+		}
+		if (l != r) {
+			// Positives: smaller magnitude bits => smaller value.
+			// Negatives: smaller magnitude bits => larger value (closer to zero).
+			return lhsNeg ? (l > r) : (l < r);
+		}
+	}
+	return false; // equal magnitudes
+}
 template<unsigned nnbits, unsigned nes, typename nbt>
-inline bool operator> (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return  operator< (rhs, lhs); }
+constexpr bool operator> (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return  operator< (rhs, lhs); }
 template<unsigned nnbits, unsigned nes, typename nbt>
-inline bool operator<=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator> (lhs, rhs); }
+constexpr bool operator<=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator> (lhs, rhs); }
 template<unsigned nnbits, unsigned nes, typename nbt>
-inline bool operator>=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator< (lhs, rhs); }
+constexpr bool operator>=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator< (lhs, rhs); }
 
 // posit - posit binary arithmetic operators
 // BINARY ADDITION

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -773,14 +773,16 @@ public:
 	}
 
 	// arithmetic operators
-	// prefix operator: negate by flipping the sign bit, EXCEPT for NaN.
-	// NaN kind is encoded in the sign bit (sNaN has sign bit set, qNaN has
-	// sign bit clear) so blindly XOR-ing SIGN_BIT_MASK on a NaN would
-	// silently flip sNaN -> qNaN and vice versa. -NaN is still NaN of the
-	// same kind, so we short-circuit.
+	// prefix operator: negate by flipping the sign bit (uniform for all
+	// values, INCLUDING NaN). For finite values this is straightforward
+	// arithmetic negation. For NaN, the sign bit doubles as the NaN-kind
+	// discriminator (sNaN has sign bit set, qNaN has sign bit clear; see
+	// setnan at line 1112), so unary -sNaN intentionally yields qNaN and
+	// vice versa. This is project-specific areal behavior and is locked
+	// in by static/range/areal/api/special_cases.cpp::TestNaN -- do NOT
+	// "fix" this to preserve NaN kind without first updating that test.
 	constexpr areal operator-() const noexcept {
 		areal tmp(*this);
-		if (tmp.isnan()) return tmp;
 		tmp._block[MSU] ^= SIGN_BIT_MASK;
 		return tmp;
 	}

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -2337,13 +2337,20 @@ template<unsigned nbits, unsigned es, typename bt>
 inline bool operator> (const areal<nbits, es, bt>& lhs, long long rhs) {
 	return operator<(areal<nbits, es, bt>(rhs), lhs);
 }
+// Forward scalar relational overloads to the primary areal/areal operators
+// rather than rebuilding the relations from operator< / operator==. The
+// rebuild approach was incorrect once operator== became bit-pattern equality
+// (so +0 != -0) and operator<= / >= acquired their own NaN-returns-false
+// guard: e.g., "lhs <= rhs" must NOT degrade to "lhs < rhs || lhs == rhs"
+// because for lhs=-0 and rhs=+0 that gives "false || false" while the
+// areal/areal operator<= correctly returns true.
 template<unsigned nbits, unsigned es, typename bt>
 inline bool operator<=(const areal<nbits, es, bt>& lhs, long long rhs) {
-	return operator<(lhs, areal<nbits, es, bt>(rhs)) || operator==(lhs, areal<nbits, es, bt>(rhs));
+	return operator<=(lhs, areal<nbits, es, bt>(rhs));
 }
 template<unsigned nbits, unsigned es, typename bt>
 inline bool operator>=(const areal<nbits, es, bt>& lhs, long long rhs) {
-	return !operator<(lhs, areal<nbits, es, bt>(rhs));
+	return operator>=(lhs, areal<nbits, es, bt>(rhs));
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -835,7 +835,7 @@ public:
 		return *this += -rhs;
 	}
 	constexpr areal& operator-=(double rhs) {
-		return *this -= areal<nbits, es>(rhs);
+		return *this -= areal(rhs);  // injected class name preserves bt
 	}
 	constexpr areal& operator*=(const areal& rhs) {
 		// special case handling of NaN
@@ -888,7 +888,7 @@ public:
 		return *this;
 	}
 	constexpr areal& operator*=(double rhs) {
-		return *this *= areal<nbits, es>(rhs);
+		return *this *= areal(rhs);  // injected class name preserves bt
 	}
 	constexpr areal& operator/=(const areal& rhs) {
 		// special case handling of NaN
@@ -951,7 +951,7 @@ public:
 		return *this;
 	}
 	constexpr areal& operator/=(double rhs) {
-		return *this /= areal<nbits, es>(rhs);
+		return *this /= areal(rhs);  // injected class name preserves bt
 	}
 	/// <summary>
 	/// move to the next bit encoding modulo 2^nbits
@@ -2173,6 +2173,14 @@ inline std::istream& operator>>(std::istream& istr, const areal<nnbits,nes,nbt>&
 	return istr;
 }
 
+// areal-specific equality: bit-pattern equality, intentionally diverging
+// from IEEE-754 in two cases:
+//   - NaN == NaN returns true if the encodings match (areal has a unique
+//     NaN encoding, so this is meaningful and useful for testing)
+//   - +0 != -0 (different bit patterns)
+// The ordering operators (<, <=, >, >=) below use IEEE-style semantics
+// (NaN ordering returns false). This mixed convention is intentional and
+// is locked in by the regression suite at static/range/areal/logic/logic.cpp.
 template<unsigned nnbits, unsigned nes, typename nbt>
 constexpr bool operator==(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) {
 	for (unsigned i = 0; i < lhs.nrBlocks; ++i) {
@@ -2227,36 +2235,44 @@ constexpr bool operator< (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,n
 }
 template<unsigned nnbits, unsigned nes, typename nbt>
 constexpr bool operator> (const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return  operator< (rhs, lhs); }
+// IEEE-754: any comparison involving NaN is false (including <= and >=);
+// otherwise <= is the negation of > and >= is the negation of <.
 template<unsigned nnbits, unsigned nes, typename nbt>
-constexpr bool operator<=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator> (lhs, rhs); }
+constexpr bool operator<=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) {
+	if (lhs.isnan() || rhs.isnan()) return false;
+	return !operator> (lhs, rhs);
+}
 template<unsigned nnbits, unsigned nes, typename nbt>
-constexpr bool operator>=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) { return !operator< (lhs, rhs); }
+constexpr bool operator>=(const areal<nnbits,nes,nbt>& lhs, const areal<nnbits,nes,nbt>& rhs) {
+	if (lhs.isnan() || rhs.isnan()) return false;
+	return !operator< (lhs, rhs);
+}
 
 // posit - posit binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, unsigned es, typename bt>
-inline areal<nbits, es, bt> operator+(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
+constexpr areal<nbits, es, bt> operator+(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
 	areal<nbits, es, bt> sum(lhs);
 	sum += rhs;
 	return sum;
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned es, typename bt>
-inline areal<nbits, es, bt> operator-(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
+constexpr areal<nbits, es, bt> operator-(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
 	areal<nbits, es, bt> diff(lhs);
 	diff -= rhs;
 	return diff;
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned es, typename bt>
-inline areal<nbits, es, bt> operator*(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
+constexpr areal<nbits, es, bt> operator*(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
 	areal<nbits, es, bt> mul(lhs);
 	mul *= rhs;
 	return mul;
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned es, typename bt>
-inline areal<nbits, es, bt> operator/(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
+constexpr areal<nbits, es, bt> operator/(const areal<nbits, es, bt>& lhs, const areal<nbits, es, bt>& rhs) {
 	areal<nbits, es, bt> ratio(lhs);
 	ratio /= rhs;
 	return ratio;

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -773,9 +773,14 @@ public:
 	}
 
 	// arithmetic operators
-	// prefix operator
+	// prefix operator: negate by flipping the sign bit, EXCEPT for NaN.
+	// NaN kind is encoded in the sign bit (sNaN has sign bit set, qNaN has
+	// sign bit clear) so blindly XOR-ing SIGN_BIT_MASK on a NaN would
+	// silently flip sNaN -> qNaN and vice versa. -NaN is still NaN of the
+	// same kind, so we short-circuit.
 	constexpr areal operator-() const noexcept {
 		areal tmp(*this);
+		if (tmp.isnan()) return tmp;
 		tmp._block[MSU] ^= SIGN_BIT_MASK;
 		return tmp;
 	}
@@ -2320,21 +2325,23 @@ areal<nbits,es> abs(const areal<nbits,es,bt>& v) {
 ///////////////////////////////////////////////////////////////////////
 ///   binary logic literal comparisons
 
-// posit - long logic operators
+// areal - long long logic operators. All forward to the primary areal/areal
+// operators (which are constexpr) and are themselves constexpr so they can
+// participate in constant evaluation (e.g., static_assert(a == 0LL)).
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator==(const areal<nbits, es, bt>& lhs, long long rhs) {
+constexpr bool operator==(const areal<nbits, es, bt>& lhs, long long rhs) {
 	return operator==(lhs, areal<nbits, es, bt>(rhs));
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator!=(const areal<nbits, es, bt>& lhs, long long rhs) {
+constexpr bool operator!=(const areal<nbits, es, bt>& lhs, long long rhs) {
 	return operator!=(lhs, areal<nbits, es, bt>(rhs));
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator< (const areal<nbits, es, bt>& lhs, long long rhs) {
+constexpr bool operator< (const areal<nbits, es, bt>& lhs, long long rhs) {
 	return operator<(lhs, areal<nbits, es, bt>(rhs));
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator> (const areal<nbits, es, bt>& lhs, long long rhs) {
+constexpr bool operator> (const areal<nbits, es, bt>& lhs, long long rhs) {
 	return operator<(areal<nbits, es, bt>(rhs), lhs);
 }
 // Forward scalar relational overloads to the primary areal/areal operators
@@ -2345,11 +2352,11 @@ inline bool operator> (const areal<nbits, es, bt>& lhs, long long rhs) {
 // because for lhs=-0 and rhs=+0 that gives "false || false" while the
 // areal/areal operator<= correctly returns true.
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator<=(const areal<nbits, es, bt>& lhs, long long rhs) {
+constexpr bool operator<=(const areal<nbits, es, bt>& lhs, long long rhs) {
 	return operator<=(lhs, areal<nbits, es, bt>(rhs));
 }
 template<unsigned nbits, unsigned es, typename bt>
-inline bool operator>=(const areal<nbits, es, bt>& lhs, long long rhs) {
+constexpr bool operator>=(const areal<nbits, es, bt>& lhs, long long rhs) {
 	return operator>=(lhs, areal<nbits, es, bt>(rhs));
 }
 

--- a/static/range/areal/api/constexpr.cpp
+++ b/static/range/areal/api/constexpr.cpp
@@ -166,6 +166,20 @@ namespace areal_constexpr_contract {
 	static_assert( post_next_value == one_dbl, "x++ must RETURN the prior encoding (not the new one)");
 	static_assert( post_prev_value == one_dbl, "x-- must RETURN the prior encoding (not the new one)");
 
+	// Zero-wrap path: the operator-- implementation has a special case where
+	// 000...000 wraps to 111...111 (mirror of operator++'s all-ones-wrap).
+	// This path does not get exercised by --1.0 above (which decrements
+	// within the normal range), so test it directly via setbits.
+	BIT_CAST_CONSTEXPR  SmokeReal dec_wrap = []() { SmokeReal x; x.setbits(0); --x; return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal all_ones = []() {
+		SmokeReal x;
+		// All nbits set: ((1 << nbits) - 1). For SmokeReal = areal<12,2>, that's
+		// 0xFFF -- representable as a uint64_t for nbits <= 64.
+		x.setbits((uint64_t(1) << SmokeReal::nbits) - 1u);
+		return x;
+	}();
+	static_assert( dec_wrap == all_ones, "--0 must wrap to the all-ones encoding (operator-- borrow path)");
+
 	// Binary (non-mutating) arithmetic operators. These are free functions
 	// that delegate to the compound forms; promoting them to constexpr lets
 	// expressions like `a + b` produce a constexpr result without an

--- a/static/range/areal/api/constexpr.cpp
+++ b/static/range/areal/api/constexpr.cpp
@@ -154,12 +154,17 @@ namespace areal_constexpr_contract {
 	static_assert( roundtrip == one_dbl, "++x; --x must round-trip");
 
 	// Postfix forms: lock in that operator++(int) and operator--(int) are
-	// also constexpr (they delegate to the prefix forms but the constexpr
-	// marker is on the wrapper too).
-	BIT_CAST_CONSTEXPR  SmokeReal post_next = []() { SmokeReal x(1.0); x++; return x; }();
-	BIT_CAST_CONSTEXPR  SmokeReal post_prev = []() { SmokeReal x(1.0); x--; return x; }();
-	static_assert( post_next == next,    "x++ and ++x must produce the same encoding");
-	static_assert( post_prev == prev,    "x-- and --x must produce the same encoding");
+	// constexpr AND that the postfix return-value contract holds (the
+	// returned value is the prior encoding; only the captured copy of x
+	// after the call is mutated).
+	BIT_CAST_CONSTEXPR  SmokeReal post_next       = []() { SmokeReal x(1.0); x++; return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal post_prev       = []() { SmokeReal x(1.0); x--; return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal post_next_value = []() { SmokeReal x(1.0); return x++; }();
+	BIT_CAST_CONSTEXPR  SmokeReal post_prev_value = []() { SmokeReal x(1.0); return x--; }();
+	static_assert( post_next       == next,    "x++ and ++x must produce the same final encoding");
+	static_assert( post_prev       == prev,    "x-- and --x must produce the same final encoding");
+	static_assert( post_next_value == one_dbl, "x++ must RETURN the prior encoding (not the new one)");
+	static_assert( post_prev_value == one_dbl, "x-- must RETURN the prior encoding (not the new one)");
 
 	// Binary (non-mutating) arithmetic operators. These are free functions
 	// that delegate to the compound forms; promoting them to constexpr lets
@@ -190,6 +195,26 @@ namespace areal_constexpr_contract {
 	static_assert( pos_zero != neg_zero,   "areal operator== is bit-pattern: +0 != -0");
 	static_assert(!(pos_zero <  neg_zero), "ordering: +0 not < -0");
 	static_assert(!(neg_zero <  pos_zero), "ordering: -0 not < +0");
+
+	// NaN convention. operator== is bit-pattern (so qNaN == qNaN with the
+	// same encoding is true; qNaN with one encoding != qNaN with another).
+	// operator< / <= / >= / > are IEEE-style (any comparison involving NaN
+	// is false). Construct distinct qNaN and sNaN encodings via setnan(int)
+	// rather than SpecificValue::qnan/snan (which both delegate to the
+	// default-NaN-type setnan() and produce identical encodings).
+	constexpr SmokeReal qnan = []() { SmokeReal x; x.setnan(sw::universal::NAN_TYPE_QUIET);       return x; }();
+	constexpr SmokeReal snan = []() { SmokeReal x; x.setnan(sw::universal::NAN_TYPE_SIGNALLING);  return x; }();
+	static_assert( qnan == qnan,           "bit-pattern: qNaN == qNaN (same encoding)");
+	static_assert(!(qnan != qnan),         "bit-pattern: !(qNaN != qNaN) for same encoding");
+	static_assert( qnan != snan,           "bit-pattern: qNaN != sNaN (different encodings)");
+	static_assert(!(qnan <  two_dbl),      "ordering: NaN < x is false");
+	static_assert(!(two_dbl <  qnan),      "ordering: x < NaN is false");
+	static_assert(!(qnan <= two_dbl),      "ordering: NaN <= x is false");
+	static_assert(!(two_dbl <= qnan),      "ordering: x <= NaN is false");
+	static_assert(!(qnan >  two_dbl),      "ordering: NaN > x is false");
+	static_assert(!(two_dbl >  qnan),      "ordering: x > NaN is false");
+	static_assert(!(qnan >= two_dbl),      "ordering: NaN >= x is false");
+	static_assert(!(two_dbl >= qnan),      "ordering: x >= NaN is false");
 
 }  // namespace areal_constexpr_contract
 #endif  // BIT_CAST_IS_CONSTEXPR

--- a/static/range/areal/api/constexpr.cpp
+++ b/static/range/areal/api/constexpr.cpp
@@ -92,6 +92,76 @@ void TestConstexprSpecificValues() {
 	}
 }
 
+// =============================================================================
+// static_assert smoke tests for the constexpr contract (issue #724)
+// =============================================================================
+// Lock in the operator-level constexpr promotion: construction (integer +
+// IEEE-754 via BIT_CAST_CONSTEXPR), arithmetic, comparison, unary negation,
+// and increment / decrement must all evaluate at compile time.
+//
+// Gated on BIT_CAST_IS_CONSTEXPR so the file still compiles on older
+// compilers that lack std::bit_cast or __builtin_bit_cast (the runtime
+// tests below still exercise the same operators in those builds).
+
+#if BIT_CAST_IS_CONSTEXPR
+namespace areal_constexpr_contract {
+
+	using sw::universal::areal;
+	using SmokeReal = areal<12, 2, std::uint8_t>;
+
+	// Construction: integer (already constexpr in current code) + IEEE-754
+	// (via BIT_CAST_CONSTEXPR -> __builtin_bit_cast).
+	constexpr           SmokeReal one_int(1);          // signed int ctor
+	BIT_CAST_CONSTEXPR  SmokeReal two_dbl(2.0);        // double via bit_cast
+	BIT_CAST_CONSTEXPR  SmokeReal three_dbl(3.0);
+
+	// Comparison: must be constexpr in same-sign and mixed-sign cases.
+	static_assert( two_dbl == two_dbl,   "operator== should be constexpr");
+	static_assert(!(two_dbl != two_dbl), "operator!= should be constexpr");
+	static_assert( two_dbl <  three_dbl, "operator<  should be constexpr (2.0 < 3.0)");
+	static_assert( three_dbl > two_dbl,  "operator>  should be constexpr (3.0 > 2.0)");
+	static_assert( two_dbl <= three_dbl, "operator<= should be constexpr");
+	static_assert( three_dbl >= two_dbl, "operator>= should be constexpr");
+
+	// Unary negation: must be constexpr and yield a strictly smaller value.
+	BIT_CAST_CONSTEXPR  SmokeReal neg_two = -two_dbl;
+	static_assert( neg_two <  two_dbl,   "unary operator- should be constexpr (-2 < 2)");
+	static_assert(-neg_two == two_dbl,   "double negation should round-trip");
+
+	// Compound arithmetic: wrap in immediately-invoked constexpr lambdas so
+	// the mutation produces a single constexpr result.
+	BIT_CAST_CONSTEXPR  SmokeReal sum  = []() { SmokeReal x(2.0); x += SmokeReal(3.0); return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal diff = []() { SmokeReal x(5.0); x -= SmokeReal(3.0); return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal prod = []() { SmokeReal x(2.0); x *= SmokeReal(3.0); return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal quot = []() { SmokeReal x(6.0); x /= SmokeReal(3.0); return x; }();
+
+	// The headline acceptance from #724: constexpr arithmetic on constexpr
+	// operands must produce a constexpr result.
+	static_assert( sum  >  two_dbl,      "constexpr 2 + 3 must be > 2");
+	static_assert( diff <  three_dbl,    "constexpr 5 - 3 must be < 3");
+	static_assert( prod >  three_dbl,    "constexpr 2 * 3 must be > 3");
+	static_assert( quot <  three_dbl,    "constexpr 6 / 3 must be < 3");
+
+	// Increment / decrement: prefix forms must be constexpr; the
+	// freshly-implemented operator-- must be the symmetric inverse of
+	// operator++ (as far as encoding ordering goes).
+	BIT_CAST_CONSTEXPR  SmokeReal next = []() { SmokeReal x(1.0); ++x; return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal prev = []() { SmokeReal x(1.0); --x; return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal one_dbl(1.0);
+	static_assert( next != one_dbl,      "++x must move x");
+	static_assert( prev != one_dbl,      "--x must move x");
+	BIT_CAST_CONSTEXPR  SmokeReal roundtrip = []() { SmokeReal x(1.0); ++x; --x; return x; }();
+	static_assert( roundtrip == one_dbl, "++x; --x must round-trip");
+
+	// Specific values are constexpr (already exercised by the runtime
+	// tests; static_assert here on the encoding equality just locks in
+	// that the SpecificValue constructor stays constexpr-clean).
+	constexpr SmokeReal zero_sv(sw::universal::SpecificValue::zero);
+	static_assert( zero_sv == zero_sv,   "SpecificValue ctor + ==  must be constexpr");
+
+}  // namespace areal_constexpr_contract
+#endif  // BIT_CAST_IS_CONSTEXPR
+
 // conditional compile flags
 #define MANUAL_TESTING 0
 #define STRESS_TESTING 0

--- a/static/range/areal/api/constexpr.cpp
+++ b/static/range/areal/api/constexpr.cpp
@@ -153,11 +153,43 @@ namespace areal_constexpr_contract {
 	BIT_CAST_CONSTEXPR  SmokeReal roundtrip = []() { SmokeReal x(1.0); ++x; --x; return x; }();
 	static_assert( roundtrip == one_dbl, "++x; --x must round-trip");
 
+	// Postfix forms: lock in that operator++(int) and operator--(int) are
+	// also constexpr (they delegate to the prefix forms but the constexpr
+	// marker is on the wrapper too).
+	BIT_CAST_CONSTEXPR  SmokeReal post_next = []() { SmokeReal x(1.0); x++; return x; }();
+	BIT_CAST_CONSTEXPR  SmokeReal post_prev = []() { SmokeReal x(1.0); x--; return x; }();
+	static_assert( post_next == next,    "x++ and ++x must produce the same encoding");
+	static_assert( post_prev == prev,    "x-- and --x must produce the same encoding");
+
+	// Binary (non-mutating) arithmetic operators. These are free functions
+	// that delegate to the compound forms; promoting them to constexpr lets
+	// expressions like `a + b` produce a constexpr result without an
+	// intermediate lambda.
+	BIT_CAST_CONSTEXPR  SmokeReal bin_sum  = two_dbl + three_dbl;
+	BIT_CAST_CONSTEXPR  SmokeReal bin_diff = SmokeReal(5.0) - three_dbl;
+	BIT_CAST_CONSTEXPR  SmokeReal bin_prod = two_dbl * three_dbl;
+	BIT_CAST_CONSTEXPR  SmokeReal bin_quot = SmokeReal(6.0) / three_dbl;
+	static_assert( bin_sum  == sum,      "binary +  should equal compound +=");
+	static_assert( bin_diff == diff,     "binary -  should equal compound -=");
+	static_assert( bin_prod == prod,     "binary *  should equal compound *=");
+	static_assert( bin_quot == quot,     "binary /  should equal compound /=");
+
 	// Specific values are constexpr (already exercised by the runtime
 	// tests; static_assert here on the encoding equality just locks in
 	// that the SpecificValue constructor stays constexpr-clean).
 	constexpr SmokeReal zero_sv(sw::universal::SpecificValue::zero);
 	static_assert( zero_sv == zero_sv,   "SpecificValue ctor + ==  must be constexpr");
+
+	// Mixed equality / ordering convention (locked in by logic/logic.cpp):
+	//   - operator== is bit-pattern equality (so +0 != -0)
+	//   - operator<  uses IEEE-style ordering (so neither +0 < -0 nor -0 < +0,
+	//     because zero values compare equal *as ordered quantities*)
+	// These constexpr asserts lock both halves of the convention.
+	BIT_CAST_CONSTEXPR  SmokeReal pos_zero(0.0);
+	BIT_CAST_CONSTEXPR  SmokeReal neg_zero = -pos_zero;
+	static_assert( pos_zero != neg_zero,   "areal operator== is bit-pattern: +0 != -0");
+	static_assert(!(pos_zero <  neg_zero), "ordering: +0 not < -0");
+	static_assert(!(neg_zero <  pos_zero), "ordering: -0 not < +0");
 
 }  // namespace areal_constexpr_contract
 #endif  // BIT_CAST_IS_CONSTEXPR


### PR DESCRIPTION
## Summary

Brings the `areal` type (faithful floating-point with uncertainty bit) to
fully constexpr across construction, arithmetic, comparison, and unary
negation. Part of Epic #723 (constexpr support across Universal number systems).

The headline acceptance criterion from #724:

```cpp
constexpr areal<12, 2> a(2.0), b(3.0);
constexpr auto c = a + b;
```

now compiles, and there are `static_assert` smoke tests in
`static/range/areal/api/constexpr.cpp` to lock in the contract.

## Approach

Followed the proven posit constexpr playbook (#714, #716, #717):

- All required building blocks were already constexpr (PR #716 promoted
  `blockbinary` arithmetic; `blocktriple::{add,sub,mul,div,at}` were
  already marked constexpr; `extractFields` is `BIT_CAST_CONSTEXPR`)
- Integer + IEEE-754 construction was already CONSTEXPRESSION-clean
- The work was therefore concentrated in two non-mechanical pieces plus
  mechanical promotion of the rest

## Changes (`include/sw/universal/number/areal/areal_impl.hpp`)

**Mechanical promotions** (just add `constexpr`):

- Unary `operator-()` (line 777) -- single bit-mask XOR
- `operator++` prefix and postfix (lines 960, 997)
- Compound arithmetic `+=`, `-=`, `*=`, `/=` and `double` overloads
  (lines 783, 826, 829, 837, 840, 890, 893, 953)
- Free `convert(blocktriple, areal, bool)` (line 1977) -- the keystone;
  every arithmetic op routes through it
- `operator==` and `operator!=` (lines 2140, 2149)
- Friend declarations updated to match

**Non-mechanical work** (functional changes needed for the constexpr contract):

- **`operator--` prefix implementation**: was an unimplemented stub
  returning `*this` with no decrement. Implemented as the symmetric
  inverse of `operator++` -- borrow-on-zero decrement on block storage
  with the modulo wrap-around (`000...000 -> 111...111`). Promoted
  postfix to `constexpr` in the same patch.

- **`operator<` family refactor**: prior implementation was
  `(lhs - rhs).isneg()` which routes through arithmetic. Replaced with
  a direct sign-magnitude bit comparison that is constexpr-clean,
  faster, and avoids the constexpr-fragile arithmetic path. Semantics:
  - NaN comparisons return `false` (IEEE-754)
  - `+0 == -0`
  - Different signs: negative < positive
  - Same sign: compare magnitude bits (sign masked off in the MSU); for
    positives larger magnitude bits == larger value; for negatives the
    sense inverts. `operator>`, `<=`, `>=` delegate to `operator<`.

## Out of scope (deferred to follow-up)

Conversion-out operators (`operator float`, `operator double`, etc.) are
NOT included. They need `ipow()` promotion plus a bit-cast pattern for
`signaling_NaN()`/`quiet_NaN()`. The headline `constexpr a + b` acceptance
does not need conversion-out; this can be a follow-up issue if desired.

## Static_assert smoke tests

Added an `areal_constexpr_contract` namespace in
`static/range/areal/api/constexpr.cpp` that locks in the compile-time
contract via `static_assert`. Covers:

- Integer + IEEE-754 `BIT_CAST_CONSTEXPR` construction
- All six comparison operators on constexpr operands
- Unary negation + double-negation round-trip
- Compound arithmetic `+=`, `-=`, `*=`, `/=` via immediately-invoked
  constexpr lambdas
- Prefix `++` and `--` with a `++; --` round-trip check
- `SpecificValue` construction + `==`

Gated on `BIT_CAST_IS_CONSTEXPR` so the file still compiles on older
compilers without `std::bit_cast` or `__builtin_bit_cast`.

## Verification

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `areal_constexpr` | OK | PASS (incl. static_asserts) | OK | PASS |
| `areal_api` | OK | PASS | OK | PASS |
| `areal_addition` | OK | PASS | OK | PASS |
| `areal_subtraction` | OK | PASS | OK | PASS |
| `areal_multiplication` | OK | PASS | OK | PASS |
| `areal_logic` | OK | PASS | OK | PASS |
| `areal_double_conversion` | OK | PASS | OK | PASS |
| `areal_float_conversion` | OK | PASS | OK | PASS |
| `areal_rounding` | OK | PASS | OK | PASS |

Cross-type sweep: no other types depend on `areal` internals; `blockbinary`
and `blocktriple` are unchanged.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #724
Relates to #723

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many arithmetic, increment/decrement, unary negation, and comparison operators are now constexpr (unary negation is noexcept); decrement implements proper symmetric wraparound and borrow behavior.
  * Free arithmetic operators (+ - * /) are constexpr and scalar relational overloads now forward to primary relations for consistent semantics.

* **Behavior**
  * Comparisons use bit-pattern semantics: +0 and -0 are distinguishable; any ordering involving NaN evaluates false.

* **Tests**
  * Added compile-time assertions validating constexpr behavior, operator semantics, and increment/decrement round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->