### PR TITLE
feat(e8m0): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/number/e8m0/e8m0_impl.hpp
+++ b/include/sw/universal/number/e8m0/e8m0_impl.hpp
@@ -24,8 +24,11 @@
 #include <iostream>
 #include <iomanip>
 #include <cmath>
+#include <cstdint>
 #include <limits>
+#include <type_traits>
 
+#include <universal/utility/bit_cast.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/e8m0/e8m0_fwd.hpp>
@@ -79,37 +82,37 @@ public:
 	}
 
 	// construct from native types
-	explicit e8m0(float iv) noexcept : _bits{} { from_float(iv); }
-	explicit e8m0(double iv) noexcept : _bits{} { from_float(static_cast<float>(iv)); }
-	e8m0(int iv) noexcept : _bits{} { from_float(static_cast<float>(iv)); }
-	e8m0(unsigned iv) noexcept : _bits{} { from_float(static_cast<float>(iv)); }
+	constexpr explicit e8m0(float iv) noexcept : _bits{} { from_float(iv); }
+	constexpr explicit e8m0(double iv) noexcept : _bits{} { from_float(static_cast<float>(iv)); }
+	constexpr e8m0(int iv) noexcept : _bits{} { from_float(static_cast<float>(iv)); }
+	constexpr e8m0(unsigned iv) noexcept : _bits{} { from_float(static_cast<float>(iv)); }
 
 	// assignment operators
-	e8m0& operator=(float rhs) noexcept { from_float(rhs); return *this; }
-	e8m0& operator=(double rhs) noexcept { from_float(static_cast<float>(rhs)); return *this; }
-	e8m0& operator=(int rhs) noexcept { from_float(static_cast<float>(rhs)); return *this; }
-	e8m0& operator=(unsigned rhs) noexcept { from_float(static_cast<float>(rhs)); return *this; }
+	constexpr e8m0& operator=(float rhs) noexcept { from_float(rhs); return *this; }
+	constexpr e8m0& operator=(double rhs) noexcept { from_float(static_cast<float>(rhs)); return *this; }
+	constexpr e8m0& operator=(int rhs) noexcept { from_float(static_cast<float>(rhs)); return *this; }
+	constexpr e8m0& operator=(unsigned rhs) noexcept { from_float(static_cast<float>(rhs)); return *this; }
 
 	// conversion operators
-	explicit operator float() const noexcept { return to_float(); }
-	explicit operator double() const noexcept { return static_cast<double>(to_float()); }
-	explicit operator int() const noexcept { return static_cast<int>(to_float()); }
+	constexpr explicit operator float() const noexcept { return to_float(); }
+	constexpr explicit operator double() const noexcept { return static_cast<double>(to_float()); }
+	constexpr explicit operator int() const noexcept { return static_cast<int>(to_float()); }
 
 	// prefix operators
