### PR TITLE
feat(td_cascade): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -629,10 +629,11 @@ namespace expansion_ops {
     }
 
     // Specialization for N=3 (triple-double)
+    // Replaces std::isinf with sw::universal::is_inf_cx (constexpr in C++20).
     template<>
-    inline floatcascade<3> renormalize<3>(const floatcascade<3>& e) {
+    constexpr inline floatcascade<3> renormalize<3>(const floatcascade<3>& e) {
         floatcascade<3> result = e;
-        if (std::isinf(result[0])) return result;
+        if (sw::universal::is_inf_cx(result[0])) return result;
 
         double s0, s1, s2 = 0.0;
 
@@ -785,7 +786,7 @@ namespace expansion_ops {
 
     // Compress 6-component cascade to 3 components following proven QD algorithm
     // Used by td_cascade for (3+3)→3 compression after addition/subtraction
-    inline floatcascade<3> compress_6to3(const floatcascade<6>& e) {
+    constexpr inline floatcascade<3> compress_6to3(const floatcascade<6>& e) {
         double r0 = e[0];
         double r1 = e[1];
         double r2 = e[2];
@@ -793,7 +794,7 @@ namespace expansion_ops {
         double r4 = e[4];
         double r5 = e[5];
 
-        double s0, s1, s2 = 0.0, s3;
+        double s0{}, s1{}, s2 = 0.0, s3{};
 
         // Phase 1: Bottom-up accumulation using fast_two_sum
         fast_two_sum(r4, r5, s0, r5);  // s0 = r4+r5, error->r5
@@ -1204,6 +1205,113 @@ namespace expansion_ops {
         result[0] = p0;
         result[1] = p1;
         return result;
+    }
+
+    // ---------------------------------------------------------------------
+    // Constexpr-friendly overloads for floatcascade<3> (used by td_cascade)
+    // ---------------------------------------------------------------------
+    //
+    // Same rationale as the floatcascade<2> overloads above: the generic
+    // templates use std::sort and std::vector and aren't constexpr in C++20.
+
+    // Add two floatcascade<3> -> floatcascade<6>.  Magnitude-sorted merge
+    // of the six limbs, then accumulates smallest-to-largest with two_sum.
+    // Bubble sort over 6 elements (5 passes) using ternary abs.
+    constexpr inline floatcascade<6> add_cascades(const floatcascade<3>& a, const floatcascade<3>& b) {
+        double m[6] = { a[0], a[1], a[2], b[0], b[1], b[2] };
+
+        auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
+
+        // Bubble sort 6 elements by descending magnitude (5 passes).
+        for (int pass = 0; pass < 5; ++pass) {
+            for (int j = 0; j < 5 - pass; ++j) {
+                if (absv(m[j]) < absv(m[j + 1])) {
+                    double t = m[j]; m[j] = m[j + 1]; m[j + 1] = t;
+                }
+            }
+        }
+
+        // Accumulate from smallest (m[5]) to largest (m[0]) with two_sum.
+        double sum = 0.0;
+        double corrections[5] = { 0.0, 0.0, 0.0, 0.0, 0.0 };
+        int nc = 0;
+
+        double new_sum = 0.0, error = 0.0;
+        for (int i = 5; i >= 0; --i) {
+            two_sum(sum, m[i], new_sum, error);
+            if (error != 0.0 && nc < 5) corrections[nc++] = error;
+            sum = new_sum;
+        }
+
+        floatcascade<6> result;
+        result[0] = sum;
+        // Store corrections in decreasing order of significance.
+        for (int i = 0; i < nc; ++i) {
+            result[i + 1] = corrections[nc - 1 - i];
+        }
+        // result[nc+1..5] already zero (default-constructed).
+
+        return result;
+    }
+
+    // Multiply two floatcascade<3> -> floatcascade<3>.  Adapted from the
+    // generic multiply_cascades algorithm: compute the 9 partial products
+    // (with two_prod for exact errors), accumulate diagonals, take the top
+    // 3 components.  Avoids std::sort/std::vector (use fixed-size arrays
+    // and a small bubble sort over the resulting expansion).
+    constexpr inline floatcascade<3> multiply_cascades(const floatcascade<3>& a, const floatcascade<3>& b) {
+        // Compute all 9 partial products with their error terms (18 doubles total).
+        double prod[9] = {};
+        double err[9]  = {};
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                two_prod(a[i], b[j], prod[i * 3 + j], err[i * 3 + j]);
+            }
+        }
+
+        // Build expansion: all 18 terms.
+        double expansion[18] = {};
+        int n_expansion = 0;
+        for (int k = 0; k < 9; ++k) {
+            if (prod[k] != 0.0) expansion[n_expansion++] = prod[k];
+            if (err[k]  != 0.0) expansion[n_expansion++] = err[k];
+        }
+
+        auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
+
+        // Sort expansion by descending magnitude (bubble sort over up to 18 elements).
+        for (int pass = 0; pass < n_expansion - 1; ++pass) {
+            for (int j = 0; j < n_expansion - 1 - pass; ++j) {
+                if (absv(expansion[j]) < absv(expansion[j + 1])) {
+                    double t = expansion[j]; expansion[j] = expansion[j + 1]; expansion[j + 1] = t;
+                }
+            }
+        }
+
+        // Accumulate sorted expansion into a 3-component result with carry
+        // propagation through two_sum chains.
+        floatcascade<3> result;
+        if (n_expansion > 0) {
+            result[0] = expansion[0];
+            for (int i = 1; i < n_expansion; ++i) {
+                double carry = expansion[i];
+                for (int j = 0; j < 3 && carry != 0.0; ++j) {
+                    double s = 0.0, e = 0.0;
+                    two_sum(result[j], carry, s, e);
+                    result[j] = s;
+                    carry = e;
+                }
+                // Sub-ULP carry below the last component is precision loss
+                // beyond what 3 doubles can represent; absorb into result[2].
+                if (carry != 0.0) {
+                    double s = 0.0, e = 0.0;
+                    two_sum(result[2], carry, s, e);
+                    result[2] = s;
+                }
+            }
+        }
+
+        return renormalize(result);
     }
 
 } // namespace expansion_ops

--- a/include/sw/universal/number/td_cascade/td_cascade_impl.hpp
+++ b/include/sw/universal/number/td_cascade/td_cascade_impl.hpp
@@ -7,17 +7,20 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include <array>
+#include <bit>
 #include <cmath>
 #include <iostream>
+#include <type_traits>
 #include <vector>
+#include <universal/utility/bit_cast.hpp>
 #include <universal/internal/floatcascade/floatcascade.hpp>
 
 namespace sw::universal {
 
 // Forward declarations
 inline bool signbit(const class td_cascade&);
-inline td_cascade operator-(const td_cascade&, const td_cascade&);
-inline td_cascade operator*(const td_cascade&, const td_cascade&);
+constexpr td_cascade operator-(const td_cascade&, const td_cascade&);
+constexpr td_cascade operator*(const td_cascade&, const td_cascade&);
 inline td_cascade pow(const td_cascade&, const td_cascade&);
 inline td_cascade frexp(const td_cascade&, int*);
 inline td_cascade ldexp(const td_cascade&, int);
@@ -126,31 +129,173 @@ public:
     constexpr td_cascade& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
     constexpr td_cascade& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
 
+private:
+    // Helper templates used by the conversion operators below.  Defined before
+    // the operators so the constexpr call chain is fully resolved at the point
+    // of operator declaration (clang requires this; gcc is more permissive).
+    //
+    // For triple-double, collapse the lower two limbs (mid + lo) into a single
+    // representative double via two_sum (sub-ULP error discarded), then apply
+    // the dd-style limb-separated truncation.  This produces exact integer
+    // values across the td_cascade's full 159-bit range on every platform.
+    template<typename Unsigned>
+    constexpr Unsigned convert_to_unsigned_impl() const noexcept {
+        const double hi = cascade[0];
+        // Collapse mid + lo into a single representative double.  The sub-ULP
+        // error from this collapse cannot affect integer truncation.
+        double lo_combined = 0.0, lo_err = 0.0;
+        expansion_ops::two_sum(cascade[1], cascade[2], lo_combined, lo_err);
+        (void)lo_err;
+        const double lo = lo_combined;
+
+        bool hi_finite;
+        if (std::is_constant_evaluated()) {
+            constexpr double inf = std::numeric_limits<double>::infinity();
+            hi_finite = !(hi != hi) && hi != inf && hi != -inf;
+        }
+        else {
+            hi_finite = std::isfinite(hi);
+        }
+        if (!hi_finite) {
+            return hi < 0.0 ? Unsigned(0) : (std::numeric_limits<Unsigned>::max)();
+        }
+        if (hi < 0.0) return Unsigned(0);
+
+        constexpr double unsigned_max_d = static_cast<double>((std::numeric_limits<Unsigned>::max)());
+        if (hi > unsigned_max_d) return (std::numeric_limits<Unsigned>::max)();
+        if (hi == unsigned_max_d) {
+            if (lo >= 0.0) return (std::numeric_limits<Unsigned>::max)();
+            double abs_lo = -lo;
+            if (abs_lo >= unsigned_max_d) return Unsigned(0);
+            Unsigned abs_lo_int = static_cast<Unsigned>(abs_lo);
+            double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+            Unsigned result = (std::numeric_limits<Unsigned>::max)();
+            if (abs_lo_frac == 0.0) return result - (abs_lo_int - 1);
+            return result - abs_lo_int;
+        }
+
+        Unsigned hi_int = static_cast<Unsigned>(hi);
+        double hi_frac = hi - static_cast<double>(hi_int);
+
+        if (lo >= 0.0) {
+            if (lo >= unsigned_max_d) return (std::numeric_limits<Unsigned>::max)();
+            Unsigned lo_int = static_cast<Unsigned>(lo);
+            double lo_frac = lo - static_cast<double>(lo_int);
+            double frac_sum = hi_frac + lo_frac;
+            if (lo_int > (std::numeric_limits<Unsigned>::max)() - hi_int) {
+                return (std::numeric_limits<Unsigned>::max)();
+            }
+            Unsigned sum = hi_int + lo_int;
+            if (frac_sum >= 1.0) {
+                if (sum == (std::numeric_limits<Unsigned>::max)()) return sum;
+                return sum + 1;
+            }
+            return sum;
+        }
+        else {
+            double abs_lo = -lo;
+            if (abs_lo >= unsigned_max_d) return Unsigned(0);
+            Unsigned abs_lo_int = static_cast<Unsigned>(abs_lo);
+            double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+            if (hi_int < abs_lo_int) return Unsigned(0);
+            if (hi_int == abs_lo_int) return Unsigned(0);
+            Unsigned diff = hi_int - abs_lo_int;
+            if (hi_frac < abs_lo_frac) return diff - 1;
+            return diff;
+        }
+    }
+
+    template<typename Signed>
+    constexpr Signed convert_to_signed_impl() const noexcept {
+        const double hi = cascade[0];
+        double lo_combined = 0.0, lo_err = 0.0;
+        expansion_ops::two_sum(cascade[1], cascade[2], lo_combined, lo_err);
+        (void)lo_err;
+        const double lo = lo_combined;
+
+        bool hi_finite;
+        if (std::is_constant_evaluated()) {
+            constexpr double inf = std::numeric_limits<double>::infinity();
+            hi_finite = !(hi != hi) && hi != inf && hi != -inf;
+        }
+        else {
+            hi_finite = std::isfinite(hi);
+        }
+        if (!hi_finite) {
+            return hi < 0.0 ? (std::numeric_limits<Signed>::min)() : (std::numeric_limits<Signed>::max)();
+        }
+
+        constexpr double signed_max_d = static_cast<double>((std::numeric_limits<Signed>::max)());
+        constexpr double signed_min_d = static_cast<double>((std::numeric_limits<Signed>::min)());
+
+        if (hi > signed_max_d) return (std::numeric_limits<Signed>::max)();
+        if (hi == signed_max_d) {
+            if (lo >= 0.0) return (std::numeric_limits<Signed>::max)();
+            double abs_lo = -lo;
+            if (abs_lo >= signed_max_d) return (std::numeric_limits<Signed>::min)();
+            Signed abs_lo_int = static_cast<Signed>(abs_lo);
+            double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+            Signed result = (std::numeric_limits<Signed>::max)();
+            if (abs_lo_frac == 0.0) return result - (abs_lo_int - 1);
+            return result - abs_lo_int;
+        }
+        if (hi < signed_min_d) return (std::numeric_limits<Signed>::min)();
+
+        Signed hi_int = static_cast<Signed>(hi);
+        if (lo >= signed_max_d) return (std::numeric_limits<Signed>::max)();
+        if (lo < signed_min_d) return (std::numeric_limits<Signed>::min)();
+        Signed lo_int = static_cast<Signed>(lo);
+        if (lo_int > 0 && hi_int > (std::numeric_limits<Signed>::max)() - lo_int) {
+            return (std::numeric_limits<Signed>::max)();
+        }
+        if (lo_int < 0 && hi_int < (std::numeric_limits<Signed>::min)() - lo_int) {
+            return (std::numeric_limits<Signed>::min)();
+        }
+        Signed sum = hi_int + lo_int;
+
+        double hi_frac = hi - static_cast<double>(hi_int);
+        double lo_frac = lo - static_cast<double>(lo_int);
+        double frac_sum = hi_frac + lo_frac;
+
+        if (frac_sum >= 1.0) {
+            if (sum == (std::numeric_limits<Signed>::max)()) return sum;
+            return sum + 1;
+        }
+        if (frac_sum <= -1.0) {
+            if (sum == (std::numeric_limits<Signed>::min)()) return sum;
+            return sum - 1;
+        }
+        if (sum > 0 && frac_sum < 0.0) return sum - 1;
+        if (sum < 0 && frac_sum > 0.0) return sum + 1;
+        return sum;
+    }
+
+public:
     // conversion operators
-    explicit operator int()                   const noexcept { return convert_to_signed<int>(); }
-    explicit operator long()                  const noexcept { return convert_to_signed<long>(); }
-    explicit operator long long()             const noexcept { return convert_to_signed<long long>(); }
-    explicit operator unsigned int()          const noexcept { return convert_to_unsigned<unsigned int>(); }
-    explicit operator unsigned long()         const noexcept { return convert_to_unsigned<unsigned long>(); }
-    explicit operator unsigned long long()    const noexcept { return convert_to_unsigned<unsigned long long>(); }
-    explicit operator float()                 const noexcept { return convert_to_ieee754<float>(); }
-    explicit operator double()                const noexcept { return convert_to_ieee754<double>(); }
+    explicit constexpr operator int()                   const noexcept { return convert_to_signed_impl<int>(); }
+    explicit constexpr operator long()                  const noexcept { return convert_to_signed_impl<long>(); }
+    explicit constexpr operator long long()             const noexcept { return convert_to_signed_impl<long long>(); }
+    explicit constexpr operator unsigned int()          const noexcept { return convert_to_unsigned_impl<unsigned int>(); }
+    explicit constexpr operator unsigned long()         const noexcept { return convert_to_unsigned_impl<unsigned long>(); }
+    explicit constexpr operator unsigned long long()    const noexcept { return convert_to_unsigned_impl<unsigned long long>(); }
+    explicit constexpr operator float()                 const noexcept { return static_cast<float>(cascade.to_double()); }
+    explicit constexpr operator double()                const noexcept { return cascade.to_double(); }
 
     td_cascade& operator=(const td_cascade&) = default;
     td_cascade& operator=(td_cascade&&) = default;
 
     // Assignment from floatcascade
-    td_cascade& operator=(const floatcascade<3>& fc) {
+    constexpr td_cascade& operator=(const floatcascade<3>& fc) {
         cascade = fc;
         return *this;
     }
 
     // Extract floatcascade
-    const floatcascade<3>& get_cascade() const { return cascade; }
-    operator floatcascade<3>() const { return cascade; }
+    constexpr const floatcascade<3>& get_cascade() const { return cascade; }
+    constexpr operator floatcascade<3>() const { return cascade; }
 
     // Assignment from dd_cascade
-    td_cascade& operator=(const floatcascade<2>& dd_cascade) {
+    constexpr td_cascade& operator=(const floatcascade<2>& dd_cascade) {
         cascade[0] = dd_cascade[0];
         cascade[1] = dd_cascade[1];
         cascade[2] = 0.0;
@@ -168,14 +313,14 @@ public:
     }
 
     // Compound assignment operators
-    td_cascade& operator+=(const td_cascade& rhs) noexcept {
+    CONSTEXPRESSION td_cascade& operator+=(const td_cascade& rhs) noexcept {
         auto result = expansion_ops::add_cascades(cascade, rhs.cascade);  // 6 components
         // Compress to 3 components using proven QD algorithm
         cascade = expansion_ops::compress_6to3(result);
         return *this;
     }
 
-    td_cascade& operator-=(const td_cascade& rhs) noexcept {
+    CONSTEXPRESSION td_cascade& operator-=(const td_cascade& rhs) noexcept {
         floatcascade<3> neg_rhs;
         neg_rhs[0]   = -rhs.cascade[0];
         neg_rhs[1]   = -rhs.cascade[1];
@@ -187,12 +332,12 @@ public:
         return *this;
     }
 
-    td_cascade& operator*=(const td_cascade& rhs) noexcept {
+    CONSTEXPRESSION td_cascade& operator*=(const td_cascade& rhs) noexcept {
         *this = expansion_ops::multiply_cascades(cascade, rhs.cascade);
         return *this;
     }
 
-    td_cascade& operator/=(const td_cascade& rhs) noexcept {
+    CONSTEXPRESSION td_cascade& operator/=(const td_cascade& rhs) noexcept {
         if (isnan())
             return *this;
         if (rhs.isnan())
@@ -201,7 +346,20 @@ public:
             if (iszero()) {
                 *this = td_cascade(SpecificValue::qnan);
             } else {
-                *this = td_cascade(sign() == rhs.sign() ? SpecificValue::infpos : SpecificValue::infneg);
+                // Determine sign of result.  At runtime use std::copysign;
+                // during constant evaluation use std::bit_cast to extract
+                // the IEEE-754 sign bit so -0.0 carries through correctly
+                // (per #727 / #797 lessons).
+                int sA, sB;
+                if (std::is_constant_evaluated()) {
+                    sA = (std::bit_cast<std::uint64_t>(cascade[0])     >> 63) ? -1 : 1;
+                    sB = (std::bit_cast<std::uint64_t>(rhs.cascade[0]) >> 63) ? -1 : 1;
+                }
+                else {
+                    sA = (std::copysign(1.0, cascade[0])     < 0.0) ? -1 : 1;
+                    sB = (std::copysign(1.0, rhs.cascade[0]) < 0.0) ? -1 : 1;
+                }
+                *this = td_cascade((sA == sB) ? SpecificValue::infpos : SpecificValue::infneg);
             }
             return *this;
         }
@@ -234,6 +392,12 @@ public:
         return *this;
     }
 
+    // Compound assignment with double
+    CONSTEXPRESSION td_cascade& operator+=(double rhs) noexcept { return *this += td_cascade(rhs); }
+    CONSTEXPRESSION td_cascade& operator-=(double rhs) noexcept { return *this -= td_cascade(rhs); }
+    CONSTEXPRESSION td_cascade& operator*=(double rhs) noexcept { return *this *= td_cascade(rhs); }
+    CONSTEXPRESSION td_cascade& operator/=(double rhs) noexcept { return *this /= td_cascade(rhs); }
+
     // modifiers
     constexpr void clear()                                         noexcept { cascade.clear(); }
     constexpr void setzero()                                       noexcept { cascade.clear(); }
@@ -265,8 +429,8 @@ public:
     }
 
     // argument is not protected for speed
-    double operator[](size_t index) const { return cascade[index]; }
-    double& operator[](size_t index) { return cascade[index]; }
+    constexpr double operator[](size_t index) const { return cascade[index]; }
+    constexpr double& operator[](size_t index) { return cascade[index]; }
 
     // create specific number system values of interest
     constexpr td_cascade& maxpos() noexcept {
@@ -373,27 +537,11 @@ protected:
     }
 #endif
 
-    // convert to native unsigned integer, use C++ conversion rules to cast down to float and double
-    template<typename Unsigned>
-    Unsigned convert_to_unsigned() const noexcept {
-        int64_t h = static_cast<int64_t>(cascade[0]);
-        int64_t l = static_cast<int64_t>(cascade[1]);
-        return Unsigned(h + l);
-    }
-
-    // convert to native unsigned integer, use C++ conversion rules to cast down to float and double
-    template<typename Signed>
-    Signed convert_to_signed() const noexcept {
-        int64_t h = static_cast<int64_t>(cascade[0]);
-        int64_t l = static_cast<int64_t>(cascade[1]);
-        return Signed(h + l);
-    }
-
-    // convert to native floating-point, use C++ conversion rules to cast down to float and double
-    template<typename Real>
-    Real convert_to_ieee754() const noexcept {
-        return Real(cascade.to_double());
-    }
+    // (convert_to_unsigned_impl / convert_to_signed_impl moved up next to the
+    // conversion operators that call them, so the constexpr call chain is
+    // fully resolved at the point of declaration.  The old int64_t-cast
+    // helpers had two bugs: they ignored cascade[2] and could trigger UB
+    // per C++20 [conv.fpint] for unnormalized inputs.)
 
 public:
     // Decimal conversion - delegates to floatcascade base class
@@ -431,52 +579,52 @@ private:
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // td_cascade - td_cascade binary arithmetic operators
 
-inline td_cascade operator+(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr td_cascade operator+(const td_cascade& lhs, const td_cascade& rhs) {
     td_cascade sum = lhs;
     sum += rhs;
     return sum;
 }
 
-inline td_cascade operator-(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr td_cascade operator-(const td_cascade& lhs, const td_cascade& rhs) {
     td_cascade diff = lhs;
     diff -= rhs;
     return diff;
 }
 
-inline td_cascade operator*(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr td_cascade operator*(const td_cascade& lhs, const td_cascade& rhs) {
     td_cascade mul = lhs;
     mul *= rhs;
     return mul;
 }
 
-inline td_cascade operator/(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr td_cascade operator/(const td_cascade& lhs, const td_cascade& rhs) {
     td_cascade div = lhs;
     div /= rhs;
     return div;
 }
 
 // td_cascade-double mixed operations
-inline td_cascade operator+(const td_cascade& lhs, double rhs) { return operator+(lhs, td_cascade(rhs)); }
-inline td_cascade operator-(const td_cascade& lhs, double rhs) { return operator-(lhs, td_cascade(rhs)); }
-inline td_cascade operator*(const td_cascade& lhs, double rhs) { return operator*(lhs, td_cascade(rhs)); }
-inline td_cascade operator/(const td_cascade& lhs, double rhs) { return operator/(lhs, td_cascade(rhs)); }
+constexpr td_cascade operator+(const td_cascade& lhs, double rhs) { return operator+(lhs, td_cascade(rhs)); }
+constexpr td_cascade operator-(const td_cascade& lhs, double rhs) { return operator-(lhs, td_cascade(rhs)); }
+constexpr td_cascade operator*(const td_cascade& lhs, double rhs) { return operator*(lhs, td_cascade(rhs)); }
+constexpr td_cascade operator/(const td_cascade& lhs, double rhs) { return operator/(lhs, td_cascade(rhs)); }
 
 // double-td_cascade mixed operations
-inline td_cascade operator+(double lhs, const td_cascade& rhs) { return operator+(td_cascade(lhs), rhs); }
-inline td_cascade operator-(double lhs, const td_cascade& rhs) { return operator-(td_cascade(lhs), rhs); }
-inline td_cascade operator*(double lhs, const td_cascade& rhs) { return operator*(td_cascade(lhs), rhs); }
-inline td_cascade operator/(double lhs, const td_cascade& rhs) { return operator/(td_cascade(lhs), rhs); }
+constexpr td_cascade operator+(double lhs, const td_cascade& rhs) { return operator+(td_cascade(lhs), rhs); }
+constexpr td_cascade operator-(double lhs, const td_cascade& rhs) { return operator-(td_cascade(lhs), rhs); }
+constexpr td_cascade operator*(double lhs, const td_cascade& rhs) { return operator*(td_cascade(lhs), rhs); }
+constexpr td_cascade operator/(double lhs, const td_cascade& rhs) { return operator/(td_cascade(lhs), rhs); }
 
 // Comparison operators
-inline bool operator==(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr bool operator==(const td_cascade& lhs, const td_cascade& rhs) {
     return lhs[0] == rhs[0] && lhs[1] == rhs[1] && lhs[2] == rhs[2];
 }
 
-inline bool operator!=(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr bool operator!=(const td_cascade& lhs, const td_cascade& rhs) {
     return !(lhs == rhs);
 }
 
-inline bool operator<(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr bool operator<(const td_cascade& lhs, const td_cascade& rhs) {
     if (lhs[0] < rhs[0]) return true;
     if (lhs[0] > rhs[0]) return false;
     if (lhs[1] < rhs[1]) return true;
@@ -484,32 +632,34 @@ inline bool operator<(const td_cascade& lhs, const td_cascade& rhs) {
     return lhs[2] < rhs[2];
 }
 
-inline bool operator>(const td_cascade& lhs, const td_cascade& rhs) {
+constexpr bool operator>(const td_cascade& lhs, const td_cascade& rhs) {
     return rhs < lhs;
 }
 
-inline bool operator<=(const td_cascade& lhs, const td_cascade& rhs) {
-    return !(rhs < lhs);
+constexpr bool operator<=(const td_cascade& lhs, const td_cascade& rhs) {
+    // NOT !operator>: that returns true for unordered (NaN) operands. Use
+    // operator< || operator== so NaN comparisons stay unordered (per #797).
+    return operator<(lhs, rhs) || operator==(lhs, rhs);
 }
 
-inline bool operator>=(const td_cascade& lhs, const td_cascade& rhs) {
-    return !(lhs < rhs);
+constexpr bool operator>=(const td_cascade& lhs, const td_cascade& rhs) {
+    return operator>(lhs, rhs) || operator==(lhs, rhs);
 }
 
 // Comparison with double
-inline bool operator==(const td_cascade& lhs, double rhs) { return lhs == td_cascade(rhs); }
-inline bool operator!=(const td_cascade& lhs, double rhs) { return lhs != td_cascade(rhs); }
-inline bool operator<(const td_cascade& lhs, double rhs) { return lhs < td_cascade(rhs); }
-inline bool operator>(const td_cascade& lhs, double rhs) { return lhs > td_cascade(rhs); }
-inline bool operator<=(const td_cascade& lhs, double rhs) { return lhs <= td_cascade(rhs); }
-inline bool operator>=(const td_cascade& lhs, double rhs) { return lhs >= td_cascade(rhs); }
+constexpr bool operator==(const td_cascade& lhs, double rhs) { return lhs == td_cascade(rhs); }
+constexpr bool operator!=(const td_cascade& lhs, double rhs) { return lhs != td_cascade(rhs); }
+constexpr bool operator<(const td_cascade& lhs, double rhs) { return lhs < td_cascade(rhs); }
+constexpr bool operator>(const td_cascade& lhs, double rhs) { return lhs > td_cascade(rhs); }
+constexpr bool operator<=(const td_cascade& lhs, double rhs) { return operator<(lhs, td_cascade(rhs)) || operator==(lhs, td_cascade(rhs)); }
+constexpr bool operator>=(const td_cascade& lhs, double rhs) { return operator>(lhs, td_cascade(rhs)) || operator==(lhs, td_cascade(rhs)); }
 
-inline bool operator==(double lhs, const td_cascade& rhs) { return td_cascade(lhs) == rhs; }
-inline bool operator!=(double lhs, const td_cascade& rhs) { return td_cascade(lhs) != rhs; }
-inline bool operator<(double lhs, const td_cascade& rhs) { return td_cascade(lhs) < rhs; }
-inline bool operator>(double lhs, const td_cascade& rhs) { return td_cascade(lhs) > rhs; }
-inline bool operator<=(double lhs, const td_cascade& rhs) { return td_cascade(lhs) <= rhs; }
-inline bool operator>=(double lhs, const td_cascade& rhs) { return td_cascade(lhs) >= rhs; }
+constexpr bool operator==(double lhs, const td_cascade& rhs) { return td_cascade(lhs) == rhs; }
+constexpr bool operator!=(double lhs, const td_cascade& rhs) { return td_cascade(lhs) != rhs; }
+constexpr bool operator<(double lhs, const td_cascade& rhs) { return td_cascade(lhs) < rhs; }
+constexpr bool operator>(double lhs, const td_cascade& rhs) { return td_cascade(lhs) > rhs; }
+constexpr bool operator<=(double lhs, const td_cascade& rhs) { return operator<(td_cascade(lhs), rhs) || operator==(td_cascade(lhs), rhs); }
+constexpr bool operator>=(double lhs, const td_cascade& rhs) { return operator>(td_cascade(lhs), rhs) || operator==(td_cascade(lhs), rhs); }
 
 
 // standard attribute function overloads

--- a/static/highprecision/td_cascade/api/constexpr.cpp
+++ b/static/highprecision/td_cascade/api/constexpr.cpp
@@ -1,0 +1,271 @@
+// constexpr.cpp: compile-time tests for td_cascade (triple-double via floatcascade<3>)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// Configure td_cascade: throwing arithmetic exceptions disabled so divide-by-zero
+// has defined constexpr-safe behavior (returns +/-inf or NaN encoding) rather
+// than throwing, which would be ill-formed in a constant expression.
+#define TD_CASCADE_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/td_cascade/td_cascade.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "td_cascade constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// td_cascade is a (1, 11, 159) floating-point triple stored as a
+	// floatcascade<3> -- an unevaluated sum of three IEEE-754 doubles.
+
+	// ----------------------------------------------------------------------------
+	// Native int construction (already constexpr -- smoke test only)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr td_cascade a(0);
+		constexpr td_cascade b(1);
+		constexpr td_cascade c(-3);
+		(void)a; (void)b; (void)c;
+	}
+
+	// ----------------------------------------------------------------------------
+	// Acceptance form from issue #742:
+	//   constexpr td_cascade a(2.0), b(3.0); constexpr auto c = a + b;
+	// (and analogous for *, -, /, +=, <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr td_cascade a(2.0);
+		constexpr td_cascade b(3.0);
+		constexpr auto cx_sum = a + b;
+		static_assert(cx_sum == td_cascade(5.0), "issue #742 acceptance: a + b");
+	}
+
+	// ----------------------------------------------------------------------------
+	// All four binary arithmetic operators in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr td_cascade a(4.5);
+		constexpr td_cascade b(1.5);
+		constexpr auto cx_sum  = a + b;          // 4.5 + 1.5 = 6.0
+		constexpr auto cx_diff = a - b;          // 4.5 - 1.5 = 3.0
+		constexpr auto cx_prod = a * b;          // 4.5 * 1.5 = 6.75
+		constexpr auto cx_quot = a / b;          // 4.5 / 1.5 = 3.0
+		constexpr auto cx_neg  = -a;             // -4.5
+		static_assert(cx_sum  == td_cascade(6.0),  "constexpr +  failed");
+		static_assert(cx_diff == td_cascade(3.0),  "constexpr -  failed");
+		static_assert(cx_prod == td_cascade(6.75), "constexpr *  failed");
+		static_assert(cx_quot == td_cascade(3.0),  "constexpr /  failed");
+		static_assert(cx_neg  == td_cascade(-4.5), "constexpr unary - failed");
+
+		// Compound assignment via lambda (constexpr lambdas are C++20)
+		constexpr td_cascade cx_addeq = []() { td_cascade t(1.5); t += td_cascade(3.0); return t; }();
+		constexpr td_cascade cx_subeq = []() { td_cascade t(4.5); t -= td_cascade(1.5); return t; }();
+		constexpr td_cascade cx_muleq = []() { td_cascade t(1.5); t *= td_cascade(3.0); return t; }();
+		constexpr td_cascade cx_diveq = []() { td_cascade t(4.5); t /= td_cascade(1.5); return t; }();
+		static_assert(cx_addeq == td_cascade(4.5), "constexpr += failed");
+		static_assert(cx_subeq == td_cascade(3.0), "constexpr -= failed");
+		static_assert(cx_muleq == td_cascade(4.5), "constexpr *= failed");
+		static_assert(cx_diveq == td_cascade(3.0), "constexpr /= failed");
+
+		// Compound assignment with double rhs
+		constexpr td_cascade cx_addeqd = []() { td_cascade t(1.5); t += 3.0; return t; }();
+		constexpr td_cascade cx_subeqd = []() { td_cascade t(4.5); t -= 1.5; return t; }();
+		constexpr td_cascade cx_muleqd = []() { td_cascade t(1.5); t *= 3.0; return t; }();
+		constexpr td_cascade cx_diveqd = []() { td_cascade t(4.5); t /= 1.5; return t; }();
+		static_assert(cx_addeqd == td_cascade(4.5), "constexpr += double failed");
+		static_assert(cx_subeqd == td_cascade(3.0), "constexpr -= double failed");
+		static_assert(cx_muleqd == td_cascade(4.5), "constexpr *= double failed");
+		static_assert(cx_diveqd == td_cascade(3.0), "constexpr /= double failed");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Constexpr comparison (issue acceptance: <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr td_cascade a(1.5);
+		constexpr td_cascade b(3.0);
+		static_assert(a < b,     "constexpr: td_cascade(1.5) < td_cascade(3.0)");
+		static_assert(b > a,     "constexpr: td_cascade(3.0) > td_cascade(1.5)");
+		static_assert(a <= b,    "constexpr: td_cascade(1.5) <= td_cascade(3.0)");
+		static_assert(b >= a,    "constexpr: td_cascade(3.0) >= td_cascade(1.5)");
+		static_assert(!(a == b), "constexpr: td_cascade(1.5) != td_cascade(3.0)");
+		static_assert(a != b,    "constexpr: != operator");
+		static_assert(a == a,    "constexpr: td_cascade(1.5) == td_cascade(1.5)");
+
+		// td_cascade vs double comparisons
+		static_assert(a < 3.0,      "constexpr: td_cascade(1.5) < 3.0");
+		static_assert(3.0 > a,      "constexpr: 3.0 > td_cascade(1.5)");
+		static_assert(a == 1.5,     "constexpr: td_cascade(1.5) == 1.5");
+		static_assert(1.5 == a,     "constexpr: 1.5 == td_cascade(1.5)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion-out: operator double() / int() / float() are now constexpr.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr td_cascade a(0.5);
+		constexpr double d = double(a);
+		static_assert(d == 0.5, "constexpr operator double()");
+
+		constexpr td_cascade b(42.0);
+		constexpr int n = int(b);
+		static_assert(n == 42, "constexpr operator int()");
+
+		constexpr td_cascade c(2.5);
+		constexpr float f = float(c);
+		static_assert(f == 2.5f, "constexpr operator float()");
+
+		// Large integer conversion: limb-separated truncation (mid+lo
+		// collapsed via two_sum) preserves precision above 2^53 on every
+		// platform regardless of long-double width.
+		// td_cascade(2^53, 1.0, 0.0) represents the exact integer 2^53 + 1.
+		constexpr td_cascade large(9007199254740992.0, 1.0, 0.0);
+		constexpr unsigned long long u = static_cast<unsigned long long>(large);
+		static_assert(u == 9007199254740993ULL,
+			"constexpr conversion preserves precision above 2^53");
+
+		// Negative large: td_cascade(-2^53, -1.0, 0.0) = -(2^53 + 1)
+		constexpr td_cascade large_neg(-9007199254740992.0, -1.0, 0.0);
+		constexpr long long s = static_cast<long long>(large_neg);
+		static_assert(s == -9007199254740993LL,
+			"constexpr signed conversion preserves precision below -2^53");
+
+		// Boundary case: hi is integer, mid subtracts a sub-ulp fraction.
+		constexpr td_cascade boundary_neg(101.0, -0x1.0p-50, 0.0);
+		constexpr int b_neg = static_cast<int>(boundary_neg);
+		static_assert(b_neg == 100,
+			"constexpr trunc handles fractional borrow across int boundary");
+
+		// Boundary case: positive mid pushing hi+mid over an integer boundary.
+		constexpr td_cascade boundary_pos(2.5, 0.6, 0.0);
+		constexpr int b_pos = static_cast<int>(boundary_pos);
+		static_assert(b_pos == 3,
+			"constexpr trunc handles fractional carry across int boundary");
+
+		// Negative td_cascade to unsigned saturates to 0.
+		constexpr td_cascade negval(-5.0);
+		constexpr unsigned int neg_u = static_cast<unsigned int>(negval);
+		static_assert(neg_u == 0u,
+			"constexpr unsigned conversion clamps negative td_cascade to 0");
+
+		// Out-of-range saturates to integer max.
+		constexpr td_cascade huge(1.0e20);
+		constexpr int huge_i = static_cast<int>(huge);
+		static_assert(huge_i == (std::numeric_limits<int>::max)(),
+			"constexpr signed conversion saturates above int max");
+
+		// hi at the rounded long long boundary, mid+lo brings it back in range.
+		constexpr td_cascade boundary_max(0x1.0p63, -2.0, 0.0);
+		constexpr long long b_max = static_cast<long long>(boundary_max);
+		static_assert(b_max == 9223372036854775806LL,
+			"constexpr signed conversion at upper boundary uses lo to stay in range");
+
+		constexpr td_cascade boundary_umax(0x1.0p64, -2.0, 0.0);
+		constexpr unsigned long long b_umax = static_cast<unsigned long long>(boundary_umax);
+		static_assert(b_umax == 18446744073709551614ULL,
+			"constexpr unsigned conversion at upper boundary uses lo to stay in range");
+
+		// Defensive saturation for unnormalized td_cascade values.
+		constexpr td_cascade unnorm_pos(0.0, 1.0e30, 0.0);
+		constexpr long long unp = static_cast<long long>(unnorm_pos);
+		static_assert(unp == (std::numeric_limits<long long>::max)(),
+			"constexpr conversion saturates on unnormalized lo > max");
+
+		constexpr td_cascade unnorm_neg(0.0, -1.0e30, 0.0);
+		constexpr long long unn = static_cast<long long>(unnorm_neg);
+		static_assert(unn == (std::numeric_limits<long long>::min)(),
+			"constexpr signed conversion saturates on unnormalized lo < min");
+		constexpr unsigned long long unn_u = static_cast<unsigned long long>(unnorm_neg);
+		static_assert(unn_u == 0ULL,
+			"constexpr unsigned conversion clamps unnormalized negative to 0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction (already constexpr -- smoke test)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr td_cascade zero(SpecificValue::zero);
+		constexpr td_cascade inf_pos(SpecificValue::infpos);
+		constexpr td_cascade inf_neg(SpecificValue::infneg);
+		static_assert(zero == td_cascade(0.0), "constexpr SpecificValue::zero");
+		static_assert(inf_pos > td_cascade(0.0), "constexpr SpecificValue::infpos");
+		static_assert(inf_neg < td_cascade(0.0), "constexpr SpecificValue::infneg");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Mixed td_cascade / double binary arithmetic in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr td_cascade a(2.0);
+		constexpr auto cx_sum  = a + 3.0;
+		constexpr auto cx_diff = a - 1.0;
+		constexpr auto cx_prod = a * 4.0;
+		constexpr auto cx_quot = a / 2.0;
+		static_assert(cx_sum  == td_cascade(5.0), "constexpr td_cascade + double");
+		static_assert(cx_diff == td_cascade(1.0), "constexpr td_cascade - double");
+		static_assert(cx_prod == td_cascade(8.0), "constexpr td_cascade * double");
+		static_assert(cx_quot == td_cascade(1.0), "constexpr td_cascade / double");
+
+		constexpr auto cx_lhs_sum = 5.0 + td_cascade(2.0);
+		static_assert(cx_lhs_sum == td_cascade(7.0), "constexpr double + td_cascade");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Sign of negative zero in divide-by-zero: -0.0 should produce -infinity.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr auto cx_q = []() { td_cascade t(1.0); t /= td_cascade(-0.0); return t; }();
+		static_assert(cx_q < td_cascade(0.0), "constexpr 1.0 / -0.0 should be -inf");
+		static_assert(cx_q.isinf(), "constexpr 1.0 / -0.0 should be inf");
+	}
+
+	// ----------------------------------------------------------------------------
+	// IEEE-754 unordered comparison: nan >= x must be false (and similar).
+	// Tested at runtime instead of via static_assert (MSVC constexpr NaN bug).
+	// ----------------------------------------------------------------------------
+	{
+		td_cascade qnan(SpecificValue::qnan);
+		td_cascade one(1.0);
+		if ( (qnan <  one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan <  1.0 should be false\n"; }
+		if ( (qnan >  one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan >  1.0 should be false\n"; }
+		if ( (qnan <= one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan <= 1.0 should be false\n"; }
+		if ( (qnan >= one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan >= 1.0 should be false\n"; }
+		if ( (qnan == one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan == 1.0 should be false\n"; }
+		if (!(qnan != one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan != 1.0 should be true\n"; }
+		if ( (one  >= qnan)){ ++nrOfFailedTestCases; std::cerr << "FAIL: 1.0 >= nan should be false\n"; }
+	}
+
+	std::cout << "td_cascade constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::td_cascade_arithmetic_exception& err) {
+	std::cerr << "Uncaught td_cascade arithmetic exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- Promotes `td_cascade` (triple-double via `floatcascade<3>`) to fully constexpr across construction, arithmetic, comparison, unary negation, and conversion-out.
- Continues the cascade trio: dd_cascade (#797 merged), td_cascade (this), qd_cascade (#743 next).
- Issue acceptance form `constexpr td_cascade a(2.0), b(3.0); constexpr auto c = a + b;` (and `*`, `-`, `/`, `+=`, `<`) compiles and locks in via `static_assert`.

## Approach
Most of the floatcascade EFT primitives (`two_sum`, `fast_two_sum`, `two_prod`, `three_sum`, `three_sum2`, `isneg`/`ispos`) were already promoted in #797. This PR adds the **N=3 specializations**:

- `compress_6to3` and `renormalize<3>` marked constexpr.
- New non-template constexpr overloads of `add_cascades` and `multiply_cascades` for `floatcascade<3>`. `add_cascades` does a 6-element bubble sort with ternary `abs` then accumulates smallest-to-largest. `multiply_cascades` computes 9 partial products with `two_prod`, sorts the 18-term expansion in a fixed-size array (no `std::sort`/`std::vector`), then accumulates via `two_sum` chains and renormalizes.

`td_cascade_impl.hpp` follows the dd_cascade pattern from #797:
- Comparisons, conversions, arithmetic operators promoted.
- NaN-safe `>=` / `<=` via `> \|\| ==` and `< \|\| ==`.
- Sign-bit fix in `/=` via `std::bit_cast` so `-0.0` produces `-inf` at compile time.
- Integer conversion uses limb-separated truncation: collapse `mid + lo` via `two_sum` into a single representative double (sub-ULP error discarded), then apply the dd-style algorithm. Fixes pre-existing bug where the old int64_t-cast helpers ignored `cascade[2]` and could trigger UB on unnormalized inputs.
- Five UB saturation guards before each `lo`/`abs_lo` cast.

## Changes
- `include/sw/universal/internal/floatcascade/floatcascade.hpp` — `compress_6to3`, `renormalize<3>` constexpr; new `add_cascades` / `multiply_cascades` overloads for `floatcascade<3>`.
- `include/sw/universal/number/td_cascade/td_cascade_impl.hpp` — operators promoted; conversion templates rewritten with limb-separated truncation; sign/NaN/UB-guard fixes from #797 applied.
- `static/highprecision/td_cascade/api/constexpr.cpp` — new test (mirrors dd_cascade's, scaled to 3 limbs).

## Test Results
| Suite | gcc | clang |
|-------|-----|-------|
| tdc_api_api / roundtrip / constexpr | PASS | PASS |
| tdc_arith_addition / arithmetic / division / multiplication / subtraction | PASS | PASS |
| tdc_math_pow / sqrt / logarithm | PASS | PASS |
| ddc_arith_arithmetic (regression) | PASS | PASS |
| qdc_arith_arithmetic (regression) | PASS | PASS |

11/11 td_cascade + 1/1 dd_cascade + 1/1 qd_cascade tests PASS on both compilers. dd_cascade and qd_cascade unaffected because the floatcascade<2> overloads and the generic templates remain unchanged.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #742

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Expanded compile-time evaluation support for floating-point cascade operations and arithmetic.
  * Added compound assignment operators for improved usability.
  * Refined handling of special values (infinity, NaN) in conversions and edge cases.

* **Bug Fixes**
  * Fixed comparison operators to correctly preserve unordered semantics.
  * Corrected division-by-zero behavior and signed-zero preservation.
  * Improved integer conversion accuracy and boundary case handling.

* **Tests**
  * Added comprehensive test suite validating compile-time arithmetic, conversions, and special value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->