### PR TITLE
feat(efloat): partial constexpr support (API surface)

### DIFF
--- a/elastic/efloat/api/constexpr.cpp
+++ b/elastic/efloat/api/constexpr.cpp
@@ -204,11 +204,13 @@ try {
 		constexpr ef4 sum  = a + b;
 		constexpr ef4 diff = a - b;
 		constexpr ef4 prod = a * b;
-		constexpr ef4 quot = a / b;
-		static_assert(sum.iszero(),  "constexpr efloat + stub returns zero");
-		static_assert(diff.iszero(), "constexpr efloat - stub returns zero");
-		static_assert(prod.iszero(), "constexpr efloat * stub returns zero");
-		static_assert(quot.iszero(), "constexpr efloat / stub returns zero");
+		// Don't pin 0/0 to current stub semantics: real division will
+		// produce NaN, so we only verify the expression is well-formed
+		// at constant evaluation.
+		[[maybe_unused]] constexpr ef4 quot = a / b;
+		static_assert(sum.iszero(),  "constexpr efloat + stub returns zero (0+0=0 holds for real semantics too)");
+		static_assert(diff.iszero(), "constexpr efloat - stub returns zero (0-0=0 holds for real semantics too)");
+		static_assert(prod.iszero(), "constexpr efloat * stub returns zero (0*0=0 holds for real semantics too)");
 	}
 
 	// ----------------------------------------------------------------------------

