### PR TITLE
feat(ereal): partial constexpr support (API surface)

### DIFF
--- a/elastic/ereal/api/constexpr.cpp
+++ b/elastic/ereal/api/constexpr.cpp
@@ -1,0 +1,163 @@
+// constexpr.cpp: compile-time tests for adaptive precision multi-component real (ereal)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage (per issue #750, parent epic #723):
+//
+//   * default construction (is_constant_evaluated() dispatch leaves
+//     _limb empty at constant evaluation; runtime path pushes 0.0)
+//   * defaulted copy / move ctors and assignment operators
+//   * selectors that don't depend on non-constexpr stdlib helpers:
+//       iszero, isone, ispos, isneg, sign, significant, limbs
+//     (all empty-_limb-guarded so the compile-time empty-vector path
+//     is well-defined; the runtime path always has _limb.size() >= 1)
+//
+// Out of scope (deferred; see comment block in ereal_impl.hpp):
+//
+//   * isnan / isinf / signbit / scale -- depend on non-constexpr
+//                                        std::fpclassify / std::signbit /
+//                                        sw::universal::scale
+//   * native-type ctors and operator=  - convert_signed/unsigned/ieee754
+//                                        all heap-mutate via clear() +
+//                                        push_back
+//   * setzero / setnan / setinf /      - clear + push_back; heap escape
+//     maxpos / minpos / maxneg / minneg
+//   * arithmetic operators (+= etc.)   - Shewchuk expansion arithmetic
+//                                        mutates the digit vector
+//   * unary -, conversion-out          - allocate or call non-constexpr
+//                                        helpers
+//   * free comparison operators        - compare_adaptive iterates the
+//                                        expansion (non-constexpr)
+//   * parse / assign / to_string       - regex / stringstream / frexp
+//
+// ereal is more complex than the other elastic types because Shewchuk's
+// expansion arithmetic is the only available algorithm for normalization
+// and ordering, and it itself is not constexpr-clean today.  This PR
+// pins the construction + read-only-selector surface so static_assert
+// usage is possible and a future arithmetic-constexpr promotion (likely
+// after the expansion_ops module is itself promoted) inherits the
+// existing contract.
+
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <utility>
+#include <universal/number/ereal/ereal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "ereal constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// Default ereal uses maxlimbs = 8; also exercise maxlimbs = 4 to
+	// confirm the constexpr surface is template-parameter-independent.
+	using er4 = ereal<4>;
+	using er8 = ereal<8>;
+
+	// ----------------------------------------------------------------------------
+	// Static structural invariants.
+	// ----------------------------------------------------------------------------
+	{
+		static_assert(er4::maxNrLimbs == 4u, "constexpr er4::maxNrLimbs == 4");
+		static_assert(er8::maxNrLimbs == 8u, "constexpr er8::maxNrLimbs == 8");
+		static_assert(er8::EXP_BIAS == 1023, "constexpr ereal::EXP_BIAS == 1023");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Default construction at constant evaluation: _limb is empty;
+	// iszero() recognizes the empty state as canonical zero.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr er8 z{};
+		static_assert( z.iszero(),   "constexpr default-constructed ereal is zero");
+		static_assert(!z.isone(),    "constexpr default-constructed ereal !isone()");
+		static_assert(!z.ispos(),    "constexpr default-constructed ereal !ispos() (empty -> not strictly positive)");
+		static_assert(!z.isneg(),    "constexpr default-constructed ereal !isneg()");
+		static_assert( z.sign() == 1, "constexpr default-constructed ereal sign() == 1");
+		static_assert( z.significant() == 0.0, "constexpr default-constructed ereal significant() == 0.0");
+		static_assert( z.limbs().empty(), "constexpr default-constructed ereal limbs() is empty at compile time");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Defaulted copy and move constructors / assignment operators.
+	// Backed by std::vector's constexpr defaulted copy/move (in C++20
+	// for empty sources).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr er8 src{};
+		constexpr er8 copied{ src };
+		static_assert( copied.iszero(),         "constexpr copy ctor preserves zero");
+		static_assert( copied.limbs().empty(),  "constexpr copy ctor preserves empty limbs");
+
+		constexpr er8 assigned = []() {
+			er8 dst{};
+			er8 s{};
+			dst = s;
+			return dst;
+		}();
+		static_assert( assigned.iszero(),       "constexpr copy assignment preserves zero");
+
+		constexpr er8 moved = []() {
+			er8 s{};
+			er8 d{ std::move(s) };
+			return d;
+		}();
+		static_assert( moved.iszero(),          "constexpr move ctor preserves zero");
+
+		constexpr er8 move_assigned = []() {
+			er8 dst{};
+			er8 s{};
+			dst = std::move(s);
+			return dst;
+		}();
+		static_assert( move_assigned.iszero(),  "constexpr move assignment preserves zero");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Template-parameter independence: same constexpr surface for er4 and er8.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr er4 z4{};
+		static_assert( z4.iszero(),  "constexpr er4{}.iszero()");
+		static_assert( z4.limbs().empty(), "constexpr er4{}.limbs() is empty at compile time");
+	}
+
+	// ----------------------------------------------------------------------------
+	// is_ereal trait is itself a constexpr variable template.
+	// ----------------------------------------------------------------------------
+	{
+		static_assert( is_ereal<er4>,           "is_ereal<er4> == true");
+		static_assert( is_ereal<er8>,           "is_ereal<er8> == true");
+		static_assert(!is_ereal<int>,           "is_ereal<int> == false");
+		static_assert(!is_ereal<double>,        "is_ereal<double> == false");
+	}
+
+	std::cout << "ereal constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/elastic/ereal/api/constexpr.cpp
+++ b/elastic/ereal/api/constexpr.cpp
@@ -90,6 +90,36 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
+	// Runtime storage-shape pin: the is_constant_evaluated() dispatch must
+	// produce _limb = [0.0] at runtime so arithmetic and conversion paths
+	// (which assume non-empty storage) keep working.  A regression that
+	// dropped the runtime push_back(0.0) would silently produce empty
+	// vectors and cause downstream undefined behavior.
+	// ----------------------------------------------------------------------------
+	{
+		er8 zr{};
+		if (zr.limbs().size() != 1) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: runtime default-constructed ereal has limbs().size() = " << zr.limbs().size() << " (expected 1)\n";
+		}
+		else if (zr.limbs()[0] != 0.0) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: runtime default-constructed ereal has limbs()[0] = " << zr.limbs()[0] << " (expected 0.0)\n";
+		}
+
+		// Same check for er4 to confirm template-parameter independence.
+		er4 zr4{};
+		if (zr4.limbs().size() != 1) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: runtime default-constructed er4 has limbs().size() = " << zr4.limbs().size() << " (expected 1)\n";
+		}
+		else if (zr4.limbs()[0] != 0.0) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: runtime default-constructed er4 has limbs()[0] = " << zr4.limbs()[0] << " (expected 0.0)\n";
+		}
+	}
+
+	// ----------------------------------------------------------------------------
 	// Defaulted copy and move constructors / assignment operators.
 	// Backed by std::vector's constexpr defaulted copy/move (in C++20
 	// for empty sources).

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -12,6 +12,7 @@
 #include <regex>
 #include <vector>
 #include <map>
