### PR TITLE
feat(microfloat): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/number/microfloat/microfloat_impl.hpp
+++ b/include/sw/universal/number/microfloat/microfloat_impl.hpp
@@ -485,6 +485,11 @@ public:
 	// exponent / fraction fields via sw::bit_cast.  Used only on the
 	// constexpr code path; runtime uses std::signbit / std::frexp etc.
 	struct float_fields { bool sign; int rawExp; uint32_t rawFrac; };
+	static_assert(sizeof(float) == sizeof(uint32_t) && std::numeric_limits<float>::is_iec559,
+		"microfloat constexpr conversion requires IEEE 754 binary32 float layout "
+		"(1 sign / 8 exp / 23 fraction bits).  On platforms where float is not "
+		"32-bit IEC 559 the constexpr path's bit-field positions would be wrong; "
+		"the runtime path (std::frexp / std::signbit) remains portable.");
 	static constexpr float_fields extract_float_fields(float v) noexcept {
 		uint32_t bits_u = sw::bit_cast<uint32_t>(v);
 		return float_fields{
@@ -824,68 +829,87 @@ inline constexpr bool operator>=(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // microfloat - literal binary logic operators
+//
+// All overloads short-circuit a float NaN operand BEFORE narrowing to
+// microfloat.  For instantiations with hasNaN == false, from_float(NaN)
+// collapses to zero, which would erase the IEEE 754 NaN-comparison
+// contract (the "all relational ops false / != true" rule) -- mf == NaN
+// would silently become mf == 0.  CodeRabbit catch on PR #811.
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator==(microfloat<n,e,i,na,s> lhs, float rhs) {
+	if (rhs != rhs) return false;  // float NaN: == always false
 	return operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator!=(microfloat<n,e,i,na,s> lhs, float rhs) {
+	if (rhs != rhs) return true;   // float NaN: != always true
 	return !operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator<(microfloat<n,e,i,na,s> lhs, float rhs) {
+	if (rhs != rhs) return false;  // float NaN: ordering always false
 	return operator<(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator>(microfloat<n,e,i,na,s> lhs, float rhs) {
+	if (rhs != rhs) return false;
 	return operator<(microfloat<n,e,i,na,s>(rhs), lhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator<=(microfloat<n,e,i,na,s> lhs, float rhs) {
+	if (rhs != rhs) return false;
 	return operator<(lhs, microfloat<n,e,i,na,s>(rhs)) || operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator>=(microfloat<n,e,i,na,s> lhs, float rhs) {
-	// NaN-safe (see microfloat-microfloat operator>= for the rationale).
+	if (rhs != rhs) return false;
+	// NaN-safe via operator> + operator== (see microfloat-microfloat
+	// operator>= for the !operator< trap rationale).
 	return operator>(lhs, microfloat<n,e,i,na,s>(rhs)) || operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-// literal - microfloat binary logic operators
+// literal - microfloat binary logic operators (symmetric NaN-safety)
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator==(float lhs, microfloat<n,e,i,na,s> rhs) {
+	if (lhs != lhs) return false;
 	return operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator!=(float lhs, microfloat<n,e,i,na,s> rhs) {
+	if (lhs != lhs) return true;
 	return !operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator<(float lhs, microfloat<n,e,i,na,s> rhs) {
+	if (lhs != lhs) return false;
 	return operator<(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator>(float lhs, microfloat<n,e,i,na,s> rhs) {
+	if (lhs != lhs) return false;
 	return operator<(rhs, microfloat<n,e,i,na,s>(lhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator<=(float lhs, microfloat<n,e,i,na,s> rhs) {
+	if (lhs != lhs) return false;
 	return operator<(microfloat<n,e,i,na,s>(lhs), rhs) || operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr bool operator>=(float lhs, microfloat<n,e,i,na,s> rhs) {
+	if (lhs != lhs) return false;
 	// NaN-safe (see microfloat-microfloat operator>= for the rationale).
 	return operator>(microfloat<n,e,i,na,s>(lhs), rhs) || operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }

--- a/include/sw/universal/number/microfloat/microfloat_impl.hpp
+++ b/include/sw/universal/number/microfloat/microfloat_impl.hpp
@@ -9,9 +9,13 @@
 #include <sstream>
 #include <iostream>
 #include <iomanip>
+#include <cstdint>
 #include <cstring>
 #include <cmath>
+#include <limits>
+#include <type_traits>
 
+#include <universal/utility/bit_cast.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/shared/infinite_encoding.hpp>
@@ -36,19 +40,19 @@ class microfloat {
 	// HELPER methods
 	template<typename SignedInt,
 		typename = typename std::enable_if< std::is_integral<SignedInt>::value, SignedInt >::type>
-	microfloat& convert_signed(SignedInt v) noexcept {
+	constexpr microfloat& convert_signed(SignedInt v) noexcept {
 		from_float(static_cast<float>(v));
 		return *this;
 	}
 	template<typename UnsignedInt,
 		typename = typename std::enable_if< std::is_integral<UnsignedInt>::value, UnsignedInt >::type>
-	microfloat& convert_unsigned(UnsignedInt v) noexcept {
+	constexpr microfloat& convert_unsigned(UnsignedInt v) noexcept {
 		from_float(static_cast<float>(v));
 		return *this;
 	}
 	template<typename Real,
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
-	microfloat& convert_ieee754(Real rhs) noexcept {
+	constexpr microfloat& convert_ieee754(Real rhs) noexcept {
 		from_float(static_cast<float>(rhs));
 		return *this;
 	}
@@ -113,61 +117,61 @@ public:
 	}
 
 	// initializers for native types
-	microfloat(signed char iv)                    noexcept : _bits{} { *this = iv; }
-	microfloat(short iv)                          noexcept : _bits{} { *this = iv; }
-	microfloat(int iv)                            noexcept : _bits{} { *this = iv; }
-	microfloat(long iv)                           noexcept : _bits{} { *this = iv; }
-	microfloat(long long iv)                      noexcept : _bits{} { *this = iv; }
-	microfloat(char iv)                           noexcept : _bits{} { *this = iv; }
-	microfloat(unsigned short iv)                 noexcept : _bits{} { *this = iv; }
-	microfloat(unsigned int iv)                   noexcept : _bits{} { *this = iv; }
-	microfloat(unsigned long iv)                  noexcept : _bits{} { *this = iv; }
-	microfloat(unsigned long long iv)             noexcept : _bits{} { *this = iv; }
-	explicit microfloat(float iv)                 noexcept : _bits{} { *this = iv; }
-	explicit microfloat(double iv)                noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(signed char iv)                    noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(short iv)                          noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(int iv)                            noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(long iv)                           noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(long long iv)                      noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(char iv)                           noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(unsigned short iv)                 noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(unsigned int iv)                   noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(unsigned long iv)                  noexcept : _bits{} { *this = iv; }
+	constexpr microfloat(unsigned long long iv)             noexcept : _bits{} { *this = iv; }
+	constexpr explicit microfloat(float iv)                 noexcept : _bits{} { *this = iv; }
+	constexpr explicit microfloat(double iv)                noexcept : _bits{} { *this = iv; }
 
 	// assignment operators for native types
-	microfloat& operator=(signed char rhs)        noexcept { return convert_signed(rhs); }
-	microfloat& operator=(short rhs)              noexcept { return convert_signed(rhs); }
-	microfloat& operator=(int rhs)                noexcept { return convert_signed(rhs); }
-	microfloat& operator=(long rhs)               noexcept { return convert_signed(rhs); }
-	microfloat& operator=(long long rhs)          noexcept { return convert_signed(rhs); }
-	microfloat& operator=(char rhs)               noexcept { return convert_unsigned(rhs); }
-	microfloat& operator=(unsigned short rhs)     noexcept { return convert_unsigned(rhs); }
-	microfloat& operator=(unsigned int rhs)       noexcept { return convert_unsigned(rhs); }
-	microfloat& operator=(unsigned long rhs)      noexcept { return convert_unsigned(rhs); }
-	microfloat& operator=(unsigned long long rhs) noexcept { return convert_unsigned(rhs); }
-	microfloat& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
-	microfloat& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
+	constexpr microfloat& operator=(signed char rhs)        noexcept { return convert_signed(rhs); }
+	constexpr microfloat& operator=(short rhs)              noexcept { return convert_signed(rhs); }
+	constexpr microfloat& operator=(int rhs)                noexcept { return convert_signed(rhs); }
+	constexpr microfloat& operator=(long rhs)               noexcept { return convert_signed(rhs); }
+	constexpr microfloat& operator=(long long rhs)          noexcept { return convert_signed(rhs); }
+	constexpr microfloat& operator=(char rhs)               noexcept { return convert_unsigned(rhs); }
+	constexpr microfloat& operator=(unsigned short rhs)     noexcept { return convert_unsigned(rhs); }
+	constexpr microfloat& operator=(unsigned int rhs)       noexcept { return convert_unsigned(rhs); }
+	constexpr microfloat& operator=(unsigned long rhs)      noexcept { return convert_unsigned(rhs); }
+	constexpr microfloat& operator=(unsigned long long rhs) noexcept { return convert_unsigned(rhs); }
+	constexpr microfloat& operator=(float rhs)              noexcept { return convert_ieee754(rhs); }
+	constexpr microfloat& operator=(double rhs)             noexcept { return convert_ieee754(rhs); }
 
 	// conversion operators
-	explicit operator float()                       const noexcept { return to_float(); }
-	explicit operator double()                      const noexcept { return static_cast<double>(to_float()); }
-	explicit operator signed char()                 const noexcept { return static_cast<signed char>(to_float()); }
-	explicit operator short()                       const noexcept { return static_cast<short>(to_float()); }
-	explicit operator int()                         const noexcept { return static_cast<int>(to_float()); }
-	explicit operator long()                        const noexcept { return static_cast<long>(to_float()); }
-	explicit operator long long()                   const noexcept { return static_cast<long long>(to_float()); }
-	explicit operator char()                        const noexcept { return static_cast<char>(to_float()); }
-	explicit operator unsigned short()              const noexcept { return static_cast<unsigned short>(to_float()); }
-	explicit operator unsigned int()                const noexcept { return static_cast<unsigned int>(to_float()); }
-	explicit operator unsigned long()               const noexcept { return static_cast<unsigned long>(to_float()); }
-	explicit operator unsigned long long()          const noexcept { return static_cast<unsigned long long>(to_float()); }
+	constexpr explicit operator float()                       const noexcept { return to_float(); }
+	constexpr explicit operator double()                      const noexcept { return static_cast<double>(to_float()); }
+	constexpr explicit operator signed char()                 const noexcept { return static_cast<signed char>(to_float()); }
+	constexpr explicit operator short()                       const noexcept { return static_cast<short>(to_float()); }
+	constexpr explicit operator int()                         const noexcept { return static_cast<int>(to_float()); }
+	constexpr explicit operator long()                        const noexcept { return static_cast<long>(to_float()); }
+	constexpr explicit operator long long()                   const noexcept { return static_cast<long long>(to_float()); }
+	constexpr explicit operator char()                        const noexcept { return static_cast<char>(to_float()); }
+	constexpr explicit operator unsigned short()              const noexcept { return static_cast<unsigned short>(to_float()); }
+	constexpr explicit operator unsigned int()                const noexcept { return static_cast<unsigned int>(to_float()); }
+	constexpr explicit operator unsigned long()               const noexcept { return static_cast<unsigned long>(to_float()); }
+	constexpr explicit operator unsigned long long()          const noexcept { return static_cast<unsigned long long>(to_float()); }
 
 #if LONG_DOUBLE_SUPPORT
-	explicit microfloat(long double iv)           noexcept : _bits{} { *this = iv; }
-	microfloat& operator=(long double rhs)        noexcept { return convert_ieee754(rhs); }
-	explicit operator long double()                 const noexcept { return static_cast<long double>(to_float()); }
+	constexpr explicit microfloat(long double iv)           noexcept : _bits{} { *this = iv; }
+	constexpr microfloat& operator=(long double rhs)        noexcept { return convert_ieee754(rhs); }
+	constexpr explicit operator long double()                 const noexcept { return static_cast<long double>(to_float()); }
 #endif
 
 	// prefix operators
-	microfloat operator-() const noexcept {
+	constexpr microfloat operator-() const noexcept {
 		microfloat tmp;
 		tmp.setbits(_bits ^ sign_mask);
 		return tmp;
 	}
 
-	microfloat& operator++() noexcept {
+	constexpr microfloat& operator++() noexcept {
 		// increment to the next encoding
 		if (_bits & sign_mask) {
 			// negative
@@ -190,12 +194,12 @@ public:
 		}
 		return *this;
 	}
-	microfloat operator++(int) noexcept {
+	constexpr microfloat operator++(int) noexcept {
 		microfloat tmp(*this);
 		operator++();
 		return tmp;
 	}
-	microfloat& operator--() noexcept {
+	constexpr microfloat& operator--() noexcept {
 		if (_bits & sign_mask) {
 			// negative: increment magnitude
 			uint8_t magnitude = _bits & static_cast<uint8_t>(~sign_mask);
@@ -215,29 +219,29 @@ public:
 		}
 		return *this;
 	}
-	microfloat operator--(int) noexcept {
+	constexpr microfloat operator--(int) noexcept {
 		microfloat tmp(*this);
 		operator--();
 		return tmp;
 	}
 
 	// arithmetic operators
-	microfloat& operator+=(const microfloat& rhs) {
+	constexpr microfloat& operator+=(const microfloat& rhs) {
 		float result = to_float() + rhs.to_float();
 		from_float(result);
 		return *this;
 	}
-	microfloat& operator-=(const microfloat& rhs) {
+	constexpr microfloat& operator-=(const microfloat& rhs) {
 		float result = to_float() - rhs.to_float();
 		from_float(result);
 		return *this;
 	}
-	microfloat& operator*=(const microfloat& rhs) {
+	constexpr microfloat& operator*=(const microfloat& rhs) {
 		float result = to_float() * rhs.to_float();
 		from_float(result);
 		return *this;
 	}
-	microfloat& operator/=(const microfloat& rhs) {
+	constexpr microfloat& operator/=(const microfloat& rhs) {
 		float result = to_float() / rhs.to_float();
 		from_float(result);
 		return *this;
@@ -417,9 +421,28 @@ public:
 		return static_cast<uint8_t>(_bits & fraction_mask);
 	}
 
-	// Convert to float
-	float to_float() const noexcept {
-		if (iszero()) return 0.0f;
+	// Constexpr-safe ldexp emulation: x * 2^exp via power-of-2 multiplication.
+	// For microfloat the |exp| range is small (at most |bias - 1|, which for
+	// e5m2 is 14, for e4m3 is 6), so the linear loop is well-bounded.
+	// Used only on the constexpr code path; runtime keeps std::ldexp.
+	static constexpr float cx_ldexp(float x, int exp) noexcept {
+		if (exp >= 0) {
+			for (int i = 0; i < exp; ++i) x *= 2.0f;
+		}
+		else {
+			for (int i = 0; i < -exp; ++i) x *= 0.5f;
+		}
+		return x;
+	}
+
+	// Convert to float.
+	// Constexpr-safe via std::is_constant_evaluated() dispatch: at runtime
+	// we use std::ldexp (fast, exact); at constant evaluation we substitute
+	// cx_ldexp (a power-of-2 loop).  Both produce bit-identical results
+	// because the 2.0/0.5 multiplications are exactly representable in
+	// IEEE 754 float.
+	constexpr float to_float() const noexcept {
+		if (iszero()) return isneg() ? -0.0f : 0.0f;
 		if constexpr (hasNaN) {
 			if (isnan()) return std::numeric_limits<float>::quiet_NaN();
 		}
@@ -438,18 +461,46 @@ public:
 		if (e == 0) {
 			// subnormal: value = (-1)^s * 2^(1-bias) * (0.fraction)
 			float frac = static_cast<float>(f) / static_cast<float>(1u << fbits);
-			value = std::ldexp(frac, 1 - bias);
+			if (std::is_constant_evaluated()) {
+				value = cx_ldexp(frac, 1 - bias);
+			}
+			else {
+				value = std::ldexp(frac, 1 - bias);
+			}
 		}
 		else {
 			// normal: value = (-1)^s * 2^(e-bias) * (1.fraction)
 			float frac = 1.0f + static_cast<float>(f) / static_cast<float>(1u << fbits);
-			value = std::ldexp(frac, static_cast<int>(e) - bias);
+			if (std::is_constant_evaluated()) {
+				value = cx_ldexp(frac, static_cast<int>(e) - bias);
+			}
+			else {
+				value = std::ldexp(frac, static_cast<int>(e) - bias);
+			}
 		}
 		return s ? -value : value;
 	}
 
-	// Convert from float with RNE rounding
-	void from_float(float v) noexcept {
+	// Constexpr-safe extraction of an IEEE 754 float's sign / biased
+	// exponent / fraction fields via sw::bit_cast.  Used only on the
+	// constexpr code path; runtime uses std::signbit / std::frexp etc.
+	struct float_fields { bool sign; int rawExp; uint32_t rawFrac; };
+	static constexpr float_fields extract_float_fields(float v) noexcept {
+		uint32_t bits_u = sw::bit_cast<uint32_t>(v);
+		return float_fields{
+			(bits_u >> 31) != 0u,
+			static_cast<int>((bits_u >> 23) & 0xFFu),
+			bits_u & 0x7FFFFFu
+		};
+	}
+
+	// Convert from float with RNE rounding.
+	// Constexpr-safe via std::is_constant_evaluated() dispatch:
+	//   * at runtime  -- std::signbit / std::isinf / std::frexp / std::ldexp
+	//   * at constexpr -- IEEE 754 field extraction via sw::bit_cast,
+	//                     plus cx_ldexp for the subnormal divisor
+	// Both paths converge on the same RNE-rounded encoding.
+	constexpr void from_float(float v) noexcept {
 		if (v != v) { // NaN check
 			if constexpr (hasNaN) {
 				setnan(NAN_TYPE_QUIET);
@@ -460,10 +511,20 @@ public:
 			return;
 		}
 
-		bool s = std::signbit(v);
+		bool s;
+		bool is_inf;
+		if (std::is_constant_evaluated()) {
+			float_fields ff = extract_float_fields(v);
+			s = ff.sign;
+			is_inf = (ff.rawExp == 0xFF) && (ff.rawFrac == 0u);
+		}
+		else {
+			s = std::signbit(v);
+			is_inf = std::isinf(v);
+		}
 		if (s) v = -v;
 
-		if (std::isinf(v)) {
+		if (is_inf) {
 			if constexpr (hasInf) {
 				setinf(s);
 			}
@@ -478,6 +539,8 @@ public:
 
 		if (v == 0.0f) {
 			setzero();
+			// Note: signed-zero preservation isn't critical for microfloat;
+			// existing behavior collapses to the canonical positive zero.
 			return;
 		}
 
@@ -507,10 +570,57 @@ public:
 			return;
 		}
 
-		// Extract exponent and fraction from the float value
+		// Extract exponent and fraction from the float value.
+		// frexp returns frac in [0.5, 1.0), exp such that v = frac * 2^exp.
+		// At constant evaluation we substitute IEEE 754 bit-extraction,
+		// which yields the same (frac, exp) for normal floats:
+		//   frac    = (1 + rawFrac/2^23) / 2     in [0.5, 1)
+		//   exp     = rawExp - 127 + 1            (frexp adds 1 to make
+		//                                          frac < 1)
+		// For subnormal floats the bit-extraction would need a leading-zero
+		// scan; subnormals here are within microfloat's subnormal range only
+		// when the source float is itself subnormal -- a rare path.  We
+		// route the constexpr subnormal-float case through the existing
+		// ldexp-based subnormal branch by computing exp via the raw
+		// exponent and frac via shifted mantissa, exactly as the runtime
+		// std::frexp does.
 		int exp;
-		float frac = std::frexp(v, &exp);
-		// frexp returns frac in [0.5, 1.0), exp such that v = frac * 2^exp
+		float frac;
+		if (std::is_constant_evaluated()) {
+			float_fields ff = extract_float_fields(v);
+			if (ff.rawExp == 0) {
+				// Source is a subnormal float.  Reconstruct via cx_ldexp
+				// to match std::frexp semantics: find the leading 1 of
+				// rawFrac, shift to align as 0.5, set exp accordingly.
+				// rawFrac > 0 here (zero already handled).
+				int leading = 22;  // top fraction bit index
+				while (leading >= 0 && ((ff.rawFrac >> leading) & 1u) == 0u) --leading;
+				int shift = 22 - leading;
+				uint32_t aligned = ff.rawFrac << shift;
+				// aligned now has its top bit at position 22, representing
+				// the implicit leading 1 of a frexp-style mantissa.
+				// frac = aligned / 2^23 + 0.5; equivalently aligned has
+				// bit 22 set, lower 22 bits are the fractional part.
+				// Construct frac directly via float bit pattern: exp_field=126
+				// (which gives 2^-1 = 0.5), mantissa = aligned bits 21..0
+				// shifted into the 23-bit field.
+				uint32_t frac_bits = (uint32_t(126) << 23) | (aligned & 0x7FFFFFu);
+				frac = sw::bit_cast<float>(frac_bits);
+				exp = -126 - shift + 1;  // frexp's exp for subnormal source
+			}
+			else {
+				// Normal float: frexp(v) = ((1 + rawFrac/2^23) / 2, rawExp - 127 + 1)
+				// Construct frac with exp_field=126 (-> 2^-1 = 0.5 base),
+				// mantissa = rawFrac.  This equals (1 + rawFrac/2^23)/2
+				// bit-exactly.
+				uint32_t frac_bits = (uint32_t(126) << 23) | ff.rawFrac;
+				frac = sw::bit_cast<float>(frac_bits);
+				exp = ff.rawExp - 127 + 1;
+			}
+		}
+		else {
+			frac = std::frexp(v, &exp);
+		}
 		// We want: v = 1.mantissa * 2^(exp-1)
 		// so our biased_exp = exp - 1 + bias
 		exp -= 1; // now v = (2*frac) * 2^exp, and 2*frac in [1.0, 2.0)
@@ -521,7 +631,14 @@ public:
 		if (biased_exp <= 0) {
 			// Subnormal range
 			// subnormal: v = f * 2^(1-bias) where f = 0.mantissa in [0, 1)
-			float subnormal_frac = v / std::ldexp(1.0f, 1 - bias);
+			float subnormal_divisor;
+			if (std::is_constant_evaluated()) {
+				subnormal_divisor = cx_ldexp(1.0f, 1 - bias);
+			}
+			else {
+				subnormal_divisor = std::ldexp(1.0f, 1 - bias);
+			}
+			float subnormal_frac = v / subnormal_divisor;
 			// subnormal_frac is in [0, 1)
 			// Quantize to fbits bits with RNE
 			float scaled = subnormal_frac * static_cast<float>(1u << fbits);
@@ -585,7 +702,7 @@ protected:
 
 private:
 	// Round-to-nearest-even helper
-	static unsigned rne_round(float v) noexcept {
+	static constexpr unsigned rne_round(float v) noexcept {
 		unsigned truncated = static_cast<unsigned>(v);
 		float remainder = v - static_cast<float>(truncated);
 		if (remainder > 0.5f) return truncated + 1u;
@@ -596,21 +713,21 @@ private:
 
 	// microfloat - microfloat logic comparisons
 	template<unsigned n, unsigned e, bool i, bool na, bool s>
-	friend bool operator==(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs);
+	friend constexpr bool operator==(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs);
 
 	// microfloat - literal logic comparisons
 	template<unsigned n, unsigned e, bool i, bool na, bool s>
-	friend bool operator==(microfloat<n,e,i,na,s> lhs, float rhs);
+	friend constexpr bool operator==(microfloat<n,e,i,na,s> lhs, float rhs);
 
 	// literal - microfloat logic comparisons
 	template<unsigned n, unsigned e, bool i, bool na, bool s>
-	friend bool operator==(float lhs, microfloat<n,e,i,na,s> rhs);
+	friend constexpr bool operator==(float lhs, microfloat<n,e,i,na,s> rhs);
 };
 
 ////////////////////////    functions   /////////////////////////////////
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> abs(microfloat<n,e,i,na,s> a) {
+inline constexpr microfloat<n,e,i,na,s> abs(microfloat<n,e,i,na,s> a) {
 	return (a.isneg() ? -a : a);
 }
 
@@ -666,7 +783,7 @@ inline std::string to_native(microfloat<nbits, es, hasInf, hasNaN, isSaturating>
 // microfloat - microfloat binary logic operators
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator==(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator==(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	if (lhs.isnan() || rhs.isnan()) return false;
 	// +0 == -0
 	if (lhs.iszero() && rhs.iszero()) return true;
@@ -674,123 +791,128 @@ inline bool operator==(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator!=(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator!=(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	return !operator==(lhs, rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator<(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator<(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return (float(lhs) - float(rhs)) < 0;
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator>(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator>(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator<(rhs, lhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator<=(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator<=(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator<(lhs, rhs) || operator==(lhs, rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator>=(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
-	return !operator<(lhs, rhs);
+inline constexpr bool operator>=(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+	// Cannot just be `!operator<`: operator< returns false for any NaN
+	// operand, so negating it would yield true for NaN >= x.  Build from
+	// operator> and operator==, both of which return false on NaN.
+	return operator>(lhs, rhs) || operator==(lhs, rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // microfloat - literal binary logic operators
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator==(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr bool operator==(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator!=(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr bool operator!=(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return !operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator<(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr bool operator<(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator<(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator>(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr bool operator>(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator<(microfloat<n,e,i,na,s>(rhs), lhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator<=(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr bool operator<=(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator<(lhs, microfloat<n,e,i,na,s>(rhs)) || operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator>=(microfloat<n,e,i,na,s> lhs, float rhs) {
-	return !operator<(lhs, microfloat<n,e,i,na,s>(rhs));
+inline constexpr bool operator>=(microfloat<n,e,i,na,s> lhs, float rhs) {
+	// NaN-safe (see microfloat-microfloat operator>= for the rationale).
+	return operator>(lhs, microfloat<n,e,i,na,s>(rhs)) || operator==(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // literal - microfloat binary logic operators
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator==(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator==(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator!=(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator!=(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return !operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator<(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator<(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator<(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator>(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator>(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator<(rhs, microfloat<n,e,i,na,s>(lhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator<=(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr bool operator<=(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator<(microfloat<n,e,i,na,s>(lhs), rhs) || operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline bool operator>=(float lhs, microfloat<n,e,i,na,s> rhs) {
-	return !operator<(microfloat<n,e,i,na,s>(lhs), rhs);
+inline constexpr bool operator>=(float lhs, microfloat<n,e,i,na,s> rhs) {
+	// NaN-safe (see microfloat-microfloat operator>= for the rationale).
+	return operator>(microfloat<n,e,i,na,s>(lhs), rhs) || operator==(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // microfloat - microfloat binary arithmetic operators
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator+(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator+(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	microfloat<n,e,i,na,s> sum = lhs;
 	sum += rhs;
 	return sum;
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator-(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator-(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	microfloat<n,e,i,na,s> diff = lhs;
 	diff -= rhs;
 	return diff;
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator*(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator*(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	microfloat<n,e,i,na,s> mul = lhs;
 	mul *= rhs;
 	return mul;
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator/(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator/(microfloat<n,e,i,na,s> lhs, microfloat<n,e,i,na,s> rhs) {
 	microfloat<n,e,i,na,s> ratio = lhs;
 	ratio /= rhs;
 	return ratio;
@@ -800,22 +922,22 @@ inline microfloat<n,e,i,na,s> operator/(microfloat<n,e,i,na,s> lhs, microfloat<n
 // microfloat - literal binary arithmetic operators
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator+(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator+(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator+(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator-(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator-(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator-(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator*(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator*(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator*(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator/(microfloat<n,e,i,na,s> lhs, float rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator/(microfloat<n,e,i,na,s> lhs, float rhs) {
 	return operator/(lhs, microfloat<n,e,i,na,s>(rhs));
 }
 
@@ -823,22 +945,22 @@ inline microfloat<n,e,i,na,s> operator/(microfloat<n,e,i,na,s> lhs, float rhs) {
 // literal - microfloat binary arithmetic operators
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator+(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator+(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator+(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator-(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator-(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator-(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator*(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator*(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator*(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 
 template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline microfloat<n,e,i,na,s> operator/(float lhs, microfloat<n,e,i,na,s> rhs) {
+inline constexpr microfloat<n,e,i,na,s> operator/(float lhs, microfloat<n,e,i,na,s> rhs) {
 	return operator/(microfloat<n,e,i,na,s>(lhs), rhs);
 }
 

--- a/include/sw/universal/number/microfloat/microfloat_impl.hpp
+++ b/include/sw/universal/number/microfloat/microfloat_impl.hpp
@@ -538,9 +538,12 @@ public:
 		}
 
 		if (v == 0.0f) {
-			setzero();
-			// Note: signed-zero preservation isn't critical for microfloat;
-			// existing behavior collapses to the canonical positive zero.
+			// Preserve the sign bit for signed zero -- microfloat models
+			// +0 / -0 distinctly (iszero() accepts both encodings, unary -
+			// flips the sign on zero, to_float() emits the matching float
+			// sign).  Pre-fix code unconditionally collapsed -0.0f to +0,
+			// breaking the round-trip contract.  CodeRabbit catch on PR #811.
+			_bits = s ? sign_mask : 0x00u;
 			return;
 		}
 

--- a/static/block/microfloat/api/constexpr.cpp
+++ b/static/block/microfloat/api/constexpr.cpp
@@ -191,6 +191,53 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Mixed-type comparison NaN-safety (CR round-2 catch on PR #811).
+	//
+	// Pre-fix the mf-float / float-mf overloads narrowed the float operand to
+	// microfloat first; for hasNaN==false instantiations from_float(NaN)
+	// collapses to zero, so `mf == NaN_float` would silently become
+	// `mf == 0` -- breaking the IEEE 754 "all relational ops false / != true
+	// for any NaN operand" contract.  Tests cover BOTH a hasNaN=true type
+	// (e4m3) and a hasNaN=false type (a synthetic 4-bit no-NaN config) so
+	// the fix is verified across the relevant configurations.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr float fnan = std::numeric_limits<float>::quiet_NaN();
+		constexpr e4m3 a(1.0f);
+
+		// e4m3 has hasNaN=true: pre-fix would also have returned false for ==
+		// because microfloat(NaN) becomes a NaN encoding and the mf-mf == op
+		// catches it.  Still, the float-NaN short-circuit is the right
+		// place to handle this and keeps behavior consistent.
+		static_assert(!(a == fnan),  "constexpr: e4m3 == float NaN -> false");
+		static_assert( (a != fnan),  "constexpr: e4m3 != float NaN -> true");
+		static_assert(!(a <  fnan),  "constexpr: e4m3 <  float NaN -> false");
+		static_assert(!(a >  fnan),  "constexpr: e4m3 >  float NaN -> false");
+		static_assert(!(a <= fnan),  "constexpr: e4m3 <= float NaN -> false");
+		static_assert(!(a >= fnan),  "constexpr: e4m3 >= float NaN -> false");
+		// Symmetric float-mf overloads
+		static_assert(!(fnan == a),  "constexpr: float NaN == e4m3 -> false");
+		static_assert( (fnan != a),  "constexpr: float NaN != e4m3 -> true");
+		static_assert(!(fnan <  a),  "constexpr: float NaN <  e4m3 -> false");
+		static_assert(!(fnan >  a),  "constexpr: float NaN >  e4m3 -> false");
+		static_assert(!(fnan <= a),  "constexpr: float NaN <= e4m3 -> false");
+		static_assert(!(fnan >= a),  "constexpr: float NaN >= e4m3 -> false");
+
+		// hasNaN=false instantiation: this is where the original bug bit.
+		// from_float(NaN) for these collapses to zero, so without the
+		// short-circuit `e_no_nan == NaN` would compare against 0.
+		using e2m1_no_nan = microfloat<4, 2, false, false, true>;
+		constexpr e2m1_no_nan z{};  // value-init -> encoding 0 (positive zero)
+		constexpr e2m1_no_nan one_v(1.0f);
+		// Without the fix, `z == fnan` would narrow fnan to 0 (= z) and return TRUE.
+		static_assert(!(z == fnan),     "constexpr: hasNaN=false e2m1 == NaN -> false");
+		static_assert( (z != fnan),     "constexpr: hasNaN=false e2m1 != NaN -> true");
+		static_assert(!(one_v < fnan),  "constexpr: hasNaN=false e2m1 < NaN -> false");
+		static_assert(!(fnan == z),     "constexpr: NaN == hasNaN=false e2m1 -> false");
+		static_assert( (fnan != z),     "constexpr: NaN != hasNaN=false e2m1 -> true");
+	}
+
+	// ----------------------------------------------------------------------------
 	// Signed zero preservation (CR catch on PR #811).  microfloat models
 	// +0 and -0 distinctly; converting from -0.0f must produce the
 	// negative-zero encoding so unary - and to_float() round-trip.

--- a/static/block/microfloat/api/constexpr.cpp
+++ b/static/block/microfloat/api/constexpr.cpp
@@ -1,0 +1,221 @@
+// constexpr.cpp: compile-time tests for microfloat (8-bit float family: e4m3, e5m2, e2m1)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+#define MICROFLOAT_THROW_ARITHMETIC_EXCEPTION 0
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/microfloat/microfloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "microfloat constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// e4m3: 8 bits, 4 exponent bits, no infinity, has NaN, saturating.
+	// e5m2: 8 bits, 5 exponent bits, has infinity, has NaN, IEEE-like.
+	using e4m3 = microfloat<8, 4, false, true, true>;
+	using e5m2 = microfloat<8, 5, true,  true, false>;
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction (smoke)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 zero(SpecificValue::zero);
+		constexpr e4m3 maxp(SpecificValue::maxpos);
+		constexpr e4m3 minp(SpecificValue::minpos);
+		constexpr e4m3 minn(SpecificValue::minneg);
+		constexpr e4m3 maxn(SpecificValue::maxneg);
+		constexpr e4m3 qn(SpecificValue::qnan);
+		static_assert(zero.iszero(),     "constexpr e4m3 zero");
+		static_assert(maxp > e4m3(0.0f), "constexpr e4m3 maxpos > 0");
+		static_assert(minp > e4m3(0.0f), "constexpr e4m3 minpos > 0");
+		static_assert(minn < e4m3(0.0f), "constexpr e4m3 minneg < 0");
+		static_assert(maxn < e4m3(0.0f), "constexpr e4m3 maxneg < 0");
+		static_assert(qn.isnan(),        "constexpr e4m3 qnan isnan");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Issue #733 acceptance form: constexpr a + b + comparison
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 a(2.0f);
+		constexpr e4m3 b(3.0f);
+		constexpr auto cx_sum = a + b;        // 5.0
+		static_assert(cx_sum == e4m3(5.0f),   "issue #733 acceptance: e4m3(2.0) + e4m3(3.0) == 5.0");
+		static_assert(a < b,                  "issue #733 acceptance: e4m3(2.0) < e4m3(3.0)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// All four binary arithmetic operators in constexpr context
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 a(4.0f);
+		constexpr e4m3 b(2.0f);
+		constexpr auto cx_sum  = a + b;       // 6.0
+		constexpr auto cx_diff = a - b;       // 2.0
+		constexpr auto cx_prod = a * b;       // 8.0
+		constexpr auto cx_quot = a / b;       // 2.0
+		constexpr auto cx_neg  = -a;          // -4.0
+		static_assert(cx_sum  == e4m3(6.0f),  "constexpr +  failed");
+		static_assert(cx_diff == e4m3(2.0f),  "constexpr -  failed");
+		static_assert(cx_prod == e4m3(8.0f),  "constexpr *  failed");
+		static_assert(cx_quot == e4m3(2.0f),  "constexpr /  failed");
+		static_assert(cx_neg  == e4m3(-4.0f), "constexpr unary - failed");
+
+		// Compound assignment via constexpr lambda (C++20)
+		constexpr e4m3 cx_addeq = []() { e4m3 t(2.0f); t += e4m3(1.0f); return t; }();
+		constexpr e4m3 cx_subeq = []() { e4m3 t(4.0f); t -= e4m3(1.0f); return t; }();
+		constexpr e4m3 cx_muleq = []() { e4m3 t(2.0f); t *= e4m3(2.0f); return t; }();
+		constexpr e4m3 cx_diveq = []() { e4m3 t(4.0f); t /= e4m3(2.0f); return t; }();
+		static_assert(cx_addeq == e4m3(3.0f), "constexpr += failed");
+		static_assert(cx_subeq == e4m3(3.0f), "constexpr -= failed");
+		static_assert(cx_muleq == e4m3(4.0f), "constexpr *= failed");
+		static_assert(cx_diveq == e4m3(2.0f), "constexpr /= failed");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Comparison operators (issue acceptance: <)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 a(1.0f);
+		constexpr e4m3 b(2.0f);
+		static_assert(a < b,      "constexpr: e4m3(1) < e4m3(2)");
+		static_assert(b > a,      "constexpr: e4m3(2) > e4m3(1)");
+		static_assert(a <= b,     "constexpr: e4m3(1) <= e4m3(2)");
+		static_assert(b >= a,     "constexpr: e4m3(2) >= e4m3(1)");
+		static_assert(!(a == b),  "constexpr: e4m3(1) != e4m3(2)");
+		static_assert(a != b,     "constexpr: != operator");
+		static_assert(a == a,     "constexpr: e4m3(1) == e4m3(1)");
+
+		// IEEE-754 semantics: ALL relational ops return false for any NaN
+		// operand, including >= and <= (the !operator< trap fires here).
+		constexpr e4m3 nan(SpecificValue::qnan);
+		static_assert(!(nan == nan), "constexpr: NaN != NaN");
+		static_assert(!(nan <  a),   "constexpr: NaN <  x  -> false");
+		static_assert(!(nan >  a),   "constexpr: NaN >  x  -> false");
+		static_assert(!(nan <= a),   "constexpr: NaN <= x  -> false");
+		static_assert(!(nan >= a),   "constexpr: NaN >= x  -> false");
+		static_assert(!(a   <  nan), "constexpr: x   <  NaN -> false");
+		static_assert(!(a   >  nan), "constexpr: x   >  NaN -> false");
+		static_assert(!(a   <= nan), "constexpr: x   <= NaN -> false");
+		static_assert(!(a   >= nan), "constexpr: x   >= NaN -> false");
+		static_assert(nan != nan,    "constexpr: NaN != NaN via operator!=");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion-out: operator float() / operator double() / operator int()
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 a(2.0f);
+		constexpr float fa = float(a);
+		static_assert(fa == 2.0f, "constexpr operator float() -> 2.0f");
+
+		constexpr e4m3 b(0.5f);
+		constexpr double db = double(b);
+		static_assert(db == 0.5,  "constexpr operator double() -> 0.5");
+
+		constexpr e4m3 c(7.0f);
+		constexpr int ic = int(c);
+		static_assert(ic == 7,    "constexpr operator int() -> 7");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Increment / decrement at encoding granularity
+	// ----------------------------------------------------------------------------
+	{
+		// e4m3 encoding 0x38 = 1.0 (sign=0, exp=7, frac=0).  ++ moves to next
+		// representable encoding; the float value is unspecified beyond
+		// "next encoding above" so we assert via comparison rather than
+		// exact float equality.
+		constexpr e4m3 cx_inc = []() { e4m3 t(1.0f); ++t; return t; }();
+		constexpr e4m3 cx_dec = []() { e4m3 t(1.0f); --t; return t; }();
+		static_assert(cx_inc > e4m3(1.0f), "constexpr ++e4m3(1.0f) > 1.0");
+		static_assert(cx_dec < e4m3(1.0f), "constexpr --e4m3(1.0f) < 1.0");
+
+		// Postfix returns pre-value, mutates operand.
+		constexpr e4m3 cx_postinc_before = []() { e4m3 t(1.0f); e4m3 old = t++; return old; }();
+		constexpr e4m3 cx_postinc_after  = []() { e4m3 t(1.0f); t++; return t; }();
+		static_assert(cx_postinc_before == e4m3(1.0f), "constexpr postfix ++ returns pre-value");
+		static_assert(cx_postinc_after  >  e4m3(1.0f), "constexpr postfix ++ mutates");
+	}
+
+	// ----------------------------------------------------------------------------
+	// e5m2 (IEEE-like with infinity) construction + arithmetic
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e5m2 a(2.0f);
+		constexpr e5m2 b(0.5f);
+		constexpr auto cx_sum = a + b;        // 2.5
+		static_assert(cx_sum == e5m2(2.5f),   "constexpr e5m2 +");
+
+		// e5m2 has infinity; constructing from numeric_limits<float>::infinity()
+		// should produce a microfloat infinity, not maxpos.
+		constexpr e5m2 inf_pos(std::numeric_limits<float>::infinity());
+		static_assert(inf_pos.isinf(),        "constexpr e5m2(+inf) isinf");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Native int construction
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 a(3);
+		constexpr e4m3 b(-2);
+		static_assert(a == e4m3(3.0f),    "constexpr e4m3(int 3) == e4m3(3.0f)");
+		static_assert(b == e4m3(-2.0f),   "constexpr e4m3(int -2) == e4m3(-2.0f)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Selectors smoke test (already constexpr -- lock in the contract)
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 a(1.0f);
+		constexpr e4m3 nan(SpecificValue::qnan);
+		static_assert(a.isone(),      "constexpr e4m3(1.0f).isone()");
+		static_assert(!a.isnan(),     "constexpr e4m3(1.0f).isnan() == false");
+		static_assert(!a.iszero(),    "constexpr e4m3(1.0f).iszero() == false");
+		static_assert(!a.sign(),      "constexpr e4m3(1.0f) is positive");
+		static_assert(nan.isnan(),    "constexpr qnan isnan");
+	}
+
+	// ----------------------------------------------------------------------------
+	// abs / unary minus
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 negv(-3.0f);
+		constexpr e4m3 absv = abs(negv);
+		static_assert(absv == e4m3(3.0f), "constexpr abs(-3.0) == 3.0");
+		constexpr e4m3 negn = -negv;
+		static_assert(negn == e4m3(3.0f), "constexpr -(-3.0) == 3.0");
+	}
+
+	std::cout << "microfloat constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/static/block/microfloat/api/constexpr.cpp
+++ b/static/block/microfloat/api/constexpr.cpp
@@ -191,6 +191,25 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Signed zero preservation (CR catch on PR #811).  microfloat models
+	// +0 and -0 distinctly; converting from -0.0f must produce the
+	// negative-zero encoding so unary - and to_float() round-trip.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr e4m3 pos_zero(0.0f);
+		constexpr e4m3 neg_zero(-0.0f);
+		static_assert(pos_zero.iszero(),     "constexpr +0.0f -> iszero");
+		static_assert(neg_zero.iszero(),     "constexpr -0.0f -> iszero");
+		static_assert(!pos_zero.sign(),      "constexpr +0.0f -> sign() == false");
+		static_assert(neg_zero.sign(),       "constexpr -0.0f -> sign() == true (preserved)");
+		// Round-trip: -0.0f -> microfloat -> float sign bit preserved
+		static_assert(float(neg_zero) == 0.0f, "constexpr -0.0 round-trips numerically");
+		// Unary minus on +0 should produce a microfloat with the sign bit set.
+		constexpr e4m3 negated_zero = -pos_zero;
+		static_assert(negated_zero.sign(),    "constexpr -(+0) sets sign bit");
+	}
+
+	// ----------------------------------------------------------------------------
 	// abs / unary minus
 	// ----------------------------------------------------------------------------
 	{


### PR DESCRIPTION
## Summary

Promotes `microfloat` (8-bit float family: e4m3, e5m2, e2m1) to fully `constexpr` across construction, assignment, arithmetic, comparison, and conversion. Part of Epic #723.

The issue body called microfloat "aliases over cfloat" but it's actually its own 845-line implementation, so the promotion surface is non-trivial. Same dispatch pattern as e8m0 (PR #810): `std::is_constant_evaluated()` selects between bit-cast/loop at constant-eval and `std::ldexp`/`std::frexp`/`std::signbit`/`std::isinf` at runtime.

## Changes

### `include/sw/universal/number/microfloat/microfloat_impl.hpp`
- All native-type ctors, assignments, conversion-out operators, `++`/`--`, unary `-`, compound arithmetic (`+= -= *= /=`), and comparisons marked `constexpr`.
- **`operator>=` fix**: changed `!operator<` to `operator> || operator==` for NaN safety. Pre-fix returned true for any NaN operand (same pattern as e8m0 PR #810 CodeRabbit catch). Applied to all three flavors (mf-mf, mf-float, float-mf).
- **`to_float()`** rewritten with `std::is_constant_evaluated()` dispatch; constexpr path uses new `cx_ldexp` helper (bounded power-of-2 loop). Bit-identical to runtime path because 2.0/0.5 are exactly representable.
- **`from_float()`** rewritten with `is_constant_evaluated()` dispatch:
  - `std::signbit` -> `bit_cast<uint32_t>(v) >> 31`
  - `std::isinf` -> `(rawExp == 0xFF && rawFrac == 0)`
  - `std::frexp` -> IEEE 754 field extraction with subnormal-source leading-zero scan
  - `std::ldexp` (subnormal divisor) -> `cx_ldexp(1.0f, 1 - bias)`
  Reconstructed `(frac, exp)` matches `std::frexp` bit-exactly via bit-cast with `exp_field = 126`.
- `rne_round` marked `constexpr` (pure FP arithmetic).
- All free function comparisons (3 flavors) and arithmetic operators marked `constexpr`. `abs()` marked `constexpr`.
- Added `<cstdint>`, `<type_traits>`, `<limits>` includes.

### `static/block/microfloat/api/constexpr.cpp` (new)
- Issue #733 acceptance form: `constexpr e4m3 a + b` + comparison.
- All four binary operators + compound forms via constexpr lambdas.
- IEEE 754 NaN semantics test: all six relational ops (incl. `>=` and `<=`) return false for any NaN operand — locks in the operator>= NaN-safety contract.
- e5m2 (IEEE-like with infinity) construction; verifies `microfloat(numeric_limits<float>::infinity())` yields a microfloat infinity.
- Conversion-out, `++`/`--`, native int, selectors, `abs`.

## Test Results

| Target | gcc | clang | UBSan |
|--------|-----|-------|-------|
| microfloat_constexpr | PASS | PASS | clean |
| microfloat_api | PASS | PASS | clean |
| microfloat_assignment | PASS | PASS | n/a |
| microfloat_addition | PASS | PASS | clean |
| microfloat_subtraction | PASS | PASS | n/a |
| microfloat_multiplication | PASS | PASS | n/a |
| microfloat_division | PASS | PASS | clean |
| microfloat_logic | PASS | PASS | clean |
| microfloat_tables | PASS | PASS | n/a |
| mxfloat_api (consumer) | PASS | PASS | clean |
| mxfloat_dot_product | PASS | PASS | n/a |

UBSan via `build_ubsan/` (per `docs/build/local-sanitizer.md`).

## Test plan
- [x] Fast CI (gcc + clang CI_LITE) passes
- [x] CodeRabbit pass
- [x] Promote to ready: `gh pr ready <#>`

Resolves #733

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensive compile-time (constexpr) support for microfloat construction, conversion, arithmetic, increments, and comparisons; constexpr-safe conversion infrastructure.

* **Bug Fixes**
  * Comparison logic made NaN-safe.
  * Conversions preserve signed zero and the sign bit for ±0.0.

* **Tests**
  * Added a comprehensive compile-time verification suite validating construction, arithmetic, increments, comparisons, conversions, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->