### PR TITLE
feat(hfloat): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/number/hfloat/hfloat_fwd.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_fwd.hpp
@@ -16,7 +16,7 @@ namespace sw { namespace universal {
 	bool parse(const std::string& number, hfloat<ndigits, es, BlockType>& v);
 
 	template<unsigned ndigits, unsigned es, typename BlockType>
-	hfloat<ndigits, es, BlockType>
+	constexpr hfloat<ndigits, es, BlockType>
 		abs(const hfloat<ndigits, es, BlockType>&);
 
 	template<unsigned ndigits, unsigned es, typename BlockType>
@@ -24,7 +24,7 @@ namespace sw { namespace universal {
 		sqrt(const hfloat<ndigits, es, BlockType>&);
 
 	template<unsigned ndigits, unsigned es, typename BlockType>
-	hfloat<ndigits, es, BlockType>
+	constexpr hfloat<ndigits, es, BlockType>
 		fabs(hfloat<ndigits, es, BlockType>);
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -115,45 +115,49 @@ public:
 	}
 
 	// initializers for native types
-	explicit hfloat(signed char iv)           noexcept : _block{} { *this = iv; }
-	explicit hfloat(short iv)                 noexcept : _block{} { *this = iv; }
-	explicit hfloat(int iv)                   noexcept : _block{} { *this = iv; }
-	explicit hfloat(long iv)                  noexcept : _block{} { *this = iv; }
-	explicit hfloat(long long iv)             noexcept : _block{} { *this = iv; }
-	explicit hfloat(char iv)                  noexcept : _block{} { *this = iv; }
-	explicit hfloat(unsigned short iv)        noexcept : _block{} { *this = iv; }
-	explicit hfloat(unsigned int iv)          noexcept : _block{} { *this = iv; }
-	explicit hfloat(unsigned long iv)         noexcept : _block{} { *this = iv; }
-	explicit hfloat(unsigned long long iv)    noexcept : _block{} { *this = iv; }
-	explicit hfloat(float iv)                 noexcept : _block{} { *this = iv; }
-	explicit hfloat(double iv)                noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(signed char iv)           noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(short iv)                 noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(int iv)                   noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(long iv)                  noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(long long iv)             noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(char iv)                  noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(unsigned short iv)        noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(unsigned int iv)          noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(unsigned long iv)         noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(unsigned long long iv)    noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(float iv)                 noexcept : _block{} { *this = iv; }
+	constexpr explicit hfloat(double iv)                noexcept : _block{} { *this = iv; }
 
 	// assignment operators for native types
-	hfloat& operator=(signed char rhs)        noexcept { return convert_signed(rhs); }
-	hfloat& operator=(short rhs)              noexcept { return convert_signed(rhs); }
-	hfloat& operator=(int rhs)                noexcept { return convert_signed(rhs); }
-	hfloat& operator=(long rhs)               noexcept { return convert_signed(rhs); }
-	hfloat& operator=(long long rhs)          noexcept { return convert_signed(rhs); }
-	hfloat& operator=(char rhs)               noexcept { return convert_unsigned(rhs); }
-	hfloat& operator=(unsigned short rhs)     noexcept { return convert_unsigned(rhs); }
-	hfloat& operator=(unsigned int rhs)       noexcept { return convert_unsigned(rhs); }
-	hfloat& operator=(unsigned long rhs)      noexcept { return convert_unsigned(rhs); }
-	hfloat& operator=(unsigned long long rhs) noexcept { return convert_unsigned(rhs); }
-	hfloat& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
-	hfloat& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
+	constexpr hfloat& operator=(signed char rhs)        noexcept { return convert_signed(rhs); }
+	constexpr hfloat& operator=(short rhs)              noexcept { return convert_signed(rhs); }
+	constexpr hfloat& operator=(int rhs)                noexcept { return convert_signed(rhs); }
+	constexpr hfloat& operator=(long rhs)               noexcept { return convert_signed(rhs); }
+	constexpr hfloat& operator=(long long rhs)          noexcept { return convert_signed(rhs); }
+	// Plain `char` may be signed or unsigned per platform; route through
+	// the signed conversion via integer promotion so hfloat(char(-1)) on
+	// signed-char targets yields -1, not UCHAR_MAX (CodeRabbit finding
+	// from PR #805 applied to the sibling type).
+	constexpr hfloat& operator=(char rhs)               noexcept { return convert_signed(static_cast<int>(rhs)); }
+	constexpr hfloat& operator=(unsigned short rhs)     noexcept { return convert_unsigned(rhs); }
+	constexpr hfloat& operator=(unsigned int rhs)       noexcept { return convert_unsigned(rhs); }
+	constexpr hfloat& operator=(unsigned long rhs)      noexcept { return convert_unsigned(rhs); }
+	constexpr hfloat& operator=(unsigned long long rhs) noexcept { return convert_unsigned(rhs); }
+	constexpr hfloat& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
+	constexpr hfloat& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
 
 	// conversion operators
-	explicit operator float()           const noexcept { return float(convert_to_double()); }
-	explicit operator double()          const noexcept { return convert_to_double(); }
+	constexpr explicit operator float()           const noexcept { return float(convert_to_double()); }
+	constexpr explicit operator double()          const noexcept { return convert_to_double(); }
 
 #if LONG_DOUBLE_SUPPORT
-	explicit hfloat(long double iv)           noexcept : _block{} { *this = iv; }
-	hfloat& operator=(long double rhs)        noexcept { return convert_ieee754(double(rhs)); }
-	explicit operator long double()     const noexcept { return (long double)convert_to_double(); }
+	constexpr explicit hfloat(long double iv)           noexcept : _block{} { *this = iv; }
+	constexpr hfloat& operator=(long double rhs)        noexcept { return convert_ieee754(double(rhs)); }
+	constexpr explicit operator long double()     const noexcept { return (long double)convert_to_double(); }
 #endif
 
 	// prefix operators
-	hfloat operator-() const {
+	constexpr hfloat operator-() const {
 		hfloat negated(*this);
 		if (!negated.iszero()) {
 			negated.setsign(!negated.sign());
@@ -162,7 +166,7 @@ public:
 	}
 
 	// arithmetic operators
-	hfloat& operator+=(const hfloat& rhs) {
+	constexpr hfloat& operator+=(const hfloat& rhs) {
 		bool lhs_sign, rhs_sign;
 		int lhs_exp, rhs_exp;
 		uint64_t lhs_frac, rhs_frac;
@@ -201,13 +205,13 @@ public:
 		return *this;
 	}
 
-	hfloat& operator-=(const hfloat& rhs) {
+	constexpr hfloat& operator-=(const hfloat& rhs) {
 		hfloat neg(rhs);
 		if (!neg.iszero()) neg.setsign(!neg.sign());
 		return operator+=(neg);
 	}
 
-	hfloat& operator*=(const hfloat& rhs) {
+	constexpr hfloat& operator*=(const hfloat& rhs) {
 		if (iszero() || rhs.iszero()) { setzero(); return *this; }
 
 		bool lhs_sign, rhs_sign;
@@ -233,14 +237,20 @@ public:
 		return *this;
 	}
 
-	hfloat& operator/=(const hfloat& rhs) {
+	constexpr hfloat& operator/=(const hfloat& rhs) {
 		if (rhs.iszero()) {
 #if HFLOAT_THROW_ARITHMETIC_EXCEPTION
-			throw hfloat_divide_by_zero();
-#else
+			// Throwing in a constant expression is ill-formed; fence the
+			// throw under runtime to keep operator/= constexpr-callable.
+			// At constant-eval, divide-by-zero falls through to setzero()
+			// (IBM HFP has no NaN/inf, so saturation is the closest
+			// constexpr-safe behavior).
+			if (!std::is_constant_evaluated()) {
+				throw hfloat_divide_by_zero();
+			}
+#endif
 			setzero();
 			return *this;
-#endif
 		}
 		if (iszero()) return *this;
 
@@ -266,37 +276,37 @@ public:
 	}
 
 	// unary operators
-	hfloat& operator++() {
+	constexpr hfloat& operator++() {
 		*this += hfloat(1);
 		return *this;
 	}
-	hfloat operator++(int) {
+	constexpr hfloat operator++(int) {
 		hfloat tmp(*this);
 		operator++();
 		return tmp;
 	}
-	hfloat& operator--() {
+	constexpr hfloat& operator--() {
 		*this -= hfloat(1);
 		return *this;
 	}
-	hfloat operator--(int) {
+	constexpr hfloat operator--(int) {
 		hfloat tmp(*this);
 		operator--();
 		return tmp;
 	}
 
 	// modifiers
-	void clear() noexcept {
+	constexpr void clear() noexcept {
 		for (unsigned i = 0; i < nrBlocks; ++i) _block[i] = bt(0);
 	}
-	void setzero() noexcept { clear(); }
+	constexpr void setzero() noexcept { clear(); }
 
-	void setsign(bool negative = true) noexcept {
+	constexpr void setsign(bool negative = true) noexcept {
 		setbit(nbits - 1, negative);
 	}
 
 	// use un-interpreted raw bits to set the value
-	inline void setbits(uint64_t value) noexcept {
+	constexpr void setbits(uint64_t value) noexcept {
 		clear();
 		for (unsigned i = 0; i < nrBlocks; ++i) {
 			_block[i] = bt(value & BLOCK_MASK);
@@ -339,11 +349,11 @@ public:
 	}
 
 	// selectors
-	bool sign() const noexcept {
+	constexpr bool sign() const noexcept {
 		return getbit(nbits - 1);
 	}
 
-	bool iszero() const noexcept {
+	constexpr bool iszero() const noexcept {
 		// zero when fraction is all zeros (exponent and sign don't matter)
 		// In IBM HFP, zero is represented as all-zeros
 		for (unsigned i = 0; i < nrBlocks; ++i) {
@@ -353,22 +363,22 @@ public:
 		return true;
 	}
 
-	bool isone() const noexcept {
+	constexpr bool isone() const noexcept {
 		bool s; int e; uint64_t f;
 		unpack(s, e, f);
 		// 1.0 = 0.1 * 16^1, so e=1, f = 1 << (fbits-4)  (leading hex digit = 1)
 		return !s && (e == 1) && (f == (1ull << (fbits - 4)));
 	}
 
-	bool ispos() const noexcept { return !sign(); }
-	bool isneg() const noexcept { return sign(); }
+	constexpr bool ispos() const noexcept { return !sign(); }
+	constexpr bool isneg() const noexcept { return sign(); }
 
 	// IBM HFP has no NaN or infinity
-	bool isinf() const noexcept { return false; }
-	bool isnan() const noexcept { return false; }
-	bool isnan(int) const noexcept { return false; }
+	constexpr bool isinf() const noexcept { return false; }
+	constexpr bool isnan() const noexcept { return false; }
+	constexpr bool isnan(int) const noexcept { return false; }
 
-	int scale() const noexcept {
+	constexpr int scale() const noexcept {
 		if (iszero()) return 0;
 		bool s; int e; uint64_t f;
 		unpack(s, e, f);
@@ -399,7 +409,7 @@ public:
 
 	///////////////////////////////////////////////////////////////////
 	// Bit access (public for free functions)
-	bool getbit(unsigned pos) const noexcept {
+	constexpr bool getbit(unsigned pos) const noexcept {
 		if (pos >= nbits) return false;
 		unsigned block_idx = pos / bitsInBlock;
 		unsigned bit_idx = pos % bitsInBlock;
@@ -408,7 +418,7 @@ public:
 
 	///////////////////////////////////////////////////////////////////
 	// Unpack into sign, unbiased exponent, and fraction
-	void unpack(bool& s, int& exponent, uint64_t& fraction) const noexcept {
+	constexpr void unpack(bool& s, int& exponent, uint64_t& fraction) const noexcept {
 		s = sign();
 		if (iszero()) { exponent = 0; fraction = 0; return; }
 
@@ -436,7 +446,7 @@ protected:
 
 	///////////////////////////////////////////////////////////////////
 	// Bit manipulation helpers
-	void setbit(unsigned pos, bool value) noexcept {
+	constexpr void setbit(unsigned pos, bool value) noexcept {
 		if (pos >= nbits) return;
 		unsigned block_idx = pos / bitsInBlock;
 		unsigned bit_idx = pos % bitsInBlock;
@@ -471,7 +481,7 @@ protected:
 
 	///////////////////////////////////////////////////////////////////
 	// Normalize: ensure leading hex digit is non-zero, then truncate
-	void normalize_and_pack(bool s, int exponent, uint64_t fraction) noexcept {
+	constexpr void normalize_and_pack(bool s, int exponent, uint64_t fraction) noexcept {
 		if (fraction == 0) { setzero(); return; }
 
 		// Normalize: shift left until the fraction fits in fbits with a non-zero leading hex digit
@@ -509,76 +519,159 @@ protected:
 	// Conversion helpers
 
 	// Convert IEEE-754 double to hfloat
-	hfloat& convert_ieee754(double rhs) noexcept {
-		if (std::isnan(rhs) || rhs == 0.0) {
+	//
+	// Constexpr-safe rewrite of the original frexp/ldexp implementation:
+	// - NaN detected via x != x (only NaN is unequal to itself)
+	// - infinity detected by bracketing against numeric_limits::max()
+	//   (numeric_limits<double>::max() is constexpr; std::isinf is not)
+	// - fabs replaced with `negative ? -rhs : rhs`
+	// - frexp/ldexp replaced with raw IEEE 754 field extraction via
+	//   sw::bit_cast (constexpr on toolchains exposing std::bit_cast or
+	//   __builtin_bit_cast; runtime fallback retains the legacy path).
+	//
+	// IBM HFP has no NaN and no infinity:
+	//   NaN double  -> hfloat zero
+	//   +/- inf     -> hfloat maxpos/maxneg (saturation)
+	constexpr hfloat& convert_ieee754(double rhs) noexcept {
+		if (rhs != rhs) {                       // NaN
 			setzero();
 			return *this;
 		}
-		if (std::isinf(rhs)) {
-			if (rhs > 0) maxpos(); else maxneg();
+		if (rhs == 0.0) {
+			setzero();
 			return *this;
 		}
+		constexpr double dbl_max = std::numeric_limits<double>::max();
+		if (rhs >  dbl_max) { maxpos(); return *this; }   // +inf
+		if (rhs < -dbl_max) { maxneg(); return *this; }   // -inf
 
 		bool negative = (rhs < 0);
-		double abs_val = std::fabs(rhs);
+		double abs_val = negative ? -rhs : rhs;
 
-		// Convert to hex floating-point: value = 0.f * 16^e
-		// First get binary exponent
-		int bin_exp;
-		double frac = std::frexp(abs_val, &bin_exp);
-		// frac is in [0.5, 1.0), bin_exp is such that abs_val = frac * 2^bin_exp
+		// Reconstruct frexp's (frac, bin_exp) without std::frexp:
+		// IEEE 754 double: bias 1023, 52 fraction bits, hidden 1 for normals.
+		//   normal: value = (1 + rawFrac/2^52) * 2^(rawExp - 1023)
+		//                 = (2^52 + rawFrac) * 2^(rawExp - 1075)
+		// frexp returns frac in [0.5, 1) such that value = frac * 2^bin_exp:
+		//   frac    = (2^52 + rawFrac) / 2^53
+		//   bin_exp = rawExp - 1022
+		// So mantissa_with_hidden = (2^52 + rawFrac) and
+		//   frac * 2^shift = mantissa_with_hidden * 2^(shift - 53)
+		int bin_exp = 0;
+		uint64_t mantissa = 0;          // 53-bit significand with hidden bit
 
-		// Convert to base-16 exponent
-		// We need hex_exp = ceil(bin_exp / 4) so the fraction 0.f fits in [1/16, 1)
-		// For positive bin_exp: ceil(n/4) = (n+3)/4
-		// For negative bin_exp: ceil(n/4) in C integer arithmetic
+		if constexpr (sw::is_bit_cast_constexpr_v) {
+			// Constexpr path: extract IEEE 754 fields via bit_cast.
+			uint64_t bits = sw::bit_cast<uint64_t>(abs_val);
+			uint64_t rawExp  = (bits >> 52) & 0x7FFu;
+			uint64_t rawFrac = bits & ((uint64_t(1) << 52) - 1u);
+			if (rawExp == 0) {
+				// Subnormal double values are far below IBM HFP's smallest
+				// representable (16^emin); flush to zero per HFP semantics.
+				setzero();
+				return *this;
+			}
+			bin_exp  = static_cast<int>(rawExp) - 1022;
+			mantissa = (uint64_t(1) << 52) | rawFrac;
+		}
+		else {
+			// Runtime fallback (legacy path).  Unreachable in constant
+			// expressions on toolchains without constexpr bit_cast --
+			// the function still compiles but constexpr callers will get
+			// a not-a-constant-expression diagnostic at the use site.
+			if (!std::is_constant_evaluated()) {
+				int e = 0;
+				double frac = std::frexp(abs_val, &e);
+				bin_exp = e;
+				// frac in [0.5, 1) -> mantissa = frac * 2^53 fits in 53 bits
+				mantissa = static_cast<uint64_t>(std::ldexp(frac, 53));
+			}
+			else {
+				return *this;  // dead code (constexpr caller would not reach here)
+			}
+		}
+
+		// Convert binary exponent to base-16 exponent.
+		// We want hex_exp = ceil(bin_exp / 4) so 0.f * 16^hex_exp == abs_val
+		// with f's leading hex digit non-zero.
+		// For bin_exp > 0: ceil(n/4) = (n + 3) / 4
+		// For bin_exp <= 0: C integer division truncates toward zero, which
+		//   matches ceil for negative numerators.
 		int hex_exp;
 		if (bin_exp > 0) {
 			hex_exp = (bin_exp + 3) / 4;
 		}
 		else {
-			// For bin_exp <= 0: ceil(bin_exp / 4)
-			// C integer division truncates toward zero, which is ceil for negative values
 			hex_exp = bin_exp / 4;
-			// But we need to ensure we don't undershoot
 		}
 
-		// Compute fraction: abs_val / 16^hex_exp, then scale to fbits
-		// fraction = abs_val * 16^(-hex_exp) * 2^fbits
-		// = frac * 2^bin_exp * 16^(-hex_exp) * 2^fbits
-		// = frac * 2^(bin_exp - 4*hex_exp + fbits)
+		// fraction = frac * 2^shift = mantissa * 2^(shift - 53)
 		int shift = bin_exp - 4 * hex_exp + static_cast<int>(fbits);
-		uint64_t fraction;
-		if (shift >= 0 && shift < 64) {
-			fraction = static_cast<uint64_t>(std::ldexp(frac, shift));
+		int mantissa_shift = shift - 53;
+		uint64_t fraction = 0;
+		if (mantissa_shift >= 0) {
+			// mantissa has at most 53 significant bits; shifts up to 11
+			// bits stay within uint64_t.
+			if (mantissa_shift < 11) {
+				fraction = mantissa << mantissa_shift;
+			}
+			else {
+				// Beyond uint64_t headroom: saturate to all-ones in fbits
+				// (fbits >= 64 is the hfloat_extended path; the truncate
+				// mask below is also no-op for fbits >= 64).
+				fraction = (fbits < 64) ? ((uint64_t(1) << fbits) - 1u) : ~uint64_t(0);
+			}
 		}
-		else if (shift >= 64) {
-			fraction = (1ull << fbits) - 1; // saturate
+		else if (-mantissa_shift < 64) {
+			// Shift right truncates low bits -- matches IBM HFP's
+			// truncation rounding contract.
+			fraction = mantissa >> static_cast<unsigned>(-mantissa_shift);
 		}
-		else {
-			fraction = 0;
-		}
+		// else: fraction stays 0
 
-		// Truncate to fbits (IBM HFP truncation rounding)
-		fraction &= ((1ull << fbits) - 1);
+		// Truncate to fbits.  Mask is no-op when fbits >= 64.
+		if constexpr (fbits < 64) {
+			fraction &= ((uint64_t(1) << fbits) - 1u);
+		}
 
 		normalize_and_pack(negative, hex_exp, fraction);
 		return *this;
 	}
 
 	// Convert hfloat to IEEE-754 double
-	double convert_to_double() const noexcept {
+	//
+	// Constexpr-safe: replaces std::ldexp(d, n) with a power-of-2 scaling
+	// loop that multiplies/divides by 2.0 (exactly representable in double).
+	// At runtime, dispatches to std::ldexp for performance.  The shift range
+	// per template config is bounded (fbits + 4*emax for hfloat_extended is
+	// ~360), so the constexpr loop is well-bounded.
+	constexpr double convert_to_double() const noexcept {
 		if (iszero()) return sign() ? -0.0 : 0.0;
 
 		bool s; int e; uint64_t f;
 		unpack(s, e, f);
 
 		// value = 0.f * 16^e = f * 2^(-fbits) * 16^e = f * 2^(4*e - fbits)
-		double result = std::ldexp(static_cast<double>(f), 4 * e - static_cast<int>(fbits));
+		int shift = 4 * e - static_cast<int>(fbits);
+		double result = static_cast<double>(f);
+		if (std::is_constant_evaluated()) {
+			// Power-of-2 scaling: 2.0 and 0.5 are exactly representable
+			// in IEEE 754 double, so this introduces no rounding error
+			// over the bounded iteration count.
+			if (shift > 0) {
+				for (int i = 0; i < shift; ++i) result *= 2.0;
+			}
+			else if (shift < 0) {
+				for (int i = 0; i < -shift; ++i) result *= 0.5;
+			}
+		}
+		else {
+			result = std::ldexp(result, shift);
+		}
 		return s ? -result : result;
 	}
 
-	hfloat& convert_signed(int64_t v) noexcept {
+	constexpr hfloat& convert_signed(int64_t v) noexcept {
 		if (v == 0) {
 			setzero();
 			return *this;
@@ -587,7 +680,7 @@ protected:
 		return convert_ieee754(static_cast<double>(v));
 	}
 
-	hfloat& convert_unsigned(uint64_t v) noexcept {
+	constexpr hfloat& convert_unsigned(uint64_t v) noexcept {
 		if (v == 0) {
 			setzero();
 			return *this;
@@ -599,15 +692,15 @@ private:
 
 	// hfloat - hfloat logic comparisons
 	template<unsigned N, unsigned E, typename B>
-	friend bool operator==(const hfloat<N, E, B>& lhs, const hfloat<N, E, B>& rhs);
+	friend constexpr bool operator==(const hfloat<N, E, B>& lhs, const hfloat<N, E, B>& rhs);
 
 	// hfloat - literal logic comparisons
 	template<unsigned N, unsigned E, typename B>
-	friend bool operator==(const hfloat<N, E, B>& lhs, const double rhs);
+	friend constexpr bool operator==(const hfloat<N, E, B>& lhs, const double rhs);
 
 	// literal - hfloat logic comparisons
 	template<unsigned N, unsigned E, typename B>
-	friend bool operator==(const double lhs, const hfloat<N, E, B>& rhs);
+	friend constexpr bool operator==(const double lhs, const hfloat<N, E, B>& rhs);
 };
 
 
@@ -667,14 +760,14 @@ inline std::string to_native(const hfloat<ndigits, es, BlockType>& v, bool = fal
 ////////////////////////    HFLOAT functions   /////////////////////////////////
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> abs(const hfloat<ndigits, es, BlockType>& a) {
+inline constexpr hfloat<ndigits, es, BlockType> abs(const hfloat<ndigits, es, BlockType>& a) {
 	hfloat<ndigits, es, BlockType> result(a);
 	result.setsign(false);
 	return result;
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> fabs(hfloat<ndigits, es, BlockType> a) {
+inline constexpr hfloat<ndigits, es, BlockType> fabs(hfloat<ndigits, es, BlockType> a) {
 	a.setsign(false);
 	return a;
 }
@@ -718,113 +811,113 @@ bool parse(const std::string& number, hfloat<ndigits, es, BlockType>& value) {
 // hfloat - hfloat binary logic operators
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator==(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator==(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	if (lhs.iszero() && rhs.iszero()) return true;
-	// compare through double
+	// compare through double (constexpr after convert_to_double promotion)
 	return double(lhs) == double(rhs);
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator!=(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator!=(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return !operator==(lhs, rhs);
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator< (const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator< (const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return double(lhs) < double(rhs);
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator> (const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator> (const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator< (rhs, lhs);
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator<=(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator<=(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator>=(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator>=(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return !operator< (lhs, rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // hfloat - literal binary logic operators
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator==(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr bool operator==(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator==(lhs, hfloat<ndigits, es, BlockType>(rhs));
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator!=(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr bool operator!=(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return !operator==(lhs, rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator< (const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr bool operator< (const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator<(lhs, hfloat<ndigits, es, BlockType>(rhs));
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator> (const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr bool operator> (const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator< (hfloat<ndigits, es, BlockType>(rhs), lhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator<=(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr bool operator<=(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator>=(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr bool operator>=(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return !operator< (lhs, rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - hfloat binary logic operators
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator==(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator==(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator==(hfloat<ndigits, es, BlockType>(lhs), rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator!=(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator!=(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return !operator==(lhs, rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator< (const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator< (const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator<(hfloat<ndigits, es, BlockType>(lhs), rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator> (const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator> (const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator< (rhs, lhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator<=(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator<=(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline bool operator>=(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr bool operator>=(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return !operator< (lhs, rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // hfloat - hfloat binary arithmetic operators
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator+(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator+(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	hfloat<ndigits, es, BlockType> sum(lhs);
 	sum += rhs;
 	return sum;
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator-(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator-(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	hfloat<ndigits, es, BlockType> diff(lhs);
 	diff -= rhs;
 	return diff;
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator*(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator*(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	hfloat<ndigits, es, BlockType> mul(lhs);
 	mul *= rhs;
 	return mul;
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator/(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator/(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	hfloat<ndigits, es, BlockType> ratio(lhs);
 	ratio /= rhs;
 	return ratio;
@@ -833,38 +926,38 @@ inline hfloat<ndigits, es, BlockType> operator/(const hfloat<ndigits, es, BlockT
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // hfloat - literal binary arithmetic operators
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator+(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator+(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator+(lhs, hfloat<ndigits, es, BlockType>(rhs));
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator-(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator-(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator-(lhs, hfloat<ndigits, es, BlockType>(rhs));
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator*(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator*(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator*(lhs, hfloat<ndigits, es, BlockType>(rhs));
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator/(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator/(const hfloat<ndigits, es, BlockType>& lhs, const double rhs) {
 	return operator/(lhs, hfloat<ndigits, es, BlockType>(rhs));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - hfloat binary arithmetic operators
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator+(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator+(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator+(hfloat<ndigits, es, BlockType>(lhs), rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator-(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator-(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator-(hfloat<ndigits, es, BlockType>(lhs), rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator*(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator*(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator*(hfloat<ndigits, es, BlockType>(lhs), rhs);
 }
 template<unsigned ndigits, unsigned es, typename BlockType>
-inline hfloat<ndigits, es, BlockType> operator/(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
+inline constexpr hfloat<ndigits, es, BlockType> operator/(const double lhs, const hfloat<ndigits, es, BlockType>& rhs) {
 	return operator/(hfloat<ndigits, es, BlockType>(lhs), rhs);
 }
 

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -557,39 +557,25 @@ protected:
 		//   bin_exp = rawExp - 1022
 		// So mantissa_with_hidden = (2^52 + rawFrac) and
 		//   frac * 2^shift = mantissa_with_hidden * 2^(shift - 53)
-		int bin_exp = 0;
-		uint64_t mantissa = 0;          // 53-bit significand with hidden bit
-
-		if constexpr (sw::is_bit_cast_constexpr_v) {
-			// Constexpr path: extract IEEE 754 fields via bit_cast.
-			uint64_t bits = sw::bit_cast<uint64_t>(abs_val);
-			uint64_t rawExp  = (bits >> 52) & 0x7FFu;
-			uint64_t rawFrac = bits & ((uint64_t(1) << 52) - 1u);
-			if (rawExp == 0) {
-				// Subnormal double values are far below IBM HFP's smallest
-				// representable (16^emin); flush to zero per HFP semantics.
-				setzero();
-				return *this;
-			}
-			bin_exp  = static_cast<int>(rawExp) - 1022;
-			mantissa = (uint64_t(1) << 52) | rawFrac;
+		//
+		// sw::bit_cast is constexpr on toolchains exposing std::bit_cast or
+		// __builtin_bit_cast (the universally-supported case in C++20+); on
+		// older toolchains it works at runtime via memcpy but is not
+		// constexpr.  Calling convert_ieee754() in a constant expression on
+		// such a toolchain produces a not-a-constant-expression diagnostic
+		// at the bit_cast invocation -- the correct behavior, vs. silently
+		// returning zero from a runtime fallback.
+		uint64_t bits = sw::bit_cast<uint64_t>(abs_val);
+		uint64_t rawExp  = (bits >> 52) & 0x7FFu;
+		uint64_t rawFrac = bits & ((uint64_t(1) << 52) - 1u);
+		if (rawExp == 0) {
+			// Subnormal double values are far below IBM HFP's smallest
+			// representable (16^emin); flush to zero per HFP semantics.
+			setzero();
+			return *this;
 		}
-		else {
-			// Runtime fallback (legacy path).  Unreachable in constant
-			// expressions on toolchains without constexpr bit_cast --
-			// the function still compiles but constexpr callers will get
-			// a not-a-constant-expression diagnostic at the use site.
-			if (!std::is_constant_evaluated()) {
-				int e = 0;
-				double frac = std::frexp(abs_val, &e);
-				bin_exp = e;
-				// frac in [0.5, 1) -> mantissa = frac * 2^53 fits in 53 bits
-				mantissa = static_cast<uint64_t>(std::ldexp(frac, 53));
-			}
-			else {
-				return *this;  // dead code (constexpr caller would not reach here)
-			}
-		}
+		int bin_exp = static_cast<int>(rawExp) - 1022;
+		uint64_t mantissa = (uint64_t(1) << 52) | rawFrac;  // 53-bit significand with hidden bit
 
 		// Convert binary exponent to base-16 exponent.
 		// We want hex_exp = ceil(bin_exp / 4) so 0.f * 16^hex_exp == abs_val
@@ -671,13 +657,32 @@ protected:
 		return s ? -result : result;
 	}
 
+	// Direct integer-to-hfloat packing for fbits <= 56 (hfloat_short and
+	// hfloat_long).  Avoids the double round-trip that would lose precision
+	// for int64_t values above 2^53 -- a value like 9007199254740993ULL
+	// IS representable in hfloat_long (56-bit fraction) but rounds via
+	// double.  For fbits >= 64 (hfloat_extended) the fraction is wider
+	// than uint64_t can hold, so we fall back to convert_ieee754; this
+	// keeps the same precision as pre-promotion code for that variant.
 	constexpr hfloat& convert_signed(int64_t v) noexcept {
 		if (v == 0) {
 			setzero();
 			return *this;
 		}
-		// Use double conversion for simplicity
-		return convert_ieee754(static_cast<double>(v));
+		bool negative = (v < 0);
+		// Compute |v| as uint64_t without ever negating an int64_t (the
+		// negation of INT64_MIN would overflow).  Bitwise-safe identity:
+		// |INT64_MIN| = -(v + 1) + 1, each step stays in range.
+		uint64_t abs_v = negative
+			? (static_cast<uint64_t>(-(v + 1)) + 1ull)
+			: static_cast<uint64_t>(v);
+		if constexpr (fbits >= 64) {
+			return convert_ieee754(static_cast<double>(v));
+		}
+		else {
+			pack_uint64(negative, abs_v);
+			return *this;
+		}
 	}
 
 	constexpr hfloat& convert_unsigned(uint64_t v) noexcept {
@@ -685,7 +690,36 @@ protected:
 			setzero();
 			return *this;
 		}
-		return convert_ieee754(static_cast<double>(v));
+		if constexpr (fbits >= 64) {
+			return convert_ieee754(static_cast<double>(v));
+		}
+		else {
+			pack_uint64(false, v);
+			return *this;
+		}
+	}
+
+	// Pack a uint64_t magnitude into the hfloat's hex representation.
+	// Precondition: v != 0 and fbits < 64.
+	//   value = v = 0.f * 16^hex_exp where 0.f's leading hex digit is non-zero.
+	// Algorithm:
+	//   p          = highest set bit of v (0-indexed)
+	//   hex_exp    = p/4 + 1   (number of hex digits to represent v)
+	//   shift      = fbits - 4*hex_exp
+	//   fraction   = (shift >= 0) ? v << shift : v >> -shift  (truncate per HFP)
+	// Worst-case shift left: p=0, fbits<=56 -> shift=fbits-4, v<<shift fits in
+	// uint64_t since v has only 1 bit.  Worst-case shift right: p=63, shift=fbits-64.
+	constexpr void pack_uint64(bool negative, uint64_t v) noexcept {
+		// Find highest set bit position (loop is bounded to 64 iterations
+		// and constexpr-clean; v != 0 by precondition).
+		unsigned p = 63;
+		while (((v >> p) & 1u) == 0u) --p;
+		int hex_exp = static_cast<int>(p / 4u) + 1;
+		int shift = static_cast<int>(fbits) - 4 * hex_exp;
+		uint64_t fraction = (shift >= 0)
+			? (v << static_cast<unsigned>(shift))
+			: (v >> static_cast<unsigned>(-shift));
+		normalize_and_pack(negative, hex_exp, fraction);
 	}
 
 private:
@@ -810,11 +844,24 @@ bool parse(const std::string& number, hfloat<ndigits, es, BlockType>& value) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // hfloat - hfloat binary logic operators
 
+// hfloat values are normalized by normalize_and_pack so that the leading
+// hex digit of the fraction is non-zero -- the (sign, exponent, fraction)
+// tuple is unique per value.  We compare tuples directly instead of via
+// double() to preserve precision for hfloat_long (56-bit fraction) and
+// hfloat_extended, where the double round-trip would lose bits below the
+// 53-bit IEEE 754 mantissa.
 template<unsigned ndigits, unsigned es, typename BlockType>
 inline constexpr bool operator==(const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
-	if (lhs.iszero() && rhs.iszero()) return true;
-	// compare through double (constexpr after convert_to_double promotion)
-	return double(lhs) == double(rhs);
+	bool lz = lhs.iszero();
+	bool rz = rhs.iszero();
+	if (lz && rz) return true;       // +0 == -0 in HFP (no signed-zero distinction)
+	if (lz || rz) return false;
+	if (lhs.sign() != rhs.sign()) return false;
+	bool ts; int le = 0, re = 0;
+	uint64_t lf = 0, rf = 0;
+	lhs.unpack(ts, le, lf);
+	rhs.unpack(ts, re, rf);
+	return le == re && lf == rf;
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>
@@ -824,7 +871,27 @@ inline constexpr bool operator!=(const hfloat<ndigits, es, BlockType>& lhs, cons
 
 template<unsigned ndigits, unsigned es, typename BlockType>
 inline constexpr bool operator< (const hfloat<ndigits, es, BlockType>& lhs, const hfloat<ndigits, es, BlockType>& rhs) {
-	return double(lhs) < double(rhs);
+	bool lz = lhs.iszero();
+	bool rz = rhs.iszero();
+	if (lz && rz) return false;
+	bool ls = lhs.sign();
+	bool rs = rhs.sign();
+	if (lz) return !rs;              // 0 < +x; 0 not < -x
+	if (rz) return ls;               // -x < 0; +x not < 0
+	if (ls != rs) return ls;         // negative < positive
+	// Same sign, both non-zero.  unpack returns (sign, biased-exp-removed,
+	// fraction).  For positives, lhs < rhs iff (le < re) || tie + (lf < rf).
+	// For negatives, the ordering reverses: lhs < rhs iff |lhs| > |rhs|.
+	bool ts; int le = 0, re = 0;
+	uint64_t lf = 0, rf = 0;
+	lhs.unpack(ts, le, lf);
+	rhs.unpack(ts, re, rf);
+	if (ls) {
+		// both negative: lhs < rhs iff |lhs| > |rhs|
+		return (le > re) || (le == re && lf > rf);
+	}
+	// both positive
+	return (le < re) || (le == re && lf < rf);
 }
 
 template<unsigned ndigits, unsigned es, typename BlockType>

--- a/static/float/hfloat/api/constexpr.cpp
+++ b/static/float/hfloat/api/constexpr.cpp
@@ -184,7 +184,7 @@ try {
 
 	// ----------------------------------------------------------------------------
 	// Special-value arithmetic in constexpr
-	//   HFP_THROW_ARITHMETIC_EXCEPTION = 0 -> divide-by-zero saturates to zero
+	//   HFLOAT_THROW_ARITHMETIC_EXCEPTION = 0 -> divide-by-zero saturates to zero
 	//   (no NaN/inf available; this is the closest constexpr-safe behavior).
 	// ----------------------------------------------------------------------------
 	{

--- a/static/float/hfloat/api/constexpr.cpp
+++ b/static/float/hfloat/api/constexpr.cpp
@@ -223,6 +223,42 @@ try {
 		static_assert(posv2 == HShort(3.5), "constexpr fabs(-3.5) == 3.5");
 	}
 
+	// ----------------------------------------------------------------------------
+	// Integer construction precision (CodeRabbit follow-up).
+	// hfloat_long has a 56-bit fraction so values above 2^53 (the IEEE 754
+	// double mantissa width) must be packed directly from the integer
+	// without round-tripping through double.
+	//
+	// 9007199254740992  = 2^53      (exactly representable in double)
+	// 9007199254740993  = 2^53 + 1  (NOT representable in double; rounds
+	//                                to 2^53 under any double round-trip)
+	//
+	// Both values fit in hfloat_long's 56-bit fraction, so direct integer
+	// packing must keep them distinct.  The previous double round-trip
+	// implementation failed this contract -- the new pack_uint64() path
+	// satisfies it.  We verify via tuple-based comparison (which is itself
+	// precision-preserving) rather than via operator double() (which would
+	// lose the very bit we're checking).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HLong a(9007199254740992LL);   // 2^53
+		constexpr HLong b(9007199254740993LL);   // 2^53 + 1
+		static_assert(a != b, "constexpr: hfloat_long preserves 2^53 + 1 distinct from 2^53");
+		static_assert(a < b,  "constexpr: hfloat_long 2^53 < 2^53 + 1 (tuple compare)");
+		static_assert(b > a,  "constexpr: hfloat_long 2^53 + 1 > 2^53");
+
+		// Same witness via the unsigned conversion path.
+		constexpr HLong au(9007199254740992ULL);
+		constexpr HLong bu(9007199254740993ULL);
+		static_assert(au != bu, "constexpr: hfloat_long unsigned preserves 2^53 + 1");
+
+		// INT64_MIN: |v| computed via -(v+1)+1 identity, no overflow.
+		constexpr long long llmin = (-9223372036854775807LL) - 1LL;  // INT64_MIN
+		constexpr HLong smin(llmin);
+		static_assert(smin.sign(), "constexpr: hfloat_long INT64_MIN is negative");
+		static_assert(!smin.iszero(), "constexpr: hfloat_long INT64_MIN is non-zero");
+	}
+
 	std::cout << "hfloat constexpr verification: "
 	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
 

--- a/static/float/hfloat/api/constexpr.cpp
+++ b/static/float/hfloat/api/constexpr.cpp
@@ -1,0 +1,247 @@
+// constexpr.cpp: compile-time tests for hfloat (IBM System/360 hexadecimal FP)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// Configure hfloat: throwing arithmetic exceptions disabled so divide-by-zero
+// has defined constexpr-safe behavior (saturates to zero per HFP semantics --
+// IBM HFP has no NaN/Inf -- rather than throwing, which would be ill-formed
+// in a constant expression.
+#define HFLOAT_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/hfloat/hfloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "hfloat constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// hfloat_short = hfloat<6, 7> = 32-bit IBM HFP short.
+	// hfloat_long  = hfloat<14, 7> = 64-bit IBM HFP long.
+	// IBM HFP has NO NaN, NO infinity, NO subnormals; truncation rounding
+	// only.  The constexpr suite focuses on these invariants in addition
+	// to the standard arithmetic / comparison contract.
+	using HShort = hfloat_short;
+	using HLong  = hfloat_long;
+
+	// ----------------------------------------------------------------------------
+	// Native int construction (smoke test)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort a(0);
+		constexpr HShort b(1);
+		constexpr HShort c(-3);
+		(void)a; (void)b; (void)c;
+	}
+
+	// ----------------------------------------------------------------------------
+	// Acceptance form from issue #732:
+	//   constexpr hfloat<...> a(2.0), b(3.0); constexpr auto c = a + b;
+	// (and analogous for *, -, /, +=, <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort a(2.0);
+		constexpr HShort b(3.0);
+		constexpr auto cx_sum = a + b;            // 2 + 3 = 5
+		static_assert((cx_sum - HShort(5.0)).iszero(), "issue #732 acceptance: a + b");
+	}
+
+	// ----------------------------------------------------------------------------
+	// All four binary arithmetic operators in constexpr context
+	//
+	// Equality is asserted via subtraction + iszero() so that wobbling-precision
+	// representations (IBM HFP truncation can leave 0-3 leading zero bits in
+	// the leading hex digit, producing different bit patterns for equal values)
+	// don't cause spurious failures.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort a(4.5);
+		constexpr HShort b(1.5);
+		constexpr auto cx_sum  = a + b;          // 4.5 + 1.5 = 6.0
+		constexpr auto cx_diff = a - b;          // 4.5 - 1.5 = 3.0
+		constexpr auto cx_prod = a * b;          // 4.5 * 1.5 = 6.75
+		constexpr auto cx_quot = a / b;          // 4.5 / 1.5 = 3.0
+		constexpr auto cx_neg  = -a;             // -4.5
+		static_assert((cx_sum  - HShort(6.0)).iszero(),  "constexpr +  failed");
+		static_assert((cx_diff - HShort(3.0)).iszero(),  "constexpr -  failed");
+		static_assert((cx_prod - HShort(6.75)).iszero(), "constexpr *  failed");
+		static_assert((cx_quot - HShort(3.0)).iszero(),  "constexpr /  failed");
+		static_assert((cx_neg  - HShort(-4.5)).iszero(), "constexpr unary - failed");
+
+		// Compound assignment via lambda (constexpr lambdas are C++20)
+		constexpr HShort cx_addeq = []() { HShort t(1.5); t += HShort(3.0); return t; }();
+		constexpr HShort cx_subeq = []() { HShort t(4.5); t -= HShort(1.5); return t; }();
+		constexpr HShort cx_muleq = []() { HShort t(1.5); t *= HShort(3.0); return t; }();
+		constexpr HShort cx_diveq = []() { HShort t(4.5); t /= HShort(1.5); return t; }();
+		static_assert((cx_addeq - HShort(4.5)).iszero(), "constexpr += failed");
+		static_assert((cx_subeq - HShort(3.0)).iszero(), "constexpr -= failed");
+		static_assert((cx_muleq - HShort(4.5)).iszero(), "constexpr *= failed");
+		static_assert((cx_diveq - HShort(3.0)).iszero(), "constexpr /= failed");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Constexpr comparison (issue acceptance: <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort a(1.5);
+		constexpr HShort b(3.0);
+		static_assert(a < b,     "constexpr: HShort(1.5) < HShort(3.0)");
+		static_assert(b > a,     "constexpr: HShort(3.0) > HShort(1.5)");
+		static_assert(a <= b,    "constexpr: HShort(1.5) <= HShort(3.0)");
+		static_assert(b >= a,    "constexpr: HShort(3.0) >= HShort(1.5)");
+		static_assert(!(a == b), "constexpr: HShort(1.5) != HShort(3.0)");
+		static_assert(a != b,    "constexpr: != operator");
+		static_assert(a == a,    "constexpr: HShort(1.5) == HShort(1.5)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion-out: operator double() / float() are now constexpr
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort a(0.5);
+		constexpr double d = double(a);
+		static_assert(d == 0.5, "constexpr operator double()");
+
+		constexpr HShort b(2.5);
+		constexpr float f = float(b);
+		static_assert(f == 2.5f, "constexpr operator float()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Default value-initialization is a constexpr-safe representation of zero.
+	// (Trivial default ctor leaves storage indeterminate; T{} value-initializes
+	// the array aggregate to zero, which IS legal in a constant expression.)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort cx_zero{};
+		static_assert(cx_zero.iszero(), "constexpr HShort{} is zero");
+
+		// ++0 -> next representable value; --0 -> previous representable value
+		constexpr HShort cx_inc_zero = []() { HShort t{}; ++t; return t; }();
+		constexpr HShort cx_dec_zero = []() { HShort t{}; --t; return t; }();
+		static_assert(cx_inc_zero > HShort(0.0), "constexpr ++0 > 0");
+		static_assert(cx_dec_zero < HShort(0.0), "constexpr --0 < 0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction.  IBM HFP has no NaN, no infinity:
+	//   infpos -> maxpos (saturation), infneg -> maxneg
+	//   qnan   -> zero,                snan   -> zero
+	// These mappings are part of the hfloat contract and must hold at
+	// constant-evaluation time as well as runtime.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort zero(SpecificValue::zero);
+		constexpr HShort maxp(SpecificValue::maxpos);
+		constexpr HShort minp(SpecificValue::minpos);
+		constexpr HShort minn(SpecificValue::minneg);
+		constexpr HShort maxn(SpecificValue::maxneg);
+		constexpr HShort infp(SpecificValue::infpos);
+		constexpr HShort infn(SpecificValue::infneg);
+		constexpr HShort qn(SpecificValue::qnan);
+		static_assert(zero == HShort(0.0), "constexpr SpecificValue::zero");
+		static_assert(maxp > HShort(0.0),  "constexpr SpecificValue::maxpos > 0");
+		static_assert(minp > HShort(0.0),  "constexpr SpecificValue::minpos > 0");
+		static_assert(minn < HShort(0.0),  "constexpr SpecificValue::minneg < 0");
+		static_assert(maxn < HShort(0.0),  "constexpr SpecificValue::maxneg < 0");
+		static_assert(maxp > minp,         "constexpr maxpos > minpos");
+
+		// HFP saturation of infinity: infpos == maxpos, infneg == maxneg
+		static_assert(infp == maxp,     "constexpr SpecificValue::infpos saturates to maxpos");
+		static_assert(infn == maxn,     "constexpr SpecificValue::infneg saturates to maxneg");
+
+		// HFP no-NaN: qnan/snan map to zero
+		static_assert(qn.iszero(),      "constexpr SpecificValue::qnan maps to zero in HFP");
+	}
+
+	// ----------------------------------------------------------------------------
+	// HFP invariants: isinf() and isnan() always return false (no infinity,
+	// no NaN -- core IBM System/360 HFP property).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort zero(0.0);
+		constexpr HShort one(1.0);
+		constexpr HShort maxp(SpecificValue::maxpos);
+		static_assert(!zero.isinf(),  "constexpr: HFP zero is not inf");
+		static_assert(!zero.isnan(),  "constexpr: HFP zero is not nan");
+		static_assert(!one.isinf(),   "constexpr: HFP one is not inf");
+		static_assert(!one.isnan(),   "constexpr: HFP one is not nan");
+		static_assert(!maxp.isinf(),  "constexpr: HFP maxpos is not inf (saturation)");
+		static_assert(!maxp.isnan(),  "constexpr: HFP maxpos is not nan");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Special-value arithmetic in constexpr
+	//   HFP_THROW_ARITHMETIC_EXCEPTION = 0 -> divide-by-zero saturates to zero
+	//   (no NaN/inf available; this is the closest constexpr-safe behavior).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort zero(0.0);
+		constexpr HShort one(1.0);
+		// 1/0 -> zero (HFP has no infinity; constexpr divide-by-zero contract)
+		constexpr auto cx_div_zero = one / zero;
+		static_assert(cx_div_zero.iszero(), "constexpr 1/0 -> zero (HFP saturation)");
+
+		// 0/0 -> zero (HFP has no NaN)
+		constexpr auto cx_zero_div_zero = zero / zero;
+		static_assert(cx_zero_div_zero.iszero(), "constexpr 0/0 -> zero (HFP saturation)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// hfloat_long smoke (wider exponent range, 56 fraction bits)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HLong a(2.0);
+		constexpr HLong b(3.0);
+		constexpr auto cx_sum = a + b;
+		static_assert((cx_sum - HLong(5.0)).iszero(), "constexpr hfloat_long +");
+
+		constexpr auto cx_prod = a * b;
+		static_assert((cx_prod - HLong(6.0)).iszero(), "constexpr hfloat_long *");
+	}
+
+	// ----------------------------------------------------------------------------
+	// abs / fabs free functions are constexpr
+	// ----------------------------------------------------------------------------
+	{
+		constexpr HShort negv(-3.5);
+		constexpr HShort posv = abs(negv);
+		static_assert(posv == HShort(3.5), "constexpr abs(-3.5) == 3.5");
+		constexpr HShort posv2 = fabs(negv);
+		static_assert(posv2 == HShort(3.5), "constexpr fabs(-3.5) == 3.5");
+	}
+
+	std::cout << "hfloat constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::hfloat_arithmetic_exception& err) {
+	std::cerr << "Uncaught hfloat arithmetic exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Promotes `hfloat` (IBM System/360 hexadecimal floating-point) to fully `constexpr` across construction, assignment, arithmetic, comparison, and conversion operators. Direct sibling of dfloat #805 / dfixpnt #803 / qd #800. Part of Epic #723.

`hfloat` is self-contained (no `blockbinary`/`blocktriple` dependencies), so this promotion is contained: 3 files (`hfloat_impl.hpp`, `hfloat_fwd.hpp`, new `constexpr.cpp`).

## Changes

- `include/sw/universal/number/hfloat/hfloat_impl.hpp`
  - All trivial helpers, selectors, storage helpers marked `constexpr`.
  - All native-type ctors/assignments, conversion-out operators, arithmetic, comparison, increment/decrement marked `constexpr`.
  - Plain `char` routed via `convert_signed(static_cast<int>(rhs))` so `hfloat(char(-1))` honors platform char signedness (CodeRabbit lesson from PR #805 applied preemptively).
  - `convert_ieee754(double)` rewritten: `std::isnan`/`isinf`/`fabs`/`frexp`/`ldexp` replaced with `x != x` / `numeric_limits::max()` bracket / sign-flip / `if constexpr (sw::is_bit_cast_constexpr_v)` IEEE 754 field extraction; runtime fallback retains the legacy `std::frexp`/`ldexp` path under `!std::is_constant_evaluated()`.
  - `convert_to_double()` rewritten: `std::ldexp` replaced with power-of-2 scaling loop using exactly-representable `2.0`/`0.5` multiplications; runtime path keeps `std::ldexp` via `is_constant_evaluated()` dispatch.
  - `operator/=` divide-by-zero throw fenced under `!std::is_constant_evaluated()`; constant-eval path saturates to zero (HFP has no NaN/inf).
- `include/sw/universal/number/hfloat/hfloat_fwd.hpp`
  - `abs` / `fabs` forward declarations marked `constexpr` to match definitions.
- `static/float/hfloat/api/constexpr.cpp` (new)
  - Issue #732 acceptance form (`constexpr auto c = a + b` with `static_assert`).
  - All four binary operators + compound forms (equality asserted via `(a - b).iszero()` to handle HFP wobbling precision).
  - All six comparison operators.
  - `operator double()` / `operator float()` constexpr.
  - Increment / decrement on value-initialized `HShort{}` (locks in `HShort{}` as a constexpr-safe representation of zero).
  - SpecificValue construction with HFP-specific saturation invariants (`infpos == maxpos`, `qnan == zero`).
  - `isinf()` / `isnan()` always return `false` (HFP invariant).
  - `1/0` and `0/0` saturate to zero in constant-eval.
  - `hfloat_long` smoke test (wider exponent range, fbits=56).
  - `abs` / `fabs` constexpr verification.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| hfloat_constexpr | OK | PASS | OK | PASS |
| hfloat_api | OK | PASS | OK | PASS |
| hfloat_addition | OK | PASS | OK | PASS |
| hfloat_subtraction | OK | PASS | OK | PASS |
| hfloat_multiplication | OK | PASS | OK | PASS |
| hfloat_division | OK | PASS | OK | PASS |
| hfloat_logic | OK | PASS | OK | PASS |
| hfloat_assignment | OK | PASS | OK | PASS |
| hfloat_short | OK | PASS | OK | PASS |

Build dirs: `build_ci/` (gcc), `build_ci_clang/` (clang). Both `UNIVERSAL_BUILD_ALL=ON`. No regressions introduced; the only diagnostic during the run was a pre-existing unused-variable warning in `arithmetic/addition.cpp:123`.

## Test plan
- [x] Fast CI (gcc + clang CI_LITE) passes
- [x] CodeRabbit pass
- [x] Promote to ready: `gh pr ready <#>`

Resolves #732

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled compile-time (constexpr) evaluation for the custom hfloat/half-float type: constructors, conversions, arithmetic, comparisons, and helpers; +0 and -0 compare equal in constexpr contexts.

* **Bug Fixes**
  * Divide-by-zero now deterministically saturates to zero during compile-time evaluation while still throwing at runtime.

* **Tests**
  * Added an exhaustive compile-time test suite validating constexpr construction, arithmetic, comparisons, conversions, special-value behavior, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->