### PR TITLE
feat: partial constexpr support for accessor subset(zfpblock)

### DIFF
--- a/include/sw/universal/number/zfpblock/zfpblock_impl.hpp
+++ b/include/sw/universal/number/zfpblock/zfpblock_impl.hpp
@@ -42,7 +42,10 @@ public:
 	zfpblock() = default;
 
 	// Compress a block of 4^Dim values
-	// Returns the number of bits in the compressed representation
+	// Returns the number of bits in the compressed representation.
+	// NOT constexpr: encode_block uses std::frexp / std::ldexp / std::memset
+	// and zfp_bitstream's bit-packing routines.  Full codec promotion is a
+	// substantial follow-up to issue #745.
 	size_t compress(const Real* src, zfp_mode mode, double param) {
 		_mode = mode;
 		_param = param;
@@ -53,7 +56,7 @@ public:
 		return _nbits;
 	}
 
-	// Decompress to a block of 4^Dim values
+	// Decompress to a block of 4^Dim values.  See compress() note above.
 	void decompress(Real* dst) const {
 		unsigned maxprec = 0;
 		size_t maxbits = 0;
@@ -82,29 +85,29 @@ public:
 	}
 
 	// Query compressed size in bits
-	size_t compressed_bits() const { return _nbits; }
+	constexpr size_t compressed_bits() const noexcept { return _nbits; }
 
 	// Query compressed size in bytes (rounded up)
-	size_t compressed_bytes() const { return (_nbits + 7) / 8; }
+	constexpr size_t compressed_bytes() const noexcept { return (_nbits + 7) / 8; }
 
 	// Compression ratio: uncompressed / compressed
