### PR TITLE
feat(utility): constexpr string-parse primitives (Phase A of #835)

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -88,6 +88,7 @@ jobs:
             dx
             tools
             ucalc
+            utility
           # Do not require a scope (scopes are recommended but optional)
           requireScope: false
           # Allow exclamation mark for breaking changes: feat!: ...

--- a/include/sw/universal/utility/string_parse.hpp
+++ b/include/sw/universal/utility/string_parse.hpp
@@ -243,14 +243,21 @@ constexpr int32_parse_result parse_int32(std::string_view s) noexcept {
 	if (s[0] == '-') { neg = true;  i = 1; }
 	else if (s[0] == '+') {          i = 1; }
 	if (i >= s.size()) return {false, 0};
+	// Conditional bound on the accumulated absolute value:
+	//   positive: at most INT32_MAX     = 2^31 - 1 = 2147483647
+	//   negative: at most |INT32_MIN|   = 2^31     = 2147483648
+	// Using a single bound of INT32_MAX would (incorrectly) reject the well-formed
+	// representation of INT32_MIN.
+	const std::int64_t bound = neg ? 2147483648LL : 2147483647LL;
 	std::int64_t v = 0;
 	for (; i < s.size(); ++i) {
 		char c = s[i];
 		if (!is_decimal_digit(c)) return {false, 0};
 		v = v * 10 + static_cast<std::int64_t>(c - '0');
-		// Clamp at int32 max; anything bigger is rejected.
-		if (v > 2147483647LL) return {false, 0};
+		if (v > bound) return {false, 0};
 	}
+	// Cast through int64 to preserve INT32_MIN. C++20 mandates two's-complement,
+	// so the int64 -> int32 narrowing for value -2147483648 yields INT32_MIN.
 	std::int32_t result = static_cast<std::int32_t>(neg ? -v : v);
 	return {true, result};
 }

--- a/include/sw/universal/utility/string_parse.hpp
+++ b/include/sw/universal/utility/string_parse.hpp
@@ -1,0 +1,298 @@
+#pragma once
+// string_parse.hpp: constexpr primitives for parsing value strings into
+// Universal number systems.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// -----------------------------------------------------------------------------
+// Phase A of issue #835: a shared, constexpr-friendly foundation for the
+// string-parsing APIs that each number system will adopt in later phases.
+// -----------------------------------------------------------------------------
+//
+// Why this exists
+// ---------------
+// Several Universal number systems (posit, cfloat, integer, fixpnt, ...) ship
+// independently-implemented string parsers today, with divergent format
+// coverage: lns refuses decimal value strings, fixpnt accepts them, posit
+// accepts a custom nbits.esXhexvalue native form, etc. As more types add
+// parse(), the divergence compounds.
+//
+// This header is the shared foundation. It provides constexpr primitives for
+// the low-level scanning work -- prefix detection, sign extraction, base-N
+// bit-pattern accumulation, decimal-float component scanning -- that every
+// number system can build on without re-inventing.
+//
+// The primitives operate on `std::string_view` only; no allocation, no
+// dependencies on the rest of Universal. That makes them callable from
+// constexpr ctors (a Phase-B-and-later goal: `constexpr posit<32,2>("3.14")`).
+//
+// Scope of Phase A
+// ----------------
+// This file ONLY provides scanning. It does not perform value reconstruction
+// (i.e., turning decimal digits into a number type's bit representation) --
+// that step depends on the target type's precision and rounding rules and so
+// belongs in each type's `parse()`. The Phase A primitives return string_views
+// pointing into the original input plus integer summaries; callers iterate.
+//
+// Conventions
+// -----------
+//   - All primitives are `constexpr`.
+//   - All take `std::string_view`; lifetime is the caller's responsibility.
+//   - Returned `string_view` results point into the input string.
+//   - "valid" means the parser reached the natural end of input without
+//     encountering an invalid character. Partial parses report `digits`
+//     consumed so callers can locate the bad character.
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace sw { namespace universal { namespace string_parse {
+
+// ============================================================================
+// number_base: which numerical base the input string is in.
+// ============================================================================
+
+enum class number_base : std::uint8_t {
+	unknown = 0,
+	binary  = 2,
+	octal   = 8,
+	decimal = 10,
+	hex     = 16
+};
+
+// ============================================================================
+// scan_prefix: detect a numerical-base prefix and return the body without it.
+// ============================================================================
+//
+// Recognized prefixes (case-insensitive):
+//   0b -> binary,  0o -> octal,  0x -> hex.
+//   No prefix -> decimal (body unchanged).
+//
+// Sign is NOT handled here; callers strip leading +/- with `scan_sign` before
+// detecting the base prefix. This keeps the primitives composable.
+
+struct prefix_scan {
+	number_base       base;
+	std::string_view  body;
+};
+
+constexpr prefix_scan scan_prefix(std::string_view s) noexcept {
+	if (s.size() >= 2 && s[0] == '0') {
+		char c = s[1];
+		if (c == 'b' || c == 'B') return {number_base::binary, s.substr(2)};
+		if (c == 'o' || c == 'O') return {number_base::octal,  s.substr(2)};
+		if (c == 'x' || c == 'X') return {number_base::hex,    s.substr(2)};
+	}
+	return {number_base::decimal, s};
+}
+
+// ============================================================================
+// scan_sign: detect a leading '+' or '-'.
+// ============================================================================
+//
+// No sign character is treated as positive. Returns `rest` advanced past
+// whatever sign was consumed.
+
+struct sign_scan {
+	bool              negative;
+	std::string_view  rest;
+};
+
+constexpr sign_scan scan_sign(std::string_view s) noexcept {
+	if (!s.empty()) {
+		if (s.front() == '-') return {true,  s.substr(1)};
+		if (s.front() == '+') return {false, s.substr(1)};
+	}
+	return {false, s};
+}
+
+// ============================================================================
+// Character classification (constexpr, locale-independent ASCII).
+// ============================================================================
+
+constexpr bool is_binary_digit (char c) noexcept { return c == '0' || c == '1'; }
+constexpr bool is_octal_digit  (char c) noexcept { return c >= '0' && c <= '7'; }
+constexpr bool is_decimal_digit(char c) noexcept { return c >= '0' && c <= '9'; }
+constexpr bool is_hex_digit    (char c) noexcept {
+	return (c >= '0' && c <= '9')
+	    || (c >= 'a' && c <= 'f')
+	    || (c >= 'A' && c <= 'F');
+}
+
+// Decode a hex digit to its integer value. Returns 0 for non-hex input;
+// callers gate with `is_hex_digit` first.
+constexpr unsigned hex_digit_value(char c) noexcept {
+	if (c >= '0' && c <= '9') return static_cast<unsigned>(c - '0');
+	if (c >= 'a' && c <= 'f') return static_cast<unsigned>(c - 'a' + 10);
+	if (c >= 'A' && c <= 'F') return static_cast<unsigned>(c - 'A' + 10);
+	return 0u;
+}
+
+// ============================================================================
+// Bit-pattern parsers: accumulate base-N digits into a uint64_t.
+// ============================================================================
+//
+// All three take an input that is a contiguous run of base-N digits (no
+// prefix, no sign, no whitespace). They scan MSB-first (left-to-right) and
+// stop at the first non-digit character.
+//
+// Return fields:
+//   value    -- accumulated bits in the low order of a uint64_t
+//   digits   -- count of characters consumed
+//   overflow -- true if the accumulator would shift past 64 bits
+//   valid    -- true iff every input character was a valid base-N digit
+//
+// For widths exceeding 64 bits, callers stride the input in chunks of
+// (64 / log2(base)) digits and shift their own multi-limb accumulator. This
+// keeps the primitive simple and avoids any allocation.
+
+struct bit_pattern_result {
+	std::uint64_t value;
+	std::size_t   digits;
+	bool          overflow;
+	bool          valid;
+};
+
+constexpr bit_pattern_result parse_binary(std::string_view s) noexcept {
+	std::uint64_t v = 0;
+	std::size_t i = 0;
+	bool overflow = false;
+	for (; i < s.size(); ++i) {
+		char c = s[i];
+		if (!is_binary_digit(c)) break;
+		if ((v >> 63) != 0u) overflow = true;
+		v = (v << 1) | static_cast<std::uint64_t>(c - '0');
+	}
+	return {v, i, overflow, i == s.size() && i > 0};
+}
+
+constexpr bit_pattern_result parse_octal(std::string_view s) noexcept {
+	std::uint64_t v = 0;
+	std::size_t i = 0;
+	bool overflow = false;
+	for (; i < s.size(); ++i) {
+		char c = s[i];
+		if (!is_octal_digit(c)) break;
+		if ((v >> 61) != 0u) overflow = true;
+		v = (v << 3) | static_cast<std::uint64_t>(c - '0');
+	}
+	return {v, i, overflow, i == s.size() && i > 0};
+}
+
+constexpr bit_pattern_result parse_hex(std::string_view s) noexcept {
+	std::uint64_t v = 0;
+	std::size_t i = 0;
+	bool overflow = false;
+	for (; i < s.size(); ++i) {
+		char c = s[i];
+		if (!is_hex_digit(c)) break;
+		if ((v >> 60) != 0u) overflow = true;
+		v = (v << 4) | static_cast<std::uint64_t>(hex_digit_value(c));
+	}
+	return {v, i, overflow, i == s.size() && i > 0};
+}
+
+// ============================================================================
+// scan_decimal_float: tokenize a decimal floating-point literal.
+// ============================================================================
+//
+// Grammar:
+//     [-+]? ( int_part )? ( '.' frac_part )? ( [eE] [-+]? int32 )?
+// with at least one digit somewhere in int_part or frac_part.
+//
+// Returns:
+//   valid    -- the whole input parsed cleanly (no trailing garbage)
+//   negative -- leading '-' detected
+//   int_part -- string_view of integer digits (no sign, no '.', no 'e')
+//   frac_part -- string_view of fractional digits (no '.')
+//   exp10    -- signed decimal exponent from the [eE] suffix; 0 if absent
+//
+// The function does NOT perform any base-10 -> bits conversion. Callers
+// iterate `int_part` and `frac_part` digit-by-digit, accumulating into
+// whatever native or extended-precision representation they target.
+//
+// The returned views point into the input; lifetime is the caller's.
+
+struct decimal_float_scan {
+	bool             valid;
+	bool             negative;
+	std::string_view int_part;
+	std::string_view frac_part;
+	std::int32_t     exp10;
+};
+
+namespace detail {
+
+// Parse a signed int32 from the start of `s`. The whole input must be a
+// well-formed integer; trailing characters cause failure. Used internally
+// for the exponent field of scan_decimal_float.
+struct int32_parse_result {
+	bool        valid;
+	std::int32_t value;
+};
+
+constexpr int32_parse_result parse_int32(std::string_view s) noexcept {
+	if (s.empty()) return {false, 0};
+	bool neg = false;
+	std::size_t i = 0;
+	if (s[0] == '-') { neg = true;  i = 1; }
+	else if (s[0] == '+') {          i = 1; }
+	if (i >= s.size()) return {false, 0};
+	std::int64_t v = 0;
+	for (; i < s.size(); ++i) {
+		char c = s[i];
+		if (!is_decimal_digit(c)) return {false, 0};
+		v = v * 10 + static_cast<std::int64_t>(c - '0');
+		// Clamp at int32 max; anything bigger is rejected.
+		if (v > 2147483647LL) return {false, 0};
+	}
+	std::int32_t result = static_cast<std::int32_t>(neg ? -v : v);
+	return {true, result};
+}
+
+}  // namespace detail
+
+constexpr decimal_float_scan scan_decimal_float(std::string_view s) noexcept {
+	decimal_float_scan out{false, false, {}, {}, 0};
+
+	auto sg = scan_sign(s);
+	out.negative = sg.negative;
+	std::string_view body = sg.rest;
+	if (body.empty()) return out;
+
+	// Integer part: zero or more digits up to '.' / 'e' / 'E' / end.
+	std::size_t i = 0;
+	while (i < body.size() && is_decimal_digit(body[i])) ++i;
+	out.int_part = body.substr(0, i);
+
+	// Optional fractional part.
+	if (i < body.size() && body[i] == '.') {
+		++i;
+		std::size_t frac_start = i;
+		while (i < body.size() && is_decimal_digit(body[i])) ++i;
+		out.frac_part = body.substr(frac_start, i - frac_start);
+	}
+
+	// Require at least one digit somewhere.
+	if (out.int_part.empty() && out.frac_part.empty()) return out;
+
+	// Optional exponent.
+	if (i < body.size() && (body[i] == 'e' || body[i] == 'E')) {
+		++i;
+		auto exp = detail::parse_int32(body.substr(i));
+		if (!exp.valid) return out;
+		out.exp10 = exp.value;
+		i = body.size();
+	}
+
+	// Anything left over means malformed input.
+	out.valid = (i == body.size());
+	return out;
+}
+
+}}}  // namespace sw::universal::string_parse

--- a/static/utility/test_string_parse.cpp
+++ b/static/utility/test_string_parse.cpp
@@ -331,6 +331,25 @@ static void test_scan_decimal_float() {
 		report(r.valid && r.frac_part.size() == 50,
 		       "scan_decimal_float 50-digit fraction");
 	}
+	// int32 exponent boundary (positive max) -- exp parser must accept INT32_MAX
+	{
+		auto r = sp::scan_decimal_float("1e2147483647");
+		report(r.valid && r.exp10 == 2147483647,
+		       "scan_decimal_float exp=INT32_MAX");
+	}
+	// int32 exponent boundary (negative min) -- exp parser must accept INT32_MIN.
+	// Regression: an earlier version rejected this because the magnitude check
+	// (v > INT32_MAX) fired before the sign was applied.
+	{
+		auto r = sp::scan_decimal_float("1e-2147483648");
+		report(r.valid && r.exp10 == (-2147483647 - 1),
+		       "scan_decimal_float exp=INT32_MIN");
+	}
+	// One past int32 max on positive side -- exp parser must reject.
+	{
+		auto r = sp::scan_decimal_float("1e2147483648");
+		report(!r.valid, "scan_decimal_float exp=INT32_MAX+1 rejected");
+	}
 }
 
 int main()