-	e8m0& operator++() noexcept {
+	constexpr e8m0& operator++() noexcept {
 		if (_bits < 254u) ++_bits;
 		return *this;
 	}
-	e8m0 operator++(int) noexcept {
+	constexpr e8m0 operator++(int) noexcept {
 		e8m0 tmp(*this);
 		operator++();
 		return tmp;
 	}
-	e8m0& operator--() noexcept {
+	constexpr e8m0& operator--() noexcept {
 		if (_bits > 0u && _bits != 0xFFu) --_bits;
 		return *this;
 	}
-	e8m0 operator--(int) noexcept {
+	constexpr e8m0 operator--(int) noexcept {
 		e8m0 tmp(*this);
 		operator--();
 		return tmp;
@@ -153,43 +156,103 @@ public:
 		return 0;
 	}
 
-	// convert to float: value = 2^(encoding - 127)
-	float to_float() const noexcept {
+	// Convert to float: value = 2^(encoding - 127).
+	// Constexpr-safe via direct IEEE 754 bit construction:
+	//   encoding 1..254 -> normal float, exp_field = encoding (bias matches),
+	//                      mantissa = 0
+	//   encoding 0      -> 2^-127 = subnormal float, mantissa MSB only set
+	//   encoding 255    -> NaN
+	// At runtime, std::ldexp is faster; dispatched via std::is_constant_evaluated().
+	constexpr float to_float() const noexcept {
 		if (_bits == 0xFFu) return std::numeric_limits<float>::quiet_NaN();
-		return std::ldexp(1.0f, static_cast<int>(_bits) - bias);
+		if (std::is_constant_evaluated()) {
+			if (_bits == 0u) {
+				// 2^-127 as a subnormal float: exp_field = 0, mantissa MSB set.
+				return sw::bit_cast<float>(uint32_t(0x00400000u));
+			}
+			uint32_t bits_u = uint32_t(_bits) << 23;
+			return sw::bit_cast<float>(bits_u);
+		}
+		else {
+			return std::ldexp(1.0f, static_cast<int>(_bits) - bias);
+		}
 	}
 
-	// convert from float: find the closest power of 2
-	void from_float(float v) noexcept {
-		if (v != v) { // NaN
+	// Convert from float: find the closest power of 2.
+	//
+	// The runtime implementation uses std::log2 + std::round, which is
+	// not constexpr.  At constant evaluation, extract the IEEE 754 fields
+	// directly via sw::bit_cast and emulate round-to-nearest-power-of-2:
+	//
+	//   v = (1 + frac/2^23) * 2^E for normal floats, where E = rawExp - 127
+	//   round(log2(v)) is E + 1 iff log2(1 + frac/2^23) >= 0.5
+	//                          iff (1 + frac/2^23) >= sqrt(2)
+	//                          iff frac >= (sqrt(2) - 1) * 2^23
+	//                          iff frac >= 3474676  (precomputed)
+	//
+	// Subnormal floats (rawExp == 0): e8m0 minpos is 2^-127, which sits in
+	// the float subnormal range.  Full conversion of arbitrary subnormals
+	// requires log2 of the fraction; in constexpr context we coarsely
+	// clamp them all to encoding 0.  This is acceptable for the OCP
+	// scaling use case (powers of 2 typically in [-126, 127]).  Runtime
+	// retains exact log2-based behavior.
+	constexpr void from_float(float v) noexcept {
+		// NaN: only value not equal to itself.
+		if (v != v) {
 			setnan();
 			return;
 		}
+		// Negative or zero: e8m0 has no representation; clamp to encoding 0.
 		if (v <= 0.0f) {
-			// e8m0 cannot represent zero or negative values
-			// clamp to smallest representable value
 			_bits = 0;
 			return;
 		}
-		if (std::isinf(v)) {
+		// Infinity: clamp to maxpos.  std::isinf is not constexpr;
+		// numeric_limits<float>::max() is.
+		constexpr float fmax = std::numeric_limits<float>::max();
+		if (v > fmax) {
 			maxpos();
 			return;
 		}
-
-		// Find the exponent: v ≈ 2^exp
-		// Use log2 to find the closest power of 2
-		float log2v = std::log2(v);
-		int exp = static_cast<int>(std::round(log2v));
-		int biased = exp + bias;
-
-		if (biased < 0) {
-			_bits = 0;
-		}
-		else if (biased > 254) {
-			_bits = 254u;
+		if (std::is_constant_evaluated()) {
+			// Constexpr path via IEEE 754 bit-extraction.
+			uint32_t bits_u = sw::bit_cast<uint32_t>(v);
+			uint32_t rawExp  = (bits_u >> 23) & 0xFFu;
+			uint32_t rawFrac = bits_u & 0x7FFFFFu;
+			if (rawExp == 0u) {
+				// subnormal -- coarse approximation, see comment above.
+				_bits = 0;
+				return;
+			}
+			// (sqrt(2) - 1) * 2^23 ~= 3474676; round half away from zero.
+			constexpr uint32_t round_up_threshold = 3474676u;
+			unsigned biased = rawExp;
+			if (rawFrac >= round_up_threshold) ++biased;
+			if (biased > 254u) {
+				_bits = 254u;
+			}
+			else {
+				_bits = static_cast<uint8_t>(biased);
+			}
 		}
 		else {
-			_bits = static_cast<uint8_t>(biased);
+			// Runtime path: legacy std::log2 + std::round implementation.
+			if (std::isinf(v)) {
+				maxpos();
+				return;
+			}
+			float log2v = std::log2(v);
+			int exp_int = static_cast<int>(std::round(log2v));
+			int biased = exp_int + bias;
+			if (biased < 0) {
+				_bits = 0;
+			}
+			else if (biased > 254) {
+				_bits = 254u;
+			}
+			else {
+				_bits = static_cast<uint8_t>(biased);
+			}
 		}
 	}
 
@@ -197,7 +260,7 @@ protected:
 	uint8_t _bits;
 
 private:
-	friend bool operator==(e8m0 lhs, e8m0 rhs);
+	friend constexpr bool operator==(e8m0 lhs, e8m0 rhs);
 };
 
 ////////////////////////    functions   /////////////////////////////////
@@ -237,29 +300,29 @@ inline std::string to_native(e8m0 v, bool nibbleMarker = false) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // e8m0 - e8m0 binary logic operators
 
-inline bool operator==(e8m0 lhs, e8m0 rhs) {
+inline constexpr bool operator==(e8m0 lhs, e8m0 rhs) {
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return lhs._bits == rhs._bits;
 }
 
-inline bool operator!=(e8m0 lhs, e8m0 rhs) {
+inline constexpr bool operator!=(e8m0 lhs, e8m0 rhs) {
 	return !operator==(lhs, rhs);
 }
 
-inline bool operator<(e8m0 lhs, e8m0 rhs) {
+inline constexpr bool operator<(e8m0 lhs, e8m0 rhs) {
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return lhs.bits() < rhs.bits();
 }
 
-inline bool operator>(e8m0 lhs, e8m0 rhs) {
+inline constexpr bool operator>(e8m0 lhs, e8m0 rhs) {
 	return operator<(rhs, lhs);
 }
 
-inline bool operator<=(e8m0 lhs, e8m0 rhs) {
+inline constexpr bool operator<=(e8m0 lhs, e8m0 rhs) {
 	return operator<(lhs, rhs) || operator==(lhs, rhs);
 }
 
-inline bool operator>=(e8m0 lhs, e8m0 rhs) {
+inline constexpr bool operator>=(e8m0 lhs, e8m0 rhs) {
 	return !operator<(lhs, rhs);
 }
 

--- a/include/sw/universal/number/e8m0/e8m0_impl.hpp
+++ b/include/sw/universal/number/e8m0/e8m0_impl.hpp
@@ -241,10 +241,9 @@ public:
 		}
 		else {
 			// Runtime path: legacy std::log2 + std::round implementation.
-			if (std::isinf(v)) {
-				maxpos();
-				return;
-			}
+			// Infinity (either sign) is already handled above via the
+			// numeric_limits<float>::max() bracket -- no need to redo
+			// std::isinf here.
 			float log2v = std::log2(v);
 			int exp_int = static_cast<int>(std::round(log2v));
 			int biased = exp_int + bias;

--- a/include/sw/universal/number/e8m0/e8m0_impl.hpp
+++ b/include/sw/universal/number/e8m0/e8m0_impl.hpp
@@ -202,16 +202,20 @@ public:
 			setnan();
 			return;
 		}
+		// Infinity (either sign): clamp to maxpos, matching the
+		// SpecificValue::infpos / SpecificValue::infneg construction path.
+		// Must be checked BEFORE the v <= 0 clamp below, otherwise -inf
+		// would silently encode as 0 (smallest representable) -- pre-PR
+		// latent bug.  std::isinf is not constexpr; numeric_limits<float>::max()
+		// is, so bracket against +/-fmax.
+		constexpr float fmax = std::numeric_limits<float>::max();
+		if (v > fmax || v < -fmax) {
+			maxpos();
+			return;
+		}
 		// Negative or zero: e8m0 has no representation; clamp to encoding 0.
 		if (v <= 0.0f) {
 			_bits = 0;
-			return;
-		}
-		// Infinity: clamp to maxpos.  std::isinf is not constexpr;
-		// numeric_limits<float>::max() is.
-		constexpr float fmax = std::numeric_limits<float>::max();
-		if (v > fmax) {
-			maxpos();
 			return;
 		}
 		if (std::is_constant_evaluated()) {
@@ -323,7 +327,10 @@ inline constexpr bool operator<=(e8m0 lhs, e8m0 rhs) {
 }
 
 inline constexpr bool operator>=(e8m0 lhs, e8m0 rhs) {
-	return !operator<(lhs, rhs);
+	// Cannot just be `!operator<(lhs, rhs)`: operator< returns false for
+	// any NaN operand, so negating it would yield true for NaN >= x.
+	// Build from operator> and operator==, both of which return false on NaN.
+	return operator>(lhs, rhs) || operator==(lhs, rhs);
 }
 
 }} // namespace sw::universal

--- a/static/float/e8m0/api/constexpr.cpp
+++ b/static/float/e8m0/api/constexpr.cpp
@@ -1,0 +1,207 @@
+// constexpr.cpp: compile-time tests for e8m0 (OCP exponent-only scaling factor)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+#define E8M0_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/e8m0/e8m0.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "e8m0 constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// e8m0: 8-bit exponent-only OCP scaling factor.
+	// Value = 2^(encoding - 127), encoding 0xFF = NaN.
+	// No fraction, no arithmetic operators (would be log-domain).
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction (smoke)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 zero(SpecificValue::zero);     // -> encoding 127 (= 1.0)
+		constexpr e8m0 one(1.0f);                     // encoding 127
+		constexpr e8m0 maxp(SpecificValue::maxpos);   // encoding 254 (= 2^127)
+		constexpr e8m0 minp(SpecificValue::minpos);   // encoding 0   (= 2^-127)
+		constexpr e8m0 qn(SpecificValue::qnan);       // encoding 0xFF (NaN)
+		static_assert(zero.bits() == 127u,            "constexpr SpecificValue::zero -> encoding 127 (1.0)");
+		static_assert(one.bits()  == 127u,            "constexpr e8m0(1.0f) -> encoding 127");
+		static_assert(maxp.bits() == 254u,            "constexpr SpecificValue::maxpos -> encoding 254");
+		static_assert(minp.bits() == 0u,              "constexpr SpecificValue::minpos -> encoding 0");
+		static_assert(qn.isnan(),                     "constexpr SpecificValue::qnan -> isnan");
+		static_assert(maxp.bits() != qn.bits(),       "constexpr maxpos != qnan encoding");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Issue #731 acceptance form: constexpr float-construction + comparison
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 a(2.0f);     // 2^1 -> encoding 128
+		constexpr e8m0 b(4.0f);     // 2^2 -> encoding 129
+		static_assert(a.bits() == 128u, "constexpr e8m0(2.0f) -> encoding 128");
+		static_assert(b.bits() == 129u, "constexpr e8m0(4.0f) -> encoding 129");
+		static_assert(a < b,            "constexpr: e8m0(2.0f) < e8m0(4.0f)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Float construction across the dynamic range (powers of 2)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 half(0.5f);          // 2^-1 -> encoding 126
+		constexpr e8m0 one(1.0f);           // 2^0  -> encoding 127
+		constexpr e8m0 two(2.0f);           // 2^1  -> encoding 128
+		constexpr e8m0 e64(64.0f);          // 2^6  -> encoding 133
+		constexpr e8m0 e1024(1024.0f);      // 2^10 -> encoding 137
+		static_assert(half.bits()  == 126u, "constexpr e8m0(0.5f)    -> 126");
+		static_assert(one.bits()   == 127u, "constexpr e8m0(1.0f)    -> 127");
+		static_assert(two.bits()   == 128u, "constexpr e8m0(2.0f)    -> 128");
+		static_assert(e64.bits()   == 133u, "constexpr e8m0(64.0f)   -> 133");
+		static_assert(e1024.bits() == 137u, "constexpr e8m0(1024.0f) -> 137");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Round-to-nearest-power-of-2: midpoint behavior.
+	// Geometric midpoint between 2^E and 2^(E+1) is sqrt(2) * 2^E.
+	//   3.0 is between 2^1 (=2) and 2^2 (=4); 3.0 / 2.0 = 1.5 > sqrt(2),
+	//   so e8m0(3.0f) rounds UP to encoding 129 (= 4.0).
+	//   1.4 < sqrt(2), so e8m0(1.4f) rounds DOWN to encoding 127 (= 1.0).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 a(3.0f);    // rounds up to 4.0 -> encoding 129
+		constexpr e8m0 b(1.4f);    // rounds down to 1.0 -> encoding 127
+		static_assert(a.bits() == 129u, "constexpr e8m0(3.0f) -> 4.0 (encoding 129)");
+		static_assert(b.bits() == 127u, "constexpr e8m0(1.4f) -> 1.0 (encoding 127)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Negative / zero input clamps to encoding 0 (e8m0 has no negative values
+	// and no zero; minpos = 2^-127 is the smallest representation).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 a(0.0f);
+		constexpr e8m0 b(-1.0f);
+		static_assert(a.bits() == 0u,   "constexpr e8m0(0.0f) clamps to encoding 0");
+		static_assert(b.bits() == 0u,   "constexpr e8m0(-1.0f) clamps to encoding 0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Integer construction
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 a(1);    // 2^0 -> 127
+		constexpr e8m0 b(8);    // 2^3 -> 130
+		constexpr e8m0 c(16);   // 2^4 -> 131
+		static_assert(a.bits() == 127u, "constexpr e8m0(int 1)  -> 127");
+		static_assert(b.bits() == 130u, "constexpr e8m0(int 8)  -> 130");
+		static_assert(c.bits() == 131u, "constexpr e8m0(int 16) -> 131");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion-out: operator float() / operator double()
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 a(2.0f);
+		constexpr float fa = float(a);
+		static_assert(fa == 2.0f,        "constexpr operator float() -> 2.0f");
+
+		constexpr e8m0 b(0.5f);
+		constexpr float fb = float(b);
+		static_assert(fb == 0.5f,        "constexpr operator float() -> 0.5f");
+
+		constexpr e8m0 c(1.0f);
+		constexpr double dc = double(c);
+		static_assert(dc == 1.0,         "constexpr operator double() -> 1.0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Increment / decrement
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 cx_inc = []() { e8m0 t(1.0f); ++t; return t; }();
+		constexpr e8m0 cx_dec = []() { e8m0 t(1.0f); --t; return t; }();
+		static_assert(cx_inc.bits() == 128u, "constexpr ++e8m0(1.0f) -> 128 (= 2.0)");
+		static_assert(cx_dec.bits() == 126u, "constexpr --e8m0(1.0f) -> 126 (= 0.5)");
+
+		// Postfix: returns pre-increment value, mutates operand.
+		constexpr e8m0 cx_postinc_before = []() { e8m0 t(1.0f); e8m0 old = t++; return old; }();
+		constexpr e8m0 cx_postinc_after  = []() { e8m0 t(1.0f); t++; return t; }();
+		static_assert(cx_postinc_before.bits() == 127u, "constexpr postfix ++ returns pre-value");
+		static_assert(cx_postinc_after.bits()  == 128u, "constexpr postfix ++ mutates");
+
+		// Saturation at boundaries: ++ caps at 254, -- caps at 0.
+		constexpr e8m0 cx_inc_max = []() { e8m0 t(SpecificValue::maxpos); ++t; return t; }();
+		constexpr e8m0 cx_dec_min = []() { e8m0 t(SpecificValue::minpos); --t; return t; }();
+		static_assert(cx_inc_max.bits() == 254u, "constexpr ++ saturates at maxpos (254)");
+		static_assert(cx_dec_min.bits() == 0u,   "constexpr -- saturates at minpos (0)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Comparison operators (issue acceptance: <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 a(1.0f);   // encoding 127
+		constexpr e8m0 b(2.0f);   // encoding 128
+		static_assert(a < b,      "constexpr: e8m0(1.0) < e8m0(2.0)");
+		static_assert(b > a,      "constexpr: e8m0(2.0) > e8m0(1.0)");
+		static_assert(a <= b,     "constexpr: e8m0(1.0) <= e8m0(2.0)");
+		static_assert(b >= a,     "constexpr: e8m0(2.0) >= e8m0(1.0)");
+		static_assert(!(a == b),  "constexpr: e8m0(1.0) != e8m0(2.0)");
+		static_assert(a != b,     "constexpr: != operator");
+		static_assert(a == a,     "constexpr: e8m0(1.0) == e8m0(1.0)");
+
+		// NaN compares unequal to anything (including itself).
+		constexpr e8m0 nan(SpecificValue::qnan);
+		static_assert(!(nan == nan), "constexpr: NaN != NaN");
+		static_assert(!(nan <  a),   "constexpr: NaN comparisons return false");
+		static_assert(!(nan >  a),   "constexpr: NaN comparisons return false");
+		static_assert(!(a   <  nan), "constexpr: NaN comparisons return false");
+		static_assert(!(a   >  nan), "constexpr: NaN comparisons return false");
+		static_assert(nan != nan,    "constexpr: NaN != NaN via operator!=");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Selectors (already constexpr -- smoke test the contract)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e8m0 a(1.0f);
+		constexpr e8m0 nan(SpecificValue::qnan);
+		static_assert(a.isone(),      "constexpr e8m0(1.0f).isone()");
+		static_assert(!a.isnan(),     "constexpr e8m0(1.0f).isnan() == false");
+		static_assert(!a.iszero(),    "constexpr e8m0 cannot represent zero");
+		static_assert(!a.sign(),      "constexpr e8m0 always positive");
+		static_assert(a.scale() == 0, "constexpr e8m0(1.0f).scale() == 0");
+		static_assert(a.exponent() == 0, "constexpr e8m0(1.0f).exponent() == 0");
+		static_assert(nan.isnan(),    "constexpr qnan isnan()");
+	}
+
+	std::cout << "e8m0 constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/static/float/e8m0/api/constexpr.cpp
+++ b/static/float/e8m0/api/constexpr.cpp
@@ -98,6 +98,20 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Infinity input clamps to maxpos (matching SpecificValue::infpos and
+	// SpecificValue::infneg, both of which encode as maxpos in e8m0).
+	// Caught by CodeRabbit on PR #810: pre-fix code routed -inf through
+	// the v <= 0 clamp, encoding it as 0 (inconsistent with infneg ctor).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr float pinf = std::numeric_limits<float>::infinity();
+		constexpr e8m0 pos_inf( pinf);
+		constexpr e8m0 neg_inf(-pinf);
+		static_assert(pos_inf.bits() == 254u, "constexpr e8m0(+inf) -> maxpos (254)");
+		static_assert(neg_inf.bits() == 254u, "constexpr e8m0(-inf) -> maxpos (254)");
+	}
+
+	// ----------------------------------------------------------------------------
 	// Integer construction
 	// ----------------------------------------------------------------------------
 	{
@@ -162,13 +176,22 @@ try {
 		static_assert(a != b,     "constexpr: != operator");
 		static_assert(a == a,     "constexpr: e8m0(1.0) == e8m0(1.0)");
 
-		// NaN compares unequal to anything (including itself).
+		// NaN compares unequal to anything (including itself).  Per IEEE 754
+		// semantics, ALL six relational ops return false when either operand
+		// is NaN -- including >= and <= (which is easy to get wrong if you
+		// implement >= as !< -- see CR finding on PR #810).
 		constexpr e8m0 nan(SpecificValue::qnan);
 		static_assert(!(nan == nan), "constexpr: NaN != NaN");
-		static_assert(!(nan <  a),   "constexpr: NaN comparisons return false");
-		static_assert(!(nan >  a),   "constexpr: NaN comparisons return false");
-		static_assert(!(a   <  nan), "constexpr: NaN comparisons return false");
-		static_assert(!(a   >  nan), "constexpr: NaN comparisons return false");
+		static_assert(!(nan <  a),   "constexpr: NaN <  x  -> false");
+		static_assert(!(nan >  a),   "constexpr: NaN >  x  -> false");
+		static_assert(!(nan <= a),   "constexpr: NaN <= x  -> false");
+		static_assert(!(nan >= a),   "constexpr: NaN >= x  -> false");
+		static_assert(!(a   <  nan), "constexpr: x   <  NaN -> false");
+		static_assert(!(a   >  nan), "constexpr: x   >  NaN -> false");
+		static_assert(!(a   <= nan), "constexpr: x   <= NaN -> false");
+		static_assert(!(a   >= nan), "constexpr: x   >= NaN -> false");
+		static_assert(!(nan <= nan), "constexpr: NaN <= NaN -> false");
+		static_assert(!(nan >= nan), "constexpr: NaN >= NaN -> false");
 		static_assert(nan != nan,    "constexpr: NaN != NaN via operator!=");
 	}
 


### PR DESCRIPTION
## Summary

Promotes `e8m0` (8-bit exponent-only OCP scaling factor used by `mxblock` / `mxfloat` / `nvblock`) to fully `constexpr` across construction, assignment, comparison, and conversion. Part of Epic #723.

e8m0 has no fraction (no rounding logic beyond round-to-nearest-power-of-2 on float input) and no arithmetic operators (would be log-domain), so the promotion surface is contained: 1 file rewrite + new test.

## Changes

- `include/sw/universal/number/e8m0/e8m0_impl.hpp`
  - Native-type ctors/assignments/conversion-out/`++`/`--`/comparisons all marked `constexpr`.
  - **`to_float()` rewritten** via direct IEEE 754 bit construction:
    - encoding 1..254 -> normal float, `exp_field = encoding` (bias 127 matches), mantissa = 0
    - encoding 0 -> 2^-127 = subnormal float with mantissa MSB set (`0x00400000`)
    - encoding 255 -> NaN
    - Runtime path keeps `std::ldexp` via `std::is_constant_evaluated()` dispatch.
  - **`from_float()` rewritten** via IEEE 754 bit-extraction:
    - `std::isinf` -> `numeric_limits<float>::max()` bracket
    - `std::log2 + std::round` -> raw exp_field gives the e8m0 encoding (matching biases); `rawFrac >= (sqrt(2) - 1) * 2^23 ~= 3474676` triggers round-up to the next power of 2
    - Subnormal floats coarsely clamped to encoding 0 in the constexpr path (acceptable for OCP scaling, typically powers in `[-126, 127]`).
  - Added `<cstdint>`, `<type_traits>`, `<universal/utility/bit_cast.hpp>` includes.
- `static/float/e8m0/api/constexpr.cpp` (new)
  - Issue #731 acceptance form, SpecificValue construction, dynamic range coverage, round-to-nearest-power-of-2 midpoint behavior, negative/zero clamping, integer construction, conversion-out, `++`/`--` saturation, NaN-aware comparisons, selector smoke tests.

## Test Results

| Target | gcc | clang | UBSan |
|--------|-----|-------|-------|
| e8m0_constexpr | PASS | PASS | clean |
| e8m0_api | PASS | PASS | clean |
| e8m0_assignment | PASS | PASS | clean |
| mxfloat_api (consumer) | PASS | PASS | clean |
| mxfloat_dot_product | PASS | PASS | n/a |
| microfloat_api | PASS | PASS | n/a |
| microfloat_assignment | PASS | PASS | n/a |

Local UBSan via `build_ubsan/` (per `docs/build/local-sanitizer.md`).

## Test plan
- [x] Fast CI (gcc + clang CI_LITE) passes
- [x] CodeRabbit pass
- [x] Promote to ready: `gh pr ready <#>`

Resolves #731

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The e8m0 numeric type gains full constexpr support for construction, assignment, explicit conversions, increment/decrement, and comparison operators; comparisons are now NaN-safe.

* **Tests**
  * Added a comprehensive constexpr verification suite exercising construction, conversions, ordering, increments/decrements, selector queries, saturation/clamping, NaN and edge-case handling, and rounding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->