### PR TITLE
feat(takum): full constexpr support across all operators

### DIFF
--- a/include/sw/universal/number/takum/takum_fwd.hpp
+++ b/include/sw/universal/number/takum/takum_fwd.hpp
@@ -12,7 +12,7 @@ namespace sw { namespace universal {
 
 // core takum types and functions
 template<unsigned nbits, unsigned rbits, typename bt> class takum;
-template<unsigned nbits, unsigned rbits, typename bt> constexpr takum<nbits, rbits, bt> abs(const takum<nbits, rbits, bt>&);
+template<unsigned nbits, unsigned rbits, typename bt> constexpr takum<nbits, rbits, bt> abs(const takum<nbits, rbits, bt>&) noexcept;
 template<unsigned nbits, unsigned rbits, typename bt> takum<nbits, rbits, bt> sqrt(const takum<nbits, rbits, bt>&);
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -34,6 +34,7 @@
 #include <universal/native/ieee754.hpp>
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/internal/abstract/triple.hpp>
+#include <math/constexpr_math/exp2.hpp>
 
 namespace sw {	namespace universal {
 
@@ -106,7 +107,7 @@ public:
 		         : (1 - static_cast<int>(1ull << (r + 1)));
 	}
 	// Given a characteristic value c, find the DR index
-	static unsigned find_dr(int c) noexcept {
+	static constexpr unsigned find_dr(int c) noexcept {
 		for (int dr = static_cast<int>(nr_dr_values) - 1; dr >= 0; --dr) {
 			if (c >= dr_to_c_bias(static_cast<unsigned>(dr)))
 				return static_cast<unsigned>(dr);
@@ -187,22 +188,22 @@ public:
 	CONSTEXPRESSION takum& operator=(float rhs)        noexcept { return convert_ieee754(rhs); }
 	CONSTEXPRESSION takum& operator=(double rhs)       noexcept { return convert_ieee754(rhs); }
 
-	explicit constexpr operator int()       const noexcept { return to_signed<int>(); }
-	explicit constexpr operator long()      const noexcept { return to_signed<long>(); }
-	explicit constexpr operator long long() const noexcept { return to_signed<long long>(); }
-	explicit operator float()     const noexcept { return to_ieee754<float>(); }
-	explicit operator double()    const noexcept { return to_ieee754<double>(); }
+	explicit CONSTEXPRESSION operator int()       const noexcept { return to_signed<int>(); }
+	explicit CONSTEXPRESSION operator long()      const noexcept { return to_signed<long>(); }
+	explicit CONSTEXPRESSION operator long long() const noexcept { return to_signed<long long>(); }
+	explicit CONSTEXPRESSION operator float()     const noexcept { return to_ieee754<float>(); }
+	explicit CONSTEXPRESSION operator double()    const noexcept { return to_ieee754<double>(); }
 
 	// guard long double support to enable ARM and RISC-V embedded environments
 #if LONG_DOUBLE_SUPPORT
-	takum(long double initial_value)                      noexcept : _block{} { *this = initial_value; }
-	takum& operator=(long double rhs)                     noexcept { return convert_ieee754(rhs); }
-	explicit operator long double()                 const noexcept { return to_ieee754<long double>(); }
+	CONSTEXPRESSION takum(long double initial_value)                      noexcept : _block{} { *this = initial_value; }
+	CONSTEXPRESSION takum& operator=(long double rhs)                     noexcept { return convert_ieee754(rhs); }
+	explicit CONSTEXPRESSION operator long double()                 const noexcept { return to_ieee754<long double>(); }
 #endif
 
 	// arithmetic operators
 	// prefix negation: two's complement negate
-	takum operator-() const {
+	constexpr takum operator-() const noexcept {
 		if (iszero() || isnar()) return *this;
 		takum result;
 		uint64_t raw = raw_bits();
@@ -212,30 +213,35 @@ public:
 		return result;
 	}
 
-	// in-place arithmetic via double conversion
-	takum& operator+=(const takum& rhs) {
+	// in-place arithmetic via double conversion.  CONSTEXPRESSION because
+	// the underlying convert_ieee754 / to_ieee754 path becomes constexpr only
+	// when sw::bit_cast is constexpr (BIT_CAST_IS_CONSTEXPR=true) and the
+	// constexpr_math::exp2 helper is constant-evaluable.
+	CONSTEXPRESSION takum& operator+=(const takum& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
 		double result = double(*this) + double(rhs);
 		return convert_ieee754(result);
 	}
-	takum& operator+=(double rhs) { return *this += takum(rhs); }
-	takum& operator-=(const takum& rhs) {
+	CONSTEXPRESSION takum& operator+=(double rhs) { return *this += takum(rhs); }
+	CONSTEXPRESSION takum& operator-=(const takum& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
 		double result = double(*this) - double(rhs);
 		return convert_ieee754(result);
 	}
-	takum& operator-=(double rhs) { return *this -= takum(rhs); }
-	takum& operator*=(const takum& rhs) {
+	CONSTEXPRESSION takum& operator-=(double rhs) { return *this -= takum(rhs); }
+	CONSTEXPRESSION takum& operator*=(const takum& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
 		double result = double(*this) * double(rhs);
 		return convert_ieee754(result);
 	}
-	takum& operator*=(double rhs) { return *this *= takum(rhs); }
-	takum& operator/=(const takum& rhs) {
+	CONSTEXPRESSION takum& operator*=(double rhs) { return *this *= takum(rhs); }
+	CONSTEXPRESSION takum& operator/=(const takum& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
 		if (rhs.iszero()) {
 #if TAKUM_THROW_ARITHMETIC_EXCEPTION
-			throw takum_divide_by_zero();
+			if (!std::is_constant_evaluated()) throw takum_divide_by_zero();
+			setnar();
+			return *this;
 #else
 			setnar();
 			return *this;
@@ -244,10 +250,10 @@ public:
 		double result = double(*this) / double(rhs);
 		return convert_ieee754(result);
 	}
-	takum& operator/=(double rhs) { return *this /= takum(rhs); }
+	CONSTEXPRESSION takum& operator/=(double rhs) { return *this /= takum(rhs); }
 
 	// prefix/postfix increment: advance to next/previous representable value
-	takum& operator++() {
+	constexpr takum& operator++() noexcept {
 		if (isnar()) return *this;
 		uint64_t raw = raw_bits();
 		uint64_t mask = nbits_mask();
@@ -256,12 +262,12 @@ public:
 		setbits(raw);
 		return *this;
 	}
-	takum operator++(int) {
+	constexpr takum operator++(int) noexcept {
 		takum tmp(*this);
 		operator++();
 		return tmp;
 	}
-	takum& operator--() {
+	constexpr takum& operator--() noexcept {
 		if (isnar()) return *this;
 		uint64_t raw = raw_bits();
 		if (raw == ((1ull << (nbits - 1)) | 1ull)) return *this; // already maxneg
@@ -269,7 +275,7 @@ public:
 		setbits(raw);
 		return *this;
 	}
-	takum operator--(int) {
+	constexpr takum operator--(int) noexcept {
 		takum tmp(*this);
 		operator--();
 		return tmp;
@@ -356,7 +362,7 @@ public:
 		uint64_t mag = magnitude_bits();
 		return static_cast<unsigned>((mag >> (nbits - overhead)) & dr_field_mask);
 	}
-	int characteristic() const noexcept {
+	constexpr int characteristic() const noexcept {
 		if (iszero() || isnar()) return 0;
 		unsigned dr = dr_field();
 		unsigned r = dr_to_r(dr);
@@ -368,7 +374,7 @@ public:
 		uint64_t C_bits = (r > avail) ? (C_stored_bits << (r - c_stored)) : C_stored_bits;
 		return dr_to_c_bias(dr) + static_cast<int>(C_bits);
 	}
-	int scale() const noexcept {
+	constexpr int scale() const noexcept {
 		if (iszero() || isnar()) return 0;
 		return characteristic();
 	}
@@ -466,7 +472,15 @@ protected:
 		return convert_ieee754(double(rhs));
 	}
 
-	/// Convert an IEEE-754 floating-point value to linear takum encoding
+	/// Convert an IEEE-754 floating-point value to linear takum encoding.
+	/// Constexpr-promoted by replacing std::frexp with bit-extraction:
+	/// for an IEEE 754 normal v = (1 + rawFrac/2^fbits) * 2^(rawExp - bias),
+	/// the takum decomposition is c = rawExp - bias and m_real = rawFrac/2^fbits
+	/// directly, with no math-library calls.  Subnormals are normalized via a
+	/// bounded leading-zero shift on rawFrac.  Long double routes through
+	/// double at constant evaluation (LONG_DOUBLE_DOWNCAST pattern); finite
+	/// long-double inputs out of double range are extremely rare in compile-
+	/// time literals.
 	template<typename Real>
 	CONSTEXPRESSION takum& convert_ieee754(Real rhs) noexcept {
 		static_assert(nbits <= 64, "takum > 64 bits not yet supported");
@@ -477,15 +491,48 @@ protected:
 		if (rhs < std::numeric_limits<Real>::lowest()) { maxneg(); return *this; }
 
 		bool s = (rhs < Real(0));
-		double v = static_cast<double>(s ? -rhs : rhs);
+		Real abs_v = s ? -rhs : rhs;
 
-		int h_raw;
-		double frac = std::frexp(v, &h_raw);
-		int h = h_raw - 1;
-		double g = 2.0 * frac - 1.0;
+		// Extract IEEE 754 fields directly so we avoid std::frexp at constant
+		// evaluation.  extractFields is BIT_CAST_CONSTEXPR.
+		bool ignored_sign = false;
+		uint64_t rawExp = 0;
+		uint64_t rawFrac = 0;
+		uint64_t bits = 0;
+		extractFields(abs_v, ignored_sign, rawExp, rawFrac, bits);
 
-		int c = h;
-		double m_real = g;
+		// Determine the source format's bias / fbits.  For long double on
+		// platforms where extractFields routes through double, we use double's
+		// parameters since the bits we got back are double-encoded.
+		using Param = ieee754_parameter<Real>;
+		constexpr int src_bias  = (std::is_same_v<Real, long double>)
+		                        ? ieee754_parameter<double>::bias
+		                        : Param::bias;
+		constexpr int src_fbits = (std::is_same_v<Real, long double>)
+		                        ? ieee754_parameter<double>::fbits
+		                        : Param::fbits;
+
+		int c = 0;
+		double m_real = 0.0;
+		if (rawExp != 0u) {
+			// normal: value = (1 + rawFrac/2^fbits) * 2^(rawExp - bias)
+			c = static_cast<int>(rawExp) - src_bias;
+			m_real = static_cast<double>(rawFrac) / static_cast<double>(1ull << src_fbits);
+		}
+		else {
+			// subnormal: rawFrac > 0 by construction (we returned for v == 0).
+			// Normalize by left-shifting rawFrac until the implicit-bit slot is
+			// set; each shift decrements the represented exponent by 1.
+			int implicit_exp = 1 - src_bias; // base subnormal exponent
+			uint64_t f = rawFrac;
+			while ((f & (1ull << src_fbits)) == 0u) {
+				f <<= 1;
+				--implicit_exp;
+			}
+			f &= (1ull << src_fbits) - 1u; // strip implicit bit
+			c = implicit_exp;
+			m_real = static_cast<double>(f) / static_cast<double>(1ull << src_fbits);
+		}
 
 		constexpr int c_max = max_characteristic();
 		constexpr int c_min = min_characteristic();
@@ -583,19 +630,22 @@ protected:
 	/// conversion routines to native types
 
 	template<typename SignedInt>
-	typename std::enable_if< std::is_integral<SignedInt>::value&& std::is_signed<SignedInt>::value, SignedInt>::type
-		to_signed() const {
+	CONSTEXPRESSION typename std::enable_if< std::is_integral<SignedInt>::value&& std::is_signed<SignedInt>::value, SignedInt>::type
+		to_signed() const noexcept {
 		return SignedInt(to_ieee754<double>());
 	}
 	template<typename UnsignedInt>
-	typename std::enable_if< std::is_integral<UnsignedInt>::value&& std::is_unsigned<UnsignedInt>::value, UnsignedInt>::type
-		to_unsigned() const {
+	CONSTEXPRESSION typename std::enable_if< std::is_integral<UnsignedInt>::value&& std::is_unsigned<UnsignedInt>::value, UnsignedInt>::type
+		to_unsigned() const noexcept {
 		return UnsignedInt(to_ieee754<double>());
 	}
 
-	/// Decode a linear takum to an IEEE-754 floating-point value
+	/// Decode a linear takum to an IEEE-754 floating-point value.
+	/// Constexpr-promoted: std::exp2 is replaced with the library's
+	/// sw::math::constexpr_math::exp2 (exact at integer arguments via direct
+	/// bit construction in detail::pow2).
 	template<typename TargetFloat>
-	TargetFloat to_ieee754() const noexcept {
+	CONSTEXPRESSION TargetFloat to_ieee754() const noexcept {
 		if (iszero()) return TargetFloat(0);
 		if (isnar()) return std::numeric_limits<TargetFloat>::quiet_NaN();
 
@@ -623,7 +673,13 @@ protected:
 			f = static_cast<TargetFloat>(M_bits) / static_cast<TargetFloat>(1ull << p);
 		}
 
-		TargetFloat value = (TargetFloat(1) + f) * std::exp2(static_cast<TargetFloat>(c));
+		// 2^c (c integer) via constexpr_math::exp2.  cm::exp2 is exact at
+		// integer arguments because detail::pow2 sets the IEEE 754 exponent
+		// field directly.  Route long double through double for portability;
+		// callers that need extreme exponent range get the runtime std::exp2
+		// path since CONSTEXPRESSION drops constexpr on those toolchains.
+		double scale_d = sw::math::constexpr_math::exp2(static_cast<double>(c));
+		TargetFloat value = (TargetFloat(1) + f) * static_cast<TargetFloat>(scale_d);
 		if (s) value = -value;
 
 		return value;
@@ -638,22 +694,22 @@ private:
 	friend std::istream& operator>> (std::istream& istr, takum<nnbits, nrbits, nbt>& r);
 
 	template<unsigned nnbits, unsigned nrbits, typename nbt>
-	friend bool operator==(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs);
+	friend constexpr bool operator==(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept;
 	template<unsigned nnbits, unsigned nrbits, typename nbt>
-	friend bool operator!=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs);
+	friend constexpr bool operator!=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept;
 	template<unsigned nnbits, unsigned nrbits, typename nbt>
-	friend bool operator< (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs);
+	friend constexpr bool operator< (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept;
 	template<unsigned nnbits, unsigned nrbits, typename nbt>
-	friend bool operator> (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs);
+	friend constexpr bool operator> (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept;
 	template<unsigned nnbits, unsigned nrbits, typename nbt>
-	friend bool operator<=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs);
+	friend constexpr bool operator<=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept;
 	template<unsigned nnbits, unsigned nrbits, typename nbt>
-	friend bool operator>=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs);
+	friend constexpr bool operator>=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept;
 };
 
 // return the Unit in the Last Position
 template<unsigned nbits, unsigned rbits, typename bt>
-inline takum<nbits, rbits, bt> ulp(const takum<nbits, rbits, bt>& a) {
+inline CONSTEXPRESSION takum<nbits, rbits, bt> ulp(const takum<nbits, rbits, bt>& a) {
 	takum<nbits, rbits, bt> b(a);
 	return ++b - a;
 }
@@ -724,18 +780,18 @@ inline std::istream& operator>>(std::istream& istr, takum<nnbits, nrbits, nbt>& 
 }
 
 template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline bool operator==(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) {
+inline constexpr bool operator==(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept {
 	if (lhs.isnar() || rhs.isnar()) return false;
 	return (lhs._block == rhs._block);
 }
 template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline bool operator!=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) {
+inline constexpr bool operator!=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept {
 	if (lhs.isnar() || rhs.isnar()) return true;
 	return !(lhs._block == rhs._block);
 }
 
 template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline bool operator< (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) {
+inline constexpr bool operator< (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept {
 	if (lhs.isnar() || rhs.isnar()) return false;
 	uint64_t l = lhs.raw_bits();
 	uint64_t r = rhs.raw_bits();
@@ -757,38 +813,38 @@ inline bool operator< (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits
 	return ls < rs;
 }
 template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline bool operator> (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) { return  operator< (rhs, lhs); }
+inline constexpr bool operator> (const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept { return  operator< (rhs, lhs); }
 template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline bool operator<=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) {
+inline constexpr bool operator<=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept {
 	if (lhs.isnar() || rhs.isnar()) return false;
 	return !operator> (lhs, rhs);
 }
 template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline bool operator>=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) {
+inline constexpr bool operator>=(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept {
 	if (lhs.isnar() || rhs.isnar()) return false;
 	return !operator< (lhs, rhs);
 }
 
 // Binary arithmetic operators
 template<unsigned nbits, unsigned rbits, typename bt>
-inline takum<nbits, rbits, bt> operator+(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
+inline CONSTEXPRESSION takum<nbits, rbits, bt> operator+(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
 	takum<nbits, rbits, bt> sum(lhs); sum += rhs; return sum;
 }
 template<unsigned nbits, unsigned rbits, typename bt>
-inline takum<nbits, rbits, bt> operator-(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
+inline CONSTEXPRESSION takum<nbits, rbits, bt> operator-(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
 	takum<nbits, rbits, bt> diff(lhs); diff -= rhs; return diff;
 }
 template<unsigned nbits, unsigned rbits, typename bt>
-inline takum<nbits, rbits, bt> operator*(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
+inline CONSTEXPRESSION takum<nbits, rbits, bt> operator*(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
 	takum<nbits, rbits, bt> mul(lhs); mul *= rhs; return mul;
 }
 template<unsigned nbits, unsigned rbits, typename bt>
-inline takum<nbits, rbits, bt> operator/(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
+inline CONSTEXPRESSION takum<nbits, rbits, bt> operator/(const takum<nbits, rbits, bt>& lhs, const takum<nbits, rbits, bt>& rhs) {
 	takum<nbits, rbits, bt> ratio(lhs); ratio /= rhs; return ratio;
 }
 
 template<unsigned nbits, unsigned rbits, typename bt>
-constexpr takum<nbits, rbits, bt> abs(const takum<nbits, rbits, bt>& v) {
+constexpr takum<nbits, rbits, bt> abs(const takum<nbits, rbits, bt>& v) noexcept {
 	if (v.isneg()) return -v;
 	return v;
 }

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -61,7 +61,11 @@ class takum {
 	static constexpr unsigned _overhead = 2 + _rbits;  // S:1 + D:1 + R:rbits
 	static_assert(_nbits > _overhead, "takum requires more bits than the fixed overhead (S + D + R)");
 	static_assert(_rbits > 0, "takum requires at least 1 regime bit");
-	static_assert(_rbits <= 7, "takum regime field limited to 7 bits");
+	// _rbits <= 5 keeps `1ull << (max_r + 1)` (with max_r = 2^_rbits - 1) within
+	// the [0, 63] shift range required by C++ for uint64_t.  Larger _rbits
+	// values exist only in degenerate test configurations; the takum reference
+	// uses _rbits = 3.
+	static_assert(_rbits <= 5, "takum regime field limited to 5 bits (avoids 1ull << 64+ UB)");
 public:
 	typedef bt BlockType;
 
@@ -97,17 +101,19 @@ public:
 		unsigned R = dr & r_mask;
 		return D ? R : (max_r - R);
 	}
-	// Given DR index, return the characteristic bias
-	static constexpr int dr_to_c_bias(unsigned dr) noexcept {
+	// Given DR index, return the characteristic bias.
+	// Returns int64_t: for _rbits up to 5 the positive branch reaches 2^31 - 1
+	// and the negative branch reaches 1 - 2^32, which both exceed int range.
+	static constexpr int64_t dr_to_c_bias(unsigned dr) noexcept {
 		bool D = (dr >> rbits) & 1;
 		unsigned r = dr_to_r(dr);
 		// D=1: c_bias = 2^r - 1 (positive range start)
 		// D=0: c_bias = -(2^(r+1)) + 1 (negative range start)
-		return D ? (static_cast<int>((1ull << r) - 1))
-		         : (1 - static_cast<int>(1ull << (r + 1)));
+		return D ? static_cast<int64_t>((1ull << r) - 1ull)
+		         : (1 - static_cast<int64_t>(1ull << (r + 1)));
 	}
 	// Given a characteristic value c, find the DR index
-	static constexpr unsigned find_dr(int c) noexcept {
+	static constexpr unsigned find_dr(int64_t c) noexcept {
 		for (int dr = static_cast<int>(nr_dr_values) - 1; dr >= 0; --dr) {
 			if (c >= dr_to_c_bias(static_cast<unsigned>(dr)))
 				return static_cast<unsigned>(dr);
@@ -115,12 +121,12 @@ public:
 		return 0;
 	}
 	// Maximum representable characteristic value
-	static constexpr int max_characteristic() noexcept {
+	static constexpr int64_t max_characteristic() noexcept {
 		// DR = nr_dr_values - 1 (D=1, R=max_r): c_bias + (2^max_r - 1)
-		return dr_to_c_bias(nr_dr_values - 1) + static_cast<int>((1ull << max_r) - 1);
+		return dr_to_c_bias(nr_dr_values - 1) + static_cast<int64_t>((1ull << max_r) - 1ull);
 	}
 	// Minimum representable characteristic value
-	static constexpr int min_characteristic() noexcept {
+	static constexpr int64_t min_characteristic() noexcept {
 		// DR = 0 (D=0, R=0): c_bias = -(2^(max_r+1)) + 1
 		return dr_to_c_bias(0);
 	}
@@ -362,7 +368,7 @@ public:
 		uint64_t mag = magnitude_bits();
 		return static_cast<unsigned>((mag >> (nbits - overhead)) & dr_field_mask);
 	}
-	constexpr int characteristic() const noexcept {
+	constexpr int64_t characteristic() const noexcept {
 		if (iszero() || isnar()) return 0;
 		unsigned dr = dr_field();
 		unsigned r = dr_to_r(dr);
@@ -372,9 +378,9 @@ public:
 		uint64_t mag = magnitude_bits();
 		uint64_t C_stored_bits = (c_stored > 0) ? ((mag >> p) & ((1ull << c_stored) - 1)) : 0;
 		uint64_t C_bits = (r > avail) ? (C_stored_bits << (r - c_stored)) : C_stored_bits;
-		return dr_to_c_bias(dr) + static_cast<int>(C_bits);
+		return dr_to_c_bias(dr) + static_cast<int64_t>(C_bits);
 	}
-	constexpr int scale() const noexcept {
+	constexpr int64_t scale() const noexcept {
 		if (iszero() || isnar()) return 0;
 		return characteristic();
 	}
@@ -486,6 +492,13 @@ protected:
 		static_assert(nbits <= 64, "takum > 64 bits not yet supported");
 
 		if (rhs != rhs) { setnar(); return *this; }
+		// Takum has no infinity (numeric_limits<>::has_infinity == false); both
+		// +inf and -inf map to NaR.  Detect via direct equality so this stays
+		// constexpr-clean (std::isinf is not constexpr until C++23).
+		if constexpr (std::numeric_limits<Real>::has_infinity) {
+			if (rhs == std::numeric_limits<Real>::infinity()) { setnar(); return *this; }
+			if (rhs == -std::numeric_limits<Real>::infinity()) { setnar(); return *this; }
+		}
 		if (rhs == Real(0)) { setzero(); return *this; }
 		if (rhs > std::numeric_limits<Real>::max()) { maxpos(); return *this; }
 		if (rhs < std::numeric_limits<Real>::lowest()) { maxneg(); return *this; }
@@ -512,18 +525,23 @@ protected:
 		                        ? ieee754_parameter<double>::fbits
 		                        : Param::fbits;
 
-		int c = 0;
+		// Use int64_t for the unbiased exponent / characteristic so that
+		// max_characteristic() / min_characteristic() comparisons stay correct
+		// for _rbits up to 5 (where the takum-format c range exceeds int).
+		// The IEEE 754 source itself produces |c| <= 1075 (double), well
+		// inside int range, so the widening is purely defensive.
+		int64_t c = 0;
 		double m_real = 0.0;
 		if (rawExp != 0u) {
 			// normal: value = (1 + rawFrac/2^fbits) * 2^(rawExp - bias)
-			c = static_cast<int>(rawExp) - src_bias;
+			c = static_cast<int64_t>(rawExp) - src_bias;
 			m_real = static_cast<double>(rawFrac) / static_cast<double>(1ull << src_fbits);
 		}
 		else {
 			// subnormal: rawFrac > 0 by construction (we returned for v == 0).
 			// Normalize by left-shifting rawFrac until the implicit-bit slot is
 			// set; each shift decrements the represented exponent by 1.
-			int implicit_exp = 1 - src_bias; // base subnormal exponent
+			int64_t implicit_exp = static_cast<int64_t>(1) - src_bias; // base subnormal exponent
 			uint64_t f = rawFrac;
 			while ((f & (1ull << src_fbits)) == 0u) {
 				f <<= 1;
@@ -534,8 +552,8 @@ protected:
 			m_real = static_cast<double>(f) / static_cast<double>(1ull << src_fbits);
 		}
 
-		constexpr int c_max = max_characteristic();
-		constexpr int c_min = min_characteristic();
+		constexpr int64_t c_max = max_characteristic();
+		constexpr int64_t c_min = min_characteristic();
 		if (c > c_max) { s ? maxneg() : maxpos(); return *this; }
 		if (c < c_min) { setzero(); return *this; }
 
@@ -545,22 +563,25 @@ protected:
 		unsigned p = (r < avail) ? (avail - r) : 0;
 		unsigned c_stored_bits = (r < avail) ? r : avail;
 
-		unsigned C_bits_full = static_cast<unsigned>(c - dr_to_c_bias(dr));
+		// C_bits_full holds c - c_bias, bounded by 2^max_r - 1 (= 2^31 - 1 at
+		// _rbits=5).  Use uint64_t to avoid the int / unsigned narrowing trap
+		// that landed us here in the first place.
+		uint64_t C_bits_full = static_cast<uint64_t>(c - dr_to_c_bias(dr));
 
 		// When r > avail, only the MSBs of C are stored (truncated)
-		unsigned C_stored;
+		uint64_t C_stored;
 		if (r <= avail) {
 			C_stored = C_bits_full;
 		}
 		else {
 			unsigned shift = r - c_stored_bits;
 			C_stored = C_bits_full >> shift;
-			unsigned remainder = C_bits_full & ((1u << shift) - 1);
-			unsigned half = 1u << (shift - 1);
-			if (remainder > half || (remainder == half && (C_stored & 1))) {
+			uint64_t remainder = C_bits_full & ((1ull << shift) - 1ull);
+			uint64_t half = 1ull << (shift - 1);
+			if (remainder > half || (remainder == half && (C_stored & 1ull))) {
 				C_stored++;
 			}
-			if (C_stored >= (1u << c_stored_bits)) {
+			if (C_stored >= (1ull << c_stored_bits)) {
 				if (dr < nr_dr_values - 1) {
 					dr++;
 					r = dr_to_r(dr);
@@ -587,7 +608,7 @@ protected:
 			if (M_bits >= (1ull << p)) {
 				M_bits = 0;
 				C_stored++;
-				unsigned max_c_val = (1u << c_stored_bits);
+				uint64_t max_c_val = (1ull << c_stored_bits);
 				if (C_stored >= max_c_val) {
 					if (dr < nr_dr_values - 1) {
 						dr++;
@@ -665,7 +686,7 @@ protected:
 			C_stored_bits = (mag >> p) & ((1ull << c_stored) - 1);
 		}
 		uint64_t C_bits = (r > avail) ? (C_stored_bits << (r - c_stored)) : C_stored_bits;
-		int c = dr_to_c_bias(dr) + static_cast<int>(C_bits);
+		int64_t c = dr_to_c_bias(dr) + static_cast<int64_t>(C_bits);
 
 		TargetFloat f = TargetFloat(0);
 		if (p > 0) {

--- a/static/tapered/takum/api/constexpr.cpp
+++ b/static/tapered/takum/api/constexpr.cpp
@@ -30,12 +30,13 @@ try {
 
 	// We use takum<16, 3, uint8_t> as the headline configuration (the linear
 	// takum reference uses rbits = 3, and uint8_t storage exercises the
-	// multi-block path) and takum<24, 3, uint32_t> for wider-storage coverage.
-	// Note: rbits >= 5 hits a pre-existing int-overflow in
-	// max_characteristic() / min_characteristic() that surfaces only at
-	// constant evaluation; tracking that as a separate fix.
+	// multi-block path), takum<24, 3, uint32_t> for wider single-block storage,
+	// and takum<16, 5, uint16_t> to cover the maximum supported regime field
+	// (rbits=5; rbits>5 is now a hard static_assert because it would trip a
+	// 1ull << 64+ shift in dr_to_c_bias).
 	using tk16  = takum<16, 3, std::uint8_t>;
 	using tk24w = takum<24, 3, std::uint32_t>;
+	using tk16r5 = takum<16, 5, std::uint16_t>;
 
 	// ----------------------------------------------------------------------------
 	// Static accessors and structural invariants (already constexpr; smoke test).
@@ -120,6 +121,20 @@ try {
 		// NaN -> NaR.
 		constexpr tk16 nan_d = tk16(std::numeric_limits<double>::quiet_NaN());
 		static_assert(nan_d.isnar(), "constexpr tk16(NaN).isnar()");
+
+		// +/- infinity -> NaR (takum has no infinity per the format spec;
+		// numeric_limits<takum>::has_infinity is false).
+		constexpr tk16 pinf_d = tk16(std::numeric_limits<double>::infinity());
+		static_assert(pinf_d.isnar(), "constexpr tk16(+inf).isnar()");
+
+		constexpr tk16 ninf_d = tk16(-std::numeric_limits<double>::infinity());
+		static_assert(ninf_d.isnar(), "constexpr tk16(-inf).isnar()");
+
+		constexpr tk16 pinf_f = tk16(std::numeric_limits<float>::infinity());
+		static_assert(pinf_f.isnar(), "constexpr tk16(float +inf).isnar()");
+
+		constexpr tk16 ninf_f = tk16(-std::numeric_limits<float>::infinity());
+		static_assert(ninf_f.isnar(), "constexpr tk16(float -inf).isnar()");
 	}
 
 	// ----------------------------------------------------------------------------
@@ -283,6 +298,33 @@ try {
 
 		constexpr tk24w prod = tk24w(2.0) * tk24w(2.0);
 		static_assert(static_cast<double>(prod) == 4.0, "constexpr tk24w 2*2 == 4");
+	}
+
+	// ----------------------------------------------------------------------------
+	// rbits=5 (maximum supported regime field) constexpr smoke test.  This
+	// exercises the int64_t widening of dr_to_c_bias / max_characteristic /
+	// min_characteristic that landed alongside this constexpr promotion.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk16r5 one(1.0);
+		static_assert(static_cast<double>(one) == 1.0, "constexpr tk16r5(1.0) -> 1.0");
+
+		constexpr tk16r5 two(2.0);
+		static_assert(static_cast<double>(two) == 2.0, "constexpr tk16r5(2.0) -> 2.0");
+
+		// 2 + 2 = 4: characteristic 2 fits well inside a takum<16, 5>'s range.
+		constexpr tk16r5 sum = two + two;
+		static_assert(static_cast<double>(sum) == 4.0, "constexpr tk16r5 2+2 == 4");
+
+		constexpr tk16r5 prod = two * tk16r5(4.0);
+		static_assert(static_cast<double>(prod) == 8.0, "constexpr tk16r5 2*4 == 8");
+
+		// max_characteristic / min_characteristic now return int64_t and exceed
+		// int range at rbits=5 (c_max = 2^32 - 2, c_min = 1 - 2^32).
+		static_assert(tk16r5::max_characteristic() > static_cast<int64_t>(0x7FFFFFFF),
+			"constexpr c_max for rbits=5 exceeds int max");
+		static_assert(tk16r5::min_characteristic() < static_cast<int64_t>(-0x7FFFFFFF) - 1,
+			"constexpr c_min for rbits=5 below int min");
 	}
 
 	std::cout << "takum constexpr verification: "

--- a/static/tapered/takum/api/constexpr.cpp
+++ b/static/tapered/takum/api/constexpr.cpp
@@ -1,0 +1,305 @@
+// constexpr.cpp: compile-time tests for takum (linear takum logarithmic encoding)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Locks in the constexpr contract for takum after the Epic #723 / issue #741
+// promotion: convert_ieee754 (frexp -> bit-extraction), to_ieee754 (std::exp2
+// -> sw::math::constexpr_math::exp2), and all arithmetic / comparison /
+// conversion operators evaluable at constant evaluation when sw::bit_cast is
+// constexpr (BIT_CAST_IS_CONSTEXPR).
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/takum/takum.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "takum constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// We use takum<16, 3, uint8_t> as the headline configuration (the linear
+	// takum reference uses rbits = 3, and uint8_t storage exercises the
+	// multi-block path) and takum<24, 3, uint32_t> for wider-storage coverage.
+	// Note: rbits >= 5 hits a pre-existing int-overflow in
+	// max_characteristic() / min_characteristic() that surfaces only at
+	// constant evaluation; tracking that as a separate fix.
+	using tk16  = takum<16, 3, std::uint8_t>;
+	using tk24w = takum<24, 3, std::uint32_t>;
+
+	// ----------------------------------------------------------------------------
+	// Static accessors and structural invariants (already constexpr; smoke test).
+	// ----------------------------------------------------------------------------
+	{
+		static_assert(tk16::nbits == 16u,  "constexpr nbits == 16");
+		static_assert(tk16::rbits == 3u,   "constexpr rbits == 3");
+		static_assert(tk16::overhead == 5u, "constexpr overhead == 2 + rbits");
+		static_assert(tk16::dr_bits == 4u, "constexpr dr_bits == 1 + rbits");
+		static_assert(tk16::nr_dr_values == 16u, "constexpr nr_dr_values == 2^dr_bits");
+		static_assert(tk16::max_r == 7u,   "constexpr max_r == 2^rbits - 1");
+		static_assert(tk16::maxCharBits == 11u, "constexpr maxCharBits == nbits - overhead");
+		static_assert(tk24w::nbits == 24u, "constexpr tk24w::nbits == 24");
+		static_assert(tk24w::rbits == 3u,  "constexpr tk24w::rbits == 3");
+	}
+
+	// ----------------------------------------------------------------------------
+	// SpecificValue construction (already constexpr in the prior code; we
+	// re-assert here so the contract is locked in alongside the new constexpr
+	// arithmetic).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk16 z(SpecificValue::zero);
+		static_assert(z.iszero(),       "constexpr SpecificValue::zero -> iszero()");
+		static_assert(!z.isnar(),       "constexpr SpecificValue::zero -> !isnar()");
+
+		constexpr tk16 mp(SpecificValue::maxpos);
+		static_assert(!mp.iszero(),     "constexpr SpecificValue::maxpos -> !iszero()");
+		static_assert(!mp.sign(),       "constexpr SpecificValue::maxpos -> sign() == false");
+		static_assert(mp.ispos(),       "constexpr SpecificValue::maxpos -> ispos()");
+
+		constexpr tk16 mn(SpecificValue::maxneg);
+		static_assert(mn.sign(),        "constexpr SpecificValue::maxneg -> sign() == true");
+		static_assert(mn.isneg(),       "constexpr SpecificValue::maxneg -> isneg()");
+
+		constexpr tk16 nar(SpecificValue::nar);
+		static_assert(nar.isnar(),      "constexpr SpecificValue::nar -> isnar()");
+		static_assert(nar.isnan(),      "constexpr SpecificValue::nar -> isnan()");
+		// takum has no infinity (NaR replaces both infinities and NaN)
+		static_assert(!nar.isinf(),     "constexpr takum has no infinity");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Trivial-default contract: default-constructed instance is non-trivially
+	// initialized (storage indeterminate).  We use value-initialization in
+	// every constexpr context so the test stays well-defined.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk16 v{};
+		static_assert(v.iszero(), "constexpr value-init takum is zero");
+		static_assert(!v.isnar(), "constexpr value-init takum is not NaR");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Conversion in (int / float / double) at constant evaluation.
+	// The key promotion: convert_ieee754 no longer calls std::frexp, so this
+	// now constant-evaluates.
+	// ----------------------------------------------------------------------------
+	{
+		// Integer one -> takum, then back to double via operator double().
+		constexpr tk16 one_i = tk16(1);
+		static_assert(!one_i.iszero(), "constexpr tk16(1) is non-zero");
+		static_assert(one_i.ispos(),   "constexpr tk16(1) is positive");
+		// 1.0 has c = 0 in the takum decomposition (m_real = 0); round-trip exact.
+		static_assert(static_cast<double>(one_i) == 1.0, "constexpr round-trip 1 -> tk16 -> 1.0");
+
+		constexpr tk16 two_d = tk16(2.0);
+		static_assert(static_cast<double>(two_d) == 2.0, "constexpr round-trip 2.0 -> tk16 -> 2.0");
+
+		constexpr tk16 four_f = tk16(4.0f);
+		static_assert(static_cast<double>(four_f) == 4.0, "constexpr round-trip 4.0f -> tk16 -> 4.0");
+
+		// Negative power-of-two: also exact.
+		constexpr tk16 mhalf = tk16(-0.5);
+		static_assert(static_cast<double>(mhalf) == -0.5, "constexpr round-trip -0.5 -> tk16 -> -0.5");
+
+		// Zero round-trip.
+		constexpr tk16 zero_d = tk16(0.0);
+		static_assert(static_cast<double>(zero_d) == 0.0, "constexpr round-trip 0.0");
+		static_assert(zero_d.iszero(), "constexpr tk16(0.0).iszero()");
+
+		// NaN -> NaR.
+		constexpr tk16 nan_d = tk16(std::numeric_limits<double>::quiet_NaN());
+		static_assert(nan_d.isnar(), "constexpr tk16(NaN).isnar()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Arithmetic operators at constant evaluation.  Internally these go
+	// through double and rely on the constexpr exp2 / bit-extraction paths.
+	// ----------------------------------------------------------------------------
+	{
+		// Addition of two power-of-two values that round to representable
+		// takum values.  2 + 2 = 4 has an exact takum encoding.
+		constexpr tk16 a = tk16(2.0);
+		constexpr tk16 b = tk16(2.0);
+		constexpr tk16 sum = a + b;
+		static_assert(static_cast<double>(sum) == 4.0, "constexpr 2 + 2 == 4");
+
+		// Subtraction: 4 - 2 = 2.
+		constexpr tk16 c = tk16(4.0);
+		constexpr tk16 d = tk16(2.0);
+		constexpr tk16 diff = c - d;
+		static_assert(static_cast<double>(diff) == 2.0, "constexpr 4 - 2 == 2");
+
+		// Multiplication: 2 * 4 = 8.
+		constexpr tk16 prod = a * c;
+		static_assert(static_cast<double>(prod) == 8.0, "constexpr 2 * 4 == 8");
+
+		// Division: 8 / 2 = 4.
+		constexpr tk16 e = tk16(8.0);
+		constexpr tk16 ratio = e / d;
+		static_assert(static_cast<double>(ratio) == 4.0, "constexpr 8 / 2 == 4");
+
+		// Negation.
+		constexpr tk16 neg = -a;
+		static_assert(static_cast<double>(neg) == -2.0, "constexpr -tk16(2) == -2");
+		static_assert(neg.isneg(),   "constexpr negation flips sign");
+		static_assert(neg.sign(),    "constexpr negation sets sign() bit");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Compound assignment forms (operator+= -= *= /=).  Lambda-driven so we
+	// can exercise the assignment in a constexpr context and inspect the
+	// final value.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk16 cx_plus_eq = []() {
+			tk16 x{ 2.0 };
+			x += tk16(2.0);
+			return x;
+		}();
+		static_assert(static_cast<double>(cx_plus_eq) == 4.0, "constexpr (a += b) leaves a = 4");
+
+		constexpr tk16 cx_mul_eq = []() {
+			tk16 x{ 2.0 };
+			x *= tk16(4.0);
+			return x;
+		}();
+		static_assert(static_cast<double>(cx_mul_eq) == 8.0, "constexpr (a *= b) leaves a = 8");
+
+		constexpr tk16 cx_div_eq = []() {
+			tk16 x{ 8.0 };
+			x /= tk16(2.0);
+			return x;
+		}();
+		static_assert(static_cast<double>(cx_div_eq) == 4.0, "constexpr (a /= b) leaves a = 4");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Comparison operators at constant evaluation.  takum uses two's
+	// complement encoding so ordered comparison reduces to signed integer
+	// comparison on the raw bits.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk16 a = tk16(1.0);
+		constexpr tk16 b = tk16(2.0);
+		constexpr tk16 c = tk16(1.0);
+
+		static_assert(a == c,  "constexpr equal takums compare ==");
+		static_assert(a != b,  "constexpr unequal takums compare !=");
+		static_assert(a <  b,  "constexpr a < b for a=1 b=2");
+		static_assert(b >  a,  "constexpr b > a for a=1 b=2");
+		static_assert(a <= b,  "constexpr a <= b");
+		static_assert(b >= a,  "constexpr b >= a");
+		static_assert(a <= c,  "constexpr a <= c (equal)");
+		static_assert(a >= c,  "constexpr a >= c (equal)");
+
+		// NaR comparisons: all return false except !=.
+		constexpr tk16 nar(SpecificValue::nar);
+		static_assert(!(nar == nar),  "constexpr NaR == NaR is false (NaN semantics)");
+		static_assert(  nar != nar,   "constexpr NaR != NaR is true (NaN semantics)");
+		static_assert(!(nar <  a),    "constexpr NaR < a is false");
+		static_assert(!(nar <= a),    "constexpr NaR <= a is false");
+		static_assert(!(nar >  a),    "constexpr NaR > a is false");
+		static_assert(!(nar >= a),    "constexpr NaR >= a is false");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Increment / decrement: navigate the lattice of representable values.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk16 cx_inc = []() {
+			tk16 x{ 1.0 };
+			++x;
+			return x;
+		}();
+		// post-increment from tk16(1.0) lands on the next-larger representable
+		// takum (some value just above 1.0); we just verify it's strictly
+		// greater than 1.0.
+		static_assert(cx_inc > tk16(1.0), "constexpr ++x > x");
+
+		constexpr tk16 cx_dec = []() {
+			tk16 x{ 1.0 };
+			--x;
+			return x;
+		}();
+		static_assert(cx_dec < tk16(1.0), "constexpr --x < x");
+
+		// Saturation: ++maxpos stays at maxpos.
+		constexpr tk16 cx_inc_sat = []() {
+			tk16 x(SpecificValue::maxpos);
+			++x;
+			return x;
+		}();
+		static_assert(cx_inc_sat == tk16(SpecificValue::maxpos),
+		              "constexpr ++maxpos saturates to maxpos");
+
+		// Saturation: --maxneg stays at maxneg.
+		constexpr tk16 cx_dec_sat = []() {
+			tk16 x(SpecificValue::maxneg);
+			--x;
+			return x;
+		}();
+		static_assert(cx_dec_sat == tk16(SpecificValue::maxneg),
+		              "constexpr --maxneg saturates to maxneg");
+	}
+
+	// ----------------------------------------------------------------------------
+	// abs(): pure constexpr free function.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk16 a = tk16(-2.0);
+		constexpr tk16 abs_a = abs(a);
+		static_assert(abs_a.ispos(),                 "constexpr abs(-2) is positive");
+		static_assert(static_cast<double>(abs_a) == 2.0, "constexpr abs(-2) == 2");
+
+		constexpr tk16 b = tk16(2.0);
+		constexpr tk16 abs_b = abs(b);
+		static_assert(abs_b == b, "constexpr abs(positive) == positive");
+
+		constexpr tk16 z = tk16(0.0);
+		constexpr tk16 abs_z = abs(z);
+		static_assert(abs_z.iszero(), "constexpr abs(zero) == zero");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Wider-storage configuration smoke test (rbits=3, uint32_t single-block).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr tk24w one(1.0);
+		static_assert(static_cast<double>(one) == 1.0, "constexpr tk24w(1.0) -> 1.0");
+
+		constexpr tk24w sum = tk24w(2.0) + tk24w(2.0);
+		static_assert(static_cast<double>(sum) == 4.0, "constexpr tk24w 2+2 == 4");
+
+		constexpr tk24w prod = tk24w(2.0) * tk24w(2.0);
+		static_assert(static_cast<double>(prod) == 4.0, "constexpr tk24w 2*2 == 4");
+	}
+
+	std::cout << "takum constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Promote linear takum encoding to fully constexpr across construction, assignment, arithmetic, comparison, increment/decrement, unary negation, and IEEE-754 conversion paths. Sibling of the constexpr Epic #723: hfloat #806, e8m0 #810, microfloat #811, mxblock #812, nvblock #813.

## Root Cause / Design Goal

`takum_impl.hpp` previously called `std::frexp` in `convert_ieee754` and `std::exp2` in `to_ieee754`. Neither is constexpr in C++20. With prerequisite #423 (constexpr `log2` / `exp2`) closed and `extractFields` already `BIT_CAST_CONSTEXPR`, both math-library calls can be replaced by direct IEEE 754 bit operations.

## Changes (commit 0e0ff94c -- the constexpr promotion)

- `include/sw/universal/number/takum/takum_impl.hpp`
  - `convert_ieee754`: replace `std::frexp` with `extractFields` + bit-extraction. For normals `c = rawExp - bias`, `m_real = rawFrac/2^fbits`. Subnormals normalize via a bounded leading-zero shift.
  - `to_ieee754`: replace `std::exp2(c)` with `sw::math::constexpr_math::exp2(c)` (exact at integer args).
  - All member operators (assignment, arithmetic, comparison, increment, decrement, unary minus, out-conversion) marked `constexpr` or `CONSTEXPRESSION`.
  - Friend comparison operators and binary arithmetic operators marked `constexpr` / `CONSTEXPRESSION`.
  - `characteristic()`, `scale()`, `find_dr()` promoted to `constexpr`.
  - `operator/=`: guards `throw takum_divide_by_zero()` under `!std::is_constant_evaluated()` so the constexpr setnar fallback is reachable.
- `include/sw/universal/number/takum/takum_fwd.hpp`
  - Forward declaration of `abs()` updated to match the `noexcept` specifier.
- `static/tapered/takum/api/constexpr.cpp` (new)
  - Static accessor invariants, SpecificValue construction
  - Round-trip conversions (int / float / double / NaN)
  - Arithmetic, comparison, increment/decrement, `abs()`

## Changes (commit 040fa586 -- CodeRabbit review fixes)

- (CR Critical) +/-infinity inputs now map to `setnar()` instead of `maxpos`/`maxneg`. Takum has `has_infinity = false` per its `numeric_limits`; NaR represents both NaN and infinity. Detect via direct equality against `numeric_limits<>::infinity()` so the check stays constexpr-clean.
- (CR Major) Widen `dr_to_c_bias`, `max_characteristic`, `min_characteristic`, `characteristic`, `scale` from `int` to `int64_t`. The previous `int` form had silent runtime UB for `_rbits >= 5` (where `2 * (2^max_r - 1)` overflows int); the constexpr promotion just made it a hard compile-time error. Tighten `static_assert` from `_rbits <= 7` to `_rbits <= 5` to keep `1ull << (max_r + 1)` within uint64_t shift range. **This commit closes #818** (the follow-up issue I filed yesterday tracking this overflow); rolling the fix in here resolves both the CR Major and the tracked bug in one PR.
- New `constexpr.cpp` cases: +/-inf -> NaR, `takum<16, 5, uint16_t>` round-trip and arithmetic, `static_assert`s that `c_max > 2^31 - 1` and `c_min < -2^31`.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| tkm_constexpr | OK | PASS | OK | PASS |
| tkm_api | OK | PASS | OK | PASS |
| tkm_values | OK | PASS | OK | PASS |
| tkm_assignment | OK | PASS | OK | PASS |
| tkm_conversion | OK | PASS | OK | PASS |
| tkm_addition | OK | PASS | OK | PASS |
| tkm_multiplication | OK | PASS | OK | PASS |
| tkm_division | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready 817`

Resolves #741
Closes #818
Relates to #723

Generated with [Claude Code](https://claude.com/claude-code)