### PR TITLE
feat(qd): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/number/qd/qd_impl.hpp
+++ b/include/sw/universal/number/qd/qd_impl.hpp
@@ -18,8 +18,11 @@
 #include <limits>
 #include <cmath>
 #include <vector>
+#include <bit>
+#include <type_traits>
 
 // supporting types and functions
+#include <universal/utility/bit_cast.hpp>
 #include <universal/native/ieee754.hpp>
 #include <universal/numerics/error_free_ops.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
@@ -32,10 +35,10 @@
 namespace sw { namespace universal {
 
 // fwd references to free functions
-inline qd operator+(const qd&, const qd&);
-inline qd operator-(const qd&, const qd&);
-inline qd operator*(const qd&, const qd&);
-inline qd operator/(const qd&, const qd&);
+constexpr qd operator+(const qd&, const qd&);
+constexpr qd operator-(const qd&, const qd&);
+constexpr qd operator*(const qd&, const qd&);
+constexpr qd operator/(const qd&, const qd&);
 inline std::ostream& operator<<(std::ostream&, const qd&);
 inline qd pown(const qd&, int);
 inline qd frexp(const qd&, int*);
@@ -132,22 +135,171 @@ public:
 	constexpr qd& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
 	constexpr qd& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
 
+private:
+	// Helper templates used by the conversion operators below.  Defined before
+	// the operators so the constexpr call chain is fully resolved at the point
+	// of operator declaration (clang requires this; gcc is more permissive).
+	//
+	// For quad-double, collapse the lower three limbs (x[1] + x[2] + x[3])
+	// into a single representative double via a two_sum chain (sub-ULP error
+	// discarded -- cannot affect integer truncation), then apply the dd-style
+	// limb-separated truncation algorithm from #796.  Extends the
+	// limb-separated approach to the full 212-bit range.
+	template<typename Unsigned>
+	constexpr Unsigned convert_to_unsigned_impl() const noexcept {
+		const double hi = x[0];
+		double e1 = 0.0;
+		double e23 = 0.0;
+		// Collapse x[2] + x[3] first, then add x[1].  error_free_ops::two_sum
+		// returns the rounded sum and writes the residual via the third arg.
+		double s23 = two_sum(x[2], x[3], e23);
+		double s1  = two_sum(x[1], s23, e1);
+		(void)e1; (void)e23;
+		const double lo = s1;
+
+		bool hi_finite;
+		if (std::is_constant_evaluated()) {
+			constexpr double inf = std::numeric_limits<double>::infinity();
+			hi_finite = !(hi != hi) && hi != inf && hi != -inf;
+		}
+		else {
+			hi_finite = std::isfinite(hi);
+		}
+		if (!hi_finite) {
+			return hi < 0.0 ? Unsigned(0) : (std::numeric_limits<Unsigned>::max)();
+		}
+		if (hi < 0.0) return Unsigned(0);
+
+		constexpr double unsigned_max_d = static_cast<double>((std::numeric_limits<Unsigned>::max)());
+		if (hi > unsigned_max_d) return (std::numeric_limits<Unsigned>::max)();
+		if (hi == unsigned_max_d) {
+			if (lo >= 0.0) return (std::numeric_limits<Unsigned>::max)();
+			double abs_lo = -lo;
+			if (abs_lo >= unsigned_max_d) return Unsigned(0);
+			Unsigned abs_lo_int = static_cast<Unsigned>(abs_lo);
+			double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+			Unsigned result = (std::numeric_limits<Unsigned>::max)();
+			if (abs_lo_frac == 0.0) return result - (abs_lo_int - 1);
+			return result - abs_lo_int;
+		}
+
+		Unsigned hi_int = static_cast<Unsigned>(hi);
+		double hi_frac = hi - static_cast<double>(hi_int);
+
+		if (lo >= 0.0) {
+			if (lo >= unsigned_max_d) return (std::numeric_limits<Unsigned>::max)();
+			Unsigned lo_int = static_cast<Unsigned>(lo);
+			double lo_frac = lo - static_cast<double>(lo_int);
+			double frac_sum = hi_frac + lo_frac;
+			if (lo_int > (std::numeric_limits<Unsigned>::max)() - hi_int) {
+				return (std::numeric_limits<Unsigned>::max)();
+			}
+			Unsigned sum = hi_int + lo_int;
+			if (frac_sum >= 1.0) {
+				if (sum == (std::numeric_limits<Unsigned>::max)()) return sum;
+				return sum + 1;
+			}
+			return sum;
+		}
+		else {
+			double abs_lo = -lo;
+			if (abs_lo >= unsigned_max_d) return Unsigned(0);
+			Unsigned abs_lo_int = static_cast<Unsigned>(abs_lo);
+			double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+			if (hi_int < abs_lo_int) return Unsigned(0);
+			if (hi_int == abs_lo_int) return Unsigned(0);
+			Unsigned diff = hi_int - abs_lo_int;
+			if (hi_frac < abs_lo_frac) return diff - 1;
+			return diff;
+		}
+	}
+
+	template<typename Signed>
+	constexpr Signed convert_to_signed_impl() const noexcept {
+		const double hi = x[0];
+		double e1 = 0.0;
+		double e23 = 0.0;
+		double s23 = two_sum(x[2], x[3], e23);
+		double s1  = two_sum(x[1], s23, e1);
+		(void)e1; (void)e23;
+		const double lo = s1;
+
+		bool hi_finite;
+		if (std::is_constant_evaluated()) {
+			constexpr double inf = std::numeric_limits<double>::infinity();
+			hi_finite = !(hi != hi) && hi != inf && hi != -inf;
+		}
+		else {
+			hi_finite = std::isfinite(hi);
+		}
+		if (!hi_finite) {
+			return hi < 0.0 ? (std::numeric_limits<Signed>::min)() : (std::numeric_limits<Signed>::max)();
+		}
+
+		constexpr double signed_max_d = static_cast<double>((std::numeric_limits<Signed>::max)());
+		constexpr double signed_min_d = static_cast<double>((std::numeric_limits<Signed>::min)());
+
+		if (hi > signed_max_d) return (std::numeric_limits<Signed>::max)();
+		if (hi == signed_max_d) {
+			if (lo >= 0.0) return (std::numeric_limits<Signed>::max)();
+			double abs_lo = -lo;
+			if (abs_lo >= signed_max_d) return (std::numeric_limits<Signed>::min)();
+			Signed abs_lo_int = static_cast<Signed>(abs_lo);
+			double abs_lo_frac = abs_lo - static_cast<double>(abs_lo_int);
+			Signed result = (std::numeric_limits<Signed>::max)();
+			if (abs_lo_frac == 0.0) return result - (abs_lo_int - 1);
+			return result - abs_lo_int;
+		}
+		if (hi < signed_min_d) return (std::numeric_limits<Signed>::min)();
+
+		Signed hi_int = static_cast<Signed>(hi);
+		if (lo >= signed_max_d) return (std::numeric_limits<Signed>::max)();
+		if (lo < signed_min_d) return (std::numeric_limits<Signed>::min)();
+		Signed lo_int = static_cast<Signed>(lo);
+		if (lo_int > 0 && hi_int > (std::numeric_limits<Signed>::max)() - lo_int) {
+			return (std::numeric_limits<Signed>::max)();
+		}
+		if (lo_int < 0 && hi_int < (std::numeric_limits<Signed>::min)() - lo_int) {
+			return (std::numeric_limits<Signed>::min)();
+		}
+		Signed sum = hi_int + lo_int;
+
+		double hi_frac = hi - static_cast<double>(hi_int);
+		double lo_frac = lo - static_cast<double>(lo_int);
+		double frac_sum = hi_frac + lo_frac;
+
+		if (frac_sum >= 1.0) {
+			if (sum == (std::numeric_limits<Signed>::max)()) return sum;
+			return sum + 1;
+		}
+		if (frac_sum <= -1.0) {
+			if (sum == (std::numeric_limits<Signed>::min)()) return sum;
+			return sum - 1;
+		}
+		if (sum > 0 && frac_sum < 0.0) return sum - 1;
+		if (sum < 0 && frac_sum > 0.0) return sum + 1;
+		return sum;
+	}
+
+public:
 	// conversion operators
-	explicit operator int()                   const noexcept { return convert_to_signed<int>(); }
-	explicit operator long()                  const noexcept { return convert_to_signed<long>(); }
-	explicit operator long long()             const noexcept { return convert_to_signed<long long>(); }
-	explicit operator unsigned int()          const noexcept { return convert_to_unsigned<unsigned int>(); }
-	explicit operator unsigned long()         const noexcept { return convert_to_unsigned<unsigned long>(); }
-	explicit operator unsigned long long()    const noexcept { return convert_to_unsigned<unsigned long long>(); }
-	explicit operator float()                 const noexcept { return convert_to_ieee754<float>(); }
-	explicit operator double()                const noexcept { return convert_to_ieee754<double>(); }
+	explicit constexpr operator int()                   const noexcept { return convert_to_signed_impl<int>(); }
+	explicit constexpr operator long()                  const noexcept { return convert_to_signed_impl<long>(); }
+	explicit constexpr operator long long()             const noexcept { return convert_to_signed_impl<long long>(); }
+	explicit constexpr operator unsigned int()          const noexcept { return convert_to_unsigned_impl<unsigned int>(); }
+	explicit constexpr operator unsigned long()         const noexcept { return convert_to_unsigned_impl<unsigned long>(); }
+	explicit constexpr operator unsigned long long()    const noexcept { return convert_to_unsigned_impl<unsigned long long>(); }
+	explicit constexpr operator float()                 const noexcept { return static_cast<float>(x[0] + x[1] + x[2] + x[3]); }
+	explicit constexpr operator double()                const noexcept { return x[0] + x[1] + x[2] + x[3]; }
 
 
 #if LONG_DOUBLE_SUPPORT
-	// can't be constexpr as remainder calculation requires volatile designation
+	// long double constructor and assignment cannot be constexpr because the
+	// remainder calculation requires volatile designation; conversion-out is
+	// constexpr-clean.
 			  qd(long double iv)                    noexcept { *this = iv; }
 			  qd& operator=(long double rhs)        noexcept { return convert_ieee754(rhs); }
-	explicit operator long double()           const noexcept { return convert_to_ieee754<long double>(); }
+	explicit constexpr operator long double() const noexcept { return static_cast<long double>(x[0]) + static_cast<long double>(x[1]) + static_cast<long double>(x[2]) + static_cast<long double>(x[3]); }
 #endif
 
 	// prefix operators
@@ -157,31 +309,31 @@ public:
 
 	// arithmetic operators
 #define IEEE_ERROR_BOUND 1
-	qd& operator+=(const qd& rhs) {
+	CONSTEXPRESSION qd& operator+=(const qd& rhs) {
 #if defined(IEEE_ERROR_BOUND)
 		return *this = accurate_addition(*this, rhs);
 #else // !IEEE_ERROR_BOUND -> CRAY_ERROR_BOUND
 		return *this = approximate_addition(*this, rhs);
 #endif
 	}
-	qd& operator+=(double rhs) {
+	CONSTEXPRESSION qd& operator+=(double rhs) {
 		return operator+=(qd(rhs));
 	}
-	qd& operator-=(const qd& rhs) {
+	CONSTEXPRESSION qd& operator-=(const qd& rhs) {
 		return *this += -rhs;
 	}
-	qd& operator-=(double rhs) {
+	CONSTEXPRESSION qd& operator-=(double rhs) {
 		return *this += qd(-rhs);
 	}
 #define ACCURATE_MULTIPLICATION 1
-	qd& operator*=(const qd& rhs) {
+	CONSTEXPRESSION qd& operator*=(const qd& rhs) {
 #if defined(ACCURATE_MULTIPLICATION)
 		return *this = accurate_multiplication(*this, rhs);
 #else
 		return *this = approximate_multiplication(*this, rhs);
 #endif
 	}
-	qd& operator*=(double rhs) {
+	CONSTEXPRESSION qd& operator*=(double rhs) {
 		double q0, q1, q2;
 
 		double p0 = two_prod(x[0], rhs, q0);
@@ -208,7 +360,7 @@ public:
 		return *this;
 	}
 #define ACCURATE_DIVISION 1
-	qd& operator/=(const qd& rhs) {
+	CONSTEXPRESSION qd& operator/=(const qd& rhs) {
 #if QUADDOUBLE_THROW_ARITHMETIC_EXCEPTION
 		if (isnan()) throw qd_not_a_number();
 		if (rhs.isnan()) throw qd_divide_by_nan();
@@ -229,7 +381,20 @@ public:
 				*this = qd(SpecificValue::qnan);
 			}
 			else {
-				*this = (sign() ? qd(SpecificValue::infneg) : qd(SpecificValue::infpos));
+				// Determine sign of result.  At runtime use std::copysign-style
+				// sign() which is `x[0] < 0.0`; during constant evaluation use
+				// std::bit_cast to extract the IEEE-754 sign bit so -0.0
+				// carries through correctly (per #727 / #797 / #798 lessons).
+				int sA, sB;
+				if (std::is_constant_evaluated()) {
+					sA = (std::bit_cast<std::uint64_t>(x[0])     >> 63) ? -1 : 1;
+					sB = (std::bit_cast<std::uint64_t>(rhs.x[0]) >> 63) ? -1 : 1;
+				}
+				else {
+					sA = (x[0] < 0.0) ? -1 : 1;
+					sB = (rhs.x[0] < 0.0) ? -1 : 1;
+				}
+				*this = ((sA == sB) ? qd(SpecificValue::infpos) : qd(SpecificValue::infneg));
 			}
 			return *this;
 		}
@@ -241,7 +406,7 @@ public:
 		return *this = approximate_division(*this, rhs);
 #endif
 	}
-	qd& operator/=(double rhs) {
+	CONSTEXPRESSION qd& operator/=(double rhs) {
 		return operator/=(qd(rhs));
 	}
 
@@ -372,8 +537,8 @@ public:
 	}
 
 	// argument is not protected for speed
-	double operator[](int index) const { return x[index]; }
-	double& operator[](int index)      { return x[index]; }
+	constexpr double operator[](int index) const { return x[index]; }
+	constexpr double& operator[](int index)      { return x[index]; }
 
 	// create specific number system values of interest
 	constexpr qd& maxpos() noexcept {
@@ -454,16 +619,19 @@ public:
 	////////////////////////////////////////////////////////////////////////////////////////////////////////
 	/// arithmetic operator helpers
 
-	qd accurate_addition(const qd& a, const qd& b) {
+	constexpr qd accurate_addition(const qd& a, const qd& b) const {
+		// std::abs(double) is not constexpr in C++20; use a ternary helper.
+		auto absv = [](double v) constexpr -> double { return v < 0.0 ? -v : v; };
+
 		double u, v;
 		int i{ 0 }, j{ 0 }, k{ 0 };
-		if (std::abs(a[i]) > std::abs(b[j])) {
+		if (absv(a[i]) > absv(b[j])) {
 			u = a[i++];
 		}
 		else {
 			u = b[j++];
 		}
-		if (std::abs(a[i]) > std::abs(b[j])) {
+		if (absv(a[i]) > absv(b[j])) {
 			v = a[i++];
 		}
 		else {
@@ -488,7 +656,7 @@ public:
 			else if (j >= 4) {
 				t = a[i++];
 			}
-			else if (std::abs(a[i]) > std::abs(b[j])) {
+			else if (absv(a[i]) > absv(b[j])) {
 				t = a[i++];
 			}
 			else {
@@ -510,7 +678,7 @@ public:
 		return qd(c[0], c[1], c[2], c[3]);
 	}
 
-	qd approximate_addition(const qd& a, const qd& b) {
+	constexpr qd approximate_addition(const qd& a, const qd& b) const {
 		double s0, s1, s2, s3;
 		double t0, t1, t2, t3;
 
@@ -528,7 +696,7 @@ public:
 		return qd(s0, s1, s2, s3);
 	}
 
-	qd approximate_addition_explicit(const qd& a, const qd& b) {
+	constexpr qd approximate_addition_explicit(const qd& a, const qd& b) const {
 		// Same as approximate_addition, but addition re-organized to guide bad compilers
 
 		double s0 = a[0] + b[0];
@@ -582,7 +750,7 @@ public:
 					  a2 * b1     8
 					  a3 * b0     9  
 	 */
-	qd approximate_multiplication(const qd& a, const qd& b) {
+	constexpr qd approximate_multiplication(const qd& a, const qd& b) const {
 		double p0, p1, p2, p3, p4, p5;
 		double q0, q1, q2, q3, q4, q5;
 		double t0, t1;
@@ -616,7 +784,7 @@ public:
 		return qd(p0, p1, s0, s1);
 	}
 
-	qd accurate_multiplication(const qd& a, const qd& b) {
+	constexpr qd accurate_multiplication(const qd& a, const qd& b) const {
 		double q0, q1, q2, q3, q4, q5;
 		double p0 = two_prod(a[0], b[0], q0);
 		
@@ -674,7 +842,7 @@ public:
 		return qd(p0, p1, s0, t0);
 	}
 	
-	qd approximate_division(const qd& a, const qd& b) {
+	constexpr qd approximate_division(const qd& a, const qd& b) const {
 		qd r{};
 
 		double q0 = a[0] / b[0];
@@ -692,7 +860,7 @@ public:
 		return qd(q0, q1, q2, q3);
 	}
 
-	qd accurate_division(const qd& a, const qd& b) {
+	constexpr qd accurate_division(const qd& a, const qd& b) const {
 		qd r{};
 
 		double q0 = a[0] / b[0];
@@ -916,27 +1084,11 @@ protected:
 	}
 #endif
 
-	// convert to native unsigned integer, use C++ conversion rules to cast down to float and double
-	template<typename Unsigned>
-	Unsigned convert_to_unsigned() const noexcept {
-		int64_t h = static_cast<int64_t>(x[0]);
-		int64_t l = static_cast<int64_t>(x[1]);
-		return Unsigned(h + l);
-	}
-	
-	// convert to native unsigned integer, use C++ conversion rules to cast down to float and double
-	template<typename Signed>
-	Signed convert_to_signed() const noexcept {
-		int64_t h = static_cast<int64_t>(x[0]);
-		int64_t l = static_cast<int64_t>(x[1]);
-		return Signed(h + l);
-	}
-
-	// convert to native floating-point, use C++ conversion rules to cast down to float and double
-	template<typename Real>
-	Real convert_to_ieee754() const noexcept {
-		return Real(x[0] + x[1] + x[2] + x[3]);
-	}
+	// (convert_to_unsigned_impl / convert_to_signed_impl moved up next to the
+	// conversion operators that call them, so the constexpr call chain is
+	// fully resolved at the point of declaration.  The old int64_t-cast
+	// helpers had two bugs: they ignored x[2] and x[3], and could trigger
+	// UB per C++20 [conv.fpint] for unnormalized inputs.)
 
 
 	////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1112,20 +1264,18 @@ protected:
 private:
 
 	// qd - qd logic comparisons
-	friend bool operator==(const qd& lhs, const qd& rhs);
-	friend bool operator!=(const qd& lhs, const qd& rhs);
-	friend bool operator<=(const qd& lhs, const qd& rhs);
-	friend bool operator>=(const qd& lhs, const qd& rhs);
-	friend bool operator<(const qd& lhs, const qd& rhs);
-	friend bool operator>(const qd& lhs, const qd& rhs);
+	friend constexpr bool operator==(const qd& lhs, const qd& rhs);
+	friend constexpr bool operator!=(const qd& lhs, const qd& rhs);
+	friend constexpr bool operator<=(const qd& lhs, const qd& rhs);
+	friend constexpr bool operator>=(const qd& lhs, const qd& rhs);
+	friend constexpr bool operator<(const qd& lhs, const qd& rhs);
+	friend constexpr bool operator>(const qd& lhs, const qd& rhs);
 
 	// qd - literal logic comparisons
-	friend bool operator==(const qd& lhs, const double rhs);
+	friend constexpr bool operator==(const qd& lhs, const double rhs);
 
 	// literal - qd logic comparisons
-	friend bool operator==(const double lhs, const qd& rhs);
-
-	friend bool operator<(const qd& lhs, const qd& rhs);
+	friend constexpr bool operator==(const double lhs, const qd& rhs);
 
 };
 
@@ -1564,87 +1714,89 @@ inline bool parse(const std::string& number, qd& value) {
 // qd - qd binary logic operators
 
 // equal: precondition is that the storage is properly nulled in all arithmetic paths
-inline bool operator==(const qd& lhs, const qd& rhs) {
+constexpr bool operator==(const qd& lhs, const qd& rhs) {
 	return (lhs[0] == rhs[0]) && (lhs[1] == rhs[1] && lhs[2] == rhs[2]) && (lhs[3] == rhs[3]);
 }
 
-inline bool operator!=(const qd& lhs, const qd& rhs) {
+constexpr bool operator!=(const qd& lhs, const qd& rhs) {
 	return !operator==(lhs, rhs);
 }
 
-inline bool operator< (const qd& lhs, const qd& rhs) {
+constexpr bool operator< (const qd& lhs, const qd& rhs) {
 	return (lhs[0] < rhs[0] ||
 		(lhs[0] == rhs[0] && (lhs[1] < rhs[1] ||
 			(lhs[1] == rhs[1] && (lhs[2] < rhs[2] ||
 				(lhs[2] == rhs[2] && lhs[3] < rhs[3]))))));
 }
 
-inline bool operator> (const qd& lhs, const qd& rhs) {
+constexpr bool operator> (const qd& lhs, const qd& rhs) {
 	return operator< (rhs, lhs);
 }
 
-inline bool operator<=(const qd& lhs, const qd& rhs) {
+constexpr bool operator<=(const qd& lhs, const qd& rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 
-inline bool operator>=(const qd& lhs, const qd& rhs) {
-	return !operator< (lhs, rhs);
+constexpr bool operator>=(const qd& lhs, const qd& rhs) {
+	// NOT !operator<: that would be true for unordered (NaN) operands. Use
+	// operator> || operator== so NaN comparisons stay unordered (per #797).
+	return operator>(lhs, rhs) || operator==(lhs, rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // qd - literal binary logic operators
 // 
 // equal: precondition is that the storage is properly nulled in all arithmetic paths
-inline bool operator==(const qd& lhs, double rhs) {
+constexpr bool operator==(const qd& lhs, double rhs) {
 	return operator==(lhs, qd(rhs));
 }
 
-inline bool operator!=(const qd& lhs, double rhs) {
+constexpr bool operator!=(const qd& lhs, double rhs) {
 	return !operator==(lhs, rhs);
 }
 
-inline bool operator< (const qd& lhs, double rhs) {
+constexpr bool operator< (const qd& lhs, double rhs) {
 	return operator<(lhs, qd(rhs));
 }
 
-inline bool operator> (const qd& lhs, double rhs) {
+constexpr bool operator> (const qd& lhs, double rhs) {
 	return operator< (qd(rhs), lhs);
 }
 
-inline bool operator<=(const qd& lhs, double rhs) {
+constexpr bool operator<=(const qd& lhs, double rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 
-inline bool operator>=(const qd& lhs, double rhs) {
-	return !operator< (lhs, rhs);
+constexpr bool operator>=(const qd& lhs, double rhs) {
+	return operator>(lhs, qd(rhs)) || operator==(lhs, qd(rhs));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - qd binary logic operators
 // 
 // equal: precondition is that the storage is properly nulled in all arithmetic paths
-inline bool operator==(double lhs, const qd& rhs) {
+constexpr bool operator==(double lhs, const qd& rhs) {
 	return operator==(qd(lhs), rhs);
 }
 
-inline bool operator!=(double lhs, const qd& rhs) {
+constexpr bool operator!=(double lhs, const qd& rhs) {
 	return !operator==(lhs, rhs);
 }
 
-inline bool operator< (double lhs, const qd& rhs) {
+constexpr bool operator< (double lhs, const qd& rhs) {
 	return operator<(qd(lhs), rhs);
 }
 
-inline bool operator> (double lhs, const qd& rhs) {
+constexpr bool operator> (double lhs, const qd& rhs) {
 	return operator< (rhs, lhs);
 }
 
-inline bool operator<=(double lhs, const qd& rhs) {
+constexpr bool operator<=(double lhs, const qd& rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 
-inline bool operator>=(double lhs, const qd& rhs) {
-	return !operator< (lhs, rhs);
+constexpr bool operator>=(double lhs, const qd& rhs) {
+	return operator>(qd(lhs), rhs) || operator==(qd(lhs), rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1652,25 +1804,25 @@ inline bool operator>=(double lhs, const qd& rhs) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // qd - qd binary arithmetic operators
 // BINARY ADDITION
-inline qd operator+(const qd& lhs, const qd& rhs) {
+constexpr qd operator+(const qd& lhs, const qd& rhs) {
 	qd sum{ lhs };
 	sum += rhs;
 	return sum;
 }
 // BINARY SUBTRACTION
-inline qd operator-(const qd& lhs, const qd& rhs) {
+constexpr qd operator-(const qd& lhs, const qd& rhs) {
 	qd diff{ lhs };
 	diff -= rhs;
 	return diff;
 }
 // BINARY MULTIPLICATION
-inline qd operator*(const qd& lhs, const qd& rhs) {
+constexpr qd operator*(const qd& lhs, const qd& rhs) {
 	qd mul{ lhs };
 	mul *= rhs;
 	return mul;
 }
 // BINARY DIVISION
-inline qd operator/(const qd& lhs, const qd& rhs) {
+constexpr qd operator/(const qd& lhs, const qd& rhs) {
 	qd ratio{ lhs };
 	ratio /= rhs;
 	return ratio;
@@ -1679,38 +1831,38 @@ inline qd operator/(const qd& lhs, const qd& rhs) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // qd - literal binary arithmetic operators
 // BINARY ADDITION
-inline qd operator+(const qd& lhs, double rhs) {
+constexpr qd operator+(const qd& lhs, double rhs) {
 	return operator+(lhs, qd(rhs));
 }
 // BINARY SUBTRACTION
-inline qd operator-(const qd& lhs, double rhs) {
+constexpr qd operator-(const qd& lhs, double rhs) {
 	return operator-(lhs, qd(rhs));
 }
 // BINARY MULTIPLICATION
-inline qd operator*(const qd& lhs, double rhs) {
+constexpr qd operator*(const qd& lhs, double rhs) {
 	return operator*(lhs, qd(rhs));
 }
 // BINARY DIVISION
-inline qd operator/(const qd& lhs, double rhs) {
+constexpr qd operator/(const qd& lhs, double rhs) {
 	return operator/(lhs, qd(rhs));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - qd binary arithmetic operators
 // BINARY ADDITION
-inline qd operator+(double lhs, const qd& rhs) {
+constexpr qd operator+(double lhs, const qd& rhs) {
 	return operator+(qd(lhs), rhs);
 }
 // BINARY SUBTRACTION
-inline qd operator-(double lhs, const qd& rhs) {
+constexpr qd operator-(double lhs, const qd& rhs) {
 	return operator-(qd(lhs), rhs);
 }
 // BINARY MULTIPLICATION
-inline qd operator*(double lhs, const qd& rhs) {
+constexpr qd operator*(double lhs, const qd& rhs) {
 	return operator*(qd(lhs), rhs);
 }
 // BINARY DIVISION
-inline qd operator/(double lhs, const qd& rhs) {
+constexpr qd operator/(double lhs, const qd& rhs) {
 	return operator/(qd(lhs), rhs);
 }
 

--- a/include/sw/universal/number/qd/qd_impl.hpp
+++ b/include/sw/universal/number/qd/qd_impl.hpp
@@ -381,18 +381,19 @@ public:
 				*this = qd(SpecificValue::qnan);
 			}
 			else {
-				// Determine sign of result.  At runtime use std::copysign-style
-				// sign() which is `x[0] < 0.0`; during constant evaluation use
-				// std::bit_cast to extract the IEEE-754 sign bit so -0.0
-				// carries through correctly (per #727 / #797 / #798 lessons).
+				// Determine sign of result.  Both branches must extract the
+				// IEEE-754 sign bit so -0.0 carries through correctly: at
+				// runtime use std::signbit (which inspects the bit), during
+				// constant evaluation use std::bit_cast (since std::signbit
+				// is not constexpr in C++20).  Per #727 / #797 / #798 lessons.
 				int sA, sB;
 				if (std::is_constant_evaluated()) {
 					sA = (std::bit_cast<std::uint64_t>(x[0])     >> 63) ? -1 : 1;
 					sB = (std::bit_cast<std::uint64_t>(rhs.x[0]) >> 63) ? -1 : 1;
 				}
 				else {
-					sA = (x[0] < 0.0) ? -1 : 1;
-					sB = (rhs.x[0] < 0.0) ? -1 : 1;
+					sA = std::signbit(x[0])     ? -1 : 1;
+					sB = std::signbit(rhs.x[0]) ? -1 : 1;
 				}
 				*this = ((sA == sB) ? qd(SpecificValue::infpos) : qd(SpecificValue::infneg));
 			}

--- a/include/sw/universal/number/qd/qd_impl.hpp
+++ b/include/sw/universal/number/qd/qd_impl.hpp
@@ -1210,7 +1210,14 @@ protected:
 		// generate the digits
 		int nrDigits = precision + 1;
 		for (int i = 0; i < nrDigits; ++i) {
-			int mostSignificantDigit = static_cast<int>(r[0]);
+			// Defensive NaN guard: if arithmetic drift in earlier iterations
+			// pushed r[0] to NaN, casting to int is C++20 [conv.fpint] UB.
+			// Coerce NaN to 0 so the cast is always safe; the resulting
+			// digit string will be incorrect, but the program does not
+			// trigger UB.  (The algorithm is supposed to keep r[0] in
+			// [0, 10) at each iteration; this is a backstop.)
+			double v = r[0];
+			int mostSignificantDigit = (v != v) ? 0 : static_cast<int>(v);
 			r -= mostSignificantDigit;
 			r *= 10.0;
 

--- a/static/highprecision/qd/api/constexpr.cpp
+++ b/static/highprecision/qd/api/constexpr.cpp
@@ -1,0 +1,269 @@
+// constexpr.cpp: compile-time tests for qd (quad-double precision)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// Configure qd: throwing arithmetic exceptions disabled so divide-by-zero
+// has defined constexpr-safe behavior (returns +/-inf or NaN encoding) rather
+// than throwing, which would be ill-formed in a constant expression.
+#define QUADDOUBLE_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/qd/qd.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "qd constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// qd is a (1, 11, 212) floating-point triple stored as an unevaluated sum
+	// of four IEEE-754 doubles.
+
+	// ----------------------------------------------------------------------------
+	// Native int construction (already constexpr -- smoke test only)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd a(0);
+		constexpr qd b(1);
+		constexpr qd c(-3);
+		(void)a; (void)b; (void)c;
+	}
+
+	// ----------------------------------------------------------------------------
+	// Acceptance form from issue #738:
+	//   constexpr qd a(2.0), b(3.0); constexpr auto c = a + b;
+	// (and analogous for *, -, /, +=, <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd a(2.0);
+		constexpr qd b(3.0);
+		constexpr auto cx_sum = a + b;
+		static_assert(cx_sum == qd(5.0), "issue #738 acceptance: a + b");
+	}
+
+	// ----------------------------------------------------------------------------
+	// All four binary arithmetic operators in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd a(4.5);
+		constexpr qd b(1.5);
+		constexpr auto cx_sum  = a + b;          // 4.5 + 1.5 = 6.0
+		constexpr auto cx_diff = a - b;          // 4.5 - 1.5 = 3.0
+		constexpr auto cx_prod = a * b;          // 4.5 * 1.5 = 6.75
+		constexpr auto cx_quot = a / b;          // 4.5 / 1.5 = 3.0
+		constexpr auto cx_neg  = -a;             // -4.5
+		static_assert(cx_sum  == qd(6.0),  "constexpr +  failed");
+		static_assert(cx_diff == qd(3.0),  "constexpr -  failed");
+		static_assert(cx_prod == qd(6.75), "constexpr *  failed");
+		static_assert(cx_quot == qd(3.0),  "constexpr /  failed");
+		static_assert(cx_neg  == qd(-4.5), "constexpr unary - failed");
+
+		// Compound assignment via lambda (constexpr lambdas are C++20)
+		constexpr qd cx_addeq = []() { qd t(1.5); t += qd(3.0); return t; }();
+		constexpr qd cx_subeq = []() { qd t(4.5); t -= qd(1.5); return t; }();
+		constexpr qd cx_muleq = []() { qd t(1.5); t *= qd(3.0); return t; }();
+		constexpr qd cx_diveq = []() { qd t(4.5); t /= qd(1.5); return t; }();
+		static_assert(cx_addeq == qd(4.5), "constexpr += failed");
+		static_assert(cx_subeq == qd(3.0), "constexpr -= failed");
+		static_assert(cx_muleq == qd(4.5), "constexpr *= failed");
+		static_assert(cx_diveq == qd(3.0), "constexpr /= failed");
+
+		// Compound assignment with double rhs
+		constexpr qd cx_addeqd = []() { qd t(1.5); t += 3.0; return t; }();
+		constexpr qd cx_subeqd = []() { qd t(4.5); t -= 1.5; return t; }();
+		constexpr qd cx_muleqd = []() { qd t(1.5); t *= 3.0; return t; }();
+		constexpr qd cx_diveqd = []() { qd t(4.5); t /= 1.5; return t; }();
+		static_assert(cx_addeqd == qd(4.5), "constexpr += double failed");
+		static_assert(cx_subeqd == qd(3.0), "constexpr -= double failed");
+		static_assert(cx_muleqd == qd(4.5), "constexpr *= double failed");
+		static_assert(cx_diveqd == qd(3.0), "constexpr /= double failed");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Constexpr comparison (issue acceptance: <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd a(1.5);
+		constexpr qd b(3.0);
+		static_assert(a < b,     "constexpr: qd(1.5) < qd(3.0)");
+		static_assert(b > a,     "constexpr: qd(3.0) > qd(1.5)");
+		static_assert(a <= b,    "constexpr: qd(1.5) <= qd(3.0)");
+		static_assert(b >= a,    "constexpr: qd(3.0) >= qd(1.5)");
+		static_assert(!(a == b), "constexpr: qd(1.5) != qd(3.0)");
+		static_assert(a != b,    "constexpr: != operator");
+		static_assert(a == a,    "constexpr: qd(1.5) == qd(1.5)");
+
+		// qd vs double comparisons
+		static_assert(a < 3.0,      "constexpr: qd(1.5) < 3.0");
+		static_assert(3.0 > a,      "constexpr: 3.0 > qd(1.5)");
+		static_assert(a == 1.5,     "constexpr: qd(1.5) == 1.5");
+		static_assert(1.5 == a,     "constexpr: 1.5 == qd(1.5)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion-out: operator double() / int() / float() are now constexpr.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd a(0.5);
+		constexpr double d = double(a);
+		static_assert(d == 0.5, "constexpr operator double()");
+
+		constexpr qd b(42.0);
+		constexpr int n = int(b);
+		static_assert(n == 42, "constexpr operator int()");
+
+		constexpr qd c(2.5);
+		constexpr float f = float(c);
+		static_assert(f == 2.5f, "constexpr operator float()");
+
+		// Large integer conversion: limb-separated truncation (lower 3 limbs
+		// collapsed via two_sum chain) preserves precision above 2^53.
+		constexpr qd large(9007199254740992.0, 1.0, 0.0, 0.0);
+		constexpr unsigned long long u = static_cast<unsigned long long>(large);
+		static_assert(u == 9007199254740993ULL,
+			"constexpr conversion preserves precision above 2^53");
+
+		// Negative large
+		constexpr qd large_neg(-9007199254740992.0, -1.0, 0.0, 0.0);
+		constexpr long long s = static_cast<long long>(large_neg);
+		static_assert(s == -9007199254740993LL,
+			"constexpr signed conversion preserves precision below -2^53");
+
+		// Boundary case: hi is integer, mid subtracts a sub-ulp fraction.
+		constexpr qd boundary_neg(101.0, -0x1.0p-50, 0.0, 0.0);
+		constexpr int b_neg = static_cast<int>(boundary_neg);
+		static_assert(b_neg == 100,
+			"constexpr trunc handles fractional borrow across int boundary");
+
+		// Boundary case: positive mid pushing hi+mid over an integer boundary.
+		constexpr qd boundary_pos(2.5, 0.6, 0.0, 0.0);
+		constexpr int b_pos = static_cast<int>(boundary_pos);
+		static_assert(b_pos == 3,
+			"constexpr trunc handles fractional carry across int boundary");
+
+		// Negative qd to unsigned saturates to 0.
+		constexpr qd negval(-5.0);
+		constexpr unsigned int neg_u = static_cast<unsigned int>(negval);
+		static_assert(neg_u == 0u,
+			"constexpr unsigned conversion clamps negative qd to 0");
+
+		// Out-of-range saturates to integer max.
+		constexpr qd huge(1.0e20);
+		constexpr int huge_i = static_cast<int>(huge);
+		static_assert(huge_i == (std::numeric_limits<int>::max)(),
+			"constexpr signed conversion saturates above int max");
+
+		// hi at the rounded long long boundary, lower limbs bring it back in range.
+		constexpr qd boundary_max(0x1.0p63, -2.0, 0.0, 0.0);
+		constexpr long long b_max = static_cast<long long>(boundary_max);
+		static_assert(b_max == 9223372036854775806LL,
+			"constexpr signed conversion at upper boundary uses lo to stay in range");
+
+		constexpr qd boundary_umax(0x1.0p64, -2.0, 0.0, 0.0);
+		constexpr unsigned long long b_umax = static_cast<unsigned long long>(boundary_umax);
+		static_assert(b_umax == 18446744073709551614ULL,
+			"constexpr unsigned conversion at upper boundary uses lo to stay in range");
+
+		// Defensive saturation for unnormalized qd values.
+		constexpr qd unnorm_pos(0.0, 1.0e30, 0.0, 0.0);
+		constexpr long long unp = static_cast<long long>(unnorm_pos);
+		static_assert(unp == (std::numeric_limits<long long>::max)(),
+			"constexpr conversion saturates on unnormalized lo > max");
+
+		constexpr qd unnorm_neg(0.0, -1.0e30, 0.0, 0.0);
+		constexpr long long unn = static_cast<long long>(unnorm_neg);
+		static_assert(unn == (std::numeric_limits<long long>::min)(),
+			"constexpr signed conversion saturates on unnormalized lo < min");
+		constexpr unsigned long long unn_u = static_cast<unsigned long long>(unnorm_neg);
+		static_assert(unn_u == 0ULL,
+			"constexpr unsigned conversion clamps unnormalized negative to 0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction (already constexpr -- smoke test)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd zero(SpecificValue::zero);
+		constexpr qd inf_pos(SpecificValue::infpos);
+		constexpr qd inf_neg(SpecificValue::infneg);
+		static_assert(zero == qd(0.0), "constexpr SpecificValue::zero");
+		static_assert(inf_pos > qd(0.0), "constexpr SpecificValue::infpos");
+		static_assert(inf_neg < qd(0.0), "constexpr SpecificValue::infneg");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Mixed qd / double binary arithmetic in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr qd a(2.0);
+		constexpr auto cx_sum  = a + 3.0;
+		constexpr auto cx_diff = a - 1.0;
+		constexpr auto cx_prod = a * 4.0;
+		constexpr auto cx_quot = a / 2.0;
+		static_assert(cx_sum  == qd(5.0), "constexpr qd + double");
+		static_assert(cx_diff == qd(1.0), "constexpr qd - double");
+		static_assert(cx_prod == qd(8.0), "constexpr qd * double");
+		static_assert(cx_quot == qd(1.0), "constexpr qd / double");
+
+		constexpr auto cx_lhs_sum = 5.0 + qd(2.0);
+		static_assert(cx_lhs_sum == qd(7.0), "constexpr double + qd");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Sign of negative zero in divide-by-zero: -0.0 should produce -infinity.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr auto cx_q = []() { qd t(1.0); t /= qd(-0.0); return t; }();
+		static_assert(cx_q < qd(0.0), "constexpr 1.0 / -0.0 should be -inf");
+		static_assert(cx_q.isinf(), "constexpr 1.0 / -0.0 should be inf");
+	}
+
+	// ----------------------------------------------------------------------------
+	// IEEE-754 unordered comparison: nan >= x must be false (and similar).
+	// Tested at runtime instead of via static_assert (MSVC constexpr NaN bug).
+	// ----------------------------------------------------------------------------
+	{
+		qd qnan(SpecificValue::qnan);
+		qd one(1.0);
+		if ( (qnan <  one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan <  1.0 should be false\n"; }
+		if ( (qnan >  one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan >  1.0 should be false\n"; }
+		if ( (qnan <= one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan <= 1.0 should be false\n"; }
+		if ( (qnan >= one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan >= 1.0 should be false\n"; }
+		if ( (qnan == one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan == 1.0 should be false\n"; }
+		if (!(qnan != one)) { ++nrOfFailedTestCases; std::cerr << "FAIL: nan != 1.0 should be true\n"; }
+		if ( (one  >= qnan)){ ++nrOfFailedTestCases; std::cerr << "FAIL: 1.0 >= nan should be false\n"; }
+	}
+
+	std::cout << "qd constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::qd_arithmetic_exception& err) {
+	std::cerr << "Uncaught qd arithmetic exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- Promotes classic `qd` (quad-double precision) to fully constexpr across construction, arithmetic, comparison, unary negation, and conversion-out.
- Issue acceptance form `constexpr qd a(2.0), b(3.0); constexpr auto c = a + b;` (and `*`, `-`, `/`, `+=`, `<`) compiles and locks in via `static_assert`.

This is the **classic qd** counterpart to qd_cascade (#739, just merged). qd uses the proven `error_free_ops.hpp` EFT primitives directly, while qd_cascade goes through the `floatcascade<4>` abstraction.

## Approach
The `error_free_ops.hpp` EFT primitives were already promoted to constexpr in #796 (dd). This PR applies the same playbook to `qd`:

- Comparison + conversion-out + arithmetic operators marked constexpr.
- Limb-separated truncation extended to 4 limbs: collapse `x[1] + x[2] + x[3]` via two_sum chain into a single representative double (sub-ULP error discarded — cannot affect integer truncation), then apply the dd-style algorithm. Fixes pre-existing bug in old int64_t-cast helpers that ignored `x[2]` and `x[3]` entirely.
- NaN-safe `>=` via `> || ==`.
- Sign-bit fix in `/=` via `std::bit_cast` so `-0.0` produces `-inf` at compile time.
- `accurate_addition`, `accurate_multiplication`, `accurate_division`, `approximate_*`: marked constexpr. In `accurate_addition`, `std::abs(double)` (not constexpr in C++20) replaced with a ternary lambda.
- Saturation guards before each limb cast.

`operator++` / `operator--` deferred (use `std::nextafter`, no C++20 constexpr replacement) — matches dd's #796 deferral.

## Changes
- `include/sw/universal/number/qd/qd_impl.hpp` — operators promoted; conversion templates rewritten with limb-separated truncation; sign/NaN/UB-guard fixes from #796/#797 applied.
- `static/highprecision/qd/api/constexpr.cpp` — new test (mirrors dd's, scaled to quad-double).

## Test Results
| Suite | gcc | clang |
|-------|-----|-------|
| qd_api_api / constants / experiments / constexpr | PASS | PASS |
| qd_arith_arithmetic | PASS | PASS |
| qd_math_pow / sqrt / logarithm | PASS | PASS |
| dd_arith_arithmetic / addition / multiplication / division (regression) | PASS | PASS |

8/8 qd + 4/4 dd tests PASS on both compilers. dd unaffected because `error_free_ops.hpp` was already constexpr from #796; nothing shared was modified.

## Constexpr coverage milestone
This PR brings the Universal library to **13 fully constexpr-compliant number systems**:
integer (#720), posit (#718), cfloat (#719), bfloat16 (#725), fixpnt (#721), lns (#776), areal (#792), dbns (#795), dd (#796), dd_cascade (#797), td_cascade (#798), qd_cascade (#799), **qd (this PR)**.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #738

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quad-double now supports compile-time evaluation for arithmetic, compound assignments, comparisons, indexing, and explicit numeric conversions (including long double when enabled).
  * Comparison logic made NaN-safe; defensive handling for NaN-to-integer casts; divide-by-zero preserves IEEE-754 sign semantics in constexpr contexts.

* **Tests**
  * Added a constexpr validation executable exercising compile-time construction, operations, comparisons and conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->