+#include <type_traits>
 
 // supporting types and functions
 #include <universal/native/ieee754.hpp>   // IEEE-754 decoders
@@ -84,14 +85,43 @@ public:
 		"non-overlapping property required by Shewchuk's expansion arithmetic. "
 		"This results in incorrect two_sum/two_product operations and silent arithmetic errors.");
 
-	// constructor
-	ereal() : _limb{ 0 } { }
+	// Partial-constexpr surface (issue #750): ereal carries a
+	// std::vector<double> _limb member, so any non-empty digit storage
+	// escapes constant evaluation under C++20's transient-allocation
+	// rule.  Default ctor uses is_constant_evaluated() dispatch: at
+	// compile time, _limb stays empty (each selector below is empty-
+	// vector-guarded so this behaves as canonical zero); at runtime,
+	// _limb is initialized to a one-element vector containing 0.0 (the
+	// historical representation that the arithmetic and conversion
+	// paths rely on).
+	//
+	// Not marked noexcept: the runtime branch allocates, which can
+	// throw std::bad_alloc.  (See comment block on the modifiers
+	// for the same reasoning applied to clear/setzero/setnan.)
+	//
+	// Out of scope -- non-constexpr stdlib helpers / heap mutation:
+	//   * isnan, isinf      - use std::fpclassify (not constexpr in C++20)
+	//   * signbit, scale    - use std::signbit / sw::universal::scale
+	//   * setzero, setnan,  - call clear() + push_back; heap escape
+	//     setinf, max/min
+	//   * arithmetic ops    - mutate via Shewchuk's expansion arithmetic
+	//   * comparison ops    - call compare_adaptive which iterates the
+	//                         expansion (also a non-constexpr path today)
+	//   * conversion-out    - sums the limb vector at runtime
+	//   * native-type ctors / operator= - convert_* allocate
+	//   * parse() / to_string() / to_digits() - std::frexp, regex,
+	//                                           stringstream
+	constexpr ereal() : _limb{} {
+		if (!std::is_constant_evaluated()) {
+			_limb.push_back(0.0);
+		}
+	}
 
