### PR TITLE
feat(unum1): full constexpr support across remaining surface

### DIFF
--- a/elastic/unum/constexpr.cpp
+++ b/elastic/unum/constexpr.cpp
@@ -234,6 +234,133 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Conversion-out at constant evaluation (issue #819).  to_double() is
+	// now constexpr via sw::math::constexpr_math::exp2 (exact at integer
+	// arguments).  Round-trip exactness is preserved for power-of-two
+	// inputs, which encode without fraction bits.
+	// ----------------------------------------------------------------------------
+	{
+		// Power-of-two values round-trip exactly at constant evaluation.
+		constexpr u22 two = u22(2.0);
+		static_assert(static_cast<double>(two) == 2.0,
+			"constexpr round-trip 2.0 -> u22 -> 2.0");
+
+		constexpr u22 four = u22(4.0);
+		static_assert(static_cast<double>(four) == 4.0,
+			"constexpr round-trip 4.0 -> u22 -> 4.0");
+
+		constexpr u22 mhalf = u22(-0.5);
+		static_assert(static_cast<double>(mhalf) == -0.5,
+			"constexpr round-trip -0.5 -> u22 -> -0.5");
+
+		// Zero round-trips to +0.0 or -0.0 depending on sign-bit (zero
+		// encoding is all bits clear -> +0.0).
+		constexpr u22 zero_u = u22(0.0);
+		static_assert(static_cast<double>(zero_u) == 0.0,
+			"constexpr round-trip 0.0");
+
+		// NaN -> NaN: x != x at constant evaluation.
+		constexpr u22 nan_u = u22(std::numeric_limits<double>::quiet_NaN());
+		constexpr double nan_d = static_cast<double>(nan_u);
+		static_assert(nan_d != nan_d, "constexpr NaN round-trip stays NaN");
+
+		// to_float / to_long_double are thin wrappers; verify constexpr.
+		constexpr float f2 = static_cast<float>(u22(2.0));
+		static_assert(f2 == 2.0f, "constexpr u22 -> float round-trip");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Comparison operators at constant evaluation (delegate through the
+	// now-constexpr to_double()).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr u22 a = u22(2.0);
+		constexpr u22 b = u22(4.0);
+		constexpr u22 a2 = u22(2.0);
+
+		static_assert(  a == a2, "constexpr u22 a == a (same value, same encoding)");
+		static_assert(  a != b,  "constexpr u22 a != b for different values");
+		static_assert(  a <  b,  "constexpr u22 a < b for a=2 b=4");
+		static_assert(  b >  a,  "constexpr u22 b > a for a=2 b=4");
+		static_assert(  a <= b,  "constexpr u22 a <= b");
+		static_assert(  b >= a,  "constexpr u22 b >= a");
+		static_assert(  a <= a2, "constexpr u22 a <= equal");
+		static_assert(  a >= a2, "constexpr u22 a >= equal");
+
+		// Ordered NaN semantics: every comparison except != returns false.
+		constexpr u22 nan_u = u22(std::numeric_limits<double>::quiet_NaN());
+		static_assert(!(nan_u == nan_u), "constexpr NaN == NaN -> false");
+		static_assert(  nan_u != nan_u,  "constexpr NaN != NaN -> true");
+		static_assert(!(nan_u <  a),     "constexpr NaN < a -> false");
+		static_assert(!(nan_u >  a),     "constexpr NaN > a -> false");
+		static_assert(!(nan_u <= a),     "constexpr NaN <= a -> false");
+		static_assert(!(nan_u >= a),     "constexpr NaN >= a -> false");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Arithmetic operators at constant evaluation.  Delegate through
+	// to_double() + double op + operator=(double), all of which are now
+	// constexpr.  Power-of-two-friendly inputs avoid fraction-bit
+	// quantization so the round-trip exactness is exact.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr u22 a = u22(2.0);
+		constexpr u22 b = u22(2.0);
+
+		// u22 has limited dynamic range; pick values that fit in
+		// representable form.
+		constexpr u22 sum = a + b;   // 2 + 2 = 4
+		static_assert(static_cast<double>(sum) == 4.0,
+			"constexpr u22 2+2 == 4");
+
+		constexpr u22 diff = u22(4.0) - a;  // 4 - 2 = 2
+		static_assert(static_cast<double>(diff) == 2.0,
+			"constexpr u22 4-2 == 2");
+
+		constexpr u22 prod = a * b;  // 2 * 2 = 4
+		static_assert(static_cast<double>(prod) == 4.0,
+			"constexpr u22 2*2 == 4");
+
+		constexpr u22 quot = u22(4.0) / a;  // 4 / 2 = 2
+		static_assert(static_cast<double>(quot) == 2.0,
+			"constexpr u22 4/2 == 2");
+
+		// Compound forms.
+		constexpr u22 plus_eq = []() {
+			u22 x = u22(2.0);
+			x += u22(2.0);
+			return x;
+		}();
+		static_assert(static_cast<double>(plus_eq) == 4.0,
+			"constexpr u22 a += b leaves a = 4");
+
+		constexpr u22 mul_eq = []() {
+			u22 x = u22(2.0);
+			x *= u22(2.0);
+			return x;
+		}();
+		static_assert(static_cast<double>(mul_eq) == 4.0,
+			"constexpr u22 a *= b leaves a = 4");
+
+		// Negation: pure bit math, exact for non-NaN/non-zero values.
+		constexpr u22 neg = -a;
+		static_assert(static_cast<double>(neg) == -2.0,
+			"constexpr -u22(2) == -2");
+		static_assert(neg.sign(),
+			"constexpr negation flips sign bit");
+
+		// NaN propagation.
+		constexpr u22 nan_sum = []() {
+			u22 x{};
+			x.setnan();
+			x += u22(2.0);
+			return x;
+		}();
+		static_assert(nan_sum.isnan(),
+			"constexpr NaN + finite stays NaN");
+	}
+
+	// ----------------------------------------------------------------------------
 	// Wider configuration smoke test (esizesize=3, fsizesize=3).
 	// ----------------------------------------------------------------------------
 	{
@@ -243,6 +370,15 @@ try {
 		constexpr u33 one = u33(1);
 		static_assert(!one.iszero(), "constexpr u33(1).iszero() == false");
 		static_assert(one.exact(),   "constexpr u33(1).exact()");
+
+		// Conversion-out and arithmetic at constant evaluation for u33.
+		constexpr u33 two_d = u33(2.0);
+		static_assert(static_cast<double>(two_d) == 2.0,
+			"constexpr u33 round-trip 2.0");
+
+		constexpr u33 sum = two_d + u33(2.0);
+		static_assert(static_cast<double>(sum) == 4.0,
+			"constexpr u33 2+2 == 4");
 	}
 
 	std::cout << "unum Type I constexpr verification: "

--- a/include/sw/universal/number/unum/unum_impl.hpp
+++ b/include/sw/universal/number/unum/unum_impl.hpp
@@ -317,8 +317,10 @@ public:
 	}
 	CONSTEXPRESSION unum& operator=(long double rhs)        { return *this = static_cast<double>(rhs); }
 
-	// arithmetic operators (Phase 4 - stubs)
-	unum operator-() const {
+	// arithmetic operators
+	// Negation is pure bit math (flip the variable-position sign bit),
+	// independent of the to_double round-trip; constexpr unconditionally.
+	constexpr unum operator-() const noexcept {
 		unum neg(*this);
 		if (!neg.iszero() && !neg.isnan()) {
 			unsigned sign_pos = neg.nbits_used() - 1u;
@@ -326,28 +328,33 @@ public:
 		}
 		return neg;
 	}
-	unum& operator+=(const unum& rhs) {
+	// Compound arithmetic: CONSTEXPRESSION because the round-trip via
+	// to_double() + double op + operator=(double) is now constexpr-clean.
+	CONSTEXPRESSION unum& operator+=(const unum& rhs) {
 		if (isnan() || rhs.isnan()) { setnan(); return *this; }
 		*this = to_double() + rhs.to_double();
 		return *this;
 	}
-	unum& operator-=(const unum& rhs) {
+	CONSTEXPRESSION unum& operator-=(const unum& rhs) {
 		if (isnan() || rhs.isnan()) { setnan(); return *this; }
 		*this = to_double() - rhs.to_double();
 		return *this;
 	}
-	unum& operator*=(const unum& rhs) {
+	CONSTEXPRESSION unum& operator*=(const unum& rhs) {
 		if (isnan() || rhs.isnan()) { setnan(); return *this; }
 		*this = to_double() * rhs.to_double();
 		return *this;
 	}
-	unum& operator/=(const unum& rhs) {
+	CONSTEXPRESSION unum& operator/=(const unum& rhs) {
 		if (isnan() || rhs.isnan()) { setnan(); return *this; }
 		if (rhs.iszero()) {
 #if UNUM_THROW_ARITHMETIC_EXCEPTION
-			throw unum_divide_by_zero();
+			if (!std::is_constant_evaluated()) throw unum_divide_by_zero();
+			setnan();
+			return *this;
 #else
-			std::cerr << "unum division by zero\n";
+			// Diagnostic stream is runtime-only.
+			if (!std::is_constant_evaluated()) std::cerr << "unum division by zero\n";
 			setnan();
 			return *this;
 #endif
@@ -355,18 +362,20 @@ public:
 		*this = to_double() / rhs.to_double();
 		return *this;
 	}
-	unum& operator++() {
+	CONSTEXPRESSION unum& operator++() {
 		// increment: add the smallest representable value (minpos)
-		// for now, use double-based increment
-		*this = to_double() + std::ldexp(1.0, -(1 << esize()));
+		// (-(1 << esize()) is the integer exponent for cm::exp2 -> 2^(-2^esize))
+		*this = to_double()
+			+ sw::math::constexpr_math::exp2(-static_cast<double>(1 << esize()));
 		return *this;
 	}
-	unum  operator++(int) { unum tmp(*this); operator++(); return tmp; }
-	unum& operator--() {
-		*this = to_double() - std::ldexp(1.0, -(1 << esize()));
+	CONSTEXPRESSION unum  operator++(int) { unum tmp(*this); operator++(); return tmp; }
+	CONSTEXPRESSION unum& operator--() {
+		*this = to_double()
+			- sw::math::constexpr_math::exp2(-static_cast<double>(1 << esize()));
 		return *this;
 	}
-	unum  operator--(int) { unum tmp(*this); operator--(); return tmp; }
+	CONSTEXPRESSION unum  operator--(int) { unum tmp(*this); operator--(); return tmp; }
 
 	// modifiers
 	constexpr void clear() noexcept { _bits.clear(); }
@@ -459,8 +468,11 @@ public:
 	constexpr bool isinf()  const noexcept { return false; }  // unum Type I has no infinity encoding
 	constexpr bool exact()  const noexcept { return !ubit(); }
 
-	// conversion to native types
-	double to_double() const {
+	// conversion to native types.  Constexpr-promoted by replacing
+	// std::ldexp(1.0, n) with sw::math::constexpr_math::exp2(double(n)),
+	// which is exact at integer arguments via direct IEEE 754 bit
+	// construction in detail::pow2.
+	constexpr double to_double() const noexcept {
 		if (iszero()) return 0.0;
 		if (isnan()) return std::numeric_limits<double>::quiet_NaN();
 		unsigned es = esize();
@@ -477,10 +489,10 @@ public:
 			double f = 0.0;
 			for (unsigned i = 0; i < fs; ++i) {
 				if (frac & (1ull << (fs - 1u - i))) {
-					f += std::ldexp(1.0, -static_cast<int>(i + 1));
+					f += sw::math::constexpr_math::exp2(-static_cast<double>(i + 1));
 				}
 			}
-			value = std::ldexp(f, 1 - bias);
+			value = f * sw::math::constexpr_math::exp2(static_cast<double>(1 - bias));
 		}
 		else {
 			// normal: hidden bit is 1, value = 1.fraction * 2^(exp-bias)
@@ -488,19 +500,19 @@ public:
 			double f = 1.0;
 			for (unsigned i = 0; i < fs; ++i) {
 				if (frac & (1ull << (fs - 1u - i))) {
-					f += std::ldexp(1.0, -static_cast<int>(i + 1));
+					f += sw::math::constexpr_math::exp2(-static_cast<double>(i + 1));
 				}
 			}
-			value = std::ldexp(f, e);
+			value = f * sw::math::constexpr_math::exp2(static_cast<double>(e));
 		}
 		return s ? -value : value;
 	}
-	float to_float() const { return static_cast<float>(to_double()); }
-	long double to_long_double() const { return static_cast<long double>(to_double()); }
+	constexpr float to_float() const noexcept { return static_cast<float>(to_double()); }
+	constexpr long double to_long_double() const noexcept { return static_cast<long double>(to_double()); }
 
-	explicit operator double() const { return to_double(); }
-	explicit operator float() const { return to_float(); }
-	explicit operator long double() const { return to_long_double(); }
+	explicit constexpr operator double() const noexcept { return to_double(); }
+	explicit constexpr operator float() const noexcept { return to_float(); }
+	explicit constexpr operator long double() const noexcept { return to_long_double(); }
 
 private:
 	StorageType _bits;
@@ -512,17 +524,17 @@ private:
 	friend std::istream& operator>>(std::istream& istr, unum<nesizesize, nfsizesize, nbt>& v);
 
 	template<unsigned nesizesize, unsigned nfsizesize, typename nbt>
-	friend bool operator==(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs);
+	friend constexpr bool operator==(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs) noexcept;
 	template<unsigned nesizesize, unsigned nfsizesize, typename nbt>
-	friend bool operator!=(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs);
+	friend constexpr bool operator!=(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs) noexcept;
 	template<unsigned nesizesize, unsigned nfsizesize, typename nbt>
-	friend bool operator< (const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs);
+	friend constexpr bool operator< (const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs) noexcept;
 	template<unsigned nesizesize, unsigned nfsizesize, typename nbt>
-	friend bool operator> (const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs);
+	friend constexpr bool operator> (const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs) noexcept;
 	template<unsigned nesizesize, unsigned nfsizesize, typename nbt>
-	friend bool operator<=(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs);
+	friend constexpr bool operator<=(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs) noexcept;
 	template<unsigned nesizesize, unsigned nfsizesize, typename nbt>
-	friend bool operator>=(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs);
+	friend constexpr bool operator>=(const unum<nesizesize, nfsizesize, nbt>& lhs, const unum<nesizesize, nfsizesize, nbt>& rhs) noexcept;
 };
 
 ////////////////////// IO operators
@@ -566,10 +578,10 @@ inline std::istream& operator>>(std::istream& istr, unum<esizesize, fsizesize, b
 	return istr;
 }
 
-////////////////////// comparison operators (Phase 3 - basic bit comparison for now)
+////////////////////// comparison operators (value-domain via to_double)
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline bool operator==(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline constexpr bool operator==(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) noexcept {
 	// NaN is not equal to anything, including itself
 	if (lhs.isnan() || rhs.isnan()) return false;
 	// two zeros are equal regardless of encoding
@@ -578,55 +590,55 @@ inline bool operator==(const unum<esizesize, fsizesize, bt>& lhs, const unum<esi
 	return lhs.to_double() == rhs.to_double();
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline bool operator!=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline constexpr bool operator!=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) noexcept {
 	// NaN is not equal to anything
 	if (lhs.isnan() || rhs.isnan()) return true;
 	return !operator==(lhs, rhs);
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline bool operator< (const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline constexpr bool operator< (const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) noexcept {
 	// NaN is not ordered
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return lhs.to_double() < rhs.to_double();
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline bool operator> (const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline constexpr bool operator> (const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) noexcept {
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return operator<(rhs, lhs);
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline bool operator<=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline constexpr bool operator<=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) noexcept {
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return !operator>(lhs, rhs);
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline bool operator>=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline constexpr bool operator>=(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) noexcept {
 	if (lhs.isnan() || rhs.isnan()) return false;
 	return !operator<(lhs, rhs);
 }
 
-////////////////////// binary arithmetic operators (Phase 4 - stubs)
+////////////////////// binary arithmetic operators
 
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline unum<esizesize, fsizesize, bt> operator+(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline CONSTEXPRESSION unum<esizesize, fsizesize, bt> operator+(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
 	unum<esizesize, fsizesize, bt> sum(lhs);
 	sum += rhs;
 	return sum;
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline unum<esizesize, fsizesize, bt> operator-(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline CONSTEXPRESSION unum<esizesize, fsizesize, bt> operator-(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
 	unum<esizesize, fsizesize, bt> diff(lhs);
 	diff -= rhs;
 	return diff;
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline unum<esizesize, fsizesize, bt> operator*(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline CONSTEXPRESSION unum<esizesize, fsizesize, bt> operator*(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
 	unum<esizesize, fsizesize, bt> mul(lhs);
 	mul *= rhs;
 	return mul;
 }
 template<unsigned esizesize, unsigned fsizesize, typename bt>
-inline unum<esizesize, fsizesize, bt> operator/(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
+inline CONSTEXPRESSION unum<esizesize, fsizesize, bt> operator/(const unum<esizesize, fsizesize, bt>& lhs, const unum<esizesize, fsizesize, bt>& rhs) {
 	unum<esizesize, fsizesize, bt> ratio(lhs);
 	ratio /= rhs;
 	return ratio;


### PR DESCRIPTION
## Summary

Follow-up to issue #743 / PR #820 (which scoped itself to construction and bitwise ops). Promote the rest of the unum Type I user-facing surface to `constexpr` / `CONSTEXPRESSION`.

Sibling of the constexpr Epic #723: hfloat #806, e8m0 #810, microfloat #811, mxblock #812, nvblock #813, zfpblock-partial #814, takum #817, unum1-partial #820, valid #821.

## Root Cause / Design Goal

`to_double()` was the gating call:

```cpp
for (unsigned i = 0; i < fs; ++i) {
    if (frac & (1ull << (fs - 1u - i))) {
        f += std::ldexp(1.0, -static_cast<int>(i + 1));  // not constexpr
    }
}
value = std::ldexp(f, e);                                  // not constexpr
```

`std::ldexp(1.0, n)` for integer `n` equals `2^n`, which `sw::math::constexpr_math::exp2` produces exactly via direct IEEE 754 bit construction (`detail::pow2`). The replacement is bit-for-bit equivalent at runtime and constexpr at constant evaluation.

Once `to_double()` goes constexpr, all of comparison, arithmetic, and the `operator double()` family fall out automatically because they were already delegating through it.

## Changes

- `include/sw/universal/number/unum/unum_impl.hpp`
  - `to_double`/`to_float`/`to_long_double`: `constexpr` via `cm::exp2` substitution
  - `operator double`/`operator float`/`operator long double`: `constexpr`
  - Friend comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`): `constexpr`
  - Compound arithmetic (`+=`, `-=`, `*=`, `/=`): `CONSTEXPRESSION`. The `UNUM_THROW_ARITHMETIC_EXCEPTION` branch in `operator/=` guards `throw` under `!std::is_constant_evaluated()` so the setnar fallback is reachable at constant evaluation.
  - Increment/decrement (`++`, `--`): `CONSTEXPRESSION` via `cm::exp2` substitution
  - Negation (`operator-`): `constexpr` (was already pure bit math)
  - Binary arithmetic free functions (`+`, `-`, `*`, `/`): `CONSTEXPRESSION`
- `elastic/unum/constexpr.cpp` extended with conversion-out, comparison, arithmetic, NaN-propagation coverage at constant evaluation

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| unum1_constexpr | OK | PASS | OK | PASS |
| unum1_api | OK | PASS | OK | PASS |
| unum1_construct | OK | PASS | OK | PASS |
| unum1_conversion | OK | PASS | OK | PASS |
| unum1_io | OK | PASS | OK | PASS |
| unum1_logic | OK | PASS | OK | PASS |
| unum1_arithmetic | OK | PASS | OK | PASS |
| unum1_math | OK | PASS | OK | PASS |
| unum1_validation | OK | PASS | OK | PASS |
| unum1_ubox | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #819
Relates to #723 (Epic)
Relates to #743 (parent issue, partial-merge in #820)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Arithmetic operations (addition, subtraction, multiplication, division) now support compile-time evaluation
  * Type conversions now support compile-time evaluation
  * Comparison operators now support compile-time evaluation

* **Tests**
  * Added new constexpr validation tests covering conversion round-trips, special number handling, and arithmetic operations under constant evaluation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->