### PR TITLE
feat(dfixpnt): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/internal/blockdecimal/blockdecimal.hpp
+++ b/include/sw/universal/internal/blockdecimal/blockdecimal.hpp
@@ -74,37 +74,37 @@ public:
 	blockdecimal& operator=(blockdecimal&&) = default;
 
 	// construct from unsigned native integer
-	blockdecimal(unsigned long long value) { convert_unsigned(value); }
+	constexpr blockdecimal(unsigned long long value) : _negative{false}, _block{} { convert_unsigned(value); }
 
 	// construct from signed native integer
-	blockdecimal(int value)       { convert_signed(static_cast<long long>(value)); }
-	blockdecimal(long value)      { convert_signed(static_cast<long long>(value)); }
-	blockdecimal(long long value) { convert_signed(value); }
+	constexpr blockdecimal(int value)       : _negative{false}, _block{} { convert_signed(static_cast<long long>(value)); }
+	constexpr blockdecimal(long value)      : _negative{false}, _block{} { convert_signed(static_cast<long long>(value)); }
+	constexpr blockdecimal(long long value) : _negative{false}, _block{} { convert_signed(value); }
 
 	// assignment from native integer types
-	blockdecimal& operator=(int rhs)                { return convert_signed(static_cast<long long>(rhs)); }
-	blockdecimal& operator=(long rhs)               { return convert_signed(static_cast<long long>(rhs)); }
-	blockdecimal& operator=(long long rhs)           { return convert_signed(rhs); }
-	blockdecimal& operator=(unsigned int rhs)        { return convert_unsigned(static_cast<unsigned long long>(rhs)); }
-	blockdecimal& operator=(unsigned long rhs)       { return convert_unsigned(static_cast<unsigned long long>(rhs)); }
-	blockdecimal& operator=(unsigned long long rhs)  { return convert_unsigned(rhs); }
+	constexpr blockdecimal& operator=(int rhs)                { return convert_signed(static_cast<long long>(rhs)); }
+	constexpr blockdecimal& operator=(long rhs)               { return convert_signed(static_cast<long long>(rhs)); }
+	constexpr blockdecimal& operator=(long long rhs)           { return convert_signed(rhs); }
+	constexpr blockdecimal& operator=(unsigned int rhs)        { return convert_unsigned(static_cast<unsigned long long>(rhs)); }
+	constexpr blockdecimal& operator=(unsigned long rhs)       { return convert_unsigned(static_cast<unsigned long long>(rhs)); }
+	constexpr blockdecimal& operator=(unsigned long long rhs)  { return convert_unsigned(rhs); }
 
 	// explicit conversion operators
-	explicit operator long long() const noexcept { return to_long_long(); }
-	explicit operator unsigned long long() const noexcept { return static_cast<unsigned long long>(to_long_long()); }
-	explicit operator int() const noexcept { return static_cast<int>(to_long_long()); }
-	explicit operator long() const noexcept { return static_cast<long>(to_long_long()); }
-	explicit operator unsigned int() const noexcept { return static_cast<unsigned int>(to_long_long()); }
-	explicit operator unsigned long() const noexcept { return static_cast<unsigned long>(to_long_long()); }
-	explicit operator float() const noexcept { return static_cast<float>(to_double()); }
-	explicit operator double() const noexcept { return to_double(); }
+	constexpr explicit operator long long() const noexcept { return to_long_long(); }
+	constexpr explicit operator unsigned long long() const noexcept { return static_cast<unsigned long long>(to_long_long()); }
+	constexpr explicit operator int() const noexcept { return static_cast<int>(to_long_long()); }
+	constexpr explicit operator long() const noexcept { return static_cast<long>(to_long_long()); }
+	constexpr explicit operator unsigned int() const noexcept { return static_cast<unsigned int>(to_long_long()); }
+	constexpr explicit operator unsigned long() const noexcept { return static_cast<unsigned long>(to_long_long()); }
+	constexpr explicit operator float() const noexcept { return static_cast<float>(to_double()); }
+	constexpr explicit operator double() const noexcept { return to_double(); }
 
 	/////////////////////////////////////////////////////////////////////////
 	// digit access (encoding-aware)
 
 	// get digit at position i (0 = least significant)