-	ereal(const ereal&) = default;
-	ereal(ereal&&) = default;
+	constexpr ereal(const ereal&) = default;
+	constexpr ereal(ereal&&) = default;
 
-	ereal& operator=(const ereal&) = default;
-	ereal& operator=(ereal&&) = default;
+	constexpr ereal& operator=(const ereal&) = default;
+	constexpr ereal& operator=(ereal&&) = default;
 
 	// initializers for native types
 	ereal(signed char iv)                      noexcept { *this = iv; }
@@ -538,20 +568,27 @@ public:
 		return s;
 	}
 
-	// selectors
-	bool iszero()  const noexcept { return _limb[0] == 0.0; }  // do we need to check that we should only have one limb?
-	bool isone()   const noexcept { return _limb[0] == 1.0; }
-	bool ispos()   const noexcept { return _limb[0] > 0.0; }
-	bool isneg()   const noexcept { return _limb[0] < 0.0; }
-	bool isinf()   const noexcept { return sw::universal::isinf(_limb[0]); }
-	bool isnan()   const noexcept { return sw::universal::isnan(_limb[0]); }
+	// selectors (empty-_limb-guarded so the constexpr default ctor's
+	// empty-vector path doesn't dereference out of bounds; the runtime
+	// path always has _limb.size() >= 1 so the guards are pure
+	// constexpr-evaluation safety)
+	constexpr bool iszero()  const noexcept { return _limb.empty() || _limb[0] == 0.0; }
+	constexpr bool isone()   const noexcept { return !_limb.empty() && _limb[0] == 1.0; }
+	constexpr bool ispos()   const noexcept { return !_limb.empty() && _limb[0] > 0.0; }
+	constexpr bool isneg()   const noexcept { return !_limb.empty() && _limb[0] < 0.0; }
+	// isinf, isnan use sw::universal::isinf/isnan which call std::fpclassify
+	// (not constexpr in C++20); not promoted.  Empty guard added for
+	// runtime safety against zero-capacity vectors after move (see
+	// modifier comment block below).
+	bool isinf()   const noexcept { return !_limb.empty() && sw::universal::isinf(_limb[0]); }
+	bool isnan()   const noexcept { return !_limb.empty() && sw::universal::isnan(_limb[0]); }
 
 	// value information selectors
