### PR TITLE
feat(zfpblock): full constexpr promotion of zfparray multi-block container

### DIFF
--- a/include/sw/universal/number/zfpblock/zfparray_impl.hpp
+++ b/include/sw/universal/number/zfpblock/zfparray_impl.hpp
@@ -10,12 +10,21 @@
 // array with random access. All blocks use fixed-rate mode so block N
 // starts at a computable byte offset. A single-block write-back cache
 // provides efficient sequential access patterns.
+//
+// All public entry points are usable in constant-evaluated contexts in C++20
+// after PR #816, building on the codec promotion from PR #815.  The supported
+// pattern is a constexpr lambda that constructs a zfparray, exercises the
+// API, and returns -- the vector storage is freed at lambda exit, satisfying
+// C++20's rule that constexpr allocations not persist beyond the constant
+// expression.  Static-storage `constexpr zfparray` instances are not
+// supported (because their vector would persist).
 
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
 #include <vector>
 #include <algorithm>
+#include <type_traits>
 
 #include <universal/number/zfpblock/zfparray_fwd.hpp>
 #include <universal/number/zfpblock/zfp_codec_traits.hpp>
@@ -33,67 +42,60 @@ public:
 	static constexpr size_t BLOCK_SIZE = zfp_block_size<Dim>::value;
 	static constexpr size_t MAX_BYTES  = zfp_max_bytes<Real, Dim>::value;
 
-	// default constructor — empty array
-	zfparray() : _n(0), _rate(0), _cached_block(SIZE_MAX), _dirty(false) {
-		std::memset(_cache, 0, sizeof(_cache));
-	}
+	// default constructor -- empty array.  In-class member initializers
+	// give us a clean constexpr default state with no memset.
+	constexpr zfparray() = default;
 
 	// construct with n elements at given rate (bits per value)
