### PR TITLE
feat(valid): partial constexpr support (API surface)

### DIFF
--- a/include/sw/universal/number/valid/valid_impl.hpp
+++ b/include/sw/universal/number/valid/valid_impl.hpp
@@ -16,8 +16,12 @@ class valid {
 	static_assert(es + 3 <= nbits, "Value for 'es' is too large for this 'nbits' value");
 	//static_assert(sizeof(long double) == 16, "Valid library requires compiler support for 128 bit long double.");
 
+	// Constexpr-promotable assignment helper.  internal::value's constexpr
+	// constructor (#717) makes the value-domain construction usable at
+	// constant evaluation; the actual posit endpoint encoding is left to a
+	// follow-up that wires the convert() result into lb / ub.
 	template <typename T>
-	valid<nbits, es>& _assign(const T& rhs) {
+	CONSTEXPRESSION valid<nbits, es>& _assign(const T& rhs) {
 		constexpr int fbits = std::numeric_limits<T>::digits - 1;
 		internal::value<fbits> v((T)rhs);
 
@@ -27,58 +31,67 @@ class valid {
 public:
 	static constexpr unsigned somebits = 10;
 
-	valid() : lb{ 0 }, ub{ 0 }, lubit{ false }, uubit{ false } { }
+	// Default ctor: zero-initialize both posit endpoints (posit1 has a
+	// constexpr default after #718) and clear the ubit flags.
+	constexpr valid() noexcept : lb{}, ub{}, lubit{ false }, uubit{ false } { }
 
-	valid(const valid&) = default;
-	valid(valid&&) = default;
+	constexpr valid(const valid&) = default;
+	constexpr valid(valid&&) = default;
 
-	valid& operator=(const valid&) = default;
-	valid& operator=(valid&&) = default;
+	constexpr valid& operator=(const valid&) = default;
+	constexpr valid& operator=(valid&&) = default;
 
-	explicit valid(int initial_value) { *this = initial_value; }
-	explicit valid(long initial_value) { *this = initial_value; }
-	explicit valid(unsigned long long initial_value) { *this = initial_value; }
-	         valid(double initial_value) { *this = initial_value; }
-	explicit valid(long double initial_value) { *this = initial_value; }
+	CONSTEXPRESSION explicit valid(int initial_value)                : lb{}, ub{}, lubit{ false }, uubit{ false } { *this = initial_value; }
+	CONSTEXPRESSION explicit valid(long initial_value)               : lb{}, ub{}, lubit{ false }, uubit{ false } { *this = initial_value; }
+	CONSTEXPRESSION explicit valid(unsigned long long initial_value) : lb{}, ub{}, lubit{ false }, uubit{ false } { *this = initial_value; }
+	CONSTEXPRESSION          valid(double initial_value)             : lb{}, ub{}, lubit{ false }, uubit{ false } { *this = initial_value; }
+	CONSTEXPRESSION explicit valid(long double initial_value)        : lb{}, ub{}, lubit{ false }, uubit{ false } { *this = initial_value; }
 
-	valid& operator=(int rhs) { return _assign(rhs); }
-	valid& operator=(unsigned long long rhs) { return _assign(rhs); }
-	valid& operator=(double rhs) { return _assign(rhs); }
-	valid& operator=(long double rhs) { return _assign(rhs); }
+	CONSTEXPRESSION valid& operator=(int rhs)                { return _assign(rhs); }
+	CONSTEXPRESSION valid& operator=(unsigned long long rhs) { return _assign(rhs); }
+	CONSTEXPRESSION valid& operator=(double rhs)             { return _assign(rhs); }
+	CONSTEXPRESSION valid& operator=(long double rhs)        { return _assign(rhs); }
 
-	valid& operator+=(const valid& rhs) {
+	// Compound arithmetic stubs: kept as no-ops until #744 follow-up
+	// implements interval arithmetic (intersection, hull, midpoint).
+	// Mark constexpr so the surface is constant-evaluable today.
+	constexpr valid& operator+=(const valid& rhs) noexcept {
+		(void)rhs;
 		return *this;
 	}
-	valid& operator-=(const valid& rhs) {
+	constexpr valid& operator-=(const valid& rhs) noexcept {
+		(void)rhs;
 		return *this;
 	}
-	valid& operator*=(const valid& rhs) {
+	constexpr valid& operator*=(const valid& rhs) noexcept {
+		(void)rhs;
 		return *this;
 	}
-	valid& operator/=(const valid& rhs) {
+	constexpr valid& operator/=(const valid& rhs) noexcept {
+		(void)rhs;
 		return *this;
 	}
 
 	// conversion operators
 
 	// selectors
-	inline bool isopen() const {
+	constexpr bool isopen() const noexcept {
 		return !isclosed();
 	}
-	inline bool isclosed() const {
+	constexpr bool isclosed() const noexcept {
 		return lubit && uubit;
 	}
-	inline bool isopenlower() const {
+	constexpr bool isopenlower() const noexcept {
 		return lubit;
 	}
-	inline bool isopenupper() const {
+	constexpr bool isopenupper() const noexcept {
 		return uubit;
 	}
-	inline bool getlb(sw::universal::posit<nbits, es>& _lb) const {
+	constexpr bool getlb(sw::universal::posit<nbits, es>& _lb) const noexcept {
 		_lb = lb;
 		return lubit;
 	}
-	inline bool getub(sw::universal::posit<nbits, es>& _ub) const {
+	constexpr bool getub(sw::universal::posit<nbits, es>& _ub) const noexcept {
 		_ub = ub;
 		return uubit;
 	}
@@ -86,32 +99,32 @@ public:
 	// modifiers
 
 	// TODO: do we clear to exact 0, or [-inf, inf]?
-	inline void clear() {
+	constexpr void clear() noexcept {
 		lb.clear();
 		ub.clear();
 		lubit = true;
 		uubit = true;
 	}
-	inline void setinclusive() {
+	constexpr void setinclusive() noexcept {
 		lb.setnar();
 		ub.setnar();
 		lubit = true;
 		uubit = true;
 	}
-	inline void setlb(sw::universal::posit<nbits, es>& _lb, bool ubit) {
+	constexpr void setlb(sw::universal::posit<nbits, es>& _lb, bool ubit) noexcept {
 		lb = _lb;
 		lubit = ubit;
 	}
-	inline void setub(sw::universal::posit<nbits, es>& _ub, bool ubit) {
+	constexpr void setub(sw::universal::posit<nbits, es>& _ub, bool ubit) noexcept {
 		ub = _ub;
 		uubit = ubit;
 	}
-	inline void setbits(uint64_t v) { // API to be consistent with the other number systems
+	constexpr void setbits(uint64_t v) noexcept { // API to be consistent with the other number systems
 		lb.setbits(v & 0xFFFFFFFFul);
 		ub.setbits((v >> 32) & 0xFFFFFFFFul);
 		lubit = false;
 		uubit = false;
-	} 
+	}
 
 	// relative_order returns -1 if v was rounded up, 0 if it was exact, and 1 if v was rounded down
 	template <unsigned NrFractionBits>
@@ -217,17 +230,17 @@ private:
 	friend std::istream& operator>> (std::istream& istr, valid<nnbits, ees>& p);
 
 	template<unsigned nnbits, unsigned ees>
-	friend bool operator==(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs);
+	friend constexpr bool operator==(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept;
 	template<unsigned nnbits, unsigned ees>
-	friend bool operator!=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs);
+	friend constexpr bool operator!=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept;
 	template<unsigned nnbits, unsigned ees>
-	friend bool operator< (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs);
+	friend constexpr bool operator< (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept;
 	template<unsigned nnbits, unsigned ees>
-	friend bool operator> (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs);
+	friend constexpr bool operator> (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept;
 	template<unsigned nnbits, unsigned ees>
-	friend bool operator<=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs);
+	friend constexpr bool operator<=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept;
 	template<unsigned nnbits, unsigned ees>
-	friend bool operator>=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs);
+	friend constexpr bool operator>=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept;
 };
 
 
@@ -258,57 +271,57 @@ inline std::istream& operator>> (std::istream& istr, const valid<nbits, es>& v) 
 
 // valid - logic operators
 template<unsigned nnbits, unsigned ees>
-inline bool operator==(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) { return false; }
+inline constexpr bool operator==(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { (void)lhs; (void)rhs; return false; }
 template<unsigned nnbits, unsigned ees>
-inline bool operator!=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) { return !operator==(lhs, rhs); }
+inline constexpr bool operator!=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { return !operator==(lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator< (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) { return false; }
+inline constexpr bool operator< (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { (void)lhs; (void)rhs; return false; }
 template<unsigned nnbits, unsigned ees>
-inline bool operator> (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) { return  operator< (rhs, lhs); }
+inline constexpr bool operator> (const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { return  operator< (rhs, lhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator<=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) { return !operator> (lhs, rhs); }
+inline constexpr bool operator<=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { return !operator> (lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator>=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) { return !operator< (lhs, rhs); }
+inline constexpr bool operator>=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { return !operator< (lhs, rhs); }
 
 // valid - literal logic operators
 template<unsigned nnbits, unsigned ees>
-inline bool operator==(const valid<nnbits, ees>& lhs, double rhs) { return lhs == valid<nnbits, ees>(rhs); }
+inline CONSTEXPRESSION bool operator==(const valid<nnbits, ees>& lhs, double rhs) { return lhs == valid<nnbits, ees>(rhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator!=(const valid<nnbits, ees>& lhs, double rhs) { return !operator==(lhs, rhs); }
+inline CONSTEXPRESSION bool operator!=(const valid<nnbits, ees>& lhs, double rhs) { return !operator==(lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator< (const valid<nnbits, ees>& lhs, double rhs) { return lhs < valid<nnbits, ees>(rhs); }
+inline CONSTEXPRESSION bool operator< (const valid<nnbits, ees>& lhs, double rhs) { return lhs < valid<nnbits, ees>(rhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator> (const valid<nnbits, ees>& lhs, double rhs) { return  operator< (rhs, lhs); }
+inline CONSTEXPRESSION bool operator> (const valid<nnbits, ees>& lhs, double rhs) { return  operator< (rhs, lhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator<=(const valid<nnbits, ees>& lhs, double rhs) { return !operator> (lhs, rhs); }
+inline CONSTEXPRESSION bool operator<=(const valid<nnbits, ees>& lhs, double rhs) { return !operator> (lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline bool operator>=(const valid<nnbits, ees>& lhs, double rhs) { return !operator< (lhs, rhs); }
+inline CONSTEXPRESSION bool operator>=(const valid<nnbits, ees>& lhs, double rhs) { return !operator< (lhs, rhs); }
 
 // valid - valid binary arithmetic operators
 // BINARY ADDITION
 template<unsigned nbits, unsigned es>
-inline valid<nbits, es> operator+(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) {
+inline constexpr valid<nbits, es> operator+(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) noexcept {
 	valid<nbits, es> sum(lhs);
 	sum += rhs;
 	return sum;
 }
 // BINARY SUBTRACTION
 template<unsigned nbits, unsigned es>
-inline valid<nbits, es> operator-(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) {
+inline constexpr valid<nbits, es> operator-(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) noexcept {
 	valid<nbits, es> diff(lhs);
 	diff -= rhs;
 	return diff;
 }
 // BINARY MULTIPLICATION
 template<unsigned nbits, unsigned es>
-inline valid<nbits, es> operator*(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) {
+inline constexpr valid<nbits, es> operator*(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) noexcept {
 	valid<nbits, es> mul(lhs);
 	mul *= rhs;
 	return mul;
 }
 // BINARY DIVISION
 template<unsigned nbits, unsigned es>
-inline valid<nbits, es> operator/(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) {
+inline constexpr valid<nbits, es> operator/(const valid<nbits, es>& lhs, const valid<nbits, es>& rhs) noexcept {
 	valid<nbits, es> ratio(lhs);
 	ratio /= rhs;
 	return ratio;

--- a/include/sw/universal/number/valid/valid_impl.hpp
+++ b/include/sw/universal/number/valid/valid_impl.hpp
@@ -111,11 +111,11 @@ public:
 		lubit = true;
 		uubit = true;
 	}
-	constexpr void setlb(sw::universal::posit<nbits, es>& _lb, bool ubit) noexcept {
+	constexpr void setlb(const sw::universal::posit<nbits, es>& _lb, bool ubit) noexcept {
 		lb = _lb;
 		lubit = ubit;
 	}
-	constexpr void setub(sw::universal::posit<nbits, es>& _ub, bool ubit) noexcept {
+	constexpr void setub(const sw::universal::posit<nbits, es>& _ub, bool ubit) noexcept {
 		ub = _ub;
 		uubit = ubit;
 	}
@@ -283,19 +283,22 @@ inline constexpr bool operator<=(const valid<nnbits, ees>& lhs, const valid<nnbi
 template<unsigned nnbits, unsigned ees>
 inline constexpr bool operator>=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { return !operator< (lhs, rhs); }
 
-// valid - literal logic operators
+// valid - literal logic operators.  All delegate to the valid-vs-valid
+// overloads after explicit-conversion of the double rhs; this keeps the
+// dependency single-direction (we don't have to define double-vs-valid
+// overloads).  noexcept matches the valid-vs-valid contract.
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator==(const valid<nnbits, ees>& lhs, double rhs) { return lhs == valid<nnbits, ees>(rhs); }
+inline CONSTEXPRESSION bool operator==(const valid<nnbits, ees>& lhs, double rhs) noexcept { return lhs == valid<nnbits, ees>(rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator!=(const valid<nnbits, ees>& lhs, double rhs) { return !operator==(lhs, rhs); }
+inline CONSTEXPRESSION bool operator!=(const valid<nnbits, ees>& lhs, double rhs) noexcept { return !operator==(lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator< (const valid<nnbits, ees>& lhs, double rhs) { return lhs < valid<nnbits, ees>(rhs); }
+inline CONSTEXPRESSION bool operator< (const valid<nnbits, ees>& lhs, double rhs) noexcept { return lhs < valid<nnbits, ees>(rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator> (const valid<nnbits, ees>& lhs, double rhs) { return  operator< (rhs, lhs); }
+inline CONSTEXPRESSION bool operator> (const valid<nnbits, ees>& lhs, double rhs) noexcept { return valid<nnbits, ees>(rhs) < lhs; }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator<=(const valid<nnbits, ees>& lhs, double rhs) { return !operator> (lhs, rhs); }
+inline CONSTEXPRESSION bool operator<=(const valid<nnbits, ees>& lhs, double rhs) noexcept { return !operator> (lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator>=(const valid<nnbits, ees>& lhs, double rhs) { return !operator< (lhs, rhs); }
+inline CONSTEXPRESSION bool operator>=(const valid<nnbits, ees>& lhs, double rhs) noexcept { return !operator< (lhs, rhs); }
 
 // valid - valid binary arithmetic operators
 // BINARY ADDITION

--- a/include/sw/universal/number/valid/valid_impl.hpp
+++ b/include/sw/universal/number/valid/valid_impl.hpp
@@ -48,6 +48,7 @@ public:
 	CONSTEXPRESSION explicit valid(long double initial_value)        : lb{}, ub{}, lubit{ false }, uubit{ false } { *this = initial_value; }
 
 	CONSTEXPRESSION valid& operator=(int rhs)                { return _assign(rhs); }
+	CONSTEXPRESSION valid& operator=(long rhs)               { return _assign(rhs); }
 	CONSTEXPRESSION valid& operator=(unsigned long long rhs) { return _assign(rhs); }
 	CONSTEXPRESSION valid& operator=(double rhs)             { return _assign(rhs); }
 	CONSTEXPRESSION valid& operator=(long double rhs)        { return _assign(rhs); }
@@ -284,21 +285,25 @@ template<unsigned nnbits, unsigned ees>
 inline constexpr bool operator>=(const valid<nnbits, ees>& lhs, const valid<nnbits, ees>& rhs) noexcept { return !operator< (lhs, rhs); }
 
 // valid - literal logic operators.  All delegate to the valid-vs-valid
-// overloads after explicit-conversion of the double rhs; this keeps the
+// overloads after explicit conversion of the double rhs; this keeps the
 // dependency single-direction (we don't have to define double-vs-valid
-// overloads).  noexcept matches the valid-vs-valid contract.
+// overloads).  These are NOT marked noexcept because the call to
+// valid<>(rhs) routes through valid::operator=(double) -> _assign() ->
+// internal::value<>::operator=(double), and that chain isn't noexcept-
+// annotated end-to-end.  Match the actual contract here; the related
+// valid-vs-valid operators above are noexcept on their own.
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator==(const valid<nnbits, ees>& lhs, double rhs) noexcept { return lhs == valid<nnbits, ees>(rhs); }
+inline CONSTEXPRESSION bool operator==(const valid<nnbits, ees>& lhs, double rhs) { return lhs == valid<nnbits, ees>(rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator!=(const valid<nnbits, ees>& lhs, double rhs) noexcept { return !operator==(lhs, rhs); }
+inline CONSTEXPRESSION bool operator!=(const valid<nnbits, ees>& lhs, double rhs) { return !operator==(lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator< (const valid<nnbits, ees>& lhs, double rhs) noexcept { return lhs < valid<nnbits, ees>(rhs); }
+inline CONSTEXPRESSION bool operator< (const valid<nnbits, ees>& lhs, double rhs) { return lhs < valid<nnbits, ees>(rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator> (const valid<nnbits, ees>& lhs, double rhs) noexcept { return valid<nnbits, ees>(rhs) < lhs; }
+inline CONSTEXPRESSION bool operator> (const valid<nnbits, ees>& lhs, double rhs) { return valid<nnbits, ees>(rhs) < lhs; }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator<=(const valid<nnbits, ees>& lhs, double rhs) noexcept { return !operator> (lhs, rhs); }
+inline CONSTEXPRESSION bool operator<=(const valid<nnbits, ees>& lhs, double rhs) { return !operator> (lhs, rhs); }
 template<unsigned nnbits, unsigned ees>
-inline CONSTEXPRESSION bool operator>=(const valid<nnbits, ees>& lhs, double rhs) noexcept { return !operator< (lhs, rhs); }
+inline CONSTEXPRESSION bool operator>=(const valid<nnbits, ees>& lhs, double rhs) { return !operator< (lhs, rhs); }
 
 // valid - valid binary arithmetic operators
 // BINARY ADDITION

--- a/static/range/valid/api/constexpr.cpp
+++ b/static/range/valid/api/constexpr.cpp
@@ -1,0 +1,197 @@
+// constexpr.cpp: compile-time tests for valid (interval arithmetic, posit endpoints)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage (per issue #744):
+//
+//   * default construction, copy, move
+//   * selectors (isopen / isclosed / isopenlower / isopenupper)
+//   * clear() modifier (constexpr-clean via posit's overridden bitblock reset)
+//   * compound arithmetic stubs (+= -= *= /=) -- currently no-ops, kept
+//     constexpr so the surface lights up at constant evaluation today
+//   * comparison operators (==, !=, <, <=, >, >=) -- currently stub-false,
+//     kept constexpr so callers can use them in static_assert
+//   * binary arithmetic free functions (+, -, *, /) -- compose from the
+//     compound stubs
+//
+// Out of scope at constant evaluation today (transitive limits of posit1):
+//
+//   * setnar / setbits / setinclusive -- ultimately call std::bitset::set,
+//     which is not constexpr until C++23 (we target C++20).  The methods
+//     are still constexpr-marked so they become callable at constant
+//     evaluation as soon as the toolchain catches up.
+//   * native-type ctors / operator=(int|double|...)  -- _assign() builds
+//     an internal::value<>, whose int / unsigned long long path runs
+//     through std::bitset mutation.  Same blocker; will light up under
+//     C++23 or after the bitblock storage gets a constexpr-clean rewrite.
+//
+// The full semantic implementation of interval arithmetic (intersection,
+// hull, midpoint) is left to a follow-up; this file locks in the constexpr
+// API surface contract.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/valid/valid.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "valid constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	using v16 = valid<16, 1>;
+	using v32 = valid<32, 2>;
+
+	// ----------------------------------------------------------------------------
+	// Static accessors and structural invariants.
+	// ----------------------------------------------------------------------------
+	{
+		static_assert(v16::somebits == 10u, "constexpr v16::somebits == 10");
+		static_assert(v32::somebits == 10u, "constexpr v32::somebits == 10");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Default construction is constexpr (zero endpoints, both ubits false).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr v16 v{};
+		static_assert(!v.isopenlower(), "constexpr default v.isopenlower() == false");
+		static_assert(!v.isopenupper(), "constexpr default v.isopenupper() == false");
+		// isclosed() := lubit && uubit -> default == false.  isopen() := !isclosed() -> true.
+		static_assert(!v.isclosed(),    "constexpr default v.isclosed() == false");
+		static_assert(v.isopen(),       "constexpr default v.isopen() == true");
+	}
+
+	// ----------------------------------------------------------------------------
+	// clear() modifier at constant evaluation.  posit::clear() is overridden
+	// to use bitblock::reset() (which is constexpr in C++20), so the whole
+	// path is constexpr-clean.
+	// ----------------------------------------------------------------------------
+	{
+		// clear(): both ubits set to true -> isclosed() returns true.
+		constexpr v16 cleared = []() {
+			v16 t{};
+			t.clear();
+			return t;
+		}();
+		static_assert(cleared.isclosed(),     "constexpr clear() -> isclosed()");
+		static_assert(!cleared.isopen(),      "constexpr clear() -> !isopen()");
+		static_assert(cleared.isopenlower(),  "constexpr clear() -> lubit == true (open-lower flag)");
+		static_assert(cleared.isopenupper(),  "constexpr clear() -> uubit == true (open-upper flag)");
+
+		// Repeated clear: idempotent.
+		constexpr v16 cleared_twice = []() {
+			v16 t{};
+			t.clear();
+			t.clear();
+			return t;
+		}();
+		static_assert(cleared_twice.isclosed(), "constexpr clear() x2 still isclosed()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Compound arithmetic stubs (currently no-ops) and binary free functions
+	// at constant evaluation.  We don't assert any value semantics here --
+	// those are left to a follow-up that implements interval arithmetic --
+	// only that the operations compile at constant evaluation.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr v16 a{};
+		constexpr v16 b{};
+
+		constexpr v16 plus_eq = []() {
+			v16 x{};
+			x += v16{};
+			return x;
+		}();
+		(void)plus_eq;
+
+		constexpr v16 minus_eq = []() {
+			v16 x{};
+			x -= v16{};
+			return x;
+		}();
+		(void)minus_eq;
+
+		constexpr v16 mul_eq = []() {
+			v16 x{};
+			x *= v16{};
+			return x;
+		}();
+		(void)mul_eq;
+
+		constexpr v16 div_eq = []() {
+			v16 x{};
+			x /= v16{};
+			return x;
+		}();
+		(void)div_eq;
+
+		constexpr v16 sum  = a + b;
+		constexpr v16 diff = a - b;
+		constexpr v16 prod = a * b;
+		constexpr v16 quot = a / b;
+		(void)sum; (void)diff; (void)prod; (void)quot;
+	}
+
+	// ----------------------------------------------------------------------------
+	// Comparison operators at constant evaluation.  They currently return
+	// false unconditionally per the stub implementation; the contract lock-in
+	// here is that the surface is constant-evaluable.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr v16 a{};
+		constexpr v16 b{};
+
+		static_assert(!(a == b),   "constexpr stub operator== returns false");
+		static_assert(  a != b,    "constexpr operator!= follows stub == result");
+		static_assert(!(a < b),    "constexpr stub operator< returns false");
+		static_assert(!(a > b),    "constexpr operator> derived from < (stub-false)");
+		static_assert(  a <= b,    "constexpr operator<= derived from > (stub-true)");
+		static_assert(  a >= b,    "constexpr operator>= derived from < (stub-true)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Wider configuration smoke (32-bit posit endpoints).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr v32 v{};
+		static_assert(v.isopen(),     "constexpr v32 default v.isopen() == true");
+		static_assert(!v.isclosed(),  "constexpr v32 default v.isclosed() == false");
+
+		constexpr v32 cleared = []() {
+			v32 t{};
+			t.clear();
+			return t;
+		}();
+		static_assert(cleared.isclosed(), "constexpr v32 clear() -> isclosed()");
+	}
+
+	std::cout << "valid constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/static/range/valid/api/constexpr.cpp
+++ b/static/range/valid/api/constexpr.cpp
@@ -162,6 +162,34 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Literal-rhs comparison operators (valid vs double) -- runtime
+	// instantiation smoke.  Cannot run at constant evaluation today because
+	// they delegate via valid<>(rhs) which goes through internal::value<>'s
+	// double path (std::bitset mutation, blocker documented above).  But the
+	// runtime instantiation pins the dependency direction so the bug CR
+	// found in the original code ("operator>(valid, double) called the non-
+	// existent operator<(double, valid)") cannot recur silently: if the
+	// signatures get reverted, this code stops compiling.
+	// ----------------------------------------------------------------------------
+	{
+		v16 a{};
+		bool b1 = (a == 0.0); (void)b1;
+		bool b2 = (a != 0.0); (void)b2;
+		bool b3 = (a <  0.0); (void)b3;
+		bool b4 = (a >  0.0); (void)b4;
+		bool b5 = (a <= 0.0); (void)b5;
+		bool b6 = (a >= 0.0); (void)b6;
+
+		// Verify the signatures are noexcept (no constant-evaluation needed).
+		static_assert(noexcept(a == 0.0), "operator==(valid, double) is noexcept");
+		static_assert(noexcept(a != 0.0), "operator!=(valid, double) is noexcept");
+		static_assert(noexcept(a <  0.0), "operator< (valid, double) is noexcept");
+		static_assert(noexcept(a >  0.0), "operator> (valid, double) is noexcept");
+		static_assert(noexcept(a <= 0.0), "operator<=(valid, double) is noexcept");
+		static_assert(noexcept(a >= 0.0), "operator>=(valid, double) is noexcept");
+	}
+
+	// ----------------------------------------------------------------------------
 	// Wider configuration smoke (32-bit posit endpoints).
 	// ----------------------------------------------------------------------------
 	{

--- a/static/range/valid/api/constexpr.cpp
+++ b/static/range/valid/api/constexpr.cpp
@@ -180,13 +180,13 @@ try {
 		bool b5 = (a <= 0.0); (void)b5;
 		bool b6 = (a >= 0.0); (void)b6;
 
-		// Verify the signatures are noexcept (no constant-evaluation needed).
-		static_assert(noexcept(a == 0.0), "operator==(valid, double) is noexcept");
-		static_assert(noexcept(a != 0.0), "operator!=(valid, double) is noexcept");
-		static_assert(noexcept(a <  0.0), "operator< (valid, double) is noexcept");
-		static_assert(noexcept(a >  0.0), "operator> (valid, double) is noexcept");
-		static_assert(noexcept(a <= 0.0), "operator<=(valid, double) is noexcept");
-		static_assert(noexcept(a >= 0.0), "operator>=(valid, double) is noexcept");
+		// Smoke that valid(long) is unambiguous.  The original code had
+		// valid(long initial_value) but no operator=(long); overload
+		// resolution among operator=(int|unsigned long long|double|long
+		// double) was ambiguous.  Adding operator=(long) (this PR's CR
+		// round 2 fix) makes the assignment well-formed.
+		v16 along(static_cast<long>(7));
+		(void)along;
 	}
 
 	// ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Promote the `valid` type's user-facing surface to `constexpr` / `CONSTEXPRESSION`. The valid type is interval arithmetic with posit endpoints; per the issue body, *"constexpr coverage is mostly transitive from #718"* (the posit constexpr trilogy). Posit1 is fully constexpr after #718, so the valid promotion is largely annotation.

Sibling of the constexpr Epic #723: hfloat #806, e8m0 #810, microfloat #811, mxblock #812, nvblock #813, zfpblock-partial #814, takum #817, unum1-partial #820.

## Changes

- `include/sw/universal/number/valid/valid_impl.hpp`
  - Default constructor `constexpr`; copy / move `constexpr = default`
  - Native-type ctors and `operator=` `CONSTEXPRESSION` (via `_assign<T>` template)
  - Compound arithmetic stubs (`+=`, `-=`, `*=`, `/=`) `constexpr` (no-ops)
  - Selectors (`isopen`, `isclosed`, `isopenlower`, `isopenupper`, `getlb`, `getub`) `constexpr`
  - Modifiers (`clear`, `setinclusive`, `setlb`, `setub`, `setbits`) `constexpr`
  - Friend comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) `constexpr` -- stub returns unchanged but now usable in `static_assert`
  - Binary arithmetic free functions (`+`, `-`, `*`, `/`) `constexpr`
  - Literal-rhs comparison operators with `double` `CONSTEXPRESSION`
- `static/range/valid/api/constexpr.cpp` (new) -- `static_assert` coverage of the promoted surface

## Constexpr-callable today (gcc + clang, C++20)

- Default ctor + every selector
- `clear()` (posit's `clear()` is overridden to use `bitblock::reset()` which is constexpr in C++20)
- Compound arithmetic stubs and binary free functions (no-ops, so the constexpr-ness is a contract lock-in)
- Comparison operators (stub-false today)

## Limited at constant evaluation today

These surface methods are constexpr-marked, but their bodies traverse `std::bitset::set` / `std::bitset::reset` which are not constexpr until C++23 (we target C++20). They will light up automatically when the toolchain catches up:

- `setnar`, `setbits`, `setinclusive`
- Native-type ctors and `operator=(int|double|...)` -- `_assign()` builds an `internal::value<>`, whose int / unsigned long long path runs through `std::bitset` mutation

The full semantic implementation of interval arithmetic (intersection, hull, midpoint, actual lb/ub computation in `operator+=` etc.) remains stubbed today. That work is independent of this constexpr promotion and not tracked under #723.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| valid_constexpr | OK | PASS | OK | PASS |
| valid_api | OK | PASS | OK | PASS |
| valid_addition | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #744
Relates to #723
Relates to #718

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `valid` interval type is now constexpr-friendly and noexcept across construction, assignment (including primitive values), accessors, modifiers, arithmetic compound operators, and comparisons, enabling safer compile-time use.

* **Tests**
  * Added a comprehensive constexpr test program with static_asserts and runtime smoke checks to verify default state, modifiers, arithmetic and comparison behavior in consteval contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->