### PR TITLE
feat(unum1): partial constexpr support (construction + bitwise)

### DIFF
--- a/elastic/unum/constexpr.cpp
+++ b/elastic/unum/constexpr.cpp
@@ -1,0 +1,265 @@
+// constexpr.cpp: compile-time tests for unum Type I (Gustafson 2015)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage (per issue #743):
+//
+//   * default construction, copy, move
+//   * bitwise selectors / modifiers (clear, setbit, setbits, at, ubit,
+//     fsize, esize, sign, exponent, fraction, iszero, isnan, etc.)
+//   * special-value helpers (minpos, maxpos, minneg, maxneg, qnan, snan)
+//   * integer / float / double / long double construction (CONSTEXPRESSION;
+//     constexpr only when sw::bit_cast is constexpr)
+//
+// Out of scope (deferred to a follow-up issue):
+//
+//   * to_double / to_float / operator double() (use std::ldexp; would need
+//     a constexpr_math::ldexp helper, plus a value-domain rewrite)
+//   * comparison operators (delegate to to_double)
+//   * arithmetic operators (delegate to to_double)
+//   * increment / decrement (use std::ldexp directly)
+//
+// Per the issue body, the variable-length encoding makes constexpr
+// arithmetic non-trivial; this file locks in the construction and bitwise
+// contract so that a follow-up can add arithmetic without re-litigating
+// the basics.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/unum/unum.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "unum Type I constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// unum<2, 2>: esizesize=2, fsizesize=2 -- maxesize=4, maxfsize=3,
+	// utagsize=5, maxbits=13.  Small enough to constant-evaluate every
+	// loop bound; large enough to exercise non-trivial encodings.
+	using u22 = unum<2, 2>;
+	using u33 = unum<3, 3>;
+
+	// ----------------------------------------------------------------------------
+	// Static structural invariants (already constexpr; smoke test).
+	// ----------------------------------------------------------------------------
+	{
+		static_assert(u22::maxesize == 4u,  "constexpr u22::maxesize == 4");
+		static_assert(u22::maxfsize == 3u,  "constexpr u22::maxfsize == 3");
+		static_assert(u22::utagsize == 5u,  "constexpr u22::utagsize == 5");
+		static_assert(u22::maxbits  == 13u, "constexpr u22::maxbits == 1+4+3+2+2+1 == 13");
+
+		static_assert(u33::maxesize == 8u,  "constexpr u33::maxesize == 8");
+		static_assert(u33::maxfsize == 7u,  "constexpr u33::maxfsize == 7");
+		static_assert(u33::utagsize == 7u,  "constexpr u33::utagsize == 7");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Default construction: zero state, all bitwise selectors agree.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr u22 z{};
+		static_assert(z.iszero(),     "constexpr value-init unum is zero");
+		static_assert(!z.isnan(),     "constexpr value-init unum is not NaN");
+		static_assert(!z.sign(),      "constexpr value-init unum has sign() == false");
+		static_assert(!z.ubit(),      "constexpr value-init unum has ubit() == false (exact)");
+		static_assert(z.fsize() == 0u, "constexpr value-init fsize() == 0");
+		static_assert(z.esize() == 0u, "constexpr value-init esize() == 0");
+		static_assert(z.fraction() == 0ull, "constexpr value-init fraction() == 0");
+		static_assert(z.exponent() == 0ull, "constexpr value-init exponent() == 0");
+		static_assert(z.exact(),      "constexpr value-init exact() == true");
+		static_assert(!z.isinf(),     "constexpr unum has no infinity (always !isinf)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Bitwise modifiers at constant evaluation: clear, setbit, setbits,
+	// setnan, setzero.
+	// ----------------------------------------------------------------------------
+	{
+		// setnan: every bit set -> isnan() returns true.
+		constexpr u22 nanv = []() {
+			u22 t{};
+			t.setnan();
+			return t;
+		}();
+		static_assert(nanv.isnan(),    "constexpr setnan() -> isnan()");
+		static_assert(!nanv.iszero(),  "constexpr setnan() -> !iszero()");
+		static_assert(!nanv.exact(),   "constexpr setnan() has ubit() set -> !exact()");
+
+		// setzero: clears all bits.
+		constexpr u22 zv = []() {
+			u22 t{};
+			t.setnan();   // first set all bits
+			t.setzero();  // then clear
+			return t;
+		}();
+		static_assert(zv.iszero(),     "constexpr setzero() round-trip -> iszero()");
+		static_assert(!zv.isnan(),     "constexpr setzero() round-trip -> !isnan()");
+
+		// setbit at specific positions: ubit (pos 0), low bit of fsize (pos 1).
+		constexpr u22 ubit_only = []() {
+			u22 t{};
+			t.setbit(0, true);  // ubit -> 1 (inexact)
+			return t;
+		}();
+		static_assert(ubit_only.ubit(),       "constexpr setbit(0,true) -> ubit() == true");
+		static_assert(!ubit_only.exact(),     "constexpr ubit set -> !exact()");
+		static_assert(!ubit_only.iszero(),    "constexpr non-zero bit -> !iszero()");
+
+		// setbits: drop a uint64_t pattern into the storage.  Bit 0 = ubit,
+		// bits 1..2 = fsize_field, bits 3..4 = esize_field, etc.  Pattern
+		// 0b00000_00_00_00_01 = ubit only.
+		constexpr u22 setbits_ubit = []() {
+			u22 t{};
+			t.setbits(1ull);
+			return t;
+		}();
+		static_assert(setbits_ubit.ubit(),    "constexpr setbits(1) -> ubit() == true");
+		static_assert(!setbits_ubit.iszero(), "constexpr setbits(1) -> !iszero()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Special-value free helpers (minpos / maxpos / minneg / maxneg / qnan /
+	// snan): all marked constexpr in this PR.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr u22 mp = []() {
+			u22 t{};
+			minpos(t);
+			return t;
+		}();
+		static_assert(!mp.iszero(),   "constexpr minpos -> !iszero()");
+		static_assert(!mp.isnan(),    "constexpr minpos -> !isnan()");
+		static_assert(!mp.sign(),     "constexpr minpos -> sign() == false");
+		static_assert(mp.exact(),     "constexpr minpos -> exact()");
+
+		constexpr u22 mxp = []() {
+			u22 t{};
+			maxpos(t);
+			return t;
+		}();
+		static_assert(!mxp.iszero(),  "constexpr maxpos -> !iszero()");
+		static_assert(!mxp.isnan(),   "constexpr maxpos -> !isnan()");
+		static_assert(!mxp.sign(),    "constexpr maxpos -> sign() == false");
+		static_assert(mxp.exact(),    "constexpr maxpos -> exact()");
+
+		constexpr u22 mn = []() {
+			u22 t{};
+			minneg(t);
+			return t;
+		}();
+		static_assert(mn.sign(),      "constexpr minneg -> sign() == true");
+		static_assert(mn.isneg(),     "constexpr minneg -> isneg()");
+
+		constexpr u22 mxn = []() {
+			u22 t{};
+			maxneg(t);
+			return t;
+		}();
+		static_assert(mxn.sign(),     "constexpr maxneg -> sign() == true");
+		static_assert(mxn.isneg(),    "constexpr maxneg -> isneg()");
+
+		constexpr u22 qn = []() {
+			u22 t{};
+			qnan(t);
+			return t;
+		}();
+		static_assert(qn.isnan(),     "constexpr qnan -> isnan()");
+
+		constexpr u22 sn = []() {
+			u22 t{};
+			snan(t);
+			return t;
+		}();
+		static_assert(sn.isnan(),     "constexpr snan -> isnan()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Integer / float / double / long double construction at constant
+	// evaluation.  CONSTEXPRESSION: requires sw::bit_cast to be constexpr
+	// (BIT_CAST_IS_CONSTEXPR).  Modern gcc and clang both satisfy that.
+	// ----------------------------------------------------------------------------
+	{
+		// 1.0 -> exact unum encoding.  Spot-check: not zero, not NaN,
+		// positive, exact (ubit == 0).  We deliberately do NOT assert the
+		// exact bit pattern because the smallest fitting encoding depends
+		// on the (esizesize, fsizesize) configuration.
+		constexpr u22 one_i = u22(1);
+		static_assert(!one_i.iszero(),   "constexpr u22(1).iszero() == false");
+		static_assert(!one_i.isnan(),    "constexpr u22(1).isnan() == false");
+		static_assert(!one_i.sign(),     "constexpr u22(1) is positive");
+		static_assert(one_i.exact(),     "constexpr u22(1) is exact");
+
+		constexpr u22 two_d = u22(2.0);
+		static_assert(!two_d.iszero(),   "constexpr u22(2.0).iszero() == false");
+		static_assert(!two_d.isnan(),    "constexpr u22(2.0).isnan() == false");
+		static_assert(!two_d.sign(),     "constexpr u22(2.0) is positive");
+		static_assert(two_d.exact(),     "constexpr u22(2.0) is exact");
+
+		// negative literal: sign bit set, still exact.
+		constexpr u22 mhalf = u22(-0.5);
+		static_assert(mhalf.sign(),      "constexpr u22(-0.5).sign()");
+		static_assert(mhalf.isneg(),     "constexpr u22(-0.5).isneg()");
+		static_assert(mhalf.exact(),     "constexpr u22(-0.5).exact()");
+
+		// 0.0 -> all-zero encoding.
+		constexpr u22 z_d = u22(0.0);
+		static_assert(z_d.iszero(),      "constexpr u22(0.0).iszero()");
+
+		// Float source.
+		constexpr u22 four_f = u22(4.0f);
+		static_assert(!four_f.iszero(),  "constexpr u22(4.0f).iszero() == false");
+		static_assert(four_f.exact(),    "constexpr u22(4.0f).exact()");
+
+		// NaN source -> NaN encoding.
+		constexpr u22 nan_d = u22(std::numeric_limits<double>::quiet_NaN());
+		static_assert(nan_d.isnan(),     "constexpr u22(NaN).isnan()");
+
+		// +/-infinity -> NaN encoding (unum Type I has no infinity).
+		constexpr u22 pinf = u22(std::numeric_limits<double>::infinity());
+		static_assert(pinf.isnan(),      "constexpr u22(+inf).isnan()");
+
+		constexpr u22 ninf = u22(-std::numeric_limits<double>::infinity());
+		static_assert(ninf.isnan(),      "constexpr u22(-inf).isnan()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Wider configuration smoke test (esizesize=3, fsizesize=3).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr u33 z{};
+		static_assert(z.iszero(),    "constexpr u33{}.iszero()");
+
+		constexpr u33 one = u33(1);
+		static_assert(!one.iszero(), "constexpr u33(1).iszero() == false");
+		static_assert(one.exact(),   "constexpr u33(1).exact()");
+	}
+
+	std::cout << "unum Type I constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/unum/unum_impl.hpp
+++ b/include/sw/universal/number/unum/unum_impl.hpp
@@ -39,13 +39,15 @@
 #include <limits>
 
 #include <universal/native/ieee754.hpp>
+#include <universal/native/extract_fields.hpp>
 #include <universal/internal/blockbinary/blockbinary.hpp>
+#include <math/constexpr_math/exp2.hpp>
 
 namespace sw { namespace universal {
 
 // fill helpers
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-unum<esizesize, fsizesize, bt>& minpos(unum<esizesize, fsizesize, bt>& u) {
+constexpr unum<esizesize, fsizesize, bt>& minpos(unum<esizesize, fsizesize, bt>& u) noexcept {
 	u.clear();
 	u.setbit(0, false);  // ubit = 0 (exact)
 	// fsize = 0 (0 fraction bits), esize = 0 (1 exponent bit)
@@ -61,7 +63,7 @@ unum<esizesize, fsizesize, bt>& minpos(unum<esizesize, fsizesize, bt>& u) {
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-unum<esizesize, fsizesize, bt>& maxpos(unum<esizesize, fsizesize, bt>& u) {
+constexpr unum<esizesize, fsizesize, bt>& maxpos(unum<esizesize, fsizesize, bt>& u) noexcept {
 	u.setnan();  // set all bits
 	u.setbit(0, false);   // ubit = 0 (exact)
 	// clear the sign bit: need to find it based on max esize/fsize
@@ -73,7 +75,7 @@ unum<esizesize, fsizesize, bt>& maxpos(unum<esizesize, fsizesize, bt>& u) {
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-unum<esizesize, fsizesize, bt>& minneg(unum<esizesize, fsizesize, bt>& u) {
+constexpr unum<esizesize, fsizesize, bt>& minneg(unum<esizesize, fsizesize, bt>& u) noexcept {
 	minpos(u);
 	// set the sign bit
 	unsigned utag = 1u + fsizesize + esizesize;
@@ -82,7 +84,7 @@ unum<esizesize, fsizesize, bt>& minneg(unum<esizesize, fsizesize, bt>& u) {
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-unum<esizesize, fsizesize, bt>& maxneg(unum<esizesize, fsizesize, bt>& u) {
+constexpr unum<esizesize, fsizesize, bt>& maxneg(unum<esizesize, fsizesize, bt>& u) noexcept {
 	maxpos(u);
 	// set the sign bit
 	unsigned maxes = (1u << esizesize) - 1u;
@@ -93,13 +95,13 @@ unum<esizesize, fsizesize, bt>& maxneg(unum<esizesize, fsizesize, bt>& u) {
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-unum<esizesize, fsizesize, bt>& qnan(unum<esizesize, fsizesize, bt>& u) {
+constexpr unum<esizesize, fsizesize, bt>& qnan(unum<esizesize, fsizesize, bt>& u) noexcept {
 	u.setnan();
 	return u;
 }
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-unum<esizesize, fsizesize, bt>& snan(unum<esizesize, fsizesize, bt>& u) {
+constexpr unum<esizesize, fsizesize, bt>& snan(unum<esizesize, fsizesize, bt>& u) noexcept {
 	u.setnan();
 	return u;
 }
@@ -123,45 +125,87 @@ public:
 	// storage type
 	using StorageType = blockbinary<maxbits, bt>;
 
-	unum() { _bits.clear(); }
+	constexpr unum() noexcept : _bits{} {}
 
-	unum(const unum&) = default;
-	unum(unum&&) = default;
-	unum& operator=(const unum&) = default;
-	unum& operator=(unum&&) = default;
+	constexpr unum(const unum&) = default;
+	constexpr unum(unum&&) = default;
+	constexpr unum& operator=(const unum&) = default;
+	constexpr unum& operator=(unum&&) = default;
 
-	// constructors from native types (Phase 2 - stubs for now)
-	unum(signed char initial_value)        { _bits.clear(); *this = initial_value; }
-	unum(short initial_value)              { _bits.clear(); *this = initial_value; }
-	unum(int initial_value)                { _bits.clear(); *this = initial_value; }
-	unum(long long initial_value)          { _bits.clear(); *this = initial_value; }
-	unum(unsigned long long initial_value) { _bits.clear(); *this = initial_value; }
-	unum(float initial_value)              { _bits.clear(); *this = initial_value; }
-	unum(double initial_value)             { _bits.clear(); *this = initial_value; }
-	unum(long double initial_value)        { _bits.clear(); *this = initial_value; }
+	// constructors from native types -- CONSTEXPRESSION because the
+	// underlying operator=(double) replaces std::frexp / std::ldexp /
+	// std::isnan / std::isinf / std::signbit with bit-extraction +
+	// constexpr_math::exp2.  Constexpr only when sw::bit_cast is constexpr
+	// (BIT_CAST_IS_CONSTEXPR=true).
+	CONSTEXPRESSION unum(signed char initial_value)        { _bits.clear(); *this = initial_value; }
+	CONSTEXPRESSION unum(short initial_value)              { _bits.clear(); *this = initial_value; }
+	CONSTEXPRESSION unum(int initial_value)                { _bits.clear(); *this = initial_value; }
+	CONSTEXPRESSION unum(long long initial_value)          { _bits.clear(); *this = initial_value; }
+	CONSTEXPRESSION unum(unsigned long long initial_value) { _bits.clear(); *this = initial_value; }
+	CONSTEXPRESSION unum(float initial_value)              { _bits.clear(); *this = initial_value; }
+	CONSTEXPRESSION unum(double initial_value)             { _bits.clear(); *this = initial_value; }
+	CONSTEXPRESSION unum(long double initial_value)        { _bits.clear(); *this = initial_value; }
 
 	// assignment operators
-	unum& operator=(signed char rhs)        { return *this = static_cast<long long>(rhs); }
-	unum& operator=(short rhs)              { return *this = static_cast<long long>(rhs); }
-	unum& operator=(int rhs)                { return *this = static_cast<long long>(rhs); }
-	unum& operator=(long long rhs)          { return *this = static_cast<double>(rhs); }
-	unum& operator=(unsigned long long rhs) { return *this = static_cast<double>(rhs); }
-	unum& operator=(float rhs)              { return *this = static_cast<double>(rhs); }
-	unum& operator=(double rhs) {
+	CONSTEXPRESSION unum& operator=(signed char rhs)        { return *this = static_cast<long long>(rhs); }
+	CONSTEXPRESSION unum& operator=(short rhs)              { return *this = static_cast<long long>(rhs); }
+	CONSTEXPRESSION unum& operator=(int rhs)                { return *this = static_cast<long long>(rhs); }
+	CONSTEXPRESSION unum& operator=(long long rhs)          { return *this = static_cast<double>(rhs); }
+	CONSTEXPRESSION unum& operator=(unsigned long long rhs) { return *this = static_cast<double>(rhs); }
+	CONSTEXPRESSION unum& operator=(float rhs)              { return *this = static_cast<double>(rhs); }
+	CONSTEXPRESSION unum& operator=(double rhs) {
 		_bits.clear();
 		if (rhs == 0.0) return *this;  // zero is all bits clear
-		if (std::isnan(rhs) || std::isinf(rhs)) { setnan(); return *this; }
+		// NaN via reflexivity; +/-inf via direct equality (std::isnan and
+		// std::isinf are not constexpr until C++23).
+		if (rhs != rhs) { setnan(); return *this; }
+		if (rhs == std::numeric_limits<double>::infinity() ||
+		    rhs == -std::numeric_limits<double>::infinity()) {
+			setnan(); return *this;
+		}
 
-		bool s = std::signbit(rhs);
-		double v = std::abs(rhs);
+		// std::signbit / std::abs replaced with sign-flip (loses signed zero
+		// detection, which we already short-circuited via rhs == 0.0).
+		bool s = (rhs < 0.0);
+		double v = s ? -rhs : rhs;
 
-		// decompose: v = significand * 2^raw_exp where 0.5 <= significand < 1.0
-		int raw_exp;
-		double significand = std::frexp(v, &raw_exp);
-		// convert to 1.fraction form: v = (2*significand) * 2^(raw_exp-1)
-		// so the unbiased exponent is (raw_exp - 1) and the hidden-bit significand is 2*significand
-		int unbiased_exp = raw_exp - 1;
-		double hidden_significand = 2.0 * significand;  // 1.0 <= hidden_significand < 2.0
+		// Decompose v = (1 + frac/2^fbits) * 2^(rawExp - bias) directly from
+		// IEEE 754 bits.  This replaces std::frexp at constant evaluation:
+		//   unbiased_exp = rawExp - bias   (the ldexp equivalent of frexp)
+		//   hidden_significand = 1 + frac/2^fbits
+		// Subnormals (rawExp == 0) are normalized via leading-zero shift on
+		// the fraction.
+		bool ignored_sign = false;
+		uint64_t rawExpBits = 0;
+		uint64_t rawFracBits = 0;
+		uint64_t rawBits = 0;
+		extractFields(v, ignored_sign, rawExpBits, rawFracBits, rawBits);
+
+		using Param = ieee754_parameter<double>;
+		int unbiased_exp = 0;
+		double hidden_significand = 0.0;
+		if (rawExpBits != 0u) {
+			// normal IEEE 754
+			unbiased_exp = static_cast<int>(rawExpBits) - Param::bias;
+			hidden_significand = 1.0
+				+ static_cast<double>(rawFracBits)
+				/ static_cast<double>(1ull << Param::fbits);
+		}
+		else {
+			// subnormal: rawFracBits > 0 (we returned for rhs == 0).  Find
+			// the leading bit position by walking the implicit-bit slot down.
+			int implicit_exp = 1 - Param::bias;
+			uint64_t f = rawFracBits;
+			while ((f & (1ull << Param::fbits)) == 0u) {
+				f <<= 1;
+				--implicit_exp;
+			}
+			f &= (1ull << Param::fbits) - 1u;
+			unbiased_exp = implicit_exp;
+			hidden_significand = 1.0
+				+ static_cast<double>(f)
+				/ static_cast<double>(1ull << Param::fbits);
+		}
 
 		// find the smallest esize that can represent this exponent
 		// with esize+1 exponent bits and bias = 2^esize - 1:
@@ -194,12 +238,15 @@ public:
 			// value = 0.fraction * 2^(1-bias)
 			// solve for fraction: fraction = v / 2^(1-bias)
 			biased_exp = 0;
-			double subnormal_scale = std::ldexp(1.0, 1 - bias);
+			// std::ldexp(1.0, n) -> sw::math::constexpr_math::exp2(double(n))
+			double subnormal_scale = sw::math::constexpr_math::exp2(static_cast<double>(1 - bias));
 			double subnormal_frac = v / subnormal_scale;  // 0.fraction value
 
 			for (unsigned fs = 1; fs <= max_fs; ++fs) {
-				uint64_t frac_bits = static_cast<uint64_t>(std::ldexp(subnormal_frac, static_cast<int>(fs)));
-				double reconstructed = std::ldexp(static_cast<double>(frac_bits), -static_cast<int>(fs));
+				double scale_up = sw::math::constexpr_math::exp2(static_cast<double>(fs));
+				uint64_t frac_bits = static_cast<uint64_t>(subnormal_frac * scale_up);
+				double scale_down = sw::math::constexpr_math::exp2(-static_cast<double>(fs));
+				double reconstructed = static_cast<double>(frac_bits) * scale_down;
 				best_fs = fs;
 				best_frac = frac_bits;
 				if (reconstructed == subnormal_frac) {
@@ -216,8 +263,10 @@ public:
 
 			if (!is_exact) {
 				for (unsigned fs = 1; fs <= max_fs; ++fs) {
-					uint64_t frac_bits = static_cast<uint64_t>(std::ldexp(frac_part, static_cast<int>(fs)));
-					double reconstructed = std::ldexp(static_cast<double>(frac_bits), -static_cast<int>(fs));
+					double scale_up = sw::math::constexpr_math::exp2(static_cast<double>(fs));
+					uint64_t frac_bits = static_cast<uint64_t>(frac_part * scale_up);
+					double scale_down = sw::math::constexpr_math::exp2(-static_cast<double>(fs));
+					double reconstructed = static_cast<double>(frac_bits) * scale_down;
 					best_fs = fs;
 					best_frac = frac_bits;
 					if (reconstructed == frac_part) {
@@ -266,7 +315,7 @@ public:
 
 		return *this;
 	}
-	unum& operator=(long double rhs)        { return *this = static_cast<double>(rhs); }
+	CONSTEXPRESSION unum& operator=(long double rhs)        { return *this = static_cast<double>(rhs); }
 
 	// arithmetic operators (Phase 4 - stubs)
 	unum operator-() const {
@@ -320,34 +369,34 @@ public:
 	unum  operator--(int) { unum tmp(*this); operator--(); return tmp; }
 
 	// modifiers
-	void clear() { _bits.clear(); }
-	void setzero() { _bits.clear(); }
-	void setnan() {
+	constexpr void clear() noexcept { _bits.clear(); }
+	constexpr void setzero() noexcept { _bits.clear(); }
+	constexpr void setnan() noexcept {
 		// NaN encoding: all bits set in the maximum-width configuration
 		for (unsigned i = 0; i < maxbits; ++i) _bits.setbit(i, true);
 	}
-	void setbits(uint64_t v) { _bits.setbits(v); }
-	void setbit(unsigned i, bool v = true) {
+	constexpr void setbits(uint64_t v) noexcept { _bits.setbits(v); }
+	constexpr void setbit(unsigned i, bool v = true) noexcept {
 		if (i < maxbits) _bits.setbit(i, v);
 	}
 
 	// raw bit access
-	StorageType bits() const { return _bits; }
-	bool at(unsigned i) const {
+	constexpr StorageType bits() const noexcept { return _bits; }
+	constexpr bool at(unsigned i) const noexcept {
 		if (i < maxbits) return _bits.at(i);
 		return false;
 	}
 
 	// decode the utag fields (always at fixed positions)
-	bool  ubit()       const { return _bits.at(0); }
-	unsigned fsize()   const {
+	constexpr bool  ubit()       const noexcept { return _bits.at(0); }
+	constexpr unsigned fsize()   const noexcept {
 		unsigned fs = 0;
 		for (unsigned i = 0; i < fsizesize; ++i) {
 			if (_bits.at(1u + i)) fs |= (1u << i);
 		}
 		return fs;
 	}
-	unsigned esize()   const {
+	constexpr unsigned esize()   const noexcept {
 		unsigned es = 0;
 		for (unsigned i = 0; i < esizesize; ++i) {
 			if (_bits.at(1u + fsizesize + i)) es |= (1u << i);
@@ -356,19 +405,19 @@ public:
 	}
 
 	// number of bits actually used by this unum word
-	unsigned nbits_used() const {
+	constexpr unsigned nbits_used() const noexcept {
 		unsigned es = esize();
 		unsigned fs = fsize();
 		return 1u + (es + 1u) + fs + esizesize + fsizesize + 1u;
 	}
 
 	// decode the sign bit (position depends on esize/fsize)
-	bool sign() const {
+	constexpr bool sign() const noexcept {
 		return _bits.at(nbits_used() - 1u);
 	}
 
 	// decode the exponent field (esize+1 bits above the utag+fraction)
-	uint64_t exponent() const {
+	constexpr uint64_t exponent() const noexcept {
 		unsigned es = esize();
 		unsigned fs = fsize();
 		unsigned exp_start = utagsize + fs;
@@ -380,7 +429,7 @@ public:
 	}
 
 	// decode the fraction field (fsize bits above the utag)
-	uint64_t fraction() const {
+	constexpr uint64_t fraction() const noexcept {
 		unsigned fs = fsize();
 		uint64_t frac = 0;
 		for (unsigned i = 0; i < fs; ++i) {
@@ -390,7 +439,7 @@ public:
 	}
 
 	// selectors
-	bool iszero() const {
+	constexpr bool iszero() const noexcept {
 		// zero: sign=0, exponent=all zeros, fraction=all zeros, ubit=0
 		// simplification: all bits are 0
 		for (unsigned i = 0; i < maxbits; ++i) {
@@ -398,17 +447,17 @@ public:
 		}
 		return true;
 	}
-	bool isnan() const {
+	constexpr bool isnan() const noexcept {
 		// NaN: all bits set to 1 in max-width configuration
 		for (unsigned i = 0; i < maxbits; ++i) {
 			if (!_bits.at(i)) return false;
 		}
 		return true;
 	}
-	bool isneg()  const { return sign(); }
-	bool ispos()  const { return !sign(); }
-	bool isinf()  const { return false; }  // unum Type I has no infinity encoding
-	bool exact()  const { return !ubit(); }
+	constexpr bool isneg()  const noexcept { return sign(); }
+	constexpr bool ispos()  const noexcept { return !sign(); }
+	constexpr bool isinf()  const noexcept { return false; }  // unum Type I has no infinity encoding
+	constexpr bool exact()  const noexcept { return !ubit(); }
 
 	// conversion to native types
 	double to_double() const {


### PR DESCRIPTION
## Summary

Bring the unum Type I (Gustafson 2015) construction and bitwise operator surface to `constexpr` / `CONSTEXPRESSION`, scoped per the issue body's own guidance: *"Variable-length encoding makes constexpr arithmetic non-trivial; scope this issue to construction and bitwise ops first, leave arithmetic for follow-up."*

Sibling of the constexpr Epic #723: hfloat #806, e8m0 #810, microfloat #811, mxblock #812, nvblock #813, zfpblock-partial #814, takum #817.

## Promoted in this PR

- Default constructor + copy / move (`constexpr`).
- All bitwise modifiers and selectors (`clear`, `setzero`, `setnan`, `setbits`, `setbit`, `at`, `bits`, `ubit`, `fsize`, `esize`, `sign`, `exponent`, `fraction`, `nbits_used`, `iszero`, `isnan`, `isneg`, `ispos`, `isinf`, `exact`) -- all `constexpr`. These were already built atop the `constexpr` `blockbinary` primitives.
- Special-value free helpers (`minpos`, `maxpos`, `minneg`, `maxneg`, `qnan`, `snan`) -- `constexpr`.
- Integer / float / double / long double construction -- `CONSTEXPRESSION`. The `operator=(double)` body replaces:
  - `std::isnan(x)` -> `x != x`
  - `std::isinf(x)` -> equality against `numeric_limits<>::infinity()`
  - `std::signbit(x)` -> `x < 0` (signed-zero already short-circuited)
  - `std::abs(x)` -> sign-flip
  - `std::frexp(x, &e)` -> `extractFields` + bit decomposition. Subnormals normalize via leading-zero shift on `rawFrac`.
  - `std::ldexp(x, n)` -> `x * sw::math::constexpr_math::exp2(n)` (exact at integer args via direct IEEE 754 bit construction in `detail::pow2`).

## Deferred (follow-up #819)

- `to_double` / `to_float` / `operator double()` (use `std::ldexp` in per-bit fraction accumulation; need a `cm::ldexp` helper or value-domain rewrite).
- Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) -- delegate to `to_double`.
- Arithmetic operators (`+=`, `-=`, `*=`, `/=`, `+`, `-`, `*`, `/`) -- delegate to `to_double`.
- Increment / decrement.

#819 is filed and tracked.

## Changes

- `include/sw/universal/number/unum/unum_impl.hpp` -- `constexpr` / `CONSTEXPRESSION` annotations + `operator=(double)` rewrite (~115 lines added, ~66 changed).
- `elastic/unum/constexpr.cpp` (new, 230 lines) -- `static_assert` coverage of the promoted surface.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| unum1_constexpr | OK | PASS | OK | PASS |
| unum1_api | OK | PASS | OK | PASS |
| unum1_construct | OK | PASS | OK | PASS |
| unum1_conversion | OK | PASS | OK | PASS |
| unum1_io | OK | PASS | OK | PASS |
| unum1_logic | OK | PASS | OK | PASS |
| unum1_arithmetic | OK | PASS | OK | PASS |
| unum1_math | OK | PASS | OK | PASS |
| unum1_validation | OK | PASS | OK | PASS |
| unum1_ubox | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #743
Relates to #723
Follow-up: #819

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced unum Type I with compile-time evaluation support via constexpr for constructors and member functions
  * Extended special value helpers (minpos, maxpos, minneg, maxneg, qnan, snan) for constexpr usage
  * Added comprehensive compile-time verification test suite for unum Type I covering construction, bit operations, and special values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->