-	zfparray(size_t n, double rate)
-		: _n(n), _rate(rate), _cached_block(SIZE_MAX), _dirty(false) {
-		std::memset(_cache, 0, sizeof(_cache));
+	constexpr zfparray(size_t n, double rate)
+		: _n(n), _rate(rate) {
 		_store.resize(num_blocks() * bytes_per_block(), 0);
 	}
 
 	// construct from raw data
-	zfparray(size_t n, double rate, const Real* src)
-		: _n(n), _rate(rate), _cached_block(SIZE_MAX), _dirty(false) {
-		std::memset(_cache, 0, sizeof(_cache));
+	constexpr zfparray(size_t n, double rate, const Real* src)
+		: _n(n), _rate(rate) {
 		_store.resize(num_blocks() * bytes_per_block(), 0);
 		compress(src);
 	}
 
-	// copy constructor — flush source cache, then copy
-	zfparray(const zfparray& other)
-		: _store(other._store), _n(other._n), _rate(other._rate),
-		  _cached_block(SIZE_MAX), _dirty(false) {
-		// flush other's dirty cache so compressed store is up-to-date
-		if (other._dirty) {
-			const_cast<zfparray&>(other).flush();
-		}
-		_store = other._store;  // re-copy after flush
-		std::memset(_cache, 0, sizeof(_cache));
+	// copy constructor -- flush source cache first so its compressed
+	// store is up-to-date, then copy.
+	constexpr zfparray(const zfparray& other)
+		: _n(other._n), _rate(other._rate) {
+		if (other._dirty) other.flush();
+		_store = other._store;
+		// _cache, _cached_block, _dirty are intentionally fresh
+		// (left at their in-class defaults) so the copy starts cold.
 	}
 
 	// move constructor
-	zfparray(zfparray&& other) noexcept
+	constexpr zfparray(zfparray&& other) noexcept
 		: _store(std::move(other._store)), _n(other._n), _rate(other._rate),
 		  _cached_block(other._cached_block), _dirty(other._dirty) {
-		std::memcpy(_cache, other._cache, sizeof(_cache));
+		for (size_t i = 0; i < BLOCK_SIZE; ++i) _cache[i] = other._cache[i];
 		other._n = 0;
 		other._cached_block = SIZE_MAX;
 		other._dirty = false;
 	}
 
 	// copy assignment
-	zfparray& operator=(const zfparray& other) {
+	constexpr zfparray& operator=(const zfparray& other) {
 		if (this != &other) {
 			flush();  // flush our dirty cache
-			if (other._dirty) {
-				const_cast<zfparray&>(other).flush();
-			}
+			if (other._dirty) other.flush();
 			_store = other._store;
 			_n = other._n;
 			_rate = other._rate;
 			_cached_block = SIZE_MAX;
 			_dirty = false;
-			std::memset(_cache, 0, sizeof(_cache));
+			for (size_t i = 0; i < BLOCK_SIZE; ++i) _cache[i] = Real(0);
 		}
 		return *this;
 	}
 
 	// move assignment
-	zfparray& operator=(zfparray&& other) noexcept {
+	constexpr zfparray& operator=(zfparray&& other) noexcept {
 		if (this != &other) {
 			flush();
 			_store = std::move(other._store);
@@ -101,7 +103,7 @@ public:
 			_rate = other._rate;
 			_cached_block = other._cached_block;
 			_dirty = other._dirty;
-			std::memcpy(_cache, other._cache, sizeof(_cache));
+			for (size_t i = 0; i < BLOCK_SIZE; ++i) _cache[i] = other._cache[i];
 			other._n = 0;
 			other._cached_block = SIZE_MAX;
 			other._dirty = false;
@@ -109,12 +111,12 @@ public:
 		return *this;
 	}
 
-	~zfparray() {
+	constexpr ~zfparray() {
 		if (_dirty) flush();
 	}
 
 	// read element at index i (logically const, may load cache)
-	Real operator()(size_t i) const {
+	constexpr Real operator()(size_t i) const {
 		size_t block_idx = i / BLOCK_SIZE;
 		size_t offset    = i % BLOCK_SIZE;
 		load_block(block_idx);
@@ -122,7 +124,7 @@ public:
 	}
 
 	// write element at index i
-	void set(size_t i, Real val) {
+	constexpr void set(size_t i, Real val) {
 		size_t block_idx = i / BLOCK_SIZE;
 		size_t offset    = i % BLOCK_SIZE;
 		load_block(block_idx);
@@ -131,7 +133,7 @@ public:
 	}
 
 	// compress entire array from raw data
-	void compress(const Real* src) {
+	constexpr void compress(const Real* src) {
 		_cached_block = SIZE_MAX;
 		_dirty = false;
 
@@ -140,107 +142,101 @@ public:
 		size_t maxbits = static_cast<size_t>(_rate * BLOCK_SIZE);
 
 		for (size_t b = 0; b < nblk; ++b) {
-			Real block_data[BLOCK_SIZE];
-			std::memset(block_data, 0, sizeof(block_data));
+			Real block_data[BLOCK_SIZE]{};
 
-			// copy valid elements (handles partial last block)
+			// copy valid elements (handles partial last block); remaining
+			// elements remain value-initialized to Real(0).
 			size_t start = b * BLOCK_SIZE;
 			size_t count = std::min(BLOCK_SIZE, _n - start);
-			std::memcpy(block_data, src + start, count * sizeof(Real));
+			for (size_t i = 0; i < count; ++i) block_data[i] = src[start + i];
 
-			uint8_t temp[MAX_BYTES];
-			std::memset(temp, 0, sizeof(temp));
+			uint8_t temp[MAX_BYTES]{};
 			unsigned maxprec = zfp_type_traits<Real>::precision_bits;
 			encode_block<Real, Dim>(block_data, temp, MAX_BYTES, maxprec, maxbits);
 
 			// copy truncated compressed data into store
-			std::memcpy(_store.data() + b * bpb, temp, bpb);
+			for (size_t i = 0; i < bpb; ++i) _store[b * bpb + i] = temp[i];
 		}
 	}
 
 	// decompress entire array to raw data
-	void decompress(Real* dst) const {
-		// flush dirty cache first so store is up-to-date
-		if (_dirty) {
-			const_cast<zfparray*>(this)->flush();
-		}
+	constexpr void decompress(Real* dst) const {
+		if (_dirty) flush();  // ensure _store is up-to-date
 
 		size_t nblk = num_blocks();
 		size_t bpb = bytes_per_block();
 		size_t maxbits = static_cast<size_t>(_rate * BLOCK_SIZE);
 
 		for (size_t b = 0; b < nblk; ++b) {
-			Real block_data[BLOCK_SIZE];
+			Real block_data[BLOCK_SIZE]{};
 			unsigned maxprec = zfp_type_traits<Real>::precision_bits;
 
 			// decode from a temporary buffer padded to MAX_BYTES
-			uint8_t temp[MAX_BYTES];
-			std::memset(temp, 0, sizeof(temp));
-			std::memcpy(temp, _store.data() + b * bpb, bpb);
+			uint8_t temp[MAX_BYTES]{};
+			for (size_t i = 0; i < bpb; ++i) temp[i] = _store[b * bpb + i];
 			decode_block<Real, Dim>(temp, MAX_BYTES, block_data, maxprec, maxbits);
 
 			// copy only valid elements
 			size_t start = b * BLOCK_SIZE;
 			size_t count = std::min(BLOCK_SIZE, _n - start);
-			std::memcpy(dst + start, block_data, count * sizeof(Real));
+			for (size_t i = 0; i < count; ++i) dst[start + i] = block_data[i];
 		}
 	}
 
 	// number of elements
-	size_t size() const { return _n; }
+	constexpr size_t size() const { return _n; }
 
 	// number of compressed blocks
-	size_t num_blocks() const {
+	constexpr size_t num_blocks() const {
 		return (_n + BLOCK_SIZE - 1) / BLOCK_SIZE;
 	}
 
 	// bits per value
-	double rate() const { return _rate; }
+	constexpr double rate() const { return _rate; }
 
 	// compressed bytes per block
-	size_t bytes_per_block() const {
+	constexpr size_t bytes_per_block() const {
 		size_t bits = static_cast<size_t>(_rate * BLOCK_SIZE);
 		return (bits + 7) / 8;
 	}
 
 	// total compressed storage in bytes
-	size_t compressed_bytes() const { return _store.size(); }
+	constexpr size_t compressed_bytes() const { return _store.size(); }
 
 	// compression ratio: uncompressed / compressed
-	double compression_ratio() const {
+	constexpr double compression_ratio() const {
 		if (_store.empty()) return 0.0;
 		return static_cast<double>(_n * sizeof(Real)) / static_cast<double>(_store.size());
 	}
 
-	// write-back dirty cache without evicting
-	void flush() {
+	// write-back dirty cache without evicting.  const-callable because
+	// it only mutates mutable members (_store, _dirty, the cache).
+	constexpr void flush() const {
 		if (_dirty && _cached_block != SIZE_MAX) {
 			write_back_cache();
 			_dirty = false;
 		}
 	}
 
-	// invalidate cache (must flush first if dirty)
-	void clear_cache() const {
-		if (_dirty) {
-			const_cast<zfparray*>(this)->flush();
-		}
+	// invalidate cache (flushes first if dirty)
+	constexpr void clear_cache() const {
+		if (_dirty) flush();
 		_cached_block = SIZE_MAX;
 		_dirty = false;
 	}
 
 	// resize, preserving rate (data is lost)
-	void resize(size_t n) {
+	constexpr void resize(size_t n) {
 		flush();
 		_n = n;
 		_store.assign(num_blocks() * bytes_per_block(), 0);
 		_cached_block = SIZE_MAX;
 		_dirty = false;
-		std::memset(_cache, 0, sizeof(_cache));
+		for (size_t i = 0; i < BLOCK_SIZE; ++i) _cache[i] = Real(0);
 	}
 
 	// change rate, recompress (requires full decompression/recompression)
-	void set_rate(double rate) {
+	constexpr void set_rate(double rate) {
 		if (_n == 0) {
 			_rate = rate;
 			return;
@@ -260,27 +256,34 @@ public:
 	}
 
 	// raw compressed data pointer
-	const uint8_t* data() const { return _store.data(); }
+	constexpr const uint8_t* data() const { return _store.data(); }
 
 	// raw compressed data size
-	size_t data_size() const { return _store.size(); }
+	constexpr size_t data_size() const { return _store.size(); }
 
 private:
-	std::vector<uint8_t> _store;            // compressed blocks
-	size_t               _n;                // total element count
-	double               _rate;             // bits per value
+	// _store is mutable because the const lazy-cache-load methods
+	// (operator(), decompress, flush, load_block, write_back_cache)
+	// need to update the compressed buffer when evicting a dirty cache
+	// line.  Conceptually the visible array contents are unchanged --
+	// the dirty cache is an internal implementation detail -- so const
+	// methods are entitled to flush.
+	mutable std::vector<uint8_t> _store{};      // compressed blocks
+	size_t                       _n     = 0;    // total element count
+	double                       _rate  = 0.0;  // bits per value
 
-	mutable Real         _cache[BLOCK_SIZE];// decompressed block
-	mutable size_t       _cached_block;     // cached block index (SIZE_MAX = none)
-	mutable bool         _dirty;            // cache modified flag
+	mutable Real         _cache[BLOCK_SIZE] = {};      // decompressed block
+	mutable size_t       _cached_block      = SIZE_MAX;// cached block index
+	mutable bool         _dirty             = false;   // cache modified flag
 
-	// load block into cache, evicting current block if necessary
-	void load_block(size_t block_idx) const {
+	// load block into cache, evicting current block if necessary.
+	// const because cache fields and _store are mutable.
+	constexpr void load_block(size_t block_idx) const {
 		if (_cached_block == block_idx) return;  // already cached
 
 		// evict current block (write-back if dirty)
 		if (_dirty && _cached_block != SIZE_MAX) {
-			const_cast<zfparray*>(this)->write_back_cache();
+			write_back_cache();
 		}
 
 		// decompress requested block into cache
@@ -288,24 +291,24 @@ private:
 		size_t maxbits = static_cast<size_t>(_rate * BLOCK_SIZE);
 		unsigned maxprec = zfp_type_traits<Real>::precision_bits;
 
-		uint8_t temp[MAX_BYTES];
-		std::memset(temp, 0, sizeof(temp));
-		std::memcpy(temp, _store.data() + block_idx * bpb, bpb);
+		uint8_t temp[MAX_BYTES]{};
+		for (size_t i = 0; i < bpb; ++i) temp[i] = _store[block_idx * bpb + i];
 		decode_block<Real, Dim>(temp, MAX_BYTES, _cache, maxprec, maxbits);
 
 		_cached_block = block_idx;
 		_dirty = false;
 	}
 
-	// write dirty cache back to compressed store
-	void write_back_cache() {
+	// write dirty cache back to compressed store.  const because _store
+	// is mutable.
+	constexpr void write_back_cache() const {
 		size_t bpb = bytes_per_block();
 		size_t maxbits = static_cast<size_t>(_rate * BLOCK_SIZE);
 		unsigned maxprec = zfp_type_traits<Real>::precision_bits;
 
 		// for partial last block, ensure padding is zero
-		Real padded[BLOCK_SIZE];
-		std::memcpy(padded, _cache, sizeof(padded));
+		Real padded[BLOCK_SIZE]{};
+		for (size_t i = 0; i < BLOCK_SIZE; ++i) padded[i] = _cache[i];
 		size_t start = _cached_block * BLOCK_SIZE;
 		if (start + BLOCK_SIZE > _n) {
 			// zero-pad beyond valid elements
@@ -315,11 +318,10 @@ private:
 			}
 		}
 
-		uint8_t temp[MAX_BYTES];
-		std::memset(temp, 0, sizeof(temp));
+		uint8_t temp[MAX_BYTES]{};
 		encode_block<Real, Dim>(padded, temp, MAX_BYTES, maxprec, maxbits);
 
-		std::memcpy(_store.data() + _cached_block * bpb, temp, bpb);
+		for (size_t i = 0; i < bpb; ++i) _store[_cached_block * bpb + i] = temp[i];
 	}
 };
 

--- a/static/block/zfpblock/array/array_constexpr.cpp
+++ b/static/block/zfpblock/array/array_constexpr.cpp
@@ -1,0 +1,194 @@
+// constexpr.cpp: compile-time tests for zfparray (multi-block compressed array)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Scope of this constexpr coverage:
+//
+// zfparray<Real, Dim> is a multi-block compressed array layered on top of
+// the single-block ZFP codec.  After PR #816 (this file) the container is
+// usable in constant-evaluated contexts, building on the codec promotion
+// from PR #815.
+//
+// Supported pattern: a constexpr lambda that constructs a zfparray,
+// exercises the API, and returns -- the vector storage is freed at lambda
+// exit, satisfying C++20's rule that constexpr allocations not persist
+// beyond the constant expression.  Static-storage `constexpr zfparray`
+// instances are NOT supported.
+
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <universal/number/zfpblock/zfpblock.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "zfparray constexpr verification";
+	std::string test_tag    = "constexpr";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	using zfparray_f1 = zfparray<float, 1>;
+
+	// ----------------------------------------------------------------------------
+	// Default-constructed zfparray has _n = 0, _rate = 0, no blocks.
+	// All trivial accessors are constexpr.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr size_t cx_size = []() {
+			zfparray_f1 a{};
+			return a.size();
+		}();
+		static_assert(cx_size == 0u, "constexpr default zfparray::size() == 0");
+
+		constexpr size_t cx_blocks = []() {
+			zfparray_f1 a{};
+			return a.num_blocks();
+		}();
+		static_assert(cx_blocks == 0u, "constexpr default zfparray::num_blocks() == 0");
+
+		constexpr size_t cx_bytes = []() {
+			zfparray_f1 a{};
+			return a.compressed_bytes();
+		}();
+		static_assert(cx_bytes == 0u, "constexpr default zfparray::compressed_bytes() == 0");
+
+		constexpr double cx_ratio = []() {
+			zfparray_f1 a{};
+			return a.compression_ratio();
+		}();
+		static_assert(cx_ratio == 0.0, "constexpr default zfparray::compression_ratio() == 0.0");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Sized-rate construction: zfparray(n, rate) sets up the compressed
+	// store but leaves blocks zero-initialized.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr bool cx_sized_ctor = []() {
+			zfparray_f1 a(8, 16.0);  // 8 elements, 16 bpv -> 2 blocks of 4
+			if (a.size() != 8u) return false;
+			if (a.num_blocks() != 2u) return false;
+			if (a.rate() != 16.0) return false;
+			// bytes_per_block = ceil(16.0 * 4 / 8) = 8
+			if (a.bytes_per_block() != 8u) return false;
+			// compressed_bytes = 2 * 8 = 16
+			if (a.compressed_bytes() != 16u) return false;
+			return true;
+		}();
+		static_assert(cx_sized_ctor, "constexpr zfparray(n, rate) sets up storage correctly");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Construct-from-source roundtrip: zfparray(n, rate, src) compresses
+	// at construction; decompress recovers values within tolerance.
+	// Exercises the full per-block codec pipeline (encode + decode)
+	// at compile time, through the multi-block container.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr bool cx_compress_decompress = []() {
+			float src[8] = { 1.0f, 2.0f, 4.0f, 8.0f, 16.0f, 32.0f, 64.0f, 128.0f };
+			zfparray_f1 a(8, 32.0, src);  // 32 bpv -> 2 blocks, lossless-ish for powers of 2
+
+			float dst[8] = {};
+			a.decompress(dst);
+
+			auto abs_diff = [](float x, float y) {
+				float d = x - y;
+				return d < 0.0f ? -d : d;
+			};
+			constexpr float tol_rel = 1.0f / (1u << 20);
+			for (unsigned i = 0; i < 8; ++i) {
+				float ref     = src[i];
+				float ref_abs = ref < 0.0f ? -ref : ref;
+				if (abs_diff(dst[i], ref) > tol_rel * ref_abs) return false;
+			}
+			return true;
+		}();
+		static_assert(cx_compress_decompress,
+			"constexpr zfparray(n, rate, src) + decompress() roundtrips within tolerance");
+	}
+
+	// ----------------------------------------------------------------------------
+	// set/get roundtrip through the write-back cache: set writes through
+	// the cache, get reads back through the cache.  This exercises
+	// load_block / write_back_cache / flush at constant evaluation.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr bool cx_set_get = []() {
+			zfparray_f1 a(4, 32.0);  // 4 elements, single block
+			a.set(0, 1.0f);
+			a.set(1, 2.0f);
+			a.set(2, 4.0f);
+			a.set(3, 8.0f);
+			a.flush();
+
+			// All reads now go through the (clean) cache.
+			auto abs_diff = [](float x, float y) {
+				float d = x - y;
+				return d < 0.0f ? -d : d;
+			};
+			constexpr float tol_rel = 1.0f / (1u << 20);
+			float refs[4] = { 1.0f, 2.0f, 4.0f, 8.0f };
+			for (size_t i = 0; i < 4; ++i) {
+				float got = a(i);
+				if (abs_diff(got, refs[i]) > tol_rel * refs[i]) return false;
+			}
+			return true;
+		}();
+		static_assert(cx_set_get,
+			"constexpr zfparray set/flush/get through write-back cache");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Cross-block access: setting elements in different blocks exercises
+	// cache eviction (load_block -> write_back_cache -> load_block).
+	// ----------------------------------------------------------------------------
+	{
+		constexpr bool cx_cross_block = []() {
+			zfparray_f1 a(8, 32.0);  // 8 elements, 2 blocks of 4
+			a.set(0, 1.0f);  // block 0
+			a.set(5, 32.0f); // block 1 (forces eviction of block 0)
+			a.set(2, 4.0f);  // block 0 (forces eviction of block 1, re-load block 0)
+			a.flush();
+
+			auto abs_diff = [](float x, float y) {
+				float d = x - y;
+				return d < 0.0f ? -d : d;
+			};
+			constexpr float tol_rel = 1.0f / (1u << 20);
+			if (abs_diff(a(0), 1.0f)  > tol_rel * 1.0f)  return false;
+			if (abs_diff(a(2), 4.0f)  > tol_rel * 4.0f)  return false;
+			if (abs_diff(a(5), 32.0f) > tol_rel * 32.0f) return false;
+			return true;
+		}();
+		static_assert(cx_cross_block,
+			"constexpr zfparray cross-block set/get with cache eviction");
+	}
+
+	std::cout << "zfparray constexpr verification: "
+	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Completes the array-layer constexpr work for the ZFP container, building on the codec promotion in PR #830 (issue #815, just merged).  `zfparray<Real, Dim>` is now usable in constant-evaluated contexts — enabling compile-time generation of compressed scientific-data tables and constinit-friendly init patterns, per the motivation in #816.

## Approach

The codec from PR #815 is constexpr, so per-block `encode_block` / `decode_block` calls work at compile time without further plumbing.  Three classes of cleanup remain:

1. **\`std::memset\` / \`std::memcpy\` → element-wise loops**: mechanical, identical runtime behavior.  Cache init, cache copy, store copy, padded-block init.
2. **\`const_cast<zfparray*>(this)\` removal**: the const lazy-cache-load methods (\`operator()\`, \`decompress\`, \`clear_cache\`, \`load_block\`) previously cast away const to call \`flush()\`/\`write_back_cache()\`.  This is now solved by making \`_store\` \`mutable\` and marking \`flush\` / \`write_back_cache\` const — the cache (\_cache, \_cached_block, \_dirty already mutable) and the compressed store are all internal implementation details, so const methods are entitled to update them when a dirty cache evicts.  This is also a strict const-correctness improvement and removes a long-standing code smell.
3. **In-class initializers + \`= default\` ctor**: every state member gets an in-class initializer, so the default constructor drops to \`= default\` and the explicit-rate constructors no longer need \`std::memset(_cache, 0, ...)\`.

Every member function is annotated \`constexpr\`. No \`std::is_constant_evaluated()\` branching is required.

## Changes

- \`include/sw/universal/number/zfpblock/zfparray_impl.hpp\` — main rewrite (91 insertions, 89 deletions, no net size change).
- \`static/block/zfpblock/array/array_constexpr.cpp\` — NEW.  static_assert-based constexpr tests covering default ctor, sized ctor, construct-from-source compress/decompress roundtrip, set/flush/get through the write-back cache, and cross-block access exercising cache eviction.  Naming: \`array_constexpr.cpp\` to match the existing \`array_*\` prefix in this directory (avoids a target-name collision with \`api/constexpr.cpp\`).

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| zfpblock_array_api | OK | PASS | OK | PASS |
| zfpblock_array_cache | OK | PASS | OK | PASS |
| zfpblock_array_copy_move | OK | PASS | OK | PASS |
| zfpblock_array_roundtrip | OK | PASS | OK | PASS |
| zfpblock_array_constexpr (NEW) | OK | PASS | OK | PASS |
| zfpblock_constexpr (regression) | OK | PASS | OK | PASS |

## C++20 \`std::vector\` constexpr scope

C++20 makes \`std::vector\` usable in constexpr contexts under one rule: no allocation may persist beyond the constant expression.  The supported pattern is a constexpr lambda that constructs a \`zfparray\`, uses it, and returns (the vector is freed at lambda exit).  Static-storage \`constexpr zfparray\` instances are NOT supported by the language and are out of scope.  All five new tests follow the supported pattern.

## Test plan

- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit feedback addressed
- [x] Promote to ready: \`gh pr ready\`
- [x] Full CI tier passes
- [x] Merge

Resolves #816

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled `zfparray` usage in compile-time (constant-evaluated) contexts through `constexpr` support for constructors, destructors, and core operations.
  * Added `data()` and `data_size()` public accessor methods for raw array access.

* **Tests**
  * Added compile-time verification test suite validating constexpr array operations and cache behavior at compile time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/831)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->