### PR TITLE
feat(qd_cascade): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -658,10 +658,11 @@ namespace expansion_ops {
     }
 
     // Specialization for N=4 (quad-double) - matches QD library exactly
+    // Replaces std::isinf with sw::universal::is_inf_cx (constexpr in C++20).
     template<>
-    inline floatcascade<4> renormalize<4>(const floatcascade<4>& e) {
+    constexpr inline floatcascade<4> renormalize<4>(const floatcascade<4>& e) {
         floatcascade<4> result = e;
-        if (std::isinf(result[0])) return result;
+        if (sw::universal::is_inf_cx(result[0])) return result;
 
         double s0, s1, s2 = 0.0, s3 = 0.0;
 
@@ -848,7 +849,7 @@ namespace expansion_ops {
     // Used by qd_cascade for (4+4)→4 compression after addition/subtraction
     // This implements the same algorithm as sw::universal::renorm(a0,a1,a2,a3,a4,...,a7)
     // Based on: Hida, Li, Bailey "Library for Double-Double and Quad-Double Arithmetic"
-    inline floatcascade<4> compress_8to4(const floatcascade<8>& e) {
+    constexpr inline floatcascade<4> compress_8to4(const floatcascade<8>& e) {
         // Note: Volatiles are used inside two_sum/fast_two_sum, so we don't need them here
         double r0 = e[0];
         double r1 = e[1];
@@ -859,7 +860,7 @@ namespace expansion_ops {
         double r6 = e[6];
         double r7 = e[7];
 
-        double s0, s1, s2 = 0.0, s3 = 0.0, s4;
+        double s0{}, s1{}, s2 = 0.0, s3 = 0.0, s4{};
 
         // Phase 1: Bottom-up accumulation using fast_two_sum
         // Following proven QD algorithm: accumulate from least to most significant
@@ -1307,6 +1308,113 @@ namespace expansion_ops {
                     double s = 0.0, e = 0.0;
                     two_sum(result[2], carry, s, e);
                     result[2] = s;
+                }
+            }
+        }
+
+        return renormalize(result);
+    }
+
+    // ---------------------------------------------------------------------
+    // Constexpr-friendly overloads for floatcascade<4> (used by qd_cascade)
+    // ---------------------------------------------------------------------
+    //
+    // Same rationale as the floatcascade<2> and floatcascade<3> overloads:
+    // the generic templates use std::sort and std::vector and aren't
+    // constexpr in C++20.
+
+    // Add two floatcascade<4> -> floatcascade<8>.  Magnitude-sorted merge
+    // of the eight limbs, then accumulates smallest-to-largest with two_sum.
+    constexpr inline floatcascade<8> add_cascades(const floatcascade<4>& a, const floatcascade<4>& b) {
+        double m[8] = { a[0], a[1], a[2], a[3], b[0], b[1], b[2], b[3] };
+
+        auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
+
+        // Bubble sort 8 elements by descending magnitude (7 passes).
+        for (int pass = 0; pass < 7; ++pass) {
+            for (int j = 0; j < 7 - pass; ++j) {
+                if (absv(m[j]) < absv(m[j + 1])) {
+                    double t = m[j]; m[j] = m[j + 1]; m[j + 1] = t;
+                }
+            }
+        }
+
+        // Accumulate from smallest (m[7]) to largest (m[0]) with two_sum.
+        double sum = 0.0;
+        double corrections[7] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+        int nc = 0;
+
+        double new_sum = 0.0, error = 0.0;
+        for (int i = 7; i >= 0; --i) {
+            two_sum(sum, m[i], new_sum, error);
+            if (error != 0.0 && nc < 7) corrections[nc++] = error;
+            sum = new_sum;
+        }
+
+        floatcascade<8> result;
+        result[0] = sum;
+        // Store corrections in decreasing order of significance.
+        for (int i = 0; i < nc; ++i) {
+            result[i + 1] = corrections[nc - 1 - i];
+        }
+        // result[nc+1..7] already zero (default-constructed).
+
+        return result;
+    }
+
+    // Multiply two floatcascade<4> -> floatcascade<4>.  Computes 16 partial
+    // products with two_prod, sorts the 32-term expansion (16 products + 16
+    // errors) by magnitude in a fixed-size array (no std::sort), then
+    // accumulates with two_sum chains into a 4-component result and
+    // renormalizes.
+    constexpr inline floatcascade<4> multiply_cascades(const floatcascade<4>& a, const floatcascade<4>& b) {
+        // Compute all 16 partial products with their error terms.
+        double prod[16] = {};
+        double err[16]  = {};
+        for (int i = 0; i < 4; ++i) {
+            for (int j = 0; j < 4; ++j) {
+                two_prod(a[i], b[j], prod[i * 4 + j], err[i * 4 + j]);
+            }
+        }
+
+        // Build expansion: up to 32 terms.
+        double expansion[32] = {};
+        int n_expansion = 0;
+        for (int k = 0; k < 16; ++k) {
+            if (prod[k] != 0.0) expansion[n_expansion++] = prod[k];
+            if (err[k]  != 0.0) expansion[n_expansion++] = err[k];
+        }
+
+        auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
+
+        // Sort expansion by descending magnitude (bubble sort over up to 32 elements).
+        for (int pass = 0; pass < n_expansion - 1; ++pass) {
+            for (int j = 0; j < n_expansion - 1 - pass; ++j) {
+                if (absv(expansion[j]) < absv(expansion[j + 1])) {
+                    double t = expansion[j]; expansion[j] = expansion[j + 1]; expansion[j + 1] = t;
+                }
+            }
+        }
+
+        // Accumulate sorted expansion into a 4-component result with carry
+        // propagation through two_sum chains.
+        floatcascade<4> result;
+        if (n_expansion > 0) {
+            result[0] = expansion[0];
+            for (int i = 1; i < n_expansion; ++i) {
+                double carry = expansion[i];
+                for (int j = 0; j < 4 && carry != 0.0; ++j) {
+                    double s = 0.0, e = 0.0;
+                    two_sum(result[j], carry, s, e);
+                    result[j] = s;
+                    carry = e;
+                }
+                // Sub-ULP carry below the last component is precision loss
+                // beyond what 4 doubles can represent; absorb into result[3].
+                if (carry != 0.0) {
+                    double s = 0.0, e = 0.0;
+                    two_sum(result[3], carry, s, e);
+                    result[3] = s;
                 }
             }
         }

--- a/include/sw/universal/number/qd_cascade/qd_cascade_impl.hpp
+++ b/include/sw/universal/number/qd_cascade/qd_cascade_impl.hpp
@@ -7,17 +7,20 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include <array>
+#include <bit>
 #include <cmath>
 #include <iostream>
+#include <type_traits>
 #include <vector>
+#include <universal/utility/bit_cast.hpp>
 #include <universal/internal/floatcascade/floatcascade.hpp>
 
 namespace sw::universal {
 
     // Forward declarations
 inline bool signbit(const class qd_cascade&);
-inline qd_cascade operator-(const qd_cascade&, const qd_cascade&);
-inline qd_cascade operator*(const qd_cascade&, const qd_cascade&);
+constexpr qd_cascade operator-(const qd_cascade&, const qd_cascade&);
+constexpr qd_cascade operator*(const qd_cascade&, const qd_cascade&);
 inline qd_cascade pow(const qd_cascade&, const qd_cascade&);
 inline qd_cascade frexp(const qd_cascade&, int*);
 inline qd_cascade ldexp(const qd_cascade&, int);
@@ -135,28 +138,173 @@ public:
     constexpr qd_cascade& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
     constexpr qd_cascade& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
 
+private:
+    // Helper templates used by the conversion operators below.  Defined before
+    // the operators so the constexpr call chain is fully resolved at the point
+    // of operator declaration (clang requires this; gcc is more permissive).
+    //
+    // For quad-double, collapse the lower three limbs (mid_hi + mid_lo + lo)
+    // into a single representative double via a two_sum chain (sub-ULP error
+    // discarded -- cannot affect integer truncation), then apply the dd-style
+    // limb-separated truncation algorithm from #797.
+    template<typename Unsigned>
+    constexpr Unsigned convert_to_unsigned_impl() const noexcept {
+        const double hi = cascade[0];
+        // Collapse the lower three limbs into a single representative double.
+        double s1 = 0.0, e1 = 0.0;
+        expansion_ops::two_sum(cascade[2], cascade[3], s1, e1);
+        double lo_combined = 0.0, lo_err = 0.0;
+        expansion_ops::two_sum(cascade[1], s1, lo_combined, lo_err);
+        (void)e1; (void)lo_err;
+        const double lo = lo_combined;
+
+        bool hi_finite;
+        if (std::is_constant_evaluated()) {
+            constexpr double inf = std::numeric_limits<double>::infinity();
+            hi_finite = !(hi != hi) && hi != inf && hi != -inf;
+        }
+        else {
+            hi_finite = std::isfinite(hi);
+        }
+        if (!hi_finite) {
+            return hi < 0.0 ? Unsigned(0) : (std::numeric_limits<Unsigned>::max)();
+        }
+        if (hi < 0.0) return Unsigned(0);
+
+        constexpr double unsigned_max_d = static_cast<double>((std::numeric_limits<Unsigned>::max)());
+        if (hi > unsigned_max_d) return (std::numeric_limits<Unsigned>::max)();
+        if (hi == unsigned_max_d) {
+            if (lo >= 0.0) return (std::numeric_limits<Unsigned>::max)();
+            double abs_lo = -lo;
+            if (abs_lo >= unsigned_max_d) return Unsigned(0);
+            Unsigned abs_lo_int = static_cast<Unsigned>(abs_lo);
+            double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+            Unsigned result = (std::numeric_limits<Unsigned>::max)();
+            if (abs_lo_frac == 0.0) return result - (abs_lo_int - 1);
+            return result - abs_lo_int;
+        }
+
+        Unsigned hi_int = static_cast<Unsigned>(hi);
+        double hi_frac = hi - static_cast<double>(hi_int);
+
+        if (lo >= 0.0) {
+            if (lo >= unsigned_max_d) return (std::numeric_limits<Unsigned>::max)();
+            Unsigned lo_int = static_cast<Unsigned>(lo);
+            double lo_frac = lo - static_cast<double>(lo_int);
+            double frac_sum = hi_frac + lo_frac;
+            if (lo_int > (std::numeric_limits<Unsigned>::max)() - hi_int) {
+                return (std::numeric_limits<Unsigned>::max)();
+            }
+            Unsigned sum = hi_int + lo_int;
+            if (frac_sum >= 1.0) {
+                if (sum == (std::numeric_limits<Unsigned>::max)()) return sum;
+                return sum + 1;
+            }
+            return sum;
+        }
+        else {
+            double abs_lo = -lo;
+            if (abs_lo >= unsigned_max_d) return Unsigned(0);
+            Unsigned abs_lo_int = static_cast<Unsigned>(abs_lo);
+            double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+            if (hi_int < abs_lo_int) return Unsigned(0);
+            if (hi_int == abs_lo_int) return Unsigned(0);
+            Unsigned diff = hi_int - abs_lo_int;
+            if (hi_frac < abs_lo_frac) return diff - 1;
+            return diff;
+        }
+    }
+
+    template<typename Signed>
+    constexpr Signed convert_to_signed_impl() const noexcept {
+        const double hi = cascade[0];
+        double s1 = 0.0, e1 = 0.0;
+        expansion_ops::two_sum(cascade[2], cascade[3], s1, e1);
+        double lo_combined = 0.0, lo_err = 0.0;
+        expansion_ops::two_sum(cascade[1], s1, lo_combined, lo_err);
+        (void)e1; (void)lo_err;
+        const double lo = lo_combined;
+
+        bool hi_finite;
+        if (std::is_constant_evaluated()) {
+            constexpr double inf = std::numeric_limits<double>::infinity();
+            hi_finite = !(hi != hi) && hi != inf && hi != -inf;
+        }
+        else {
+            hi_finite = std::isfinite(hi);
+        }
+        if (!hi_finite) {
+            return hi < 0.0 ? (std::numeric_limits<Signed>::min)() : (std::numeric_limits<Signed>::max)();
+        }
+
+        constexpr double signed_max_d = static_cast<double>((std::numeric_limits<Signed>::max)());
+        constexpr double signed_min_d = static_cast<double>((std::numeric_limits<Signed>::min)());
+
+        if (hi > signed_max_d) return (std::numeric_limits<Signed>::max)();
+        if (hi == signed_max_d) {
+            if (lo >= 0.0) return (std::numeric_limits<Signed>::max)();
+            double abs_lo = -lo;
+            if (abs_lo >= signed_max_d) return (std::numeric_limits<Signed>::min)();
+            Signed abs_lo_int = static_cast<Signed>(abs_lo);
+            double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+            Signed result = (std::numeric_limits<Signed>::max)();
+            if (abs_lo_frac == 0.0) return result - (abs_lo_int - 1);
+            return result - abs_lo_int;
+        }
+        if (hi < signed_min_d) return (std::numeric_limits<Signed>::min)();
+
+        Signed hi_int = static_cast<Signed>(hi);
+        if (lo >= signed_max_d) return (std::numeric_limits<Signed>::max)();
+        if (lo < signed_min_d) return (std::numeric_limits<Signed>::min)();
+        Signed lo_int = static_cast<Signed>(lo);
+        if (lo_int > 0 && hi_int > (std::numeric_limits<Signed>::max)() - lo_int) {
+            return (std::numeric_limits<Signed>::max)();
+        }
+        if (lo_int < 0 && hi_int < (std::numeric_limits<Signed>::min)() - lo_int) {
+            return (std::numeric_limits<Signed>::min)();
+        }
+        Signed sum = hi_int + lo_int;
+
+        double hi_frac = hi - static_cast<double>(hi_int);
+        double lo_frac = lo - static_cast<double>(lo_int);
+        double frac_sum = hi_frac + lo_frac;
+
+        if (frac_sum >= 1.0) {
+            if (sum == (std::numeric_limits<Signed>::max)()) return sum;
+            return sum + 1;
+        }
+        if (frac_sum <= -1.0) {
+            if (sum == (std::numeric_limits<Signed>::min)()) return sum;
+            return sum - 1;
+        }
+        if (sum > 0 && frac_sum < 0.0) return sum - 1;
+        if (sum < 0 && frac_sum > 0.0) return sum + 1;
+        return sum;
+    }
+
+public:
     // conversion operators
-    explicit operator int()                   const noexcept { return convert_to_signed<int>(); }
-    explicit operator long()                  const noexcept { return convert_to_signed<long>(); }
-    explicit operator long long()             const noexcept { return convert_to_signed<long long>(); }
-    explicit operator unsigned int()          const noexcept { return convert_to_unsigned<unsigned int>(); }
-    explicit operator unsigned long()         const noexcept { return convert_to_unsigned<unsigned long>(); }
-    explicit operator unsigned long long()    const noexcept { return convert_to_unsigned<unsigned long long>(); }
-    explicit operator float()                 const noexcept { return convert_to_ieee754<float>(); }
-    explicit operator double()                const noexcept { return convert_to_ieee754<double>(); }
+    explicit constexpr operator int()                   const noexcept { return convert_to_signed_impl<int>(); }
+    explicit constexpr operator long()                  const noexcept { return convert_to_signed_impl<long>(); }
+    explicit constexpr operator long long()             const noexcept { return convert_to_signed_impl<long long>(); }
+    explicit constexpr operator unsigned int()          const noexcept { return convert_to_unsigned_impl<unsigned int>(); }
+    explicit constexpr operator unsigned long()         const noexcept { return convert_to_unsigned_impl<unsigned long>(); }
+    explicit constexpr operator unsigned long long()    const noexcept { return convert_to_unsigned_impl<unsigned long long>(); }
+    explicit constexpr operator float()                 const noexcept { return static_cast<float>(cascade.to_double()); }
+    explicit constexpr operator double()                const noexcept { return cascade.to_double(); }
 
     qd_cascade& operator=(const qd_cascade&) = default;
     qd_cascade& operator=(qd_cascade&&) = default;
 
     // Assignment from floatcascade
-    qd_cascade& operator=(const floatcascade<4>& fc) {
+    constexpr qd_cascade& operator=(const floatcascade<4>& fc) {
         cascade = fc;
         return *this;
     }
 
     // Extract floatcascade
-    const floatcascade<4>& get_cascade() const { return cascade; }
-    operator floatcascade<4>() const { return cascade; }
+    constexpr const floatcascade<4>& get_cascade() const { return cascade; }
+    constexpr operator floatcascade<4>() const { return cascade; }
 
     // Arithmetic operations
 
@@ -170,14 +318,14 @@ public:
 	}
 
     // Compound assignment operators
-    qd_cascade& operator+=(const qd_cascade& rhs) noexcept {
+    CONSTEXPRESSION qd_cascade& operator+=(const qd_cascade& rhs) noexcept {
 		auto result = expansion_ops::add_cascades(cascade, rhs.cascade);  // 8 components
 		// Compress to 4 components using proven QD algorithm
 		cascade = expansion_ops::compress_8to4(result);
         return *this;
     }
 
-    qd_cascade& operator-=(const qd_cascade& rhs) noexcept {
+    CONSTEXPRESSION qd_cascade& operator-=(const qd_cascade& rhs) noexcept {
 		floatcascade<4> neg_rhs;
 		neg_rhs[0] = -rhs.cascade[0];
 		neg_rhs[1] = -rhs.cascade[1];
@@ -190,12 +338,12 @@ public:
 		return *this;
     }
 
-    qd_cascade& operator*=(const qd_cascade& rhs) noexcept {
+    CONSTEXPRESSION qd_cascade& operator*=(const qd_cascade& rhs) noexcept {
 		*this = expansion_ops::multiply_cascades(cascade, rhs.cascade);
         return *this;
     }
 
-    qd_cascade& operator/=(const qd_cascade& rhs) noexcept {
+    CONSTEXPRESSION qd_cascade& operator/=(const qd_cascade& rhs) noexcept {
 		if (isnan())
 			return *this;
 		if (rhs.isnan())
@@ -204,7 +352,20 @@ public:
 			if (iszero()) {
 				*this = qd_cascade(SpecificValue::qnan);
 			} else {
-				*this = qd_cascade(sign() == rhs.sign() ? SpecificValue::infpos : SpecificValue::infneg);
+				// Determine sign of result.  At runtime use std::copysign;
+				// during constant evaluation use std::bit_cast to extract
+				// the IEEE-754 sign bit so -0.0 carries through correctly
+				// (per #727 / #797 / #798 lessons).
+				int sA, sB;
+				if (std::is_constant_evaluated()) {
+					sA = (std::bit_cast<std::uint64_t>(cascade[0])     >> 63) ? -1 : 1;
+					sB = (std::bit_cast<std::uint64_t>(rhs.cascade[0]) >> 63) ? -1 : 1;
+				}
+				else {
+					sA = (std::copysign(1.0, cascade[0])     < 0.0) ? -1 : 1;
+					sB = (std::copysign(1.0, rhs.cascade[0]) < 0.0) ? -1 : 1;
+				}
+				*this = qd_cascade((sA == sB) ? SpecificValue::infpos : SpecificValue::infneg);
 			}
 			return *this;
 		}
@@ -242,6 +403,12 @@ public:
 		*this = expansion_ops::renormalize(result_cascade);
         return *this;
     }
+
+    // Compound assignment with double
+    CONSTEXPRESSION qd_cascade& operator+=(double rhs) noexcept { return *this += qd_cascade(rhs); }
+    CONSTEXPRESSION qd_cascade& operator-=(double rhs) noexcept { return *this -= qd_cascade(rhs); }
+    CONSTEXPRESSION qd_cascade& operator*=(double rhs) noexcept { return *this *= qd_cascade(rhs); }
+    CONSTEXPRESSION qd_cascade& operator/=(double rhs) noexcept { return *this /= qd_cascade(rhs); }
 
     // modifiers
     constexpr void clear()                                         noexcept { cascade.clear(); }
@@ -283,8 +450,8 @@ public:
 	}
 
     // argument is not protected for speed
-    double operator[](size_t index) const { return cascade[index]; }
-	double& operator[](size_t index) { return cascade[index]; }
+    constexpr double operator[](size_t index) const { return cascade[index]; }
+    constexpr double& operator[](size_t index) { return cascade[index]; }
 
     // create specific number system values of interest
     constexpr qd_cascade& maxpos() noexcept {
@@ -386,27 +553,11 @@ protected:
         return *this;
     }
 
-    // convert to native unsigned integer, use C++ conversion rules to cast down to float and double
-    template<typename Unsigned>
-    Unsigned convert_to_unsigned() const noexcept {
-        int64_t h = static_cast<int64_t>(cascade[0]);
-        int64_t l = static_cast<int64_t>(cascade[1]);
-        return Unsigned(h + l);
-    }
-
-    // convert to native signed integer, use C++ conversion rules to cast down to float and double
-    template<typename Signed>
-    Signed convert_to_signed() const noexcept {
-        int64_t h = static_cast<int64_t>(cascade[0]);
-        int64_t l = static_cast<int64_t>(cascade[1]);
-        return Signed(h + l);
-    }
-
-    // convert to native floating-point, use C++ conversion rules to cast down to float and double
-    template<typename Real>
-    Real convert_to_ieee754() const noexcept {
-        return Real(cascade.to_double());
-    }
+    // (convert_to_unsigned_impl / convert_to_signed_impl moved up next to the
+    // conversion operators that call them, so the constexpr call chain is
+    // fully resolved at the point of declaration.  The old int64_t-cast
+    // helpers had two bugs: they ignored cascade[2] and cascade[3], and
+    // could trigger UB per C++20 [conv.fpint] for unnormalized inputs.)
 
 public:
     // Decimal conversion - delegates to floatcascade base class
@@ -461,52 +612,52 @@ inline qd_cascade ulp(const qd_cascade& a) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // qd_cascade - qd_cascade binary arithmetic operators
 
-inline qd_cascade operator+(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr qd_cascade operator+(const qd_cascade& lhs, const qd_cascade& rhs) {
 	qd_cascade sum = lhs;
 	sum += rhs;
 	return sum;
 }
 
-inline qd_cascade operator-(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr qd_cascade operator-(const qd_cascade& lhs, const qd_cascade& rhs) {
 	qd_cascade diff = lhs;
 	diff -= rhs;
 	return diff;
 }
 
-inline qd_cascade operator*(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr qd_cascade operator*(const qd_cascade& lhs, const qd_cascade& rhs) {
 	qd_cascade mul = lhs;
 	mul *= rhs;
 	return mul;
 }
 
-inline qd_cascade operator/(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr qd_cascade operator/(const qd_cascade& lhs, const qd_cascade& rhs) {
 	qd_cascade div = lhs;
 	div /= rhs;
 	return div;
 }
 
 // qd_cascade-double mixed operations
-inline qd_cascade operator+(const qd_cascade& lhs, double rhs) { return operator+(lhs, qd_cascade(rhs)); }
-inline qd_cascade operator-(const qd_cascade& lhs, double rhs) { return operator-(lhs, qd_cascade(rhs)); }
-inline qd_cascade operator*(const qd_cascade& lhs, double rhs) { return operator*(lhs, qd_cascade(rhs)); }
-inline qd_cascade operator/(const qd_cascade& lhs, double rhs) { return operator/(lhs, qd_cascade(rhs)); }
+constexpr qd_cascade operator+(const qd_cascade& lhs, double rhs) { return operator+(lhs, qd_cascade(rhs)); }
+constexpr qd_cascade operator-(const qd_cascade& lhs, double rhs) { return operator-(lhs, qd_cascade(rhs)); }
+constexpr qd_cascade operator*(const qd_cascade& lhs, double rhs) { return operator*(lhs, qd_cascade(rhs)); }
+constexpr qd_cascade operator/(const qd_cascade& lhs, double rhs) { return operator/(lhs, qd_cascade(rhs)); }
 
 // double-qd_cascade mixed operations
-inline qd_cascade operator+(double lhs, const qd_cascade& rhs) { return operator+(qd_cascade(lhs), rhs); }
-inline qd_cascade operator-(double lhs, const qd_cascade& rhs) { return operator-(qd_cascade(lhs), rhs); }
-inline qd_cascade operator*(double lhs, const qd_cascade& rhs) { return operator*(qd_cascade(lhs), rhs); }
-inline qd_cascade operator/(double lhs, const qd_cascade& rhs) { return operator/(qd_cascade(lhs), rhs); }
+constexpr qd_cascade operator+(double lhs, const qd_cascade& rhs) { return operator+(qd_cascade(lhs), rhs); }
+constexpr qd_cascade operator-(double lhs, const qd_cascade& rhs) { return operator-(qd_cascade(lhs), rhs); }
+constexpr qd_cascade operator*(double lhs, const qd_cascade& rhs) { return operator*(qd_cascade(lhs), rhs); }
+constexpr qd_cascade operator/(double lhs, const qd_cascade& rhs) { return operator/(qd_cascade(lhs), rhs); }
 
 // Comparison operators
-inline bool operator==(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr bool operator==(const qd_cascade& lhs, const qd_cascade& rhs) {
     return lhs[0] == rhs[0] && lhs[1] == rhs[1] && lhs[2] == rhs[2] && lhs[3] == rhs[3];
 }
 
-inline bool operator!=(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr bool operator!=(const qd_cascade& lhs, const qd_cascade& rhs) {
     return !(lhs == rhs);
 }
 
-inline bool operator<(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr bool operator<(const qd_cascade& lhs, const qd_cascade& rhs) {
     if (lhs[0] < rhs[0]) return true;
     if (lhs[0] > rhs[0]) return false;
     if (lhs[1] < rhs[1]) return true;
@@ -516,32 +667,34 @@ inline bool operator<(const qd_cascade& lhs, const qd_cascade& rhs) {
     return lhs[3] < rhs[3];
 }
 
-inline bool operator>(const qd_cascade& lhs, const qd_cascade& rhs) {
+constexpr bool operator>(const qd_cascade& lhs, const qd_cascade& rhs) {
     return rhs < lhs;
 }
 
-inline bool operator<=(const qd_cascade& lhs, const qd_cascade& rhs) {
-    return !(rhs < lhs);
+constexpr bool operator<=(const qd_cascade& lhs, const qd_cascade& rhs) {
+    // NOT !operator>: that returns true for unordered (NaN) operands. Use
+    // operator< || operator== so NaN comparisons stay unordered (per #797).
+    return operator<(lhs, rhs) || operator==(lhs, rhs);
 }
 
-inline bool operator>=(const qd_cascade& lhs, const qd_cascade& rhs) {
-    return !(lhs < rhs);
+constexpr bool operator>=(const qd_cascade& lhs, const qd_cascade& rhs) {
+    return operator>(lhs, rhs) || operator==(lhs, rhs);
 }
 
 // Comparison with double
-inline bool operator==(const qd_cascade& lhs, double rhs) { return lhs == qd_cascade(rhs); }
-inline bool operator!=(const qd_cascade& lhs, double rhs) { return lhs != qd_cascade(rhs); }
-inline bool operator<(const qd_cascade& lhs, double rhs) { return lhs < qd_cascade(rhs); }
-inline bool operator>(const qd_cascade& lhs, double rhs) { return lhs > qd_cascade(rhs); }
-inline bool operator<=(const qd_cascade& lhs, double rhs) { return lhs <= qd_cascade(rhs); }
-inline bool operator>=(const qd_cascade& lhs, double rhs) { return lhs >= qd_cascade(rhs); }
+constexpr bool operator==(const qd_cascade& lhs, double rhs) { return lhs == qd_cascade(rhs); }
+constexpr bool operator!=(const qd_cascade& lhs, double rhs) { return lhs != qd_cascade(rhs); }
+constexpr bool operator<(const qd_cascade& lhs, double rhs) { return lhs < qd_cascade(rhs); }
+constexpr bool operator>(const qd_cascade& lhs, double rhs) { return lhs > qd_cascade(rhs); }
+constexpr bool operator<=(const qd_cascade& lhs, double rhs) { return operator<(lhs, qd_cascade(rhs)) || operator==(lhs, qd_cascade(rhs)); }
+constexpr bool operator>=(const qd_cascade& lhs, double rhs) { return operator>(lhs, qd_cascade(rhs)) || operator==(lhs, qd_cascade(rhs)); }
 
-inline bool operator==(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) == rhs; }
-inline bool operator!=(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) != rhs; }
-inline bool operator<(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) < rhs; }
-inline bool operator>(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) > rhs; }
-inline bool operator<=(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) <= rhs; }
-inline bool operator>=(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) >= rhs; }
+constexpr bool operator==(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) == rhs; }
+constexpr bool operator!=(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) != rhs; }
+constexpr bool operator<(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) < rhs; }
+constexpr bool operator>(double lhs, const qd_cascade& rhs) { return qd_cascade(lhs) > rhs; }
+constexpr bool operator<=(double lhs, const qd_cascade& rhs) { return operator<(qd_cascade(lhs), rhs) || operator==(qd_cascade(lhs), rhs); }
+constexpr bool operator>=(double lhs, const qd_cascade& rhs) { return operator>(qd_cascade(lhs), rhs) || operator==(qd_cascade(lhs), rhs); }
 
 // standard attribute function overloads
 

--- a/static/highprecision/qd_cascade/api/constexpr.cpp
+++ b/static/highprecision/qd_cascade/api/constexpr.cpp
@@ -1,0 +1,269 @@
+// constexpr.cpp: compile-time tests for qd_cascade (quad-double via floatcascade<4>)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// Configure qd_cascade: throwing arithmetic exceptions disabled so divide-by-zero
+// has defined constexpr-safe behavior (returns +/-inf or NaN encoding) rather
+// than throwing, which would be ill-formed in a constant expression.
+#define QD_CASCADE_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/qd_cascade/qd_cascade.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "qd_cascade constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// qd_cascade is a (1, 11, 212) floating-point triple stored as a
+	// floatcascade<4> -- an unevaluated sum of four IEEE-754 doubles.
+
+	// ----------------------------------------------------------------------------
+	// Native int construction (already constexpr -- smoke test only)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd_cascade a(0);
+		constexpr qd_cascade b(1);
+		constexpr qd_cascade c(-3);
+		(void)a; (void)b; (void)c;
+	}
+
+	// ----------------------------------------------------------------------------
+	// Acceptance form from issue #739:
+	//   constexpr qd_cascade a(2.0), b(3.0); constexpr auto c = a + b;
+	// (and analogous for *, -, /, +=, <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd_cascade a(2.0);
+		constexpr qd_cascade b(3.0);
+		constexpr auto cx_sum = a + b;
+		static_assert(cx_sum == qd_cascade(5.0), "issue #739 acceptance: a + b");
+	}
+
+	// ----------------------------------------------------------------------------
+	// All four binary arithmetic operators in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd_cascade a(4.5);
+		constexpr qd_cascade b(1.5);
+		constexpr auto cx_sum  = a + b;          // 4.5 + 1.5 = 6.0
+		constexpr auto cx_diff = a - b;          // 4.5 - 1.5 = 3.0
+		constexpr auto cx_prod = a * b;          // 4.5 * 1.5 = 6.75
+		constexpr auto cx_quot = a / b;          // 4.5 / 1.5 = 3.0
+		constexpr auto cx_neg  = -a;             // -4.5
+		static_assert(cx_sum  == qd_cascade(6.0),  "constexpr +  failed");
+		static_assert(cx_diff == qd_cascade(3.0),  "constexpr -  failed");
+		static_assert(cx_prod == qd_cascade(6.75), "constexpr *  failed");
+		static_assert(cx_quot == qd_cascade(3.0),  "constexpr /  failed");
+		static_assert(cx_neg  == qd_cascade(-4.5), "constexpr unary - failed");
+
+		// Compound assignment via lambda (constexpr lambdas are C++20)
+		constexpr qd_cascade cx_addeq = []() { qd_cascade t(1.5); t += qd_cascade(3.0); return t; }();
+		constexpr qd_cascade cx_subeq = []() { qd_cascade t(4.5); t -= qd_cascade(1.5); return t; }();
+		constexpr qd_cascade cx_muleq = []() { qd_cascade t(1.5); t *= qd_cascade(3.0); return t; }();
+		constexpr qd_cascade cx_diveq = []() { qd_cascade t(4.5); t /= qd_cascade(1.5); return t; }();
+		static_assert(cx_addeq == qd_cascade(4.5), "constexpr += failed");
+		static_assert(cx_subeq == qd_cascade(3.0), "constexpr -= failed");
+		static_assert(cx_muleq == qd_cascade(4.5), "constexpr *= failed");
+		static_assert(cx_diveq == qd_cascade(3.0), "constexpr /= failed");
+
+		// Compound assignment with double rhs
+		constexpr qd_cascade cx_addeqd = []() { qd_cascade t(1.5); t += 3.0; return t; }();
+		constexpr qd_cascade cx_subeqd = []() { qd_cascade t(4.5); t -= 1.5; return t; }();
+		constexpr qd_cascade cx_muleqd = []() { qd_cascade t(1.5); t *= 3.0; return t; }();
+		constexpr qd_cascade cx_diveqd = []() { qd_cascade t(4.5); t /= 1.5; return t; }();
+		static_assert(cx_addeqd == qd_cascade(4.5), "constexpr += double failed");
+		static_assert(cx_subeqd == qd_cascade(3.0), "constexpr -= double failed");
+		static_assert(cx_muleqd == qd_cascade(4.5), "constexpr *= double failed");
+		static_assert(cx_diveqd == qd_cascade(3.0), "constexpr /= double failed");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Constexpr comparison (issue acceptance: <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd_cascade a(1.5);
+		constexpr qd_cascade b(3.0);
+		static_assert(a < b,     "constexpr: qd_cascade(1.5) < qd_cascade(3.0)");
+		static_assert(b > a,     "constexpr: qd_cascade(3.0) > qd_cascade(1.5)");
+		static_assert(a <= b,    "constexpr: qd_cascade(1.5) <= qd_cascade(3.0)");
+		static_assert(b >= a,    "constexpr: qd_cascade(3.0) >= qd_cascade(1.5)");
+		static_assert(!(a == b), "constexpr: qd_cascade(1.5) != qd_cascade(3.0)");
+		static_assert(a != b,    "constexpr: != operator");
+		static_assert(a == a,    "constexpr: qd_cascade(1.5) == qd_cascade(1.5)");
+
+		// qd_cascade vs double comparisons
+		static_assert(a < 3.0,      "constexpr: qd_cascade(1.5) < 3.0");
+		static_assert(3.0 > a,      "constexpr: 3.0 > qd_cascade(1.5)");
+		static_assert(a == 1.5,     "constexpr: qd_cascade(1.5) == 1.5");
+		static_assert(1.5 == a,     "constexpr: 1.5 == qd_cascade(1.5)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion-out: operator double() / int() / float() are now constexpr.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd_cascade a(0.5);
+		constexpr double d = double(a);
+		static_assert(d == 0.5, "constexpr operator double()");
+
+		constexpr qd_cascade b(42.0);
+		constexpr int n = int(b);
+		static_assert(n == 42, "constexpr operator int()");
+
+		constexpr qd_cascade c(2.5);
+		constexpr float f = float(c);
+		static_assert(f == 2.5f, "constexpr operator float()");
+
+		// Large integer conversion: limb-separated truncation (lower 3 limbs
+		// collapsed via two_sum chain) preserves precision above 2^53.
+		constexpr qd_cascade large(9007199254740992.0, 1.0, 0.0, 0.0);
+		constexpr unsigned long long u = static_cast<unsigned long long>(large);
+		static_assert(u == 9007199254740993ULL,
+			"constexpr conversion preserves precision above 2^53");
+
+		// Negative large
+		constexpr qd_cascade large_neg(-9007199254740992.0, -1.0, 0.0, 0.0);
+		constexpr long long s = static_cast<long long>(large_neg);
+		static_assert(s == -9007199254740993LL,
+			"constexpr signed conversion preserves precision below -2^53");
+
+		// Boundary case: hi is integer, mid subtracts a sub-ulp fraction.
+		constexpr qd_cascade boundary_neg(101.0, -0x1.0p-50, 0.0, 0.0);
+		constexpr int b_neg = static_cast<int>(boundary_neg);
+		static_assert(b_neg == 100,
+			"constexpr trunc handles fractional borrow across int boundary");
+
+		// Boundary case: positive mid pushing hi+mid over an integer boundary.
+		constexpr qd_cascade boundary_pos(2.5, 0.6, 0.0, 0.0);
+		constexpr int b_pos = static_cast<int>(boundary_pos);
+		static_assert(b_pos == 3,
+			"constexpr trunc handles fractional carry across int boundary");
+
+		// Negative qd_cascade to unsigned saturates to 0.
+		constexpr qd_cascade negval(-5.0);
+		constexpr unsigned int neg_u = static_cast<unsigned int>(negval);
+		static_assert(neg_u == 0u,
+			"constexpr unsigned conversion clamps negative qd_cascade to 0");
+
+		// Out-of-range saturates to integer max.
+		constexpr qd_cascade huge(1.0e20);
+		constexpr int huge_i = static_cast<int>(huge);
+		static_assert(huge_i == (std::numeric_limits<int>::max)(),
+			"constexpr signed conversion saturates above int max");
+
+		// hi at the rounded long long boundary, lower limbs bring it back in range.
+		constexpr qd_cascade boundary_max(0x1.0p63, -2.0, 0.0, 0.0);
+		constexpr long long b_max = static_cast<long long>(boundary_max);
+		static_assert(b_max == 9223372036854775806LL,
+			"constexpr signed conversion at upper boundary uses lo to stay in range");
+
+		constexpr qd_cascade boundary_umax(0x1.0p64, -2.0, 0.0, 0.0);
+		constexpr unsigned long long b_umax = static_cast<unsigned long long>(boundary_umax);
+		static_assert(b_umax == 18446744073709551614ULL,
+			"constexpr unsigned conversion at upper boundary uses lo to stay in range");
+
+		// Defensive saturation for unnormalized qd_cascade values.
+		constexpr qd_cascade unnorm_pos(0.0, 1.0e30, 0.0, 0.0);
+		constexpr long long unp = static_cast<long long>(unnorm_pos);
+		static_assert(unp == (std::numeric_limits<long long>::max)(),
+			"constexpr conversion saturates on unnormalized lo > max");
+
+		constexpr qd_cascade unnorm_neg(0.0, -1.0e30, 0.0, 0.0);
+		constexpr long long unn = static_cast<long long>(unnorm_neg);
+		static_assert(unn == (std::numeric_limits<long long>::min)(),
+			"constexpr signed conversion saturates on unnormalized lo < min");
+		constexpr unsigned long long unn_u = static_cast<unsigned long long>(unnorm_neg);
+		static_assert(unn_u == 0ULL,
+			"constexpr unsigned conversion clamps unnormalized negative to 0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction (already constexpr -- smoke test)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd_cascade zero(SpecificValue::zero);
+		constexpr qd_cascade inf_pos(SpecificValue::infpos);
+		constexpr qd_cascade inf_neg(SpecificValue::infneg);
+		static_assert(zero == qd_cascade(0.0), "constexpr SpecificValue::zero");
+		static_assert(inf_pos > qd_cascade(0.0), "constexpr SpecificValue::infpos");
+		static_assert(inf_neg < qd_cascade(0.0), "constexpr SpecificValue::infneg");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Mixed qd_cascade / double binary arithmetic in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd_cascade a(2.0);
+		constexpr auto cx_sum  = a + 3.0;
+		constexpr auto cx_diff = a - 1.0;
+		constexpr auto cx_prod = a * 4.0;
+		constexpr auto cx_quot = a / 2.0;
+		static_assert(cx_sum  == qd_cascade(5.0), "constexpr qd_cascade + double");
+		static_assert(cx_diff == qd_cascade(1.0), "constexpr qd_cascade - double");
+		static_assert(cx_prod == qd_cascade(8.0), "constexpr qd_cascade * double");
+		static_assert(cx_quot == qd_cascade(1.0), "constexpr qd_cascade / double");
+
+		constexpr auto cx_lhs_sum = 5.0 + qd_cascade(2.0);
+		static_assert(cx_lhs_sum == qd_cascade(7.0), "constexpr double + qd_cascade");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Sign of negative zero in divide-by-zero: -0.0 should produce -infinity.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr auto cx_q = []() { qd_cascade t(1.0); t /= qd_cascade(-0.0); return t; }();
+		static_assert(cx_q < qd_cascade(0.0), "constexpr 1.0 / -0.0 should be -inf");
+		static_assert(cx_q.isinf(), "constexpr 1.0 / -0.0 should be inf");
+	}
+
+	// ----------------------------------------------------------------------------
+	// IEEE-754 unordered comparison: nan >= x must be false (and similar).
+	// Tested at runtime instead of via static_assert (MSVC constexpr NaN bug).
+	// ----------------------------------------------------------------------------
+	{
+		qd_cascade qnan(SpecificValue::qnan);
+		qd_cascade one(1.0);
+		if ( (qnan <  one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan <  1.0 should be false\n"; }
+		if ( (qnan >  one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan >  1.0 should be false\n"; }
+		if ( (qnan <= one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan <= 1.0 should be false\n"; }
+		if ( (qnan >= one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan >= 1.0 should be false\n"; }
+		if ( (qnan == one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan == 1.0 should be false\n"; }
+		if (!(qnan != one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan != 1.0 should be true\n"; }
+		if ( (one  >= qnan)){ ++nrOfFailedTestCases; std::cerr << "FAIL: 1.0 >= nan should be false\n"; }
+	}
+
+	std::cout << "qd_cascade constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::qd_cascade_arithmetic_exception& err) {
+	std::cerr << "Uncaught qd_cascade arithmetic exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- Promotes `qd_cascade` (quad-double via `floatcascade<4>`) to fully constexpr across construction, arithmetic, comparison, unary negation, and conversion-out.
- **Completes the cascade trio**: dd_cascade (#797), td_cascade (#798), qd_cascade (this PR).

## Approach
The EFT primitives (`two_sum`, `fast_two_sum`, `two_prod`, `three_sum`, `three_sum2`, `isneg`/`ispos`) were already promoted in #797. This PR adds the **N=4 specializations**:

- `compress_8to4` and `renormalize<4>` marked constexpr.
- New non-template constexpr overloads of `add_cascades` (8-element bubble sort) and `multiply_cascades` (16 partial products + 32-term sort, all in fixed-size arrays — no `std::sort`/`std::vector`).

`qd_cascade_impl.hpp` follows the established cascade pattern from #797 / #798:
- Comparisons, conversions, arithmetic operators promoted.
- NaN-safe `>=` / `<=` via `> \|\| ==` and `< \|\| ==`.
- Sign-bit fix in `/=` via `std::bit_cast` so `-0.0` produces `-inf` at compile time.
- Integer conversion uses limb-separated truncation: collapse `mid_hi + mid_lo + lo` via a two_sum chain (sub-ULP error discarded — cannot affect integer truncation), then apply the dd-style algorithm. Fixes pre-existing bug where the old int64_t-cast helpers ignored `cascade[2]` and `cascade[3]` entirely.
- Saturation guards before each limb cast.

## Changes
- `include/sw/universal/internal/floatcascade/floatcascade.hpp` — `compress_8to4`, `renormalize<4>` constexpr; new `add_cascades` / `multiply_cascades` overloads for `floatcascade<4>`.
- `include/sw/universal/number/qd_cascade/qd_cascade_impl.hpp` — operators promoted; conversion templates rewritten with limb-separated truncation; sign/NaN/UB-guard fixes from #797 / #798 applied.
- `static/highprecision/qd_cascade/api/constexpr.cpp` — new test (mirrors td_cascade's, scaled to 4 limbs).

## Test Results
| Suite | gcc | clang |
|-------|-----|-------|
| qdc_api_api / constants / roundtrip / constexpr | PASS | PASS |
| qdc_arith_addition / arithmetic / division / multiplication / subtraction | PASS | PASS |
| qdc_math_pow / sqrt / logarithm | PASS | PASS |
| ddc_arith_arithmetic (regression) | PASS | PASS |
| tdc_arith_arithmetic (regression) | PASS | PASS |

12/12 qd_cascade + 1/1 dd_cascade + 1/1 td_cascade tests PASS on both compilers. dd_cascade and td_cascade unaffected because the floatcascade<2> / floatcascade<3> overloads remain unchanged.

## Cascade trio progress
- `dd_cascade`: merged in #797 (a28f6727) ✅
- `td_cascade`: merged in #798 (625032bf) ✅
- `qd_cascade`: this PR

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #739

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added compile-time (constexpr) evaluation support for quad-double arithmetic operations including addition, multiplication, and type conversions.
  * Introduced compound assignment operators with mixed-type operands (quad-double with double).
  * Expanded comparison operators with improved semantics for less-than-or-equal and greater-than-or-equal comparisons.

* **Improvements**
  * Enhanced precision handling in floating-point conversions and cascade arithmetic.
  * Improved signed zero preservation in division operations.

* **Tests**
  * Added constexpr verification test suite validating compile-time arithmetic evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->