### PR TITLE
fix(dfixpnt): handle ndigits >= 20 overflow in to_int64 and operator=(double)

### DIFF
--- a/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
+++ b/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
@@ -145,6 +145,19 @@ public:
 	}
 
 	constexpr dfixpnt& operator=(double rhs) {
+		// IEEE 754 double's representable decimal exponent range is +/- ~308.
+		// Once `ndigits` (or `radix`) exceeds that, the `scaled *= 10.0` and
+		// `max_magnitude *= 10.0` loops below overflow to +inf -- and `inf >=
+		// inf` is true, so the saturation check would silently coerce ANY
+		// input (including 1.0) to all-nines.  Other constructors (string,
+		// integer) don't go through this path, so the constraint is local to
+		// double conversion -- the type itself remains usable for
+		// arbitrarily-wide configurations.
+		static_assert(ndigits <= static_cast<unsigned>(std::numeric_limits<double>::max_exponent10),
+			"dfixpnt::operator=(double): ndigits exceeds double's decimal exponent range "
+			"(~308); use a narrower instantiation for double conversion, or assign via a "
+			"non-FP path (string / integer).");
+
 		clear();
 		// std::isnan is not constexpr in C++20; use a NaN-safe equivalent
 		// (NaN is the only value not equal to itself).

--- a/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
+++ b/include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <cmath>
 #include <cassert>
+#include <limits>
 #include <type_traits>
 
 // supporting types and functions
@@ -157,27 +158,59 @@ public:
 		// scale up by 10^radix to get the fixed-point integer representation
 		double scaled = rhs;
 		for (unsigned i = 0; i < radix; ++i) scaled *= 10.0;
-		// round to nearest.  std::round is not constexpr in C++20; use the
-		// half-away-from-zero formula directly: floor(x + 0.5) for x >= 0.
-		// Hand-rolled floor: cast to int64 truncates toward zero, then back.
-		// This is safe here because we already clamped to non-negative above.
-		double half = scaled + 0.5;
-		// std::floor not constexpr; emulate via integer cast (only safe for
-		// values that fit in long long, which the subsequent clamp ensures).
-		// Compute max representable magnitude via constexpr lambda.
-		constexpr double max_magnitude = []() {
-			double m = 1.0;
-			for (unsigned i = 0; i < ndigits; ++i) m *= 10.0;
-			return m - 1.0;
-		}();
-		if (half > max_magnitude) half = max_magnitude + 1.0; // will clamp below
-		// Clamp before any potentially-UB cast.
-		if (half > max_magnitude) half = max_magnitude;
-		// Truncate toward zero (works because half >= 0 here).
-		uint64_t value = static_cast<uint64_t>(half);
-		for (unsigned i = 0; i < ndigits && value > 0; ++i) {
-			_block.setdigit(i, static_cast<unsigned>(value % 10));
-			value /= 10;
+		// round to nearest, half away from zero (scaled >= 0 here)
+		scaled += 0.5;
+
+		// Compute representational ceiling = 10^ndigits in FP space.
+		double max_magnitude = 1.0;
+		for (unsigned i = 0; i < ndigits; ++i) max_magnitude *= 10.0;
+
+		// Saturate at the storage limit before any out-of-range cast.
+		// Pre-fix code materialized scaled into uint64_t, which overflows
+		// (UB per C++20 [conv.fpint]) for ndigits >= 20 since 10^20 exceeds
+		// UINT64_MAX (~1.84e19).  Now we extract digits in FP space, so the
+		// only constraint is that scaled fit in double's exponent range
+		// (covers ndigits up to ~308).
+		if (scaled >= max_magnitude) {
+			for (unsigned i = 0; i < ndigits; ++i) _block.setdigit(i, 9);
+			return *this;
+		}
+
+		// Extract decimal digits LSD-first via FP-domain repeated div/mod by 10.
+		//
+		// Per iteration we want:
+		//   digit_i = scaled mod 10
+		//   scaled  = floor(scaled / 10)
+		//
+		// 10.0 is exactly representable in IEEE 754 double, but 0.1 is not,
+		// so dividing by 10.0 is the closest correct primitive.  The floor
+		// emulation handles two regimes:
+		//
+		//   * scaled / 10.0 < 2^53: q is in the dense-integer range of double,
+		//     casting to unsigned long long truncates correctly.
+		//   * scaled / 10.0 >= 2^53: q is already representable at integer
+		//     (or coarser) granularity in double, so q is its own floor.
+		//
+		// For source values above 2^53 the lower decimal digits accumulate
+		// FP rounding error -- intrinsic to converting from a double, which
+		// carries only ~16 significant decimal digits regardless of which
+		// extraction algorithm is used.
+		constexpr double pow2_53 = 9007199254740992.0;  // 2^53
+		double v = scaled;
+		for (unsigned i = 0; i < ndigits; ++i) {
+			if (v < 1.0) break;
+			double q = v / 10.0;
+			double q_floor = (q < pow2_53)
+				? static_cast<double>(static_cast<unsigned long long>(q))
+				: q;
+			// digit = v - 10 * floor(v/10).  Clamp against any FP noise
+			// from the subtraction so we never write an out-of-range digit.
+			double d_d = v - 10.0 * q_floor;
+			unsigned d = (d_d < 0.0) ? 0u
+			           : (d_d >= 10.0) ? 9u
+			           : static_cast<unsigned>(d_d);
+			_block.setdigit(i, d);
+			v = q_floor;
 		}
 		return *this;
 	}
@@ -556,15 +589,41 @@ private:
 	bool _sign;
 	blockdecimal<ndigits, _encoding, bt> _block;
 
-	// convert to int64_t (truncates fractional part)
+	// Convert to long long (truncates fractional part), clamped to
+	// [LLONG_MIN, LLONG_MAX].  The previous LSD-first accumulator with
+	// scale *= 10 overflowed long long for idigits >= 19 (10^19 already
+	// exceeds LLONG_MAX) -- UB at runtime, hard compile error in a
+	// constant expression.  Switch to MSD-first Horner with per-step
+	// overflow detection in unsigned long long, then clamp on cast.
+	// Matches blockdecimal::to_long_long.
 	constexpr long long to_int64() const {
-		long long result = 0;
-		long long scale = 1;
-		for (unsigned i = radix; i < ndigits; ++i) {
-			result += _block.digit(i) * scale;
-			scale *= 10;
+		constexpr unsigned long long pos_max =
+			static_cast<unsigned long long>(std::numeric_limits<long long>::max());
+		constexpr unsigned long long neg_max = pos_max + 1ull;  // |LLONG_MIN|
+
+		unsigned long long mag = 0;
+		bool overflow = false;
+		// MSD-first: iterate i from ndigits-1 down to radix (inclusive on radix).
+		// Loop bound expressed as `i > radix` with `i - 1` index, so radix
+		// itself is the last digit consumed.
+		for (unsigned i = ndigits; i > radix; --i) {
+			// Detect overflow before mag *= 10 (would wrap around in unsigned).
+			if (mag > neg_max / 10ull) { overflow = true; break; }
+			mag *= 10ull;
+			unsigned d = _block.digit(i - 1);
+			// Detect overflow before mag += d.
+			if (mag > neg_max - d) { overflow = true; break; }
+			mag += d;
 		}
-		return _sign ? -result : result;
+		if (_sign) {
+			// Negative: |LLONG_MIN| = LLONG_MAX + 1 = neg_max, so values in
+			// [0, neg_max] represent.  mag == neg_max is exactly LLONG_MIN.
+			if (overflow || mag == neg_max) return std::numeric_limits<long long>::min();
+			return -static_cast<long long>(mag);
+		}
+		// Positive: clamp at LLONG_MAX.
+		if (overflow || mag > pos_max) return std::numeric_limits<long long>::max();
+		return static_cast<long long>(mag);
 	}
 
 	// convert to double

--- a/static/fixpnt/decimal/api/constexpr.cpp
+++ b/static/fixpnt/decimal/api/constexpr.cpp
@@ -190,6 +190,81 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Wide instantiations (ndigits >= 20) -- issue #804.
+	//
+	// Pre-fix, both to_int64() (LSD-first scale *= 10 overflows long long for
+	// idigits >= 19) and operator=(double) (uint64_t materialization overflows
+	// when scaled exceeds UINT64_MAX) were UB.  In a constant expression that
+	// UB hard-fails compilation, so simply instantiating these constexpr
+	// constructions is the test.
+	// ----------------------------------------------------------------------------
+	{
+		// dfixpnt<25, 5>: 25 digits total, 5 fractional, 20 integer digits.
+		// idigits = 20 -> to_int64()'s scale would reach 10^19 (overflows long long).
+		// Pre-fix this would hard-fail in constexpr context.
+		using D25 = dfixpnt<25, 5>;
+		constexpr D25 small(42.0);
+		constexpr long long round_trip = static_cast<long long>(small);
+		static_assert(round_trip == 42LL, "constexpr: dfixpnt<25,5>(42) -> 42");
+
+		// Negative path also goes through to_int64()'s clamp logic.
+		constexpr D25 neg(-7.0);
+		constexpr long long neg_round = static_cast<long long>(neg);
+		static_assert(neg_round == -7LL, "constexpr: dfixpnt<25,5>(-7) -> -7");
+
+		// Conversion-out clamping: a value larger than LLONG_MAX in dfixpnt
+		// must clamp to LLONG_MAX rather than producing garbage / UB.
+		// dfixpnt<25,5>'s max value (10^20 - 1, in integer digits) far exceeds
+		// LLONG_MAX (~9.22e18).  Construct a value beyond LLONG_MAX via
+		// repeated addition to verify clamping behavior.
+		// Note: the maxpos SpecificValue construction sets all digits to 9,
+		// giving the largest representable magnitude.
+		constexpr D25 maxp(SpecificValue::maxpos);
+		constexpr long long clamped = static_cast<long long>(maxp);
+		static_assert(clamped == std::numeric_limits<long long>::max(),
+			"constexpr: dfixpnt<25,5>(maxpos) clamps to LLONG_MAX");
+
+		constexpr D25 maxn(SpecificValue::maxneg);
+		constexpr long long clamped_neg = static_cast<long long>(maxn);
+		static_assert(clamped_neg == std::numeric_limits<long long>::min(),
+			"constexpr: dfixpnt<25,5>(maxneg) clamps to LLONG_MIN");
+	}
+	{
+		// dfixpnt<20, 5>: ndigits = 20 -> max_magnitude = 10^20 exceeds UINT64_MAX.
+		// Pre-fix the static_cast<uint64_t>(scaled) was UB for any scaled
+		// approaching the type's range.  After the fix, FP-domain digit
+		// extraction handles the wide range without an out-of-range cast.
+		using D20 = dfixpnt<20, 5>;
+		constexpr D20 small(123.5);
+		constexpr long long lo = static_cast<long long>(small);
+		static_assert(lo == 123LL, "constexpr: dfixpnt<20,5>(123.5) -> 123");
+
+		// Round-trip the largest value that still fits in dfixpnt<20,5>'s
+		// 15 integer digits.  Past this we saturate -- not a defect, just
+		// the type's representational limit.
+		constexpr D20 big(123456789012345.0);
+		constexpr long long big_lo = static_cast<long long>(big);
+		static_assert(big_lo == 123456789012345LL,
+			"constexpr: dfixpnt<20,5> preserves 15-digit integer through wide path");
+
+		// Above the 15-digit integer range, dfixpnt<20,5> saturates to maxpos.
+		// Pre-fix the cast-to-uint64 of an out-of-range double was UB.
+		constexpr D20 huge(1.0e15);  // exceeds 10^15 - 1, the max for D20
+		constexpr long long huge_lo = static_cast<long long>(huge);
+		static_assert(huge_lo == 999999999999999LL,
+			"constexpr: dfixpnt<20,5>(>=1e15) saturates to maxpos magnitude");
+	}
+	{
+		// dfixpnt<25,5> can hold the full 1e15 value (15 integer digits +
+		// room to spare; 20 integer digits available).
+		using D25_2 = dfixpnt<25, 5>;
+		constexpr D25_2 big(1.0e15);
+		constexpr long long big_lo = static_cast<long long>(big);
+		static_assert(big_lo == 1000000000000000LL,
+			"constexpr: dfixpnt<25,5>(1e15) round-trips through wide to_int64");
+	}
+
+	// ----------------------------------------------------------------------------
 	// Encoding variants: BCD (default), BID, DPD
 	// ----------------------------------------------------------------------------
 	{


### PR DESCRIPTION
## Summary

Two pre-existing UB bugs in `dfixpnt` for wide instantiations (`ndigits >= 20`), surfaced by CodeRabbit on PR #803 and filed as issue #804. Both were silent garbage at runtime; the constexpr promotion in #803 made them hard compile errors in constant expressions.

- **`to_int64()`**: LSD-first accumulator with `scale *= 10` overflowed `long long` for `idigits >= 19` (10^19 > LLONG_MAX). Affected all int conversion operators on `dfixpnt<25, 5>` and similar.
- **`operator=(double)`**: Materialized `scaled` (potentially > UINT64_MAX) into `uint64_t` — UB per C++20 [conv.fpint]. `max_magnitude = 10^ndigits - 1` exceeds UINT64_MAX for `ndigits >= 20`, so the existing clamp didn't protect the cast.

## Changes

- `include/sw/universal/number/dfixpnt/dfixpnt_impl.hpp`
  - `to_int64()` rewritten as MSD-first Horner over `unsigned long long` with per-step overflow detection; clamps to `[LLONG_MIN, LLONG_MAX]`. Matches `blockdecimal::to_long_long`.
  - `operator=(double)` rewritten with FP-domain digit extraction: `q = v / 10.0`, `q_floor = (q < 2^53) ? cast/back : q`, `digit = v - 10*q_floor` (clamped to `[0, 9]` against FP noise). Avoids out-of-range double→uint64 cast.
  - Added `<limits>` include.
- `static/fixpnt/decimal/api/constexpr.cpp`
  - New tests covering `dfixpnt<25, 5>` and `dfixpnt<20, 5>`:
    - Small-value round-trip (sanity).
    - `LLONG_MAX/MIN` clamping at maxpos/maxneg.
    - 15-digit boundary preservation.
    - Saturation above the type's representational max.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| dfixpnt_constexpr | OK | PASS | OK | PASS |
| dfixpnt_api | OK | PASS | OK | PASS |
| dfixpnt_assignment | OK | PASS | OK | PASS |
| dfixpnt_addition | OK | PASS | OK | PASS |
| dfixpnt_subtraction | OK | PASS | OK | PASS |
| dfixpnt_multiplication | OK | PASS | OK | PASS |
| dfixpnt_division | OK | PASS | OK | PASS |
| dfixpnt_logic | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI (gcc + clang CI_LITE) passes
- [x] CodeRabbit pass
- [x] Promote to ready: `gh pr ready <PR#>`

Resolves #804

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved floating-point to fixed-point conversion with stronger rounding, saturation and noise safeguards; enhanced fixed-point to integer conversion with robust overflow detection and correct clamping for extreme values.

* **Tests**
  * Added compile-time test coverage for large fixed-point decimal instantiations to verify construction, conversion, saturation, and round-trip behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->