### PR TITLE
feat(edecimal): partial constexpr support (API surface)

### DIFF
--- a/elastic/decimal/api/constexpr.cpp
+++ b/elastic/decimal/api/constexpr.cpp
@@ -1,0 +1,159 @@
+// constexpr.cpp: compile-time tests for adaptive precision decimal integer (edecimal)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage (per issue #746, parent epic #723):
+//
+//   * default construction (constant-evaluated branch produces an empty
+//     std::vector<uint8_t> + negative=false; iszero() recognizes the
+//     empty vector as zero)
+//   * sign selectors:    sign(), isneg(), ispos()
+//   * sign modifiers:    setsign(), setneg(), setpos()
+//   * iszero() on the empty (constant-evaluated) state
+//   * defaulted copy / move ctors and assignment operators
+//
+// Out of scope (deferred; see comment block in edecimal_impl.hpp):
+//
+//   * setzero / setdigit / setbits           - call push_back; heap-escape
+//   * native-type ctors and operator=        - go through convert_integer
+//                                              / convert_ieee754, both of
+//                                              which call push_back
+//   * compound arithmetic (+= -= *= /= %=)   - mutate the digit vector
+//   * unary -, ++, --                        - allocate temporary edecimals
+//   * conversion operators (to_long_long etc.) iterate the digit vector
+//   * comparison operators (==, !=, <, ...)  - read the digit vector via
+//                                              non-constexpr free funcs
+//   * parse() / regex                        - regex is not constexpr
+//
+// The fundamental constraint is C++20's "transient allocation" rule:
+// memory allocated in a constant expression cannot persist outside it.
+// edecimal inherits from std::vector, so any non-empty digit storage
+// disqualifies the object from being a constexpr variable.  This file
+// locks in the surface that the language permits today; relaxation of
+// the transient-allocation rule (P2738 / C++23) will lift the boundary.
+
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/edecimal/edecimal.hpp>
+#include <universal/traits/edecimal_traits.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "edecimal constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----------------------------------------------------------------------------
+	// Default construction at constant evaluation: empty vector + sign=false.
+	// iszero() recognizes the empty vector as canonical zero.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr edecimal z{};
+		static_assert(z.iszero(),  "constexpr default-constructed edecimal is zero");
+		static_assert(!z.sign(),   "constexpr default-constructed edecimal sign() == false");
+		static_assert(!z.isneg(),  "constexpr default-constructed edecimal !isneg()");
+		static_assert(z.ispos(),   "constexpr default-constructed edecimal ispos()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Sign-only modifiers at constant evaluation: setsign, setneg, setpos
+	// operate purely on the bool member (no vector mutation).
+	// ----------------------------------------------------------------------------
+	{
+		// setsign(true) round-trip.
+		constexpr edecimal neg = []() {
+			edecimal t{};
+			t.setsign(true);
+			return t;
+		}();
+		static_assert(neg.sign(),   "constexpr setsign(true) -> sign() == true");
+		static_assert(neg.isneg(),  "constexpr setsign(true) -> isneg()");
+		static_assert(!neg.ispos(), "constexpr setsign(true) -> !ispos()");
+		// iszero() ignores the sign bit; an empty vector with negative=true
+		// is still zero.
+		static_assert(neg.iszero(), "constexpr empty vector + sign=true -> iszero()");
+
+		// setneg() / setpos() round-trip.
+		constexpr edecimal flipped = []() {
+			edecimal t{};
+			t.setneg();
+			t.setpos();
+			return t;
+		}();
+		static_assert(flipped.ispos(), "constexpr setneg+setpos -> ispos()");
+		static_assert(!flipped.sign(), "constexpr setneg+setpos -> sign() == false");
+
+		// setsign(true) followed by setsign(false) is identity for sign-only
+		// state; the vector remains empty.
+		constexpr edecimal toggled = []() {
+			edecimal t{};
+			t.setsign(true);
+			t.setsign(false);
+			return t;
+		}();
+		static_assert(!toggled.sign(),  "constexpr setsign true->false -> sign() == false");
+		static_assert(toggled.iszero(), "constexpr toggled is still zero");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Defaulted copy and move constructors / assignment operators are
+	// constexpr (the underlying std::vector copy/move is constexpr in C++20
+	// when applied to an empty source).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr edecimal src{};
+		constexpr edecimal copied{ src };
+		static_assert(copied.iszero(), "constexpr copy ctor preserves zero");
+		static_assert(!copied.sign(),  "constexpr copy ctor preserves sign");
+
+		// Copy assignment via lambda (so we can persist the result).
+		constexpr edecimal assigned = []() {
+			edecimal dst{};
+			edecimal s{};
+			s.setsign(true);
+			dst = s;
+			return dst;
+		}();
+		static_assert(assigned.iszero(), "constexpr copy assignment preserves zero");
+		static_assert(assigned.isneg(),  "constexpr copy assignment carries sign over");
+	}
+
+	// ----------------------------------------------------------------------------
+	// is_edecimal trait is itself a constexpr variable template.  This
+	// also pins the spelling fix for the type alias (was is_edecimalal_trait).
+	// ----------------------------------------------------------------------------
+	{
+		static_assert(is_edecimal<edecimal>,        "is_edecimal<edecimal> == true");
+		static_assert(!is_edecimal<int>,            "is_edecimal<int> == false");
+		static_assert(!is_edecimal<unsigned long>,  "is_edecimal<unsigned long> == false");
+	}
+
+	std::cout << "edecimal constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/edecimal/edecimal.hpp
+++ b/include/sw/universal/number/edecimal/edecimal.hpp
@@ -23,6 +23,7 @@
 #include <limits>
 #include <regex>
 #include <algorithm>
+#include <type_traits>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES

--- a/include/sw/universal/number/edecimal/edecimal_impl.hpp
+++ b/include/sw/universal/number/edecimal/edecimal_impl.hpp
@@ -26,13 +26,28 @@ class edecimal : public std::vector<uint8_t> {
 	static occurrence<edecimal> ops;
 #endif
 public:
-	edecimal() { setzero(); }
+	// Partial-constexpr surface (issue #746): edecimal inherits from
+	// std::vector<uint8_t>, so any non-empty vector escapes constant
+	// evaluation under C++20's transient-allocation rules.  The default
+	// ctor uses is_constant_evaluated() to keep two parallel invariants:
+	// at constant evaluation the vector is empty (canonical constexpr
+	// zero, recognized by iszero() via the size() == 0 branch); at
+	// runtime push_back(0) restores the historical "size() == 1, [0] == 0"
+	// representation that comparison and arithmetic operators rely on.
+	// Sign-only selectors/modifiers operate purely on the bool member and
+	// are constexpr-clean.  All digit-mutating paths (setzero, setdigit,
+	// arithmetic, conversion-out) remain non-constexpr until C++23.
+	constexpr edecimal() noexcept : std::vector<uint8_t>(), negative{ false } {
+		if (!std::is_constant_evaluated()) {
+			push_back(0);
+		}
+	}
 
-	edecimal(const edecimal&) = default;
-	edecimal(edecimal&&) = default;
+	constexpr edecimal(const edecimal&) = default;
+	constexpr edecimal(edecimal&&) = default;
 
-	edecimal& operator=(const edecimal&) = default;
-	edecimal& operator=(edecimal&&) = default;
+	constexpr edecimal& operator=(const edecimal&) = default;
+	constexpr edecimal& operator=(edecimal&&) = default;
 
 	// initializers for native types
 	edecimal(char initial_value)                { *this = initial_value; }
@@ -314,19 +329,25 @@ public:
 	explicit operator long double()        const noexcept { return to_long_double(); }
 
 	// selectors
-	inline bool iszero() const {
+	// iszero() is constexpr-callable on the default-constructed (empty) state;
+	// once any digit-mutating op runs, the vector heap-escapes and constexpr
+	// usage is no longer permitted on the resulting object (C++20).
+	constexpr bool iszero() const noexcept {
 		if (size() == 0) return true;
-		return std::all_of(begin(), end(), [](uint8_t i) { return 0 == i; });
+		for (auto d : *this) {
+			if (d != 0) return false;
+		}
+		return true;
 	}
-	inline bool sign() const { return negative; }
-	inline bool isneg() const { return negative; }   // <  0
-	inline bool ispos() const { return !negative; }  // >= 0
+	constexpr bool sign() const noexcept { return negative; }
+	constexpr bool isneg() const noexcept { return negative; }   // <  0
+	constexpr bool ispos() const noexcept { return !negative; }  // >= 0
 
 	// modifiers
 	inline void setzero() { clear(); push_back(0); negative = false; }
-	inline void setsign(bool sign) { negative = sign; }
-	inline void setneg() { negative = true; }
-	inline void setpos() { negative = false; }
+	constexpr void setsign(bool sign) noexcept { negative = sign; }
+	constexpr void setneg() noexcept { negative = true; }
+	constexpr void setpos() noexcept { negative = false; }
 	inline void setdigit(uint8_t d, bool sign = false) {
 		assert(d <= 9); // test argument assumption
 		clear();

--- a/include/sw/universal/traits/edecimal_traits.hpp
+++ b/include/sw/universal/traits/edecimal_traits.hpp
@@ -21,7 +21,7 @@ namespace sw { namespace universal {
 	};
 
 	template<typename _Ty>
-	constexpr bool is_edecimal = is_edecimalal_trait<_Ty>::value;
+	constexpr bool is_edecimal = is_edecimal_trait<_Ty>::value;
 
 	template<typename _Ty, typename Type = void>
 	using enable_if_edecimal = std::enable_if_t<is_edecimal<_Ty>, Type>;


### PR DESCRIPTION
## Summary

- Promote `edecimal`'s user-facing surface to `constexpr` where C++20 transient-allocation rules permit; mirrors the partial-constexpr playbook from #820 (unum) and #821 (valid).
- `edecimal` inherits from `std::vector<uint8_t>`, so any non-empty digit storage disqualifies the object from being a `constexpr` variable. Default ctor uses `std::is_constant_evaluated()` to keep two parallel invariants: empty vector at constant evaluation; `push_back(0)` at runtime so all existing comparison and arithmetic code continues to see the historical "size 1, [0] == 0" zero.
- Drive-by typo fix in `edecimal_traits.hpp` (`is_edecimalal_trait` -> `is_edecimal_trait`); latent bug -- any user instantiating `is_edecimal<T>` would have hit a compile error.

## Changes

- `include/sw/universal/number/edecimal/edecimal_impl.hpp` -- default ctor + defaulted copy/move + `iszero()` + sign-only selectors/modifiers (`sign()`, `isneg()`, `ispos()`, `setsign()`, `setneg()`, `setpos()`) marked `constexpr`. Comment block documents the heap-allocation boundary.
- `include/sw/universal/number/edecimal/edecimal.hpp` -- add `<type_traits>` for `std::is_constant_evaluated`.
- `include/sw/universal/traits/edecimal_traits.hpp` -- spelling fix on line 24.
- `elastic/decimal/api/constexpr.cpp` -- new file. `static_assert` smoke tests for default ctor, selectors, sign-modifier round-trip, defaulted copy/move, and the `is_edecimal` trait. Header documents what is in / out of scope. `CMakeLists.txt` auto-registers via existing `api/*.cpp` glob.

## Constexpr-callable surface today (gcc + clang, C++20)

- Default ctor and selectors at constant evaluation
- Sign modifier round-trips at constant evaluation
- Copy and copy-assignment at constant evaluation (when source is the empty default-constructed state)

## Limited at constant evaluation today (heap-escape boundary)

`setzero` / `setdigit` / `setbits` / native-type ctors / compound arithmetic / unary `-` `++` `--` / conversion-out / comparison operators / `parse()`. All call into `push_back`, `insert`, `erase`, or `std::regex` and will light up automatically when the toolchain catches up to C++23 P2738.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `edec_constexpr` (NEW) | OK | PASS | OK | PASS |
| `edec_api` | OK | PASS | OK | PASS |
| `edec_assignment` | OK | PASS | OK | PASS |
| `edec_addition` | OK | PASS | OK | PASS |
| `edec_subtraction` | OK | PASS | OK | PASS |
| `edec_multiplication` | OK | PASS | OK | PASS |
| `edec_division` | OK | PASS | OK | PASS |
| `edec_comparison` | OK | PASS | OK | PASS |
| `edec_exceptions` | OK | PASS | OK | PASS |
| `edec_factorial` | OK | PASS | OK | PASS |
| `edec_example` | OK | PASS | OK | PASS |
| `edec_performance` | OK | PASS | OK | PASS |

12/12 elastic/decimal regression suite passes on both compilers.

## Test plan

- [x] Fast CI (gcc + clang CI_LITE) green
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #746

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended C++20 constexpr support for edecimal operations, including constructors, state queries, and sign manipulation, enabling compile-time evaluation of decimal numbers.

* **Bug Fixes**
  * Fixed type trait reference that was preventing proper type checking for edecimal types.

* **Tests**
  * Added comprehensive compile-time verification test suite validating constexpr functionality with static assertions and runtime checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/824)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->