-	unsigned digit(unsigned i) const {
-		assert(i < ndigits);
+	constexpr unsigned digit(unsigned i) const {
+		// assert(i < ndigits) -- not constexpr-safe; enforced by caller
 		if constexpr (encoding == DecimalEncoding::BCD) {
 			return extract_nibble(i);
 		} else if constexpr (encoding == DecimalEncoding::BID) {
@@ -117,9 +117,8 @@ public:
 	}
 
 	// set digit at position i (0 = least significant)
-	void setdigit(unsigned i, unsigned d) {
-		assert(i < ndigits);
-		assert(d <= 9);
+	constexpr void setdigit(unsigned i, unsigned d) {
+		// assert(i < ndigits && d <= 9) -- not constexpr-safe; enforced by caller
 		if constexpr (encoding == DecimalEncoding::BCD) {
 			set_nibble(i, d);
 		} else if constexpr (encoding == DecimalEncoding::BID) {
@@ -137,18 +136,18 @@ public:
 	/////////////////////////////////////////////////////////////////////////
 	// queries
 
-	bool iszero() const { return _block.iszero(); }
-	bool sign() const { return _negative; }
-	bool isneg() const { return _negative && !iszero(); }
-	bool ispos() const { return !_negative || iszero(); }
+	constexpr bool iszero() const { return _block.iszero(); }
+	constexpr bool sign() const { return _negative; }
+	constexpr bool isneg() const { return _negative && !iszero(); }
+	constexpr bool ispos() const { return !_negative || iszero(); }
 
-	void clear() { _negative = false; _block.clear(); }
+	constexpr void clear() { _negative = false; _block.clear(); }
 
-	void setsign(bool s) { _negative = s; }
-	void setbits(uint64_t v) { convert_unsigned(v); }
+	constexpr void setsign(bool s) { _negative = s; }
+	constexpr void setbits(uint64_t v) { convert_unsigned(v); }
 
 	// set all digits to 9 (max representable value)
-	void maxval() {
+	constexpr void maxval() {
 		_negative = false;
 		if constexpr (encoding == DecimalEncoding::BID) {
 			uint64_t max_v = pow10(ndigits) - 1;
@@ -163,7 +162,7 @@ public:
 
 	// convert magnitude to uint64_t
 	// uint64_t can hold at most 19 decimal digits (9'999'999'999'999'999'999)
-	uint64_t to_uint64() const {
+	constexpr uint64_t to_uint64() const {
 		if constexpr (encoding == DecimalEncoding::BID) {
 			return bb_to_uint64();
 		} else {
@@ -180,7 +179,7 @@ public:
 	}
 
 	// convert to long long (signed), clamped to [LLONG_MIN, LLONG_MAX]
-	long long to_long_long() const noexcept {
+	constexpr long long to_long_long() const noexcept {
 		uint64_t mag = to_uint64();
 		if (_negative) {
 			// LLONG_MIN magnitude is LLONG_MAX + 1
@@ -194,7 +193,7 @@ public:
 	}
 
 	// convert to double (signed)
-	double to_double() const {
+	constexpr double to_double() const {
 		double result = 0.0;
 		double scale = 1.0;
 		for (unsigned i = 0; i < ndigits; ++i) {
@@ -221,7 +220,7 @@ public:
 	/////////////////////////////////////////////////////////////////////////
 	// unary negation
 
-	blockdecimal operator-() const {
+	constexpr blockdecimal operator-() const {
 		blockdecimal tmp(*this);
 		if (!tmp.iszero()) tmp._negative = !tmp._negative;
 		return tmp;
@@ -231,7 +230,7 @@ public:
 	// arithmetic operators (sign-magnitude)
 
 	// addition
-	blockdecimal& operator+=(const blockdecimal& rhs) {
+	constexpr blockdecimal& operator+=(const blockdecimal& rhs) {
 		if (_negative != rhs._negative) {
 			// different signs: subtract magnitude of rhs
 			blockdecimal tmp(rhs);
@@ -254,7 +253,7 @@ public:
 	}
 
 	// subtraction
-	blockdecimal& operator-=(const blockdecimal& rhs) {
+	constexpr blockdecimal& operator-=(const blockdecimal& rhs) {
 		if (_negative != rhs._negative) {
 			// different signs: add magnitude of rhs
 			blockdecimal tmp(rhs);
@@ -302,7 +301,7 @@ public:
 	}
 
 	// multiplication: schoolbook digit-by-digit
-	blockdecimal& operator*=(const blockdecimal& rhs) {
+	constexpr blockdecimal& operator*=(const blockdecimal& rhs) {
 		if (iszero() || rhs.iszero()) {
 			clear();
 			return *this;
@@ -327,8 +326,9 @@ public:
 	}
 
 	// division by single digit (helper) - magnitude only
-	blockdecimal& divide_by(unsigned divisor, unsigned& remainder) {
-		assert(divisor > 0 && divisor <= 9);
+	// Note: assert(divisor > 0 && divisor <= 9) replaced with comment for constexpr-friendliness.
+	constexpr blockdecimal& divide_by(unsigned divisor, unsigned& remainder) {
+		// caller-enforced precondition: 0 < divisor <= 9
 		remainder = 0;
 		for (int i = static_cast<int>(ndigits) - 1; i >= 0; --i) {
 			unsigned cur = remainder * 10 + digit(static_cast<unsigned>(i));
@@ -339,12 +339,15 @@ public:
 	}
 
 	// long division by another blockdecimal
-	blockdecimal& operator/=(const blockdecimal& rhs) {
+	constexpr blockdecimal& operator/=(const blockdecimal& rhs) {
 		if (rhs.iszero()) {
 #if BLOCKDECIMAL_THROW_ARITHMETIC_EXCEPTION
 			throw blockdecimal_divide_by_zero();
 #else
-			std::cerr << "blockdecimal: division by zero\n";
+			// std::cerr is not constexpr; suppress at compile time.
+			if (!std::is_constant_evaluated()) {
+				std::cerr << "blockdecimal: division by zero\n";
+			}
 			return *this;
 #endif
 		}
@@ -374,12 +377,14 @@ public:
 		return *this;
 	}
 
-	blockdecimal& operator%=(const blockdecimal& rhs) {
+	constexpr blockdecimal& operator%=(const blockdecimal& rhs) {
 		if (rhs.iszero()) {
 #if BLOCKDECIMAL_THROW_ARITHMETIC_EXCEPTION
 			throw blockdecimal_divide_by_zero();
 #else
-			std::cerr << "blockdecimal: division by zero\n";
+			if (!std::is_constant_evaluated()) {
+				std::cerr << "blockdecimal: division by zero\n";
+			}
 			return *this;
 #endif
 		}
@@ -405,7 +410,7 @@ public:
 	}
 
 	// multiply by a power of 10 (shift left by decimal positions)
-	void shift_left(unsigned positions) {
+	constexpr void shift_left(unsigned positions) {
 		if (positions == 0) return;
 		if (positions >= ndigits) { clear(); return; }
 		for (int i = static_cast<int>(ndigits) - 1; i >= static_cast<int>(positions); --i) {
@@ -417,7 +422,7 @@ public:
 	}
 
 	// divide by a power of 10 (shift right by decimal positions)
-	void shift_right(unsigned positions) {
+	constexpr void shift_right(unsigned positions) {
 		if (positions == 0) return;
 		if (positions >= ndigits) { clear(); return; }
 		for (unsigned i = 0; i < ndigits - positions; ++i) {
@@ -429,12 +434,12 @@ public:
 	}
 
 	// digit shift operators (matching blockdigit interface)
-	blockdecimal& operator<<=(int shift) {
+	constexpr blockdecimal& operator<<=(int shift) {
 		if (shift < 0) return operator>>=(-shift);
 		shift_left(static_cast<unsigned>(shift));
 		return *this;
 	}
-	blockdecimal& operator>>=(int shift) {
+	constexpr blockdecimal& operator>>=(int shift) {
 		if (shift < 0) return operator<<=(-shift);
 		shift_right(static_cast<unsigned>(shift));
 		if (iszero()) _negative = false;
@@ -444,15 +449,15 @@ public:
 	/////////////////////////////////////////////////////////////////////////
 	// comparison operators (signed)
 
-	friend bool operator==(const blockdecimal& lhs, const blockdecimal& rhs) {
+	friend constexpr bool operator==(const blockdecimal& lhs, const blockdecimal& rhs) {
 		if (lhs.iszero() && rhs.iszero()) return true; // +0 == -0
 		if (lhs._negative != rhs._negative) return false;
 		return lhs._block == rhs._block;
 	}
-	friend bool operator!=(const blockdecimal& lhs, const blockdecimal& rhs) {
+	friend constexpr bool operator!=(const blockdecimal& lhs, const blockdecimal& rhs) {
 		return !(lhs == rhs);
 	}
-	friend bool operator<(const blockdecimal& lhs, const blockdecimal& rhs) {
+	friend constexpr bool operator<(const blockdecimal& lhs, const blockdecimal& rhs) {
 		bool lzero = lhs.iszero();
 		bool rzero = rhs.iszero();
 		if (lzero && rzero) return false;
@@ -465,14 +470,15 @@ public:
 			return less_than_magnitude(rhs, lhs);
 		}
 	}
-	friend bool operator>(const blockdecimal& lhs, const blockdecimal& rhs) {
+	friend constexpr bool operator>(const blockdecimal& lhs, const blockdecimal& rhs) {
 		return rhs < lhs;
 	}
-	friend bool operator<=(const blockdecimal& lhs, const blockdecimal& rhs) {
-		return !(rhs < lhs);
+	friend constexpr bool operator<=(const blockdecimal& lhs, const blockdecimal& rhs) {
+		// NaN-safe form (matches #797 lessons; even though blockdecimal has no NaN, keep the contract uniform).
+		return operator<(lhs, rhs) || operator==(lhs, rhs);
 	}
-	friend bool operator>=(const blockdecimal& lhs, const blockdecimal& rhs) {
-		return !(lhs < rhs);
+	friend constexpr bool operator>=(const blockdecimal& lhs, const blockdecimal& rhs) {
+		return operator>(lhs, rhs) || operator==(lhs, rhs);
 	}
 
 	/////////////////////////////////////////////////////////////////////////
@@ -509,7 +515,7 @@ private:
 	/////////////////////////////////////////////////////////////////////////
 	// conversion helpers
 
-	blockdecimal& convert_signed(long long rhs) {
+	constexpr blockdecimal& convert_signed(long long rhs) {
 		clear();
 		if (rhs < 0) {
 			_negative = true;
@@ -526,13 +532,13 @@ private:
 		return *this;
 	}
 
-	blockdecimal& convert_unsigned(unsigned long long rhs) {
+	constexpr blockdecimal& convert_unsigned(unsigned long long rhs) {
 		clear();
 		store_magnitude(rhs);
 		return *this;
 	}
 
-	void store_magnitude(unsigned long long value) {
+	constexpr void store_magnitude(unsigned long long value) {
 		if constexpr (encoding == DecimalEncoding::BID) {
 			from_uint64(static_cast<uint64_t>(value));
 		} else {
@@ -545,7 +551,7 @@ private:
 
 	/////////////////////////////////////////////////////////////////////////
 	// magnitude comparison (ignoring sign), returns -1, 0, +1
-	int compare_magnitude(const blockdecimal& rhs) const {
+	constexpr int compare_magnitude(const blockdecimal& rhs) const {
 		for (int i = static_cast<int>(ndigits) - 1; i >= 0; --i) {
 			unsigned ld = digit(static_cast<unsigned>(i));
 			unsigned rd = rhs.digit(static_cast<unsigned>(i));
@@ -566,7 +572,7 @@ private:
 	/////////////////////////////////////////////////////////////////////////
 	// blockbinary <-> uint64_t helpers (for BID and DPD)
 
-	uint64_t bb_to_uint64() const {
+	constexpr uint64_t bb_to_uint64() const {
 		uint64_t value = 0;
 		constexpr unsigned maxbit = (nbits < 64) ? nbits : 64;
 		for (unsigned i = 0; i < maxbit; ++i) {
@@ -575,7 +581,7 @@ private:
 		return value;
 	}
 
-	void from_uint64(uint64_t value) {
+	constexpr void from_uint64(uint64_t value) {
 		_block.clear();
 		constexpr unsigned maxbit = (nbits < 64) ? nbits : 64;
 		for (unsigned i = 0; i < maxbit; ++i) {
@@ -586,7 +592,7 @@ private:
 	/////////////////////////////////////////////////////////////////////////
 	// BCD nibble access helpers
 
-	unsigned extract_nibble(unsigned digit_pos) const {
+	constexpr unsigned extract_nibble(unsigned digit_pos) const {
 		unsigned bit_pos = digit_pos * 4;
 		unsigned nibble = 0;
 		for (unsigned b = 0; b < 4; ++b) {
@@ -596,7 +602,7 @@ private:
 		return nibble;
 	}
 
-	void set_nibble(unsigned digit_pos, unsigned value) {
+	constexpr void set_nibble(unsigned digit_pos, unsigned value) {
 		unsigned bit_pos = digit_pos * 4;
 		for (unsigned b = 0; b < 4; ++b) {
 			_block.setbit(bit_pos + b, (value >> b) & 1);
@@ -607,7 +613,7 @@ private:
 	// DPD declet access helpers
 
 	// extract a 10-bit declet starting at bit position 'bit_start'
-	uint16_t extract_declet(unsigned bit_start) const {
+	constexpr uint16_t extract_declet(unsigned bit_start) const {
 		uint16_t declet = 0;
 		for (unsigned b = 0; b < 10; ++b) {
 			if (bit_start + b < nbits && _block.test(bit_start + b))
@@ -617,7 +623,7 @@ private:
 	}
 
 	// store a 10-bit declet starting at bit position 'bit_start'
-	void store_declet(unsigned bit_start, uint16_t declet) {
+	constexpr void store_declet(unsigned bit_start, uint16_t declet) {
 		for (unsigned b = 0; b < 10; ++b) {
 			if (bit_start + b < nbits)
 				_block.setbit(bit_start + b, (declet >> b) & 1);
@@ -625,7 +631,7 @@ private:
 	}
 
 	// extract 4-bit BCD digit from DPD remainder bits
-	unsigned extract_dpd_remainder_digit(unsigned bit_start) const {
+	constexpr unsigned extract_dpd_remainder_digit(unsigned bit_start) const {
 		unsigned val = 0;
 		for (unsigned b = 0; b < 4; ++b) {
 			if (bit_start + b < nbits && _block.test(bit_start + b))
@@ -635,7 +641,7 @@ private:
 	}
 
 	// store 4-bit BCD digit into DPD remainder bits
-	void store_dpd_remainder_digit(unsigned bit_start, unsigned d) {
+	constexpr void store_dpd_remainder_digit(unsigned bit_start, unsigned d) {
 		for (unsigned b = 0; b < 4; ++b) {
 			if (bit_start + b < nbits)
 				_block.setbit(bit_start + b, (d >> b) & 1);
@@ -643,7 +649,7 @@ private:
 	}
 
 	// DPD digit extraction: extract the i-th decimal digit
-	unsigned dpd_extract_digit(unsigned i) const {
+	constexpr unsigned dpd_extract_digit(unsigned i) const {
 		// digits are organized as: groups of 3 from LSB, with remainder at top
 		unsigned group = i / 3;
 		unsigned pos_in_group = i % 3;  // 0=units, 1=tens, 2=hundreds of the group
@@ -676,7 +682,7 @@ private:
 	}
 
 	// DPD digit setting: set the i-th decimal digit
-	void dpd_set_digit(unsigned i, unsigned d) {
+	constexpr void dpd_set_digit(unsigned i, unsigned d) {
 		unsigned group = i / 3;
 		unsigned pos_in_group = i % 3;
 		unsigned full_groups = ndigits / 3;
@@ -712,7 +718,7 @@ private:
 	// magnitude-only comparison (unsigned)
 
 	// digit-by-digit comparison of magnitude (MSD to LSD)
-	static bool less_than_magnitude(const blockdecimal& lhs, const blockdecimal& rhs) {
+	static constexpr bool less_than_magnitude(const blockdecimal& lhs, const blockdecimal& rhs) {
 		if constexpr (encoding == DecimalEncoding::BID) {
 			return lhs._block < rhs._block;
 		} else {
@@ -731,7 +737,7 @@ private:
 // free function: wide multiply returning 2*ndigits result
 
 template<unsigned ndigits, DecimalEncoding encoding, typename bt>
-blockdecimal<2 * ndigits, encoding, bt> wide_mul(
+constexpr blockdecimal<2 * ndigits, encoding, bt> wide_mul(
 	const blockdecimal<ndigits, encoding, bt>& lhs,
 	const blockdecimal<ndigits, encoding, bt>& rhs) {
 	blockdecimal<2 * ndigits, encoding, bt> result;
@@ -760,31 +766,31 @@ blockdecimal<2 * ndigits, encoding, bt> wide_mul(
 // binary arithmetic operators
 
 template<unsigned N, DecimalEncoding E, typename BT>
-inline blockdecimal<N, E, BT> operator+(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
+constexpr blockdecimal<N, E, BT> operator+(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
 	blockdecimal<N, E, BT> sum(lhs);
 	sum += rhs;
 	return sum;
 }
 template<unsigned N, DecimalEncoding E, typename BT>
-inline blockdecimal<N, E, BT> operator-(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
+constexpr blockdecimal<N, E, BT> operator-(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
 	blockdecimal<N, E, BT> diff(lhs);
 	diff -= rhs;
 	return diff;
 }
 template<unsigned N, DecimalEncoding E, typename BT>
-inline blockdecimal<N, E, BT> operator*(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
+constexpr blockdecimal<N, E, BT> operator*(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
 	blockdecimal<N, E, BT> product(lhs);
 	product *= rhs;
 	return product;
 }
 template<unsigned N, DecimalEncoding E, typename BT>
-inline blockdecimal<N, E, BT> operator/(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
+constexpr blockdecimal<N, E, BT> operator/(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
 	blockdecimal<N, E, BT> quotient(lhs);
 	quotient /= rhs;
 	return quotient;
 }
 template<unsigned N, DecimalEncoding E, typename BT>
-inline blockdecimal<N, E, BT> operator%(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
+constexpr blockdecimal<N, E, BT> operator%(const blockdecimal<N, E, BT>& lhs, const blockdecimal<N, E, BT>& rhs) {
 	blockdecimal<N, E, BT> remainder(lhs);
 	remainder %= rhs;
 	return remainder;

--- a/include/sw/universal/internal/blockdecimal/blockdecimal.hpp
+++ b/include/sw/universal/internal/blockdecimal/blockdecimal.hpp
@@ -91,11 +91,29 @@ public:
 
 	// explicit conversion operators
 	constexpr explicit operator long long() const noexcept { return to_long_long(); }
-	constexpr explicit operator unsigned long long() const noexcept { return static_cast<unsigned long long>(to_long_long()); }
+	// For non-negative values, route through to_uint64() to preserve the full
+	// 64-bit unsigned range; for negative values, follow the standard 2's
+	// complement reinterpretation by going through long long first.  Going
+	// through to_long_long() unconditionally would clamp magnitudes above
+	// LLONG_MAX -- losing the upper half of the unsigned range.
+	constexpr explicit operator unsigned long long() const noexcept {
+		return _negative ? static_cast<unsigned long long>(to_long_long()) : to_uint64();
+	}
 	constexpr explicit operator int() const noexcept { return static_cast<int>(to_long_long()); }
 	constexpr explicit operator long() const noexcept { return static_cast<long>(to_long_long()); }
-	constexpr explicit operator unsigned int() const noexcept { return static_cast<unsigned int>(to_long_long()); }
-	constexpr explicit operator unsigned long() const noexcept { return static_cast<unsigned long>(to_long_long()); }
+	// Saturate to the destination type's max (instead of truncating, which
+	// would silently lose the upper bits) -- matches the behavior of the
+	// long/long-long path which clamps via to_long_long().
+	constexpr explicit operator unsigned int() const noexcept {
+		const auto v = static_cast<unsigned long long>(*this);
+		constexpr auto max_v = static_cast<unsigned long long>((std::numeric_limits<unsigned int>::max)());
+		return static_cast<unsigned int>(v > max_v ? max_v : v);
+	}
+	constexpr explicit operator unsigned long() const noexcept {
+		const auto v = static_cast<unsigned long long>(*this);
+		constexpr auto max_v = static_cast<unsigned long long>((std::numeric_limits<unsigned long>::max)());
+		return static_cast<unsigned long>(v > max_v ? max_v : v);
+	}
 	constexpr explicit operator float() const noexcept { return static_cast<float>(to_double()); }
 	constexpr explicit operator double() const noexcept { return to_double(); }
 

--- a/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
+++ b/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <cmath>
 #include <cassert>
+#include <type_traits>
 
 // supporting types and functions
 #include <universal/number/shared/specific_value_encoding.hpp>
@@ -67,7 +68,7 @@ public:
 	dfixpnt& operator=(dfixpnt&&) = default;
 
 	// specific value constructor
-	dfixpnt(const SpecificValue code) : _sign{ false }, _block{} {
+	constexpr dfixpnt(const SpecificValue code) : _sign{ false }, _block{} {
 		switch (code) {
 		case SpecificValue::infpos:
 		case SpecificValue::maxpos:
@@ -94,25 +95,25 @@ public:
 	}
 
 	// constructors from native integer types
-	dfixpnt(signed char iv)        { *this = static_cast<long long>(iv); }
-	dfixpnt(short iv)              { *this = static_cast<long long>(iv); }
-	dfixpnt(int iv)                { *this = static_cast<long long>(iv); }
-	dfixpnt(long iv)               { *this = static_cast<long long>(iv); }
-	dfixpnt(long long iv)          { *this = iv; }
-	dfixpnt(char iv)               { *this = static_cast<long long>(iv); }
-	dfixpnt(unsigned short iv)     { *this = static_cast<unsigned long long>(iv); }
-	dfixpnt(unsigned int iv)       { *this = static_cast<unsigned long long>(iv); }
-	dfixpnt(unsigned long iv)      { *this = static_cast<unsigned long long>(iv); }
-	dfixpnt(unsigned long long iv) { *this = iv; }
+	constexpr dfixpnt(signed char iv)        : _sign{false}, _block{} { *this = static_cast<long long>(iv); }
+	constexpr dfixpnt(short iv)              : _sign{false}, _block{} { *this = static_cast<long long>(iv); }
+	constexpr dfixpnt(int iv)                : _sign{false}, _block{} { *this = static_cast<long long>(iv); }
+	constexpr dfixpnt(long iv)               : _sign{false}, _block{} { *this = static_cast<long long>(iv); }
+	constexpr dfixpnt(long long iv)          : _sign{false}, _block{} { *this = iv; }
+	constexpr dfixpnt(char iv)               : _sign{false}, _block{} { *this = static_cast<long long>(iv); }
+	constexpr dfixpnt(unsigned short iv)     : _sign{false}, _block{} { *this = static_cast<unsigned long long>(iv); }
+	constexpr dfixpnt(unsigned int iv)       : _sign{false}, _block{} { *this = static_cast<unsigned long long>(iv); }
+	constexpr dfixpnt(unsigned long iv)      : _sign{false}, _block{} { *this = static_cast<unsigned long long>(iv); }
+	constexpr dfixpnt(unsigned long long iv) : _sign{false}, _block{} { *this = iv; }
 
 	// constructors from floating-point types
-	dfixpnt(float iv)  { *this = static_cast<double>(iv); }
-	dfixpnt(double iv) { *this = iv; }
+	constexpr dfixpnt(float iv)  : _sign{false}, _block{} { *this = static_cast<double>(iv); }
+	constexpr dfixpnt(double iv) : _sign{false}, _block{} { *this = iv; }
 
 	/////////////////////////////////////////////////////////////////////////
 	// assignment operators for native types
 
-	dfixpnt& operator=(long long rhs) {
+	constexpr dfixpnt& operator=(long long rhs) {
 		clear();
 		uint64_t value;
 		if (rhs < 0) {
@@ -131,7 +132,7 @@ public:
 		return *this;
 	}
 
-	dfixpnt& operator=(unsigned long long rhs) {
+	constexpr dfixpnt& operator=(unsigned long long rhs) {
 		clear();
 		_sign = false;
 		uint64_t value = rhs;
@@ -142,9 +143,11 @@ public:
 		return *this;
 	}
 
-	dfixpnt& operator=(double rhs) {
+	constexpr dfixpnt& operator=(double rhs) {
 		clear();
-		if (std::isnan(rhs) || rhs == 0.0) return *this;
+		// std::isnan is not constexpr in C++20; use a NaN-safe equivalent
+		// (NaN is the only value not equal to itself).
+		if (rhs != rhs || rhs == 0.0) return *this;
 		if (rhs < 0) {
 			_sign = true;
 			rhs = -rhs;
@@ -154,17 +157,24 @@ public:
 		// scale up by 10^radix to get the fixed-point integer representation
 		double scaled = rhs;
 		for (unsigned i = 0; i < radix; ++i) scaled *= 10.0;
-		// round to nearest using std::round (avoids +0.5 overflow)
-		scaled = std::round(scaled);
-		// clamp to the maximum representable magnitude (10^ndigits - 1)
-		// to avoid undefined behavior in the cast to uint64_t
+		// round to nearest.  std::round is not constexpr in C++20; use the
+		// half-away-from-zero formula directly: floor(x + 0.5) for x >= 0.
+		// Hand-rolled floor: cast to int64 truncates toward zero, then back.
+		// This is safe here because we already clamped to non-negative above.
+		double half = scaled + 0.5;
+		// std::floor not constexpr; emulate via integer cast (only safe for
+		// values that fit in long long, which the subsequent clamp ensures).
+		// Compute max representable magnitude via constexpr lambda.
 		constexpr double max_magnitude = []() {
 			double m = 1.0;
 			for (unsigned i = 0; i < ndigits; ++i) m *= 10.0;
 			return m - 1.0;
 		}();
-		if (scaled > max_magnitude) scaled = max_magnitude;
-		uint64_t value = static_cast<uint64_t>(scaled);
+		if (half > max_magnitude) half = max_magnitude + 1.0; // will clamp below
+		// Clamp before any potentially-UB cast.
+		if (half > max_magnitude) half = max_magnitude;
+		// Truncate toward zero (works because half >= 0 here).
+		uint64_t value = static_cast<uint64_t>(half);
 		for (unsigned i = 0; i < ndigits && value > 0; ++i) {
 			_block.setdigit(i, static_cast<unsigned>(value % 10));
 			value /= 10;
@@ -172,31 +182,31 @@ public:
 		return *this;
 	}
 
-	dfixpnt& operator=(signed char rhs)        { return *this = static_cast<long long>(rhs); }
-	dfixpnt& operator=(short rhs)              { return *this = static_cast<long long>(rhs); }
-	dfixpnt& operator=(int rhs)                { return *this = static_cast<long long>(rhs); }
-	dfixpnt& operator=(long rhs)               { return *this = static_cast<long long>(rhs); }
-	dfixpnt& operator=(char rhs)               { return *this = static_cast<long long>(rhs); }
-	dfixpnt& operator=(unsigned short rhs)     { return *this = static_cast<unsigned long long>(rhs); }
-	dfixpnt& operator=(unsigned int rhs)       { return *this = static_cast<unsigned long long>(rhs); }
-	dfixpnt& operator=(unsigned long rhs)      { return *this = static_cast<unsigned long long>(rhs); }
-	dfixpnt& operator=(float rhs)              { return *this = static_cast<double>(rhs); }
+	constexpr dfixpnt& operator=(signed char rhs)        { return *this = static_cast<long long>(rhs); }
+	constexpr dfixpnt& operator=(short rhs)              { return *this = static_cast<long long>(rhs); }
+	constexpr dfixpnt& operator=(int rhs)                { return *this = static_cast<long long>(rhs); }
+	constexpr dfixpnt& operator=(long rhs)               { return *this = static_cast<long long>(rhs); }
+	constexpr dfixpnt& operator=(char rhs)               { return *this = static_cast<long long>(rhs); }
+	constexpr dfixpnt& operator=(unsigned short rhs)     { return *this = static_cast<unsigned long long>(rhs); }
+	constexpr dfixpnt& operator=(unsigned int rhs)       { return *this = static_cast<unsigned long long>(rhs); }
+	constexpr dfixpnt& operator=(unsigned long rhs)      { return *this = static_cast<unsigned long long>(rhs); }
+	constexpr dfixpnt& operator=(float rhs)              { return *this = static_cast<double>(rhs); }
 
 	/////////////////////////////////////////////////////////////////////////
 	// conversion operators
 
-	explicit operator int() const { return static_cast<int>(to_int64()); }
-	explicit operator long() const { return static_cast<long>(to_int64()); }
-	explicit operator long long() const { return to_int64(); }
-	explicit operator unsigned long long() const { return static_cast<unsigned long long>(to_int64()); }
-	explicit operator float() const { return static_cast<float>(to_double()); }
-	explicit operator double() const { return to_double(); }
+	constexpr explicit operator int() const { return static_cast<int>(to_int64()); }
+	constexpr explicit operator long() const { return static_cast<long>(to_int64()); }
+	constexpr explicit operator long long() const { return to_int64(); }
+	constexpr explicit operator unsigned long long() const { return static_cast<unsigned long long>(to_int64()); }
+	constexpr explicit operator float() const { return static_cast<float>(to_double()); }
+	constexpr explicit operator double() const { return to_double(); }
 
 	/////////////////////////////////////////////////////////////////////////
 	// arithmetic operators
 
 	// prefix increment
-	dfixpnt& operator++() {
+	constexpr dfixpnt& operator++() {
 		dfixpnt one;
 		one._sign = false;
 		one._block.clear();
@@ -204,13 +214,13 @@ public:
 		return *this += one;
 	}
 	// postfix increment
-	dfixpnt operator++(int) {
+	constexpr dfixpnt operator++(int) {
 		dfixpnt tmp(*this);
 		++(*this);
 		return tmp;
 	}
 	// prefix decrement
-	dfixpnt& operator--() {
+	constexpr dfixpnt& operator--() {
 		dfixpnt one;
 		one._sign = false;
 		one._block.clear();
@@ -218,21 +228,21 @@ public:
 		return *this -= one;
 	}
 	// postfix decrement
-	dfixpnt operator--(int) {
+	constexpr dfixpnt operator--(int) {
 		dfixpnt tmp(*this);
 		--(*this);
 		return tmp;
 	}
 
 	// unary negation
-	dfixpnt operator-() const {
+	constexpr dfixpnt operator-() const {
 		dfixpnt result(*this);
 		if (!result.iszero()) result._sign = !result._sign;
 		return result;
 	}
 
 	// addition
-	dfixpnt& operator+=(const dfixpnt& rhs) {
+	constexpr dfixpnt& operator+=(const dfixpnt& rhs) {
 		if (_sign == rhs._sign) {
 			// same sign: add magnitudes
 			_block += rhs._block;
@@ -262,14 +272,14 @@ public:
 	}
 
 	// subtraction
-	dfixpnt& operator-=(const dfixpnt& rhs) {
+	constexpr dfixpnt& operator-=(const dfixpnt& rhs) {
 		dfixpnt neg(rhs);
 		if (!neg.iszero()) neg._sign = !neg._sign;
 		return *this += neg;
 	}
 
 	// multiplication
-	dfixpnt& operator*=(const dfixpnt& rhs) {
+	constexpr dfixpnt& operator*=(const dfixpnt& rhs) {
 		bool result_sign = _sign != rhs._sign;
 
 		// wide multiply: 2*ndigits product
@@ -304,12 +314,14 @@ public:
 	}
 
 	// division
-	dfixpnt& operator/=(const dfixpnt& rhs) {
+	constexpr dfixpnt& operator/=(const dfixpnt& rhs) {
 		if (rhs.iszero()) {
 #if DFIXPNT_THROW_ARITHMETIC_EXCEPTION
 			throw dfixpnt_divide_by_zero();
 #else
-			std::cerr << "dfixpnt: division by zero\n";
+			if (!std::is_constant_evaluated()) {
+				std::cerr << "dfixpnt: division by zero\n";
+			}
 			return *this;
 #endif
 		}
@@ -349,17 +361,17 @@ public:
 	/////////////////////////////////////////////////////////////////////////
 	// digit access (public for manipulators)
 
-	unsigned digit(unsigned i) const { return _block.digit(i); }
-	void setdigit(unsigned i, unsigned d) { _block.setdigit(i, d); }
+	constexpr unsigned digit(unsigned i) const { return _block.digit(i); }
+	constexpr void setdigit(unsigned i, unsigned d) { _block.setdigit(i, d); }
 
 	/////////////////////////////////////////////////////////////////////////
 	// queries
 
-	bool iszero() const { return _block.iszero(); }
-	bool sign() const { return _sign; }
-	bool ispos() const { return !_sign && !iszero(); }
-	bool isneg() const { return _sign; }
-	bool isinteger() const {
+	constexpr bool iszero() const { return _block.iszero(); }
+	constexpr bool sign() const { return _sign; }
+	constexpr bool ispos() const { return !_sign && !iszero(); }
+	constexpr bool isneg() const { return _sign; }
+	constexpr bool isinteger() const {
 		for (unsigned i = 0; i < radix; ++i) {
 			if (_block.digit(i) != 0) return false;
 		}
@@ -369,36 +381,36 @@ public:
 	/////////////////////////////////////////////////////////////////////////
 	// modifiers
 
-	void setsign(bool s) { _sign = s; }
+	constexpr void setsign(bool s) { _sign = s; }
 
-	void clear() {
+	constexpr void clear() {
 		_sign = false;
 		_block.clear();
 	}
-	void setzero() { clear(); }
+	constexpr void setzero() { clear(); }
 
 	// set to specific extremes
-	dfixpnt& zero() {
+	constexpr dfixpnt& zero() {
 		clear();
 		return *this;
 	}
-	dfixpnt& minpos() {
+	constexpr dfixpnt& minpos() {
 		clear();
 		_block.setdigit(0, 1);
 		return *this;
 	}
-	dfixpnt& maxpos() {
+	constexpr dfixpnt& maxpos() {
 		clear();
 		_block.maxval();
 		return *this;
 	}
-	dfixpnt& minneg() {
+	constexpr dfixpnt& minneg() {
 		clear();
 		_sign = true;
 		_block.setdigit(0, 1);
 		return *this;
 	}
-	dfixpnt& maxneg() {
+	constexpr dfixpnt& maxneg() {
 		clear();
 		_sign = true;
 		_block.maxval();
@@ -495,15 +507,15 @@ public:
 	/////////////////////////////////////////////////////////////////////////
 	// comparison operators
 
-	friend bool operator==(const dfixpnt& lhs, const dfixpnt& rhs) {
+	friend constexpr bool operator==(const dfixpnt& lhs, const dfixpnt& rhs) {
 		if (lhs.iszero() && rhs.iszero()) return true; // +0 == -0
 		if (lhs._sign != rhs._sign) return false;
 		return lhs._block == rhs._block;
 	}
-	friend bool operator!=(const dfixpnt& lhs, const dfixpnt& rhs) {
+	friend constexpr bool operator!=(const dfixpnt& lhs, const dfixpnt& rhs) {
 		return !(lhs == rhs);
 	}
-	friend bool operator<(const dfixpnt& lhs, const dfixpnt& rhs) {
+	friend constexpr bool operator<(const dfixpnt& lhs, const dfixpnt& rhs) {
 		if (lhs.iszero() && rhs.iszero()) return false;
 		if (lhs._sign && !rhs._sign) return true;   // neg < pos
 		if (!lhs._sign && rhs._sign) return false;   // pos > neg
@@ -514,25 +526,26 @@ public:
 		// both negative: larger magnitude is smaller value
 		return rhs._block < lhs._block;
 	}
-	friend bool operator>(const dfixpnt& lhs, const dfixpnt& rhs) {
+	friend constexpr bool operator>(const dfixpnt& lhs, const dfixpnt& rhs) {
 		return rhs < lhs;
 	}
-	friend bool operator<=(const dfixpnt& lhs, const dfixpnt& rhs) {
-		return !(rhs < lhs);
+	friend constexpr bool operator<=(const dfixpnt& lhs, const dfixpnt& rhs) {
+		// dfixpnt has no NaN, but follow the #797 NaN-safe pattern for uniformity.
+		return operator<(lhs, rhs) || operator==(lhs, rhs);
 	}
-	friend bool operator>=(const dfixpnt& lhs, const dfixpnt& rhs) {
-		return !(lhs < rhs);
+	friend constexpr bool operator>=(const dfixpnt& lhs, const dfixpnt& rhs) {
+		return operator>(lhs, rhs) || operator==(lhs, rhs);
 	}
 
 	// access to internal block (for testing/debug)
-	const blockdecimal<ndigits, _encoding, bt>& block() const { return _block; }
+	constexpr const blockdecimal<ndigits, _encoding, bt>& block() const { return _block; }
 
 private:
 	bool _sign;
 	blockdecimal<ndigits, _encoding, bt> _block;
 
 	// convert to int64_t (truncates fractional part)
-	long long to_int64() const {
+	constexpr long long to_int64() const {
 		long long result = 0;
 		long long scale = 1;
 		for (unsigned i = radix; i < ndigits; ++i) {
@@ -543,7 +556,7 @@ private:
 	}
 
 	// convert to double
-	double to_double() const {
+	constexpr double to_double() const {
 		double result = 0.0;
 		double scale = 1.0;
 		for (unsigned i = 0; i < ndigits; ++i) {
@@ -562,7 +575,7 @@ private:
 // binary arithmetic operators (non-member)
 
 template<unsigned ndigits, unsigned radix, DecimalEncoding encoding, bool arithmetic, typename bt>
-dfixpnt<ndigits, radix, encoding, arithmetic, bt>
+constexpr dfixpnt<ndigits, radix, encoding, arithmetic, bt>
 operator+(const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& lhs,
           const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& rhs) {
 	dfixpnt<ndigits, radix, encoding, arithmetic, bt> result(lhs);
@@ -571,7 +584,7 @@ operator+(const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& lhs,
 }
 
 template<unsigned ndigits, unsigned radix, DecimalEncoding encoding, bool arithmetic, typename bt>
-dfixpnt<ndigits, radix, encoding, arithmetic, bt>
+constexpr dfixpnt<ndigits, radix, encoding, arithmetic, bt>
 operator-(const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& lhs,
           const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& rhs) {
 	dfixpnt<ndigits, radix, encoding, arithmetic, bt> result(lhs);
@@ -580,7 +593,7 @@ operator-(const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& lhs,
 }
 
 template<unsigned ndigits, unsigned radix, DecimalEncoding encoding, bool arithmetic, typename bt>
-dfixpnt<ndigits, radix, encoding, arithmetic, bt>
+constexpr dfixpnt<ndigits, radix, encoding, arithmetic, bt>
 operator*(const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& lhs,
           const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& rhs) {
 	dfixpnt<ndigits, radix, encoding, arithmetic, bt> result(lhs);
@@ -589,7 +602,7 @@ operator*(const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& lhs,
 }
 
 template<unsigned ndigits, unsigned radix, DecimalEncoding encoding, bool arithmetic, typename bt>
-dfixpnt<ndigits, radix, encoding, arithmetic, bt>
+constexpr dfixpnt<ndigits, radix, encoding, arithmetic, bt>
 operator/(const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& lhs,
           const dfixpnt<ndigits, radix, encoding, arithmetic, bt>& rhs) {
 	dfixpnt<ndigits, radix, encoding, arithmetic, bt> result(lhs);

--- a/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
+++ b/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
@@ -206,12 +206,21 @@ public:
 	// arithmetic operators
 
 	// prefix increment
+	// For dfixpnt<N, N> (idigits == 0, e.g. dfixpnt<3,3>), the type holds
+	// values in (-1, 1) and 1 is not representable, so ++/-- on the integer
+	// part are no-ops: setdigit(radix, 1) would write past the last digit
+	// (radix == ndigits) and the storage no longer asserts.  Guarded with
+	// if constexpr so the OOB path is removed at compile time.
 	constexpr dfixpnt& operator++() {
-		dfixpnt one;
-		one._sign = false;
-		one._block.clear();
-		one._block.setdigit(radix, 1); // value = 1.0
-		return *this += one;
+		if constexpr (idigits > 0) {
+			dfixpnt one;
+			one._sign = false;
+			one._block.clear();
+			one._block.setdigit(radix, 1); // value = 1.0
+			return *this += one;
+		}
+		// For idigits == 0, no integer-part-of-1 to add; ++ is a no-op.
+		return *this;
 	}
 	// postfix increment
 	constexpr dfixpnt operator++(int) {
@@ -221,11 +230,14 @@ public:
 	}
 	// prefix decrement
 	constexpr dfixpnt& operator--() {
-		dfixpnt one;
-		one._sign = false;
-		one._block.clear();
-		one._block.setdigit(radix, 1);
-		return *this -= one;
+		if constexpr (idigits > 0) {
+			dfixpnt one;
+			one._sign = false;
+			one._block.clear();
+			one._block.setdigit(radix, 1);
+			return *this -= one;
+		}
+		return *this;
 	}
 	// postfix decrement
 	constexpr dfixpnt operator--(int) {

--- a/static/fixpnt/decimal/api/constexpr.cpp
+++ b/static/fixpnt/decimal/api/constexpr.cpp
@@ -1,0 +1,194 @@
+// constexpr.cpp: compile-time tests for dfixpnt (decimal fixed-point)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// Configure dfixpnt: throwing arithmetic exceptions disabled so divide-by-zero
+// has defined constexpr-safe behavior (silently returns *this) rather than
+// throwing, which would be ill-formed in a constant expression.
+#define DFIXPNT_THROW_ARITHMETIC_EXCEPTION 0
+#define BLOCKDECIMAL_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/dfixpnt/dfixpnt.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "dfixpnt constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// dfixpnt<8,3> = 8 total decimal digits, 3 fractional -> range +/- 99999.999
+
+	using D = dfixpnt<8, 3>;
+
+	// ----------------------------------------------------------------------------
+	// Native int construction (already constexpr -- smoke test only)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr D a(0);
+		constexpr D b(1);
+		constexpr D c(-3);
+		(void)a; (void)b; (void)c;
+	}
+
+	// ----------------------------------------------------------------------------
+	// Acceptance form from issue #729:
+	//   constexpr dfixpnt<...> a(2.0), b(3.0); constexpr auto c = a + b;
+	// (and analogous for *, -, /, +=, <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr D a(2.0);
+		constexpr D b(3.0);
+		constexpr auto cx_sum = a + b;  // 2 + 3 = 5
+		static_assert(cx_sum == D(5.0), "issue #729 acceptance: a + b");
+	}
+
+	// ----------------------------------------------------------------------------
+	// All four binary arithmetic operators in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr D a(4.5);
+		constexpr D b(1.5);
+		constexpr auto cx_sum  = a + b;          // 4.5 + 1.5 = 6.0
+		constexpr auto cx_diff = a - b;          // 4.5 - 1.5 = 3.0
+		constexpr auto cx_prod = a * b;          // 4.5 * 1.5 = 6.75
+		constexpr auto cx_quot = a / b;          // 4.5 / 1.5 = 3.0
+		constexpr auto cx_neg  = -a;             // -4.5
+		static_assert(cx_sum  == D(6.0),  "constexpr +  failed");
+		static_assert(cx_diff == D(3.0),  "constexpr -  failed");
+		static_assert(cx_prod == D(6.75), "constexpr *  failed");
+		static_assert(cx_quot == D(3.0),  "constexpr /  failed");
+		static_assert(cx_neg  == D(-4.5), "constexpr unary - failed");
+
+		// Compound assignment via lambda (constexpr lambdas are C++20)
+		constexpr D cx_addeq = []() { D t(1.5); t += D(3.0); return t; }();
+		constexpr D cx_subeq = []() { D t(4.5); t -= D(1.5); return t; }();
+		constexpr D cx_muleq = []() { D t(1.5); t *= D(3.0); return t; }();
+		constexpr D cx_diveq = []() { D t(4.5); t /= D(1.5); return t; }();
+		static_assert(cx_addeq == D(4.5), "constexpr += failed");
+		static_assert(cx_subeq == D(3.0), "constexpr -= failed");
+		static_assert(cx_muleq == D(4.5), "constexpr *= failed");
+		static_assert(cx_diveq == D(3.0), "constexpr /= failed");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Constexpr comparison (issue acceptance: <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr D a(1.5);
+		constexpr D b(3.0);
+		static_assert(a < b,     "constexpr: D(1.5) < D(3.0)");
+		static_assert(b > a,     "constexpr: D(3.0) > D(1.5)");
+		static_assert(a <= b,    "constexpr: D(1.5) <= D(3.0)");
+		static_assert(b >= a,    "constexpr: D(3.0) >= D(1.5)");
+		static_assert(!(a == b), "constexpr: D(1.5) != D(3.0)");
+		static_assert(a != b,    "constexpr: != operator");
+		static_assert(a == a,    "constexpr: D(1.5) == D(1.5)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion-out: operator double() / int() are now constexpr
+	// ----------------------------------------------------------------------------
+	{
+		constexpr D a(0.5);
+		constexpr double d = double(a);
+		static_assert(d == 0.5, "constexpr operator double()");
+
+		constexpr D b(42.0);
+		constexpr int n = int(b);
+		static_assert(n == 42, "constexpr operator int()");
+
+		constexpr D c(2.5);
+		constexpr float f = float(c);
+		static_assert(f == 2.5f, "constexpr operator float()");
+
+		// Negative int truncates toward zero
+		constexpr D neg(-3.7);
+		constexpr int neg_i = int(neg);
+		static_assert(neg_i == -3, "constexpr operator int() truncates toward zero (negative)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Increment / decrement
+	// ----------------------------------------------------------------------------
+	{
+		constexpr D cx_inc = []() { D t(2.5); ++t; return t; }();
+		constexpr D cx_dec = []() { D t(2.5); --t; return t; }();
+		static_assert(cx_inc == D(3.5), "constexpr ++ failed");
+		static_assert(cx_dec == D(1.5), "constexpr -- failed");
+	}
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction
+	// ----------------------------------------------------------------------------
+	{
+		constexpr D zero(SpecificValue::zero);
+		constexpr D maxp(SpecificValue::maxpos);
+		constexpr D minp(SpecificValue::minpos);
+		constexpr D minn(SpecificValue::minneg);
+		constexpr D maxn(SpecificValue::maxneg);
+		static_assert(zero == D(0.0), "constexpr SpecificValue::zero");
+		static_assert(maxp > D(0.0),  "constexpr SpecificValue::maxpos > 0");
+		static_assert(minp > D(0.0),  "constexpr SpecificValue::minpos > 0");
+		static_assert(minn < D(0.0),  "constexpr SpecificValue::minneg < 0");
+		static_assert(maxn < D(0.0),  "constexpr SpecificValue::maxneg < 0");
+		static_assert(maxp > minp,    "constexpr maxpos > minpos");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Encoding variants: BCD (default), BID, DPD
+	// ----------------------------------------------------------------------------
+	{
+		using D_BCD = dfixpnt<6, 2, DecimalEncoding::BCD>;
+		using D_BID = dfixpnt<6, 2, DecimalEncoding::BID>;
+		using D_DPD = dfixpnt<6, 2, DecimalEncoding::DPD>;
+
+		constexpr D_BCD a_bcd(12.5);
+		constexpr D_BCD b_bcd(2.5);
+		constexpr auto sum_bcd = a_bcd + b_bcd;
+		static_assert(sum_bcd == D_BCD(15.0), "constexpr BCD addition");
+
+		constexpr D_BID a_bid(12.5);
+		constexpr D_BID b_bid(2.5);
+		constexpr auto sum_bid = a_bid + b_bid;
+		static_assert(sum_bid == D_BID(15.0), "constexpr BID addition");
+
+		constexpr D_DPD a_dpd(12.5);
+		constexpr D_DPD b_dpd(2.5);
+		constexpr auto sum_dpd = a_dpd + b_dpd;
+		static_assert(sum_dpd == D_DPD(15.0), "constexpr DPD addition");
+	}
+
+	std::cout << "dfixpnt constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::dfixpnt_arithmetic_exception& err) {
+	std::cerr << "Uncaught dfixpnt arithmetic exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/static/fixpnt/decimal/api/constexpr.cpp
+++ b/static/fixpnt/decimal/api/constexpr.cpp
@@ -147,6 +147,39 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Pure-fractional dfixpnt<N, N> (idigits == 0): ++/-- must not write OOB.
+	// For these types ++/-- are no-ops since 1 is not representable.
+	// (Per CodeRabbit critical finding on PR #803.)
+	// ----------------------------------------------------------------------------
+	{
+		using DF = dfixpnt<3, 3>;  // values in (-0.999, 0.999); idigits == 0
+		constexpr DF half(0.5);
+		constexpr DF cx_inc = []() { DF t(0.5); ++t; return t; }();
+		constexpr DF cx_dec = []() { DF t(0.5); --t; return t; }();
+		// ++/-- are no-ops for fully-fractional dfixpnt -- the alternative
+		// would write past the last digit (UB).
+		static_assert(cx_inc == half, "constexpr ++ is no-op for dfixpnt<N,N>");
+		static_assert(cx_dec == half, "constexpr -- is no-op for dfixpnt<N,N>");
+	}
+
+	// ----------------------------------------------------------------------------
+	// blockdecimal unsigned conversion preserves the full 64-bit range.
+	// Pre-fix would clamp via to_long_long() at LLONG_MAX, losing the upper
+	// half of the unsigned range.  (Per CodeRabbit major finding on PR #803.)
+	// ----------------------------------------------------------------------------
+	{
+		// Use blockdecimal<19, BID> directly to exercise the unsigned conversion.
+		// 19 digits = max for BID (uint64_t fits 9999999999999999999 < 2^64).
+		using BD = blockdecimal<19, DecimalEncoding::BID>;
+		// 9999999999999999999 > LLONG_MAX (9223372036854775807) but fits in uint64_t.
+		constexpr unsigned long long large = 9999999999999999999ULL;
+		constexpr BD a(large);
+		constexpr unsigned long long round_trip = static_cast<unsigned long long>(a);
+		static_assert(round_trip == large,
+			"blockdecimal -> unsigned long long preserves upper 64-bit range");
+	}
+
+	// ----------------------------------------------------------------------------
 	// Encoding variants: BCD (default), BID, DPD
 	// ----------------------------------------------------------------------------
 	{

--- a/static/fixpnt/decimal/api/constexpr.cpp
+++ b/static/fixpnt/decimal/api/constexpr.cpp
@@ -120,13 +120,23 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
-	// Increment / decrement
+	// Increment / decrement (prefix and postfix)
 	// ----------------------------------------------------------------------------
 	{
 		constexpr D cx_inc = []() { D t(2.5); ++t; return t; }();
 		constexpr D cx_dec = []() { D t(2.5); --t; return t; }();
 		static_assert(cx_inc == D(3.5), "constexpr ++ failed");
 		static_assert(cx_dec == D(1.5), "constexpr -- failed");
+
+		// Postfix returns the pre-increment value but mutates the operand.
+		constexpr D cx_postinc_before = []() { D t(2.5); D old = t++; return old; }();
+		constexpr D cx_postinc_after  = []() { D t(2.5); t++; return t; }();
+		constexpr D cx_postdec_before = []() { D t(2.5); D old = t--; return old; }();
+		constexpr D cx_postdec_after  = []() { D t(2.5); t--; return t; }();
+		static_assert(cx_postinc_before == D(2.5), "constexpr postfix ++ return failed");
+		static_assert(cx_postinc_after  == D(3.5), "constexpr postfix ++ state failed");
+		static_assert(cx_postdec_before == D(2.5), "constexpr postfix -- return failed");
+		static_assert(cx_postdec_after  == D(1.5), "constexpr postfix -- state failed");
 	}
 
 	// ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Promotes `dfixpnt` (decimal fixed-point) to fully constexpr across construction, arithmetic, comparison, conversion, increment/decrement, and unary negation.
- Promotes the underlying `blockdecimal` storage class to fully constexpr (prerequisite for dfixpnt).
- Issue acceptance form `constexpr dfixpnt<8,3> a(2.0), b(3.0); constexpr auto c = a + b;` (and `*`, `-`, `/`, `+=`, `<`) compiles and locks in via `static_assert`.

This is the first **static-storage-tier** type promoted under Epic #723 beyond the cascade trio + dd/qd. dfixpnt has 3 encoding variants (BCD, BID, DPD); all three are exercised in the constexpr test.

## Approach
Two-file scope:

- **`internal/blockdecimal/blockdecimal.hpp`** (817 lines) — the underlying decimal storage, similar role to `blockbinary` for binary fixpnt. Marked all operators, accessors, and helpers as `constexpr`. Replaced `assert(...)` with caller-enforced precondition comments. Guarded `std::cerr` divide-by-zero diagnostics under `!std::is_constant_evaluated()` so `operator/=` and `operator%=` are fully constexpr-callable when THROW configuration is off.

- **`number/dfixpnt/dfixpnt_impl.hpp`** (600 lines) — promoted all operators with the established #797 lessons:
  - Constructors with member-initializer list (`_sign{false}, _block{}`) for constexpr safety.
  - `operator=(double)`: `std::isnan` replaced with NaN-safe `rhs != rhs`; `std::round` replaced with `floor(x + 0.5)` emulation using a clamped integer cast.
  - NaN-safe `<=` / `>=` via `< || ==` and `> || ==`  (uniform with #797 pattern, even though dfixpnt has no NaN).

`operator++` / `operator--` ARE supported here (unlike dd/qd) because dfixpnt increment uses `+=` rather than `std::nextafter`.

## Changes
- `include/sw/universal/internal/blockdecimal/blockdecimal.hpp` — full constexpr promotion of arithmetic, comparison, conversion, helpers
- `include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp` — full constexpr promotion + NaN-safe comparison pattern
- `static/fixpnt/decimal/api/constexpr.cpp` — new test exercising all three encoding variants (BCD/BID/DPD)

## Test Results
| Suite | gcc | clang |
|-------|-----|-------|
| dfixpnt_api / addition / subtraction / multiplication / division / logic / constexpr | PASS | PASS |
| dfloat_api / addition / multiplication / division (regression -- shared blockdecimal) | PASS | PASS |

7/7 dfixpnt + 4/4 dfloat tests PASS on both compilers.

## Constexpr coverage milestone
Universal library now has 14 fully constexpr-compliant number systems:
integer, posit, cfloat, bfloat16, fixpnt, lns, areal, dbns, dd, dd_cascade, td_cascade, qd_cascade, qd, **dfixpnt**.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #729

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric types now expose many operations as constexpr, enabling broader compile-time construction, conversion, arithmetic, shifts and comparisons.

* **Bug Fixes**
  * Suppressed runtime diagnostics during constant-evaluation and improved constexpr-safe numeric conversion and rounding behavior.

* **Tests**
  * Added a compile-time verification suite exercising constexpr construction, arithmetic, increments/decrements, conversions and comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->