-	bool                       signbit()     const noexcept { return std::signbit(_limb[0]); }
-	int                        sign()        const noexcept { return (isneg() ? -1 : 1); }
-	int64_t                    scale()       const noexcept { return sw::universal::scale(_limb[0]); }
-	double                     significant() const noexcept { return _limb[0]; }
-	const std::vector<double>& limbs()       const noexcept { return _limb; }
+	bool                       signbit()     const noexcept { return !_limb.empty() && std::signbit(_limb[0]); }
+	constexpr int              sign()        const noexcept { return (isneg() ? -1 : 1); }
+	int64_t                    scale()       const noexcept { return _limb.empty() ? 0 : sw::universal::scale(_limb[0]); }
+	constexpr double           significant() const noexcept { return _limb.empty() ? 0.0 : _limb[0]; }
+	constexpr const std::vector<double>& limbs()       const noexcept { return _limb; }
 
 protected:
 	std::vector<double> _limb;     // components of the real value


### PR DESCRIPTION
## Summary

- Promote `ereal<maxlimbs>`'s user-facing surface to `constexpr` where C++20 transient-allocation rules and non-constexpr stdlib helpers permit; mirrors the partial-constexpr playbook from #820/#821/#824/#825/#826/#827.
- ereal uses Shewchuk's expansion arithmetic over a `std::vector<double>`, so the constexpr surface is necessarily smaller than other elastic types: arithmetic and comparison go through `expansion_ops` which is itself not yet constexpr, and selectors like `isinf`/`isnan` use `std::fpclassify` (not constexpr in C++20).
- Default ctor uses `is_constant_evaluated()` dispatch — empty `_limb` at compile time, `push_back(0.0)` at runtime.
- Default ctor is intentionally NOT `noexcept`: matches the codebase convention documented at line 234 of the impl, since the runtime branch's `push_back` can throw `bad_alloc`.

## Changes

- `include/sw/universal/number/ereal/ereal_impl.hpp`:
  - Add `<type_traits>` include for `std::is_constant_evaluated`
  - Default ctor + defaulted copy/move/assignment marked `constexpr`
  - Selectors marked `constexpr` (with empty-_limb guards): `iszero`, `isone`, `ispos`, `isneg`, `sign`, `significant`, `limbs`
  - Added empty-_limb safety guards on `isinf`, `isnan`, `signbit`, `scale` (not constexpr-promotable but now safe against zero-capacity moved-from state)
  - Comment block documenting heap-allocation + stdlib-helper boundaries
- `elastic/ereal/api/constexpr.cpp` — new file. `static_assert` smoke tests covering default ctor, all promoted selectors, copy/move/assignment, and `is_ereal` trait. Exercises er4 and er8 to confirm template-parameter independence. CMakeLists.txt auto-registers via existing `api/*.cpp` glob.

## Constexpr-callable surface today (gcc + clang, C++20)

- Default ctor + read-only selectors at constant evaluation
- Copy / move / assignment at constant evaluation
- Static structural constants (`maxNrLimbs`, `EXP_BIAS`, etc.)

## Limited at constant evaluation today

`isnan`/`isinf`/`signbit`/`scale` (use non-constexpr stdlib), native-type ctors/`operator=` (heap allocation), all modifiers, arithmetic, comparison operators (expansion_ops is non-constexpr), conversion-out (`std::frexp`), `parse`/`to_string` (regex / stringstream).

Will inherit constexpr-ness automatically when (a) the expansion_ops module becomes constexpr-clean and (b) toolchains catch up to C++23 P2738.

## Test Results

- `er_api_constexpr` (NEW): builds + passes on gcc and clang
- Full `elastic/ereal` regression sweep: **36/36 tests pass on both compilers**

## Test plan

- [ ] Fast CI passes
- [ ] Promote to ready: `gh pr ready <NNN>`

Resolves #750

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a constexpr verification executable validating compile-time behavior and runtime checks for extended real types.

* **Bug Fixes**
  * Improved safety for selectors to handle empty/moved states without out-of-bounds access.

* **Refactor**
  * Broadened constexpr support for default construction, copy/move operations, and value-query methods.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/828)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->