-	double compression_ratio() const {
+	constexpr double compression_ratio() const noexcept {
 		if (_nbits == 0) return 0.0;
 		return static_cast<double>(BLOCK_SIZE * sizeof(Real) * 8) / static_cast<double>(_nbits);
 	}
 
 	// Access the raw compressed buffer
-	const uint8_t* data() const { return _buffer; }
+	constexpr const uint8_t* data() const noexcept { return _buffer; }
 
 	// Mode and parameter accessors
-	zfp_mode mode() const { return _mode; }
-	double param() const { return _param; }
+	constexpr zfp_mode mode() const noexcept { return _mode; }
+	constexpr double param() const noexcept { return _param; }
 
 	// Block size (number of elements)
-	static constexpr size_t block_size() { return BLOCK_SIZE; }
+	static constexpr size_t block_size() noexcept { return BLOCK_SIZE; }
 
 	// Dimensionality
-	static constexpr unsigned dim() { return Dim; }
+	static constexpr unsigned dim() noexcept { return Dim; }
 
 private:
 	uint8_t  _buffer[MAX_BYTES];
@@ -113,8 +116,8 @@ private:
 	double   _param;
 
 	// Compute maxprec and maxbits from mode and parameter
-	static void compute_limits(zfp_mode mode, double param,
-	                           unsigned& maxprec, size_t& maxbits) {
+	static constexpr void compute_limits(zfp_mode mode, double param,
+	                                     unsigned& maxprec, size_t& maxbits) noexcept {
 		constexpr unsigned full_prec = traits_type::precision_bits;
 		constexpr size_t header_size = 1 + traits_type::ebits;  // zero bit + exponent
 		constexpr size_t max_data_bits = BLOCK_SIZE * full_prec + header_size;

--- a/static/block/zfpblock/api/constexpr.cpp
+++ b/static/block/zfpblock/api/constexpr.cpp
@@ -1,0 +1,152 @@
+// constexpr.cpp: compile-time tests for zfpblock (accessor subset)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage:
+//
+// zfpblock combines:
+//   * a static block-buffer container with simple integer accessors -- all
+//     constexpr-promotable (this file exercises that subset);
+//   * a 564-line ZFP transform codec (zfp_codec.hpp) using std::frexp /
+//     std::ldexp / std::memset and bit-stream packing -- NOT yet constexpr;
+//   * a std::vector-backed multi-block array (zfparray) -- NOT in scope.
+//
+// The codec promotion is deferred per the issue note in zfpblock_impl.hpp.
+// This file locks in the constexpr contract for what IS achievable today.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/zfpblock/zfpblock.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "zfpblock constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// zfpblock<float, 1>: 4-element 1D block of floats.
+	// zfpblock<double, 2>: 4x4 = 16-element 2D block of doubles.
+	// zfpblock<double, 3>: 4x4x4 = 64-element 3D block of doubles.
+	using zfp_f1 = zfpblock<float, 1>;
+	using zfp_d2 = zfpblock<double, 2>;
+	using zfp_d3 = zfpblock<double, 3>;
+
+	// ----------------------------------------------------------------------------
+	// Static accessors: BLOCK_SIZE, MAX_BYTES, block_size(), dim().
+	// ----------------------------------------------------------------------------
+	{
+		// zfp_block_size<Dim>::value = 4^Dim (4, 16, 64 for Dim 1/2/3)
+		static_assert(zfp_f1::BLOCK_SIZE == 4u,  "constexpr zfpblock<float, 1>::BLOCK_SIZE == 4");
+		static_assert(zfp_d2::BLOCK_SIZE == 16u, "constexpr zfpblock<double, 2>::BLOCK_SIZE == 16");
+		static_assert(zfp_d3::BLOCK_SIZE == 64u, "constexpr zfpblock<double, 3>::BLOCK_SIZE == 64");
+
+		static_assert(zfp_f1::block_size() == 4u,  "constexpr zfp_f1::block_size() == 4");
+		static_assert(zfp_d3::block_size() == 64u, "constexpr zfp_d3::block_size() == 64");
+
+		static_assert(zfp_f1::dim() == 1u, "constexpr zfp_f1::dim() == 1");
+		static_assert(zfp_d2::dim() == 2u, "constexpr zfp_d2::dim() == 2");
+		static_assert(zfp_d3::dim() == 3u, "constexpr zfp_d3::dim() == 3");
+
+		// MAX_BYTES = upper bound on compressed buffer size; non-zero per Dim.
+		static_assert(zfp_f1::MAX_BYTES > 0u, "constexpr zfp_f1::MAX_BYTES > 0");
+		static_assert(zfp_d3::MAX_BYTES > 0u, "constexpr zfp_d3::MAX_BYTES > 0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// compute_limits is a private static helper, but the public-facing
+	// behavior is reachable via the constexpr accessors.  We exercise the
+	// accessor subset directly: a default-constructed zfpblock has _nbits=0,
+	// so compressed_bits() / compressed_bytes() / compression_ratio() are all
+	// constexpr-deterministic.
+	// ----------------------------------------------------------------------------
+	{
+		// Wrap construction + accessor reads in a constexpr lambda so we
+		// can value-initialize the zfpblock storage (default ctor leaves
+		// the byte buffer indeterminate).
+		constexpr size_t cx_nbits = []() {
+			zfp_f1 b{};
+			return b.compressed_bits();
+		}();
+		// Default constructed _nbits is uninitialized per the trivial ctor,
+		// so we don't assert a specific value -- just that compressed_bits()
+		// is constexpr-callable.  The cx_nbits value is whatever the
+		// value-init produced (typically 0 for explicit `{}` aggregates).
+		(void)cx_nbits;
+
+		constexpr size_t cx_bytes = []() {
+			zfp_f1 b{};
+			return b.compressed_bytes();
+		}();
+		(void)cx_bytes;
+
+		constexpr double cx_ratio = []() {
+			zfp_f1 b{};
+			return b.compression_ratio();
+		}();
+		// With _nbits == 0 (value-init), compression_ratio returns 0.0 by contract.
+		static_assert(cx_ratio == 0.0, "constexpr compression_ratio for empty block == 0.0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// data() pointer is constexpr (returns &_buffer[0]).  Useful for
+	// constexpr inspection of pre-populated blocks.  We just verify the
+	// expression is well-formed at constant evaluation.
+	// ----------------------------------------------------------------------------
+	{
+		// data() returns const uint8_t* pointing into the block's buffer.
+		// In a constant expression, the pointer's value isn't directly
+		// comparable across translation units, but the call must compile.
+		constexpr bool has_data = []() {
+			zfp_f1 b{};
+			return b.data() != nullptr;
+		}();
+		static_assert(has_data, "constexpr data() returns valid pointer");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Mode and parameter accessors.  Default-constructed zfpblock has
+	// _mode and _param value-initialized (zfp_mode is an enum, defaulted to
+	// 0 = zfp_mode::fixed_rate; _param defaulted to 0.0).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr zfp_mode cx_mode = []() {
+			zfp_f1 b{};
+			return b.mode();
+		}();
+		(void)cx_mode;  // value depends on zfp_mode enum's first entry; not pinned
+
+		constexpr double cx_param = []() {
+			zfp_f1 b{};
+			return b.param();
+		}();
+		static_assert(cx_param == 0.0, "constexpr default param() == 0.0");
+	}
+
+	std::cout << "zfpblock constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/static/block/zfpblock/api/constexpr.cpp
+++ b/static/block/zfpblock/api/constexpr.cpp
@@ -63,37 +63,31 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
-	// compute_limits is a private static helper, but the public-facing
-	// behavior is reachable via the constexpr accessors.  We exercise the
-	// accessor subset directly: a default-constructed zfpblock has _nbits=0,
-	// so compressed_bits() / compressed_bytes() / compression_ratio() are all
-	// constexpr-deterministic.
+	// Empty-state contract: a value-initialized zfpblock has _nbits = 0,
+	// _mode = 0 (first enum value), _param = 0.0.  All three accessors are
+	// constexpr-deterministic at value-init.  (Note: trivial default
+	// construction `zfp_f1 b;` leaves storage indeterminate; this contract
+	// applies only to `zfp_f1 b{};` value-init, which we use throughout.)
 	// ----------------------------------------------------------------------------
 	{
-		// Wrap construction + accessor reads in a constexpr lambda so we
-		// can value-initialize the zfpblock storage (default ctor leaves
-		// the byte buffer indeterminate).
 		constexpr size_t cx_nbits = []() {
 			zfp_f1 b{};
 			return b.compressed_bits();
 		}();
-		// Default constructed _nbits is uninitialized per the trivial ctor,
-		// so we don't assert a specific value -- just that compressed_bits()
-		// is constexpr-callable.  The cx_nbits value is whatever the
-		// value-init produced (typically 0 for explicit `{}` aggregates).
-		(void)cx_nbits;
+		static_assert(cx_nbits == 0u, "constexpr compressed_bits for empty block == 0");
 
 		constexpr size_t cx_bytes = []() {
 			zfp_f1 b{};
 			return b.compressed_bytes();
 		}();
-		(void)cx_bytes;
+		static_assert(cx_bytes == 0u, "constexpr compressed_bytes for empty block == 0");
 
 		constexpr double cx_ratio = []() {
 			zfp_f1 b{};
 			return b.compression_ratio();
 		}();
-		// With _nbits == 0 (value-init), compression_ratio returns 0.0 by contract.
+		// With _nbits == 0, compression_ratio returns 0.0 by contract
+		// (the early-out branch in compression_ratio()).
 		static_assert(cx_ratio == 0.0, "constexpr compression_ratio for empty block == 0.0");
 	}
 


### PR DESCRIPTION
## Summary

Partial fix for issue #745 — promotes `zfpblock`'s static accessors + `compute_limits` helper to `constexpr` (the achievable subset that doesn't require rewriting the ZFP transform codec). Part of Epic #723.

## Scope decision

`zfpblock` has three layers:

1. **Static block-buffer container** with simple integer accessors (`compressed_bits`, `compressed_bytes`, `compression_ratio`, `data`, `mode`, `param`, `block_size`, `dim`). **THIS PR.**
2. **ZFP transform codec** (`zfp_codec.hpp`, 564 lines): uses `std::frexp` / `std::ldexp` / `std::memset` and a `uint8_t` bit-stream packer. **DEFERRED.**
3. **zfparray multi-block container** (`zfparray_impl.hpp`, 326 lines): uses `std::vector<uint8_t>` backing + `std::memcpy/memset`. **DEFERRED.**

Layers 2 and 3 are non-trivial constexpr lifts that warrant their own follow-up PRs. This PR delivers the immediately-achievable subset and locks the contract via `static_assert`. Use `Relates to #745` since the codec promotion is the bulk of the issue.

## Changes

- `include/sw/universal/number/zfpblock/zfpblock_impl.hpp`
  - All simple accessors marked `constexpr noexcept`.
  - `compute_limits` marked `constexpr noexcept` (pure integer arithmetic).
  - `compress` / `decompress` deliberately NOT promoted; comment points to the codec deferral.
- `static/block/zfpblock/api/constexpr.cpp` (new)
  - Static accessor verification (`BLOCK_SIZE`, `MAX_BYTES`, `block_size`, `dim`) for `zfpblock<float, 1>`, `<double, 2>`, `<double, 3>`.
  - Constexpr-lambda exercises of the runtime accessors with value-initialized blocks.
  - Header documents the deferred codec scope.

## Test Results

| Target | gcc | clang | UBSan |
|--------|-----|-------|-------|
| zfpblock_constexpr | PASS | PASS | clean |
| zfpblock_api | PASS | PASS | clean |
| zfpblock_array_api / cache / copy_move / roundtrip | PASS | PASS | n/a |
| zfpblock_bitplane / fixed_rate / lifting / negabinary | PASS | PASS | n/a |
| zfpblock_roundtrip_1d / 2d / 3d | PASS | PASS | clean (1d) |

12 zfpblock targets all PASS on gcc + clang.

## Test plan
- [x] Fast CI passes
- [ ] CodeRabbit review
- [ ] When clean: `gh pr ready <#>`
- [ ] **Follow-up**: codec + zfparray full constexpr promotion (separate PR)

Relates to #745

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Accessor and utility methods for the numeric compression block API are now constexpr and noexcept where applicable, improving compile-time evaluability, performance, and robustness.

* **Tests**
  * Added a compile-time verification executable that statically validates block size, dimensions, accessors, and default values and reports pass/fail results at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->