--- a/static/utility/test_string_parse.cpp
+++ b/static/utility/test_string_parse.cpp
@@ -1,0 +1,362 @@
+// test_string_parse.cpp: tests for the constexpr string-parsing primitives
+//                       (issue #835 Phase A foundation)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <iostream>
+#include <iomanip>
+#include <string_view>
+#include <universal/utility/string_parse.hpp>
+
+namespace sp = sw::universal::string_parse;
+
+// ============================================================================
+// Tiny test bench (no dependency on the regression framework -- this header
+// is a leaf utility and its tests should compile standalone).
+// ============================================================================
+
+static int g_failures = 0;
+static int g_total    = 0;
+
+static void report(bool condition, const char* what) {
+	++g_total;
+	if (!condition) {
+		++g_failures;
+		std::cout << "FAIL  " << what << '\n';
+	}
+}
+
+// ============================================================================
+// constexpr-correctness smoke tests: these have to compile, full stop.
+// ============================================================================
+
+namespace constexpr_tests {
+
+constexpr auto pfx_0b = sp::scan_prefix("0b1010");
+static_assert(pfx_0b.base == sp::number_base::binary, "0b prefix should be binary");
+
+constexpr auto pfx_dec = sp::scan_prefix("123");
+static_assert(pfx_dec.base == sp::number_base::decimal, "no prefix should be decimal");
+
+constexpr auto sg_neg = sp::scan_sign("-42");
+static_assert(sg_neg.negative,            "minus should be detected");
+static_assert(sg_neg.rest == "42",        "scan_sign should advance past '-'");
+
+constexpr auto bin = sp::parse_binary("1010");
+static_assert(bin.value == 10u,           "binary 1010 = 10");
+static_assert(bin.digits == 4u,           "consumed 4 digits");
+static_assert(!bin.overflow,              "no overflow");
+static_assert(bin.valid,                  "fully valid");
+
+constexpr auto hex = sp::parse_hex("FF");
+static_assert(hex.value == 255u,          "hex FF = 255");
+static_assert(hex.digits == 2u,           "consumed 2 digits");
+static_assert(hex.valid,                  "fully valid");
+
+constexpr auto df = sp::scan_decimal_float("-3.14e2");
+static_assert(df.valid,                       "-3.14e2 parses");
+static_assert(df.negative,                    "negative detected");
+static_assert(df.int_part == "3",             "int part is \"3\"");
+static_assert(df.frac_part == "14",           "frac part is \"14\"");
+static_assert(df.exp10 == 2,                  "exponent is 2");
+
+}  // namespace constexpr_tests
+
+// ============================================================================
+// scan_prefix
+// ============================================================================
+
+static void test_scan_prefix() {
+	// Lowercase prefixes
+	{
+		auto r = sp::scan_prefix("0b1010");
+		report(r.base == sp::number_base::binary,  "scan_prefix 0b -> binary");
+		report(r.body == "1010",                    "scan_prefix 0b body");
+	}
+	{
+		auto r = sp::scan_prefix("0o777");
+		report(r.base == sp::number_base::octal,   "scan_prefix 0o -> octal");
+		report(r.body == "777",                     "scan_prefix 0o body");
+	}
+	{
+		auto r = sp::scan_prefix("0xDEADBEEF");
+		report(r.base == sp::number_base::hex,     "scan_prefix 0x -> hex");
+		report(r.body == "DEADBEEF",                "scan_prefix 0x body");
+	}
+	// Uppercase prefixes
+	{
+		auto r = sp::scan_prefix("0B11");
+		report(r.base == sp::number_base::binary,  "scan_prefix 0B -> binary");
+	}
+	{
+		auto r = sp::scan_prefix("0O77");
+		report(r.base == sp::number_base::octal,   "scan_prefix 0O -> octal");
+	}
+	{
+		auto r = sp::scan_prefix("0X1F");
+		report(r.base == sp::number_base::hex,     "scan_prefix 0X -> hex");
+	}
+	// No prefix -> decimal
+	{
+		auto r = sp::scan_prefix("123");
+		report(r.base == sp::number_base::decimal, "scan_prefix bare -> decimal");
+		report(r.body == "123",                     "scan_prefix bare body unchanged");
+	}
+	// Leading '0' without prefix char -> decimal (just "0" or "012")
+	{
+		auto r = sp::scan_prefix("0");
+		report(r.base == sp::number_base::decimal, "scan_prefix \"0\" -> decimal");
+		report(r.body == "0",                       "scan_prefix \"0\" body unchanged");
+	}
+	{
+		auto r = sp::scan_prefix("012");
+		report(r.base == sp::number_base::decimal, "scan_prefix \"012\" -> decimal (no octal default)");
+	}
+	// Empty
+	{
+		auto r = sp::scan_prefix("");
+		report(r.base == sp::number_base::decimal, "scan_prefix empty -> decimal");
+		report(r.body.empty(),                       "scan_prefix empty body empty");
+	}
+}
+
+// ============================================================================
+// scan_sign
+// ============================================================================
+
+static void test_scan_sign() {
+	{
+		auto r = sp::scan_sign("-42");
+		report(r.negative,           "scan_sign '-' negative");
+		report(r.rest == "42",       "scan_sign '-' rest");
+	}
+	{
+		auto r = sp::scan_sign("+42");
+		report(!r.negative,          "scan_sign '+' not negative");
+		report(r.rest == "42",       "scan_sign '+' rest");
+	}
+	{
+		auto r = sp::scan_sign("42");
+		report(!r.negative,          "scan_sign no sign positive");
+		report(r.rest == "42",       "scan_sign no sign rest unchanged");
+	}
+	{
+		auto r = sp::scan_sign("");
+		report(!r.negative,          "scan_sign empty positive");
+		report(r.rest.empty(),       "scan_sign empty rest");
+	}
+	{
+		// Only first character consumed; "--7" -> negative, rest "-7"
+		auto r = sp::scan_sign("--7");
+		report(r.negative,           "scan_sign '--' first char only");
+		report(r.rest == "-7",       "scan_sign '--' rest is \"-7\"");
+	}
+}
+
+// ============================================================================
+// parse_binary / parse_octal / parse_hex
+// ============================================================================
+
+static void test_parse_binary() {
+	{
+		auto r = sp::parse_binary("1010");
+		report(r.value == 10u && r.digits == 4 && !r.overflow && r.valid,
+		       "parse_binary 1010");
+	}
+	{
+		auto r = sp::parse_binary("0");
+		report(r.value == 0u && r.digits == 1 && r.valid, "parse_binary 0");
+	}
+	{
+		// 64 ones = 2^64 - 1, no overflow
+		auto r = sp::parse_binary("1111111111111111111111111111111111111111111111111111111111111111");
+		report(r.value == 0xFFFFFFFFFFFFFFFFull && r.digits == 64 && !r.overflow && r.valid,
+		       "parse_binary 64 ones");
+	}
+	{
+		// 65 bits => overflow
+		auto r = sp::parse_binary("10000000000000000000000000000000000000000000000000000000000000000");
+		report(r.overflow && r.digits == 65, "parse_binary 65-bit overflow");
+	}
+	{
+		// Stops at invalid char
+		auto r = sp::parse_binary("101z01");
+		report(r.value == 5u && r.digits == 3 && !r.valid, "parse_binary stops at 'z'");
+	}
+	{
+		auto r = sp::parse_binary("");
+		report(!r.valid && r.digits == 0, "parse_binary empty -> invalid");
+	}
+}
+
+static void test_parse_octal() {
+	{
+		auto r = sp::parse_octal("777");
+		report(r.value == 0777u && r.valid && r.digits == 3 && !r.overflow,
+		       "parse_octal 777");
+	}
+	{
+		auto r = sp::parse_octal("01234567");
+		report(r.value == 01234567u && r.valid && r.digits == 8 && !r.overflow,
+		       "parse_octal 01234567");
+	}
+	{
+		// '8' is not octal
+		auto r = sp::parse_octal("128");
+		report(r.value == 012u && r.digits == 2 && !r.valid, "parse_octal stops at '8'");
+	}
+	{
+		auto r = sp::parse_octal("");
+		report(!r.valid, "parse_octal empty -> invalid");
+	}
+}
+
+static void test_parse_hex() {
+	{
+		auto r = sp::parse_hex("FF");
+		report(r.value == 0xFFu && r.valid && r.digits == 2, "parse_hex FF");
+	}
+	{
+		auto r = sp::parse_hex("DEADBEEF");
+		report(r.value == 0xDEADBEEFu && r.valid && r.digits == 8, "parse_hex DEADBEEF");
+	}
+	{
+		// Lowercase and uppercase mixed
+		auto r = sp::parse_hex("DeAdC0De");
+		report(r.value == 0xDEADC0DEu && r.valid, "parse_hex mixed case");
+	}
+	{
+		// 16 hex digits = 64 bits, no overflow
+		auto r = sp::parse_hex("FFFFFFFFFFFFFFFF");
+		report(r.value == 0xFFFFFFFFFFFFFFFFull && r.valid && !r.overflow,
+		       "parse_hex 16 F's");
+	}
+	{
+		// 17 hex digits => overflow
+		auto r = sp::parse_hex("10000000000000000");
+		report(r.overflow && r.digits == 17, "parse_hex 17-digit overflow");
+	}
+	{
+		// Stops at invalid
+		auto r = sp::parse_hex("FF.AA");
+		report(r.value == 0xFFu && r.digits == 2 && !r.valid, "parse_hex stops at '.'");
+	}
+}
+
+// ============================================================================
+// scan_decimal_float
+// ============================================================================
+
+static void test_scan_decimal_float() {
+	// Integer only
+	{
+		auto r = sp::scan_decimal_float("42");
+		report(r.valid && !r.negative && r.int_part == "42" && r.frac_part.empty() && r.exp10 == 0,
+		       "scan_decimal_float \"42\"");
+	}
+	// Negative integer
+	{
+		auto r = sp::scan_decimal_float("-7");
+		report(r.valid && r.negative && r.int_part == "7", "scan_decimal_float \"-7\"");
+	}
+	// Explicit positive
+	{
+		auto r = sp::scan_decimal_float("+5");
+		report(r.valid && !r.negative && r.int_part == "5", "scan_decimal_float \"+5\"");
+	}
+	// Integer + fraction
+	{
+		auto r = sp::scan_decimal_float("3.14");
+		report(r.valid && r.int_part == "3" && r.frac_part == "14" && r.exp10 == 0,
+		       "scan_decimal_float \"3.14\"");
+	}
+	// Fraction only
+	{
+		auto r = sp::scan_decimal_float(".5");
+		report(r.valid && r.int_part.empty() && r.frac_part == "5",
+		       "scan_decimal_float \".5\"");
+	}
+	// Integer only with trailing dot
+	{
+		auto r = sp::scan_decimal_float("5.");
+		report(r.valid && r.int_part == "5" && r.frac_part.empty(),
+		       "scan_decimal_float \"5.\"");
+	}
+	// Exponent
+	{
+		auto r = sp::scan_decimal_float("1e10");
+		report(r.valid && r.int_part == "1" && r.exp10 == 10, "scan_decimal_float \"1e10\"");
+	}
+	{
+		auto r = sp::scan_decimal_float("1E-5");
+		report(r.valid && r.exp10 == -5, "scan_decimal_float \"1E-5\"");
+	}
+	// All the things
+	{
+		auto r = sp::scan_decimal_float("-3.14159e+2");
+		report(r.valid && r.negative && r.int_part == "3" && r.frac_part == "14159" && r.exp10 == 2,
+		       "scan_decimal_float \"-3.14159e+2\"");
+	}
+	// Just a dot
+	{
+		auto r = sp::scan_decimal_float(".");
+		report(!r.valid, "scan_decimal_float \".\" should fail");
+	}
+	// Empty
+	{
+		auto r = sp::scan_decimal_float("");
+		report(!r.valid, "scan_decimal_float empty should fail");
+	}
+	// Trailing garbage
+	{
+		auto r = sp::scan_decimal_float("3.14x");
+		report(!r.valid, "scan_decimal_float \"3.14x\" should reject trailing garbage");
+	}
+	// Bad exponent
+	{
+		auto r = sp::scan_decimal_float("1e");
+		report(!r.valid, "scan_decimal_float \"1e\" should fail (no exp digits)");
+	}
+	{
+		auto r = sp::scan_decimal_float("1ex");
+		report(!r.valid, "scan_decimal_float \"1ex\" should fail");
+	}
+	// Long fraction (constexpr-friendly: views point into input)
+	{
+		auto r = sp::scan_decimal_float("3.14159265358979323846264338327950288419716939937510");
+		report(r.valid && r.frac_part.size() == 50,
+		       "scan_decimal_float 50-digit fraction");
+	}
+}
+
+int main()
+try {
+	std::cout << "string_parse primitives (Phase A of #835): test suite\n\n";
+
+	test_scan_prefix();
+	test_scan_sign();
+	test_parse_binary();
+	test_parse_octal();
+	test_parse_hex();
+	test_scan_decimal_float();
+
+	std::cout << "\nResults: " << (g_total - g_failures) << " / " << g_total << " tests passed";
+	if (g_failures > 0) {
+		std::cout << "  (" << g_failures << " FAILED)\n";
+		return EXIT_FAILURE;
+	}
+	std::cout << "\n";
+	return EXIT_SUCCESS;
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << err.what() << '\n';
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

- Adds `include/sw/universal/utility/string_parse.hpp` -- a shared, constexpr-friendly foundation for the string-parsing APIs that each number system will adopt in later phases of issue #835.
- **Phase A only**: this PR establishes the contract every later phase will plug into; it intentionally does **not** migrate any specific number system yet. Closes nothing in #835 by itself.

## Why this needs a foundation first

A pre-implementation survey (see issue #835 for the roadmap) found that today's `parse()` implementations are reimplemented per type, with divergent format coverage:
- `lns` refuses decimal value strings while `fixpnt` accepts them
- `posit` accepts a custom `nbits.esXhexvalue` form not found anywhere else
- `dfloat` accepts decimal but not binary bit-patterns; `lns` is the opposite

Without a shared scanner, every type that adopts string parsing will continue this divergence. Phase A fixes that.

## What's in the header

`sw::universal::string_parse` namespace:

| Primitive | Returns | Notes |
|-----------|---------|-------|
| `scan_prefix(string_view)` | `{number_base, body}` | 0b/0o/0x detection (case-insensitive); no prefix -> decimal |
| `scan_sign(string_view)`   | `{negative, rest}`   | +/- detection; no sign -> positive |
| `parse_binary/octal/hex(string_view)` | `{value, digits, overflow, valid}` | MSB-first `uint64_t` accumulation with overflow detection |
| `scan_decimal_float(string_view)` | `{valid, negative, int_part, frac_part, exp10}` | `[-+]?int.frac[eE][-+]?exp` tokenized to string_views over input |

Plus character classifiers (`is_decimal_digit`, `is_hex_digit`, ...) and a `hex_digit_value` helper.

## Scope (what's explicitly *out*)

Phase A does NOT perform value reconstruction (turning digit strings into a number type's bit representation). That step depends on the target type's precision and rounding rules and so belongs in each type's own `parse()` in Phase B and later.

`scan_decimal_float` returns `string_view`s pointing into the input, plus a signed `int32_t` exponent -- so the caller can iterate the digits and accumulate into whatever representation it wants (`uint64_t`, multi-limb `blockbinary`, decimal accumulator, ...).

## Tests

`static/utility/test_string_parse.cpp` -- 57 test assertions + 8 `static_assert` smoke tests proving constexpr.

- `scan_prefix`: 0b/0B/0o/0O/0x/0X case variants, decimal default, leading-0-without-prefix, empty input
- `scan_sign`: '+', '-', no sign, empty, double-sign (first only consumed)
- `parse_binary/octal/hex`: valid input, partial-stop-at-invalid-char, 64-bit boundary (no overflow), 65/17-digit overflow detection, empty -> invalid
- `scan_decimal_float`: integer-only, fraction-only, integer+fraction, positive/negative exponent, mixed signs, malformed (bare dot, trailing garbage, ``"1e"`` no exp digits), 50-digit fraction (constexpr-friendly: views point into input, no allocation)

## Test results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| `utility_test_string_parse` | OK | 57/57 PASS | OK | 57/57 PASS |

## Phased roadmap (for context; only Phase A is in this PR)

| Phase | Scope | Size |
|-------|-------|------|
| **A. Foundation (this PR)** | Shared constexpr string-parse utility + tests | M |
| B. Conforming uplift | Migrate posit/cfloat/integer/fixpnt onto this | M-L |
| C. Partial uplift | lns/dbns/areal/dfloat/hfloat/dfixpnt/edecimal/unum1 | L |
| D. Greenfield | dd/qd/bfloat16/valid/microfloats/elastics/block formats | XL |
| E. Cross-cutting tests | Format x type coverage matrix | M |

## Test plan

- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit feedback addressed
- [x] Promote to ready when satisfied: \`gh pr ready <NN>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added allocation-free, constexpr-capable parsing primitives: sign and base-prefix detection, digit classifiers, MSB-first binary/octal/hex integer parsing with digit count and overflow reporting, and a decimal floating-point tokenizer with optional fractional and exponent parts.

* **Tests**
  * Added a standalone test suite with compile-time assertions and runtime tests covering valid, invalid, edge, and overflow cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->