### PR TITLE
feat(erational): partial constexpr support (API surface)

### DIFF
--- a/elastic/rational/binary/api/constexpr.cpp
+++ b/elastic/rational/binary/api/constexpr.cpp
@@ -1,0 +1,159 @@
+// constexpr.cpp: compile-time tests for adaptive precision rational (erational)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage (per issue #749, parent epic #723):
+//
+//   * default construction: is_constant_evaluated() dispatch keeps
+//     numerator/denominator as default-empty edecimals at constant
+//     evaluation; setzero() is called at runtime to preserve the
+//     historical "0/1" representation
+//   * defaulted copy / move ctors and assignment operators (rely on
+//     edecimal's now-constexpr defaults from #824)
+//   * selectors that delegate to constexpr-clean edecimal selectors
+//     or read trivial bool members:
+//       iszero, isneg, ispos, isinf, isnan, sign, top, bottom
+//   * sign-only modifiers: setsign, setneg, setpos
+//
+// Out of scope (deferred; see comment block in erational_impl.hpp):
+//
+//   * native-type ctors and operator=        - chain to convert_signed/
+//                                              unsigned/ieee754 -> edecimal
+//                                              heap operations
+//   * arithmetic operators (+= -= *= /=)     - chain through edecimal
+//                                              arithmetic which is
+//                                              non-constexpr
+//   * unary -, ++, --                        - allocate temporaries
+//   * conversion-out (operator double, etc.) - uses edecimal arithmetic
+//   * free comparison operators              - depend on non-constexpr
+//                                              edecimal == and <
+//                                              (edecimal arithmetic is
+//                                              still pre-constexpr)
+//   * setbits, setnumerator, setdenominator  - heap mutation
+//   * parse() / normalize()                  - regex / arithmetic
+//
+// erational is composed of two edecimal members; the constexpr surface
+// is therefore intersected with edecimal's own constexpr surface.  When
+// edecimal arithmetic / comparison get promoted in a follow-up, the
+// erational arithmetic and comparison surface will inherit constexpr-
+// ness automatically.
+
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/erational/erational.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "erational constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----------------------------------------------------------------------------
+	// Default construction at constant evaluation: numerator/denominator
+	// are default-constructed empty edecimals; iszero() recognizes the
+	// empty numerator state via edecimal::iszero().
+	// ----------------------------------------------------------------------------
+	{
+		constexpr erational z{};
+		static_assert( z.iszero(),  "constexpr default-constructed erational is zero (numerator empty)");
+		// Note: at constant evaluation BOTH numerator and denominator are
+		// empty, so isnan() (defined as numerator.iszero() && denominator.iszero())
+		// returns true.  This is the deliberate consequence of the empty-
+		// vector constexpr representation: the runtime default ctor calls
+		// setzero() which sets denominator = 1, but that path heap-allocates
+		// and is not available at constant evaluation under C++20's
+		// transient-allocation rule.  Users who need a non-NaN constexpr
+		// erational must wait for edecimal arithmetic to become constexpr
+		// (which would let them initialize denominator = 1 at compile time).
+		static_assert( z.isnan(),   "constexpr default-constructed erational has empty num+denom -> isnan() at compile time");
+		static_assert(!z.isinf(),   "constexpr default-constructed erational !isinf()");
+		static_assert(!z.sign(),    "constexpr default-constructed erational sign() == false");
+		static_assert(!z.isneg(),   "constexpr default-constructed erational !isneg()");
+		static_assert( z.ispos(),   "constexpr default-constructed erational ispos()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Sign-only modifiers at constant evaluation: setsign, setneg, setpos
+	// operate purely on the bool member (no edecimal touch).
+	// ----------------------------------------------------------------------------
+	{
+		// setsign(true) round-trip.
+		constexpr erational neg = []() {
+			erational t{};
+			t.setsign(true);
+			return t;
+		}();
+		static_assert( neg.sign(),    "constexpr setsign(true) -> sign() == true");
+		static_assert( neg.isneg(),   "constexpr setsign(true) -> isneg()");
+		static_assert(!neg.ispos(),   "constexpr setsign(true) -> !ispos()");
+
+		// setneg() then setpos() round-trip.
+		constexpr erational flipped = []() {
+			erational t{};
+			t.setneg();
+			t.setpos();
+			return t;
+		}();
+		static_assert(!flipped.sign(),  "constexpr setneg+setpos -> sign() == false");
+		static_assert( flipped.ispos(), "constexpr setneg+setpos -> ispos()");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Defaulted copy and move constructors / assignment operators.
+	// Backed by edecimal's defaulted copy/move which are constexpr per #824.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr erational src{};
+		constexpr erational copied{ src };
+		static_assert( copied.iszero(), "constexpr copy ctor preserves zero");
+		static_assert(!copied.sign(),   "constexpr copy ctor preserves sign");
+
+		constexpr erational assigned = []() {
+			erational dst{};
+			erational s{};
+			s.setsign(true);
+			dst = s;
+			return dst;
+		}();
+		static_assert( assigned.iszero(), "constexpr copy assignment preserves zero");
+		static_assert( assigned.isneg(),  "constexpr copy assignment carries sign");
+	}
+
+	// ----------------------------------------------------------------------------
+	// is_erational trait is itself a constexpr variable template.
+	// ----------------------------------------------------------------------------
+	{
+		static_assert( is_erational<erational>,    "is_erational<erational> == true");
+		static_assert(!is_erational<int>,          "is_erational<int> == false");
+		static_assert(!is_erational<double>,       "is_erational<double> == false");
+	}
+
+	std::cout << "erational constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/elastic/rational/binary/api/constexpr.cpp
+++ b/elastic/rational/binary/api/constexpr.cpp
@@ -45,6 +45,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <utility>
 #include <universal/number/erational/erational.hpp>
 #include <universal/verification/test_suite.hpp>
 
@@ -128,6 +129,29 @@ try {
 		}();
 		static_assert( assigned.iszero(), "constexpr copy assignment preserves zero");
 		static_assert( assigned.isneg(),  "constexpr copy assignment carries sign");
+
+		// Move ctor / move assignment: also defaulted, also constexpr.
+		// At constant evaluation the moved-from edecimals stay empty so
+		// the operations are no-ops on heap state -- pure trivial-member
+		// transfer.
+		constexpr erational moved = []() {
+			erational s{};
+			s.setsign(true);
+			erational d{ std::move(s) };
+			return d;
+		}();
+		static_assert( moved.isneg(),     "constexpr move ctor carries sign");
+		static_assert( moved.iszero(),    "constexpr move ctor preserves zero");
+
+		constexpr erational move_assigned = []() {
+			erational dst{};
+			erational s{};
+			s.setsign(true);
+			dst = std::move(s);
+			return dst;
+		}();
+		static_assert( move_assigned.isneg(),  "constexpr move assignment carries sign");
+		static_assert( move_assigned.iszero(), "constexpr move assignment preserves zero");
 	}
 
 	// ----------------------------------------------------------------------------

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -46,7 +46,11 @@ public:
 	// edecimal::iszero); at runtime setzero() restores the historical
 	// "0/1" representation that arithmetic and the existing comparison
 	// operators rely on.
-	constexpr erational() noexcept : negative{ false }, numerator{}, denominator{} {
+	// Not noexcept: the runtime branch calls setzero() -> edecimal::operator=
+	// which calls push_back, and that may throw std::bad_alloc.  Constexpr
+	// invocation never throws (the empty-vector path doesn't allocate),
+	// but the function signature must reflect the runtime contract.
+	constexpr erational() : negative{ false }, numerator{}, denominator{} {
 		if (!std::is_constant_evaluated()) {
 			setzero();
 		}

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -29,13 +29,34 @@ namespace sw { namespace universal {
 /// The digits of both are managed as a vector with the digit for 10^0 stored at index 0, 10^1 stored at index 1, etc.
 class erational {
 public:
-	erational() { setzero(); }
+	// Partial-constexpr surface (issue #749): erational is composed of
+	// two edecimal members (numerator and denominator), each carrying a
+	// std::vector<uint8_t> digit storage.  Under C++20's transient-
+	// allocation rule, any non-empty digit storage escapes constant
+	// evaluation, so the constexpr surface mirrors edecimal's (per
+	// PR #824): default ctor + selectors that read trivial / empty-
+	// constexpr-clean members + sign-only modifiers.  Arithmetic and
+	// free comparison operators chain through edecimal arithmetic,
+	// which itself remains non-constexpr (depends on push_back/insert),
+	// so they are out of scope here.
+	//
+	// Default ctor uses std::is_constant_evaluated() to keep parallel
+	// invariants: at constant evaluation the edecimal members stay
+	// default-constructed (empty digit vectors, recognized as zero by
+	// edecimal::iszero); at runtime setzero() restores the historical
+	// "0/1" representation that arithmetic and the existing comparison
+	// operators rely on.
+	constexpr erational() noexcept : negative{ false }, numerator{}, denominator{} {
+		if (!std::is_constant_evaluated()) {
+			setzero();
+		}
+	}
 
-	erational(const erational&) = default;
-	erational(erational&&) = default;
+	constexpr erational(const erational&) = default;
+	constexpr erational(erational&&) = default;
 
-	erational& operator=(const erational&) = default;
-	erational& operator=(erational&&) = default;
+	constexpr erational& operator=(const erational&) = default;
+	constexpr erational& operator=(erational&&) = default;
 
 	erational(std::int64_t n, std::uint64_t d) : negative{ false }, numerator { n }, denominator{ d } {
 		negative = ((n < 0) ^ (d < 0));
@@ -180,15 +201,16 @@ public:
 		return *this;
 	}
 
-	// selectors
-	bool iszero()                   const noexcept { return numerator.iszero(); }
-	bool isneg()                    const noexcept { return negative; }   // <  0
-	bool ispos()                    const noexcept { return !negative; }  // >= 0
-	bool isinf()                    const noexcept { return false; }
-	bool isnan()                    const noexcept { return numerator.iszero() && denominator.iszero(); }
-	bool sign()                     const noexcept { return negative; }
-	edecimal top()                  const noexcept { return numerator; }
-	edecimal bottom()               const noexcept { return denominator; }
+	// selectors (delegate to edecimal selectors, which are constexpr-clean
+	// on empty digit vectors per #824, or read trivial bool member)
+	constexpr bool iszero()         const noexcept { return numerator.iszero(); }
+	constexpr bool isneg()          const noexcept { return negative; }   // <  0
+	constexpr bool ispos()          const noexcept { return !negative; }  // >= 0
+	constexpr bool isinf()          const noexcept { return false; }
+	constexpr bool isnan()          const noexcept { return numerator.iszero() && denominator.iszero(); }
+	constexpr bool sign()           const noexcept { return negative; }
+	constexpr edecimal top()        const noexcept { return numerator; }
+	constexpr edecimal bottom()     const noexcept { return denominator; }
 	std::pair<int64_t, int64_t> toPair() const noexcept {
 		return { int64_t(numerator), int64_t(denominator) };
 	}
@@ -199,9 +221,9 @@ public:
 		numerator   = 0;
 		denominator = 1;
 	}
-	void setsign(bool sign) { negative = sign; }
-	void setneg() { negative = true; }
-	void setpos() { negative = false; }
+	constexpr void setsign(bool sign) noexcept { negative = sign; }
+	constexpr void setneg() noexcept { negative = true; }
+	constexpr void setpos() noexcept { negative = false; }
 	void setnumerator(const edecimal& num) { numerator = num; }
 	void setdenominator(const edecimal& denom) { denominator = denom; }
 	void setbits(uint64_t v) { *this = v; } // API to be consistent with the other number systems


### PR DESCRIPTION
## Summary

- Promote `erational`'s user-facing surface to `constexpr` where C++20 transient-allocation rules and edecimal's own constexpr boundary permit; mirrors the partial-constexpr playbook from #820/#821/#824/#825/#826.
- `erational` is composed of two `edecimal` members (numerator + denominator). Default ctor uses `std::is_constant_evaluated()` to keep parallel invariants: at constant evaluation, both edecimals stay default-empty (recognized as zero); at runtime `setzero()` restores the historical "0/1" representation.
- Smaller surface than `einteger` (#826) because edecimal's own arithmetic and comparison operators are not yet constexpr — those are bounded by `std::vector::push_back/insert` escape-on-persist rules in C++20.

## Changes

- `include/sw/universal/number/erational/erational_impl.hpp`:
  - Default ctor + defaulted copy/move/assignment marked `constexpr`
  - Selectors marked `constexpr`: `iszero`, `isneg`, `ispos`, `isinf`, `isnan`, `sign`, `top`, `bottom`
  - Sign-only modifiers marked `constexpr`: `setsign`, `setneg`, `setpos`
  - Comment block documenting heap-allocation + composite boundaries
- `elastic/rational/binary/api/constexpr.cpp` — new file. `static_assert` smoke tests covering default ctor, all promoted selectors, sign-modifier round-trip, copy/move/assignment, and `is_erational` trait. Header documents in/out of scope. CMakeLists.txt auto-registers via existing `api/*.cpp` glob.

## Constexpr-callable surface today (gcc + clang, C++20)

- Default ctor + selectors at constant evaluation
- Sign modifier round-trips at constant evaluation
- Copy / copy-assignment at constant evaluation

## Limited at constant evaluation today

Native-type ctors / `operator=`, arithmetic operators, unary `-` / `++` / `--`, conversion-out, free comparison operators (depend on non-constexpr edecimal `==`/`<`), `setbits`, `setnumerator`/`denominator`, `parse()` / `normalize()`. Will inherit constexpr-ness automatically when edecimal arithmetic becomes constexpr.

## Behavioral subtlety documented

At constant evaluation, BOTH numerator and denominator are empty vectors, so `isnan()` (defined as `numerator.iszero() && denominator.iszero()`) returns **true** on a default-constructed erational at compile time. The runtime path's `setzero()` sets denominator = 1, but that requires `push_back` which heap-allocates and cannot persist in a constexpr variable. The smoke test asserts the actual behavior with a clear comment so future readers understand the divergence.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `ebinratio_constexpr` (NEW) | OK | PASS | OK | PASS |
| `ebinratio_api` | OK | PASS | OK | PASS |
| `erat_api` | OK | PASS | OK | PASS |
| `erat_addition` | OK | PASS | OK | PASS |
| `erat_subtraction` | OK | PASS | OK | PASS |
| `erat_multiplication` | OK | PASS | OK | PASS |
| `erat_division` | OK | PASS | OK | PASS |
| `erat_logic` | OK | PASS | OK | PASS |
| `erat_exceptions` | OK | PASS | OK | PASS |
| `erat_sqrt` | OK | PASS | OK | PASS |

10/10 elastic/rational regression suite (binary + decimal rationals) passes on both compilers.

## Test plan

- [ ] Fast CI (gcc + clang CI_LITE) green
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #749

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C++20 constexpr support to the erational type, enabling compile-time construction, copying/moving, and sign operations for rational numbers.

* **Tests**
  * Added compile-time verification that exercises constexpr construction, copy/move, sign modifiers, and type-trait behavior; test suite reports PASS/FAIL results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/827)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->