--- a/elastic/efloat/api/constexpr.cpp
+++ b/elastic/efloat/api/constexpr.cpp
@@ -1,0 +1,252 @@
+// constexpr.cpp: compile-time tests for adaptive precision binary floating-point (efloat)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage (per issue #747, parent epic #723):
+//
+//   * default construction (constant-evaluated branch produces an empty
+//     std::vector<uint32_t> _limb + state=Zero; iszero() recognizes the
+//     Zero state directly without inspecting _limb)
+//   * defaulted copy / move ctor + assignment operators
+//   * state-only and sign-only selectors:
+//       iszero, isone, isodd, iseven, ispos, isneg,
+//       isinf, isnan, isqnan, issnan, sign, scale
+//   * modifiers:  clear(), setzero()
+//   * unary minus, compound arithmetic stubs (+= -= *= /=)
+//   * free comparison operators (==, !=, <, <=, >, >=)
+//   * free binary arithmetic operators (+, -, *, /)
+//
+// The compound arithmetic and comparison operators are currently no-op
+// stubs in efloat_impl.hpp; their constexpr promotion locks in the
+// surface so the contract is usable in static_assert today and the real
+// arithmetic semantics will inherit constexpr-ness automatically when
+// implemented.
+//
+// Out of scope (deferred; see comment block in efloat_impl.hpp):
+//
+//   * native-type ctors and operator=        - convert_ieee754 calls
+//                                              std::fpclassify, which is
+//                                              not constexpr in C++20
+//   * conversion-out (operator double, etc.) - uses std::pow
+//   * parse() / assign(string)               - std::regex is not constexpr
+//
+// The fundamental constraint is C++20's "transient allocation" rule:
+// memory allocated in a constant expression cannot persist outside it.
+// efloat carries a std::vector member, so any non-empty digit storage
+// disqualifies the object from being a constexpr variable.  The default
+// ctor uses std::is_constant_evaluated() to keep parallel invariants:
+// empty vector at constant evaluation; push_back(0) at runtime.
+
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "efloat constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// Use a small nlimbs so the type instantiation is cheap; the constexpr
+	// surface is independent of nlimbs since _limb stays empty at constant
+	// evaluation regardless.
+	using ef4 = efloat<4>;
+	using ef8 = efloat<8>;
+
+	// ----------------------------------------------------------------------------
+	// Default construction at constant evaluation: _state = Zero, sign = false,
+	// _exponent = 0, _limb empty.  iszero() recognizes the Zero state
+	// directly without dereferencing _limb.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr ef4 z{};
+		static_assert( z.iszero(),  "constexpr default-constructed efloat is zero");
+		static_assert(!z.isnan(),   "constexpr default-constructed efloat !isnan()");
+		static_assert(!z.isqnan(),  "constexpr default-constructed efloat !isqnan()");
+		static_assert(!z.issnan(),  "constexpr default-constructed efloat !issnan()");
+		static_assert(!z.isinf(),   "constexpr default-constructed efloat !isinf()");
+		static_assert(!z.ispos(),   "constexpr default-constructed efloat ispos()==false (state==Zero, not Normal)");
+		static_assert(!z.isneg(),   "constexpr default-constructed efloat isneg()==false (state==Zero, not Normal)");
+		static_assert(!z.isone(),   "constexpr default-constructed efloat !isone()");
+		static_assert(!z.isodd(),   "constexpr default-constructed efloat !isodd()");
+		static_assert( z.iseven(),  "constexpr default-constructed efloat iseven()");
+		static_assert( z.sign() == 1,  "constexpr default-constructed efloat sign() == 1 (positive zero)");
+		static_assert( z.scale() == 0, "constexpr default-constructed efloat scale() == 0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Modifiers at constant evaluation: clear() resets to a Normal-state
+	// non-zero, setzero() restores Zero state.  Both are constexpr-clean
+	// because std::vector::clear() is constexpr in C++20 and our default
+	// ctor leaves _limb empty in constant-evaluated context.
+	// ----------------------------------------------------------------------------
+	{
+		// clear() leaves the object in Normal state (so iszero() == false).
+		constexpr ef4 cleared = []() {
+			ef4 t{};
+			t.clear();
+			return t;
+		}();
+		static_assert(!cleared.iszero(),  "constexpr clear() -> state=Normal -> !iszero()");
+		static_assert( cleared.ispos(),   "constexpr clear() -> state=Normal, sign=false -> ispos()");
+
+		// setzero() restores Zero state (issue #747 drive-by: previously
+		// setzero() left state=Normal, contradicting its name; the
+		// constexpr smoke test would otherwise flag this as buggy).
+		constexpr ef4 zeroed = []() {
+			ef4 t{};
+			t.clear();    // first push to Normal
+			t.setzero();  // then back to Zero
+			return t;
+		}();
+		static_assert(zeroed.iszero(),    "constexpr setzero() -> state=Zero -> iszero()");
+		static_assert(!zeroed.ispos(),    "constexpr setzero() -> state=Zero -> !ispos()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Defaulted copy and move constructors / assignment operators.
+	// Std::vector copy of an empty source is constexpr in C++20.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr ef4 src{};
+		constexpr ef4 copied{ src };
+		static_assert(copied.iszero(),   "constexpr copy ctor preserves zero");
+
+		constexpr ef4 assigned = []() {
+			ef4 dst{};
+			ef4 s{};
+			dst = s;
+			return dst;
+		}();
+		static_assert(assigned.iszero(), "constexpr copy assignment preserves zero");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Unary minus at constant evaluation.  Returns a copy of *this; on the
+	// empty default-constructed source the copy stays empty too.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr ef4 z{};
+		constexpr ef4 neg = -z;
+		// (negation is currently a stub that just copies; the surface is
+		// promoted to constexpr to lock in the contract.)
+		static_assert(neg.iszero(), "constexpr -z preserves zero state on stub negation");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Compound arithmetic stubs: marked constexpr, return *this unchanged.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr ef4 plus_eq = []() {
+			ef4 x{};
+			ef4 y{};
+			x += y;
+			return x;
+		}();
+		static_assert(plus_eq.iszero(), "constexpr += stub leaves zero unchanged");
+
+		constexpr ef4 minus_eq = []() {
+			ef4 x{};
+			ef4 y{};
+			x -= y;
+			return x;
+		}();
+		static_assert(minus_eq.iszero(), "constexpr -= stub leaves zero unchanged");
+
+		constexpr ef4 times_eq = []() {
+			ef4 x{};
+			ef4 y{};
+			x *= y;
+			return x;
+		}();
+		static_assert(times_eq.iszero(), "constexpr *= stub leaves zero unchanged");
+
+		constexpr ef4 div_eq = []() {
+			ef4 x{};
+			ef4 y{};
+			x /= y;
+			return x;
+		}();
+		static_assert(div_eq.iszero(), "constexpr /= stub leaves zero unchanged");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Free comparison operators (currently stubs returning constants).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr ef4 a{};
+		constexpr ef4 b{};
+		static_assert(  a == b,  "constexpr efloat == stub returns true");
+		static_assert(!(a != b), "constexpr efloat != stub returns false");
+		static_assert(!(a <  b), "constexpr efloat <  stub returns false");
+		static_assert(!(a >  b), "constexpr efloat >  stub returns false");
+		static_assert(  a <= b,  "constexpr efloat <= stub returns true (! < || ==)");
+		static_assert(  a >= b,  "constexpr efloat >= stub returns true (! <)");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Free binary arithmetic operators compose from constexpr compounds.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr ef4 a{};
+		constexpr ef4 b{};
+		constexpr ef4 sum  = a + b;
+		constexpr ef4 diff = a - b;
+		constexpr ef4 prod = a * b;
+		constexpr ef4 quot = a / b;
+		static_assert(sum.iszero(),  "constexpr efloat + stub returns zero");
+		static_assert(diff.iszero(), "constexpr efloat - stub returns zero");
+		static_assert(prod.iszero(), "constexpr efloat * stub returns zero");
+		static_assert(quot.iszero(), "constexpr efloat / stub returns zero");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Wider configuration smoke: confirm the constexpr surface is template-
+	// parameter-independent (the heap-escape boundary is the same regardless
+	// of nlimbs because _limb stays empty at constant evaluation).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr ef8 z{};
+		static_assert(z.iszero(),       "constexpr ef8{}.iszero()");
+		static_assert(ef8::maxNrLimbs == 8u, "constexpr ef8::maxNrLimbs == 8");
+	}
+
+	// ----------------------------------------------------------------------------
+	// is_efloat trait is a constexpr variable template.
+	// ----------------------------------------------------------------------------
+	{
+		static_assert( is_efloat<ef4>,           "is_efloat<ef4> == true");
+		static_assert( is_efloat<ef8>,           "is_efloat<ef8> == true");
+		static_assert(!is_efloat<int>,           "is_efloat<int> == false");
+		static_assert(!is_efloat<double>,        "is_efloat<double> == false");
+	}
+
+	std::cout << "efloat constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/efloat.hpp
+++ b/include/sw/universal/number/efloat/efloat.hpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <iomanip>
 #include <vector>
+#include <type_traits>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -44,14 +44,36 @@ class efloat {
 public:
 	static constexpr unsigned maxNrLimbs = nlimbs;
 
-	// constructor
-	efloat() : _state{ FloatingPointState::Zero }, _sign{ false }, _exponent{ 0 }, _limb{ 0 } { }
+	// Partial-constexpr surface (issue #747): efloat carries a
+	// std::vector<uint32_t> _limb member, so any non-empty digit storage
+	// escapes constant evaluation under C++20's transient-allocation
+	// rules.  The default ctor uses is_constant_evaluated() to keep two
+	// parallel invariants: at constant evaluation _limb stays empty
+	// (the canonical constexpr zero -- iszero() relies on _state == Zero,
+	// not on _limb size); at runtime push_back(0) restores the historical
+	// "_limb has one element of value 0" representation for callers that
+	// inspect bits()/significant().  Sign-only and state-only selectors
+	// and modifiers operate purely on the trivial members and are
+	// constexpr-clean.  Compound arithmetic and free comparison operators
+	// are currently stubs (returning *this or a constant) and are
+	// therefore promoted to constexpr too -- the surface lights up at
+	// constant evaluation today, and real arithmetic semantics will
+	// inherit constexpr automatically when implemented.
+	// Out of scope (heap-escape boundary): native-type ctors / operator=
+	// (convert_ieee754 calls std::fpclassify which is not constexpr in
+	// C++20), conversion-out (std::pow), parse() (std::regex).
+	constexpr efloat() noexcept
+		: _state{ FloatingPointState::Zero }, _sign{ false }, _exponent{ 0 }, _limb{} {
+		if (!std::is_constant_evaluated()) {
+			_limb.push_back(0);
+		}
+	}
 
-	efloat(const efloat&) = default;
-	efloat(efloat&&) = default;
+	constexpr efloat(const efloat&) = default;
+	constexpr efloat(efloat&&) = default;
 
-	efloat& operator=(const efloat&) = default;
-	efloat& operator=(efloat&&) = default;
+	constexpr efloat& operator=(const efloat&) = default;
+	constexpr efloat& operator=(efloat&&) = default;
 
 	// initializers for native types
 	efloat(signed char iv)                      noexcept { *this = iv; }
@@ -92,61 +114,63 @@ public:
 #endif 
 
 	// prefix operators
-	efloat operator-() const {
+	constexpr efloat operator-() const noexcept {
 		efloat negated(*this);
 		return negated;
 	}
 
-	// arithmetic operators
-	efloat& operator+=(const efloat& rhs) {
+	// arithmetic operators (currently stubs; constexpr-marked so the
+	// surface lights up at constant evaluation today and real semantics
+	// will inherit constexpr-ness automatically when implemented)
+	constexpr efloat& operator+=(const efloat& /* rhs */) noexcept {
 		return *this;
 	}
-	efloat& operator+=(double rhs) {
+	constexpr efloat& operator+=(double /* rhs */) noexcept {
 		return *this;
 	}
-	efloat& operator-=(const efloat& rhs) {
+	constexpr efloat& operator-=(const efloat& /* rhs */) noexcept {
 		return *this;
 	}
-	efloat& operator-=(double rhs) {
+	constexpr efloat& operator-=(double /* rhs */) noexcept {
 		return *this;
 	}
-	efloat& operator*=(const efloat& /* rhs */) {
+	constexpr efloat& operator*=(const efloat& /* rhs */) noexcept {
 		return *this;
 	}
-	efloat& operator*=(double rhs) {
+	constexpr efloat& operator*=(double /* rhs */) noexcept {
 		return *this;
 	}
-	efloat& operator/=(const efloat& rhs) {
+	constexpr efloat& operator/=(const efloat& /* rhs */) noexcept {
 		return *this;
 	}
-	efloat& operator/=(double rhs) {
+	constexpr efloat& operator/=(double /* rhs */) noexcept {
 		return *this;
 	}
 
 	// modifiers
-	void clear() { _state = FloatingPointState::Normal;  _sign = false; _exponent = 0; _limb.clear(); }
-	void setzero() { clear(); }
+	constexpr void clear() noexcept { _state = FloatingPointState::Normal;  _sign = false; _exponent = 0; _limb.clear(); }
+	constexpr void setzero() noexcept { clear(); _state = FloatingPointState::Zero; }
 
-	efloat& assign(const std::string& txt) {
+	efloat& assign(const std::string& /* txt */) {
 		return *this;
 	}
 
 	// selectors
-	bool iszero() const noexcept { return _state == FloatingPointState::Zero; }
-	bool isone()  const noexcept { return (_state == FloatingPointState::Normal && !_sign && _exponent == 0 && _limb.size() == 1 && _limb[0] == 0x8000'000); }
-	bool isodd()  const noexcept { return false; }
-	bool iseven() const noexcept { return !isodd(); }
-	bool ispos()  const noexcept { return (_state == FloatingPointState::Normal && !_sign); }
-	bool isneg()  const noexcept { return (_state == FloatingPointState::Normal && _sign); }
-	bool isinf()  const noexcept { return (_state == FloatingPointState::Infinite); }
-	bool isnan()  const noexcept { return (_state == FloatingPointState::QuietNaN || _state == FloatingPointState::SignalingNaN); }
-	bool isqnan()  const noexcept { return (_state == FloatingPointState::QuietNaN); }
-	bool issnan()  const noexcept { return (_state == FloatingPointState::SignalingNaN); }
+	constexpr bool iszero() const noexcept { return _state == FloatingPointState::Zero; }
+	constexpr bool isone()  const noexcept { return (_state == FloatingPointState::Normal && !_sign && _exponent == 0 && _limb.size() == 1 && _limb[0] == 0x8000'000); }
+	constexpr bool isodd()  const noexcept { return false; }
+	constexpr bool iseven() const noexcept { return !isodd(); }
+	constexpr bool ispos()  const noexcept { return (_state == FloatingPointState::Normal && !_sign); }
+	constexpr bool isneg()  const noexcept { return (_state == FloatingPointState::Normal && _sign); }
+	constexpr bool isinf()  const noexcept { return (_state == FloatingPointState::Infinite); }
+	constexpr bool isnan()  const noexcept { return (_state == FloatingPointState::QuietNaN || _state == FloatingPointState::SignalingNaN); }
+	constexpr bool isqnan()  const noexcept { return (_state == FloatingPointState::QuietNaN); }
+	constexpr bool issnan()  const noexcept { return (_state == FloatingPointState::SignalingNaN); }
 
 
 	// value information selectors
-	int     sign()        const noexcept { return (_sign ? -1 : 1); }
-	int64_t scale()       const noexcept { return _exponent; }
+	constexpr int     sign()        const noexcept { return (_sign ? -1 : 1); }
+	constexpr int64_t scale()       const noexcept { return _exponent; }
 	double  significant() const noexcept {
 		// efloat is a normalized floating-point, thus the significant falls in the range [1.0, 2.0)
 		double v{ 0.0 };
@@ -323,7 +347,7 @@ private:
 
 	// efloat - efloat logic comparisons
 	template<unsigned nnlimbs>
-	friend bool operator==(const efloat<nnlimbs>& lhs, const efloat<nnlimbs>& rhs);
+	friend constexpr bool operator==(const efloat<nnlimbs>& lhs, const efloat<nnlimbs>& rhs) noexcept;
 
 	// efloat - literal logic comparisons
 	template<unsigned nnlimbs>
@@ -403,28 +427,29 @@ inline std::istream& operator>>(std::istream& istr, efloat<nlimbs>& p) {
 // efloat - efloat binary logic operators
 
 // equal: precondition is that the storage is properly nulled in all arithmetic paths
+// (currently stubs; constexpr-marked so the surface is usable in static_assert)
 template<unsigned nlimbs>
-inline bool operator==(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr bool operator==(const efloat<nlimbs>& /* lhs */, const efloat<nlimbs>& /* rhs */) noexcept {
 	return true;
 }
 template<unsigned nlimbs>
-inline bool operator!=(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr bool operator!=(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	return !operator==(lhs, rhs);
 }
 template<unsigned nlimbs>
-inline bool operator< (const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr bool operator< (const efloat<nlimbs>& /* lhs */, const efloat<nlimbs>& /* rhs */) noexcept {
 	return false; // lhs and rhs are the same
 }
 template<unsigned nlimbs>
-inline bool operator> (const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr bool operator> (const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	return operator< (rhs, lhs);
 }
 template<unsigned nlimbs>
-inline bool operator<=(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr bool operator<=(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	return operator< (lhs, rhs) || operator==(lhs, rhs);
 }
 template<unsigned nlimbs>
-inline bool operator>=(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr bool operator>=(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	return !operator< (lhs, rhs);
 }
 
@@ -489,30 +514,31 @@ inline bool operator>=(double lhs, const efloat<nlimbs>& rhs) {
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // efloat - efloat binary arithmetic operators
+// (compose from constexpr-marked compound operators)
 // BINARY ADDITION
 template<unsigned nlimbs>
-inline efloat<nlimbs> operator+(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr efloat<nlimbs> operator+(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	efloat<nlimbs> sum = lhs;
 	sum += rhs;
 	return sum;
 }
 // BINARY SUBTRACTION
 template<unsigned nlimbs>
-inline efloat<nlimbs> operator-(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr efloat<nlimbs> operator-(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	efloat<nlimbs> diff = lhs;
 	diff -= rhs;
 	return diff;
 }
 // BINARY MULTIPLICATION
 template<unsigned nlimbs>
-inline efloat<nlimbs> operator*(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr efloat<nlimbs> operator*(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	efloat<nlimbs> mul = lhs;
 	mul *= rhs;
 	return mul;
 }
 // BINARY DIVISION
 template<unsigned nlimbs>
-inline efloat<nlimbs> operator/(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) {
+constexpr efloat<nlimbs> operator/(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
 	efloat<nlimbs> ratio = lhs;
 	ratio /= rhs;
 	return ratio;

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -149,7 +149,17 @@ public:
 
 	// modifiers
 	constexpr void clear() noexcept { _state = FloatingPointState::Normal;  _sign = false; _exponent = 0; _limb.clear(); }
-	constexpr void setzero() noexcept { clear(); _state = FloatingPointState::Zero; }
+	constexpr void setzero() noexcept {
+		clear();
+		_state = FloatingPointState::Zero;
+		// Match the default ctor's runtime representation (_limb = [0])
+		// so isone(), bits(), significant() see identical state regardless
+		// of how the zero was reached.  Empty _limb stays at constant
+		// evaluation (heap-escape boundary).
+		if (!std::is_constant_evaluated()) {
+			_limb.push_back(0);
+		}
+	}
 
 	efloat& assign(const std::string& /* txt */) {
 		return *this;


### PR DESCRIPTION
## Summary

- Promote `efloat<nlimbs>`'s user-facing surface to `constexpr` where C++20 transient-allocation rules permit; mirrors the partial-constexpr playbook from #820 (unum), #821 (valid), and #824 (edecimal).
- `efloat` carries a `std::vector<uint32_t> _limb` member, so any non-empty digit storage disqualifies the object from being a `constexpr` variable. Default ctor uses `std::is_constant_evaluated()` to keep two parallel invariants: empty `_limb` at constant evaluation; `push_back(0)` at runtime so all existing code continues to see the historical "_limb has one element of value 0" representation.
- Drive-by fix in `setzero()`: previously delegated to `clear()` which sets `_state = Normal`, meaning `iszero()` returned false right after `setzero()` -- contrary to the function's name. Restored to set `_state = Zero`. Only internal stub callers used it; constexpr smoke test pins the contract going forward.

## Changes

- `include/sw/universal/number/efloat/efloat_impl.hpp`:
  - Default ctor + defaulted copy/move/assignment marked `constexpr`
  - State-only / sign-only selectors marked `constexpr`: `iszero`, `isone`, `isodd`, `iseven`, `ispos`, `isneg`, `isinf`, `isnan`, `isqnan`, `issnan`, `sign`, `scale`
  - Modifiers marked `constexpr`: `clear`, `setzero` (with the drive-by fix)
  - Unary `operator-` marked `constexpr` (currently a stub copy)
  - Compound arithmetic stubs `+= -= *= /=` (and `double` overloads) marked `constexpr`
  - Free comparison operators `==, !=, <, <=, >, >=` marked `constexpr`
  - Free binary arithmetic operators `+, -, *, /` marked `constexpr` (compose from the constexpr-marked compounds)
  - Matching friend declaration of `operator==` updated to `constexpr` (compiler-required)
  - Comment block documenting the heap-allocation boundary
- `include/sw/universal/number/efloat/efloat.hpp` -- add `<type_traits>` for `std::is_constant_evaluated`
- `elastic/efloat/api/constexpr.cpp` -- new file. `static_assert` smoke tests covering default ctor, all promoted selectors, `clear`/`setzero` round-trip, copy/move/assignment, unary minus, compound stubs, comparison stubs, binary arithmetic stubs, and the `is_efloat` trait. Header documents in/out of scope. CMakeLists.txt auto-registers via existing `api/*.cpp` glob.

## Constexpr-callable surface today (gcc + clang, C++20)

- Default ctor + state/sign selectors at constant evaluation
- `clear()` / `setzero()` round-trips at constant evaluation
- Compound arithmetic stubs and binary free functions at constant evaluation (no-ops; contract lock-in)
- Comparison operators at constant evaluation (stub-true / stub-false)

## Limited at constant evaluation today (heap-escape + non-constexpr stdlib)

Native-type ctors / operator= (`convert_ieee754` uses `std::fpclassify`), conversion-out (`std::pow`), `parse()` / `assign(string)` (`std::regex`). All will light up automatically when the toolchain catches up to C++23.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `efloat_constexpr` (NEW) | OK | PASS | OK | PASS |
| `efloat_api` | OK | PASS | OK | PASS |
| `efloat_addition` | OK | PASS | OK | PASS |
| `efloat_pow` | OK | PASS | OK | PASS |

4/4 elastic/efloat regression suite passes on both compilers.

## Test plan

- [x] Fast CI (gcc + clang CI_LITE) green
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #747

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * efloat now provides broad constexpr support: construction, copy/move, modifiers, selectors, unary and binary arithmetic, and comparisons are usable at compile time.

* **Tests**
  * Added a constexpr verification test program that validates compile-time construction, operations, comparisons, and related type traits, and reports pass/fail.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/825)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->