### PR TITLE
feat(integer, fixpnt): migrate/implement parse() onto string_parse (Phase B1 of #835)

### DIFF
--- a/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
@@ -19,6 +19,7 @@
 #include <universal/native/ieee754.hpp>   // IEEE-754 decoders
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/native/integers.hpp>   // manipulators for native integer types
+#include <universal/utility/string_parse.hpp>   // shared constexpr scan_prefix / scan_sign / char classifiers
 
 /*
 The fixed-point arithmetic can be configured to:
@@ -2065,13 +2066,115 @@ inline std::ostream& operator<<(std::ostream& ostr, const fixpnt<nbits, rbits, a
 	return ostr << ss.str();
 }
 
+// Parse an ASCII string into a fixpnt value.
+//
+// Accepted syntax (Phase B1 of issue #835):
+//
+//   [+-]? ( 0[bB][01]+      |    // binary bit-pattern, fills _block MSB-first
+//           0[oO][0-7]+     |    // octal bit-pattern
+//           0[xX][0-9A-F']+ |    // hex bit-pattern (apostrophe allowed as separator)
+//           [0-9]+          )    // decimal integer; mapped to a fixpnt by shifting left by rbits
+//
+// Bit-pattern parsing populates the underlying storage directly: the bits go
+// into positions [nbits-1 .. 0], i.e., the most significant input character
+// fills the high-order bits. This matches the convention used by setbits()
+// and is what test programs typically want for "raw" initialization.
+//
+// Decimal parsing is integer-only in this phase. The accumulated integer K is
+// converted to fixpnt as (K << rbits), i.e., parse("5") on fixpnt<8,4> yields
+// the value 5.0 (raw bits 0101.0000). Decimal-fraction parsing ("3.14") is
+// deferred to Phase B2 alongside posit/cfloat float-from-string.
+//
+// All scanning is delegated to the constexpr primitives in
+// `<universal/utility/string_parse.hpp>`.
+//
+// Returns true on successful parse, false on malformed input.
+template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
+bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& value) {
+	namespace sp = sw::universal::string_parse;
+	using FP = fixpnt<nbits, rbits, arithmetic, bt>;
+
+	value.clear();
+	std::string_view s{number};
+
+	auto sg = sp::scan_sign(s);
+	const bool negative = sg.negative;
+	s = sg.rest;
+	if (s.empty()) return false;
+
+	auto pfx = sp::scan_prefix(s);
+	std::string_view body = pfx.body;
+	if (body.empty()) return false;
+
+	switch (pfx.base) {
+	case sp::number_base::binary: {
+		for (char c : body) {
+			if (!sp::is_binary_digit(c)) return false;
+			value <<= 1;
+			if (c == '1') value.setbit(0, true);
+		}
+		break;
+	}
+	case sp::number_base::octal: {
+		for (char c : body) {
+			if (!sp::is_octal_digit(c)) return false;
+			value <<= 3;
+			unsigned digit = static_cast<unsigned>(c - '0');
+			for (unsigned b = 0; b < 3; ++b) {
+				if ((digit >> b) & 1u) value.setbit(b, true);
+			}
+		}
+		break;
+	}
+	case sp::number_base::hex: {
+		for (char c : body) {
+			if (c == '\'') continue;
+			if (!sp::is_hex_digit(c)) return false;
+			value <<= 4;
+			unsigned digit = sp::hex_digit_value(c);
+			for (unsigned b = 0; b < 4; ++b) {
+				if ((digit >> b) & 1u) value.setbit(b, true);
+			}
+		}
+		break;
+	}
+	case sp::number_base::decimal: {
+		// Accumulate the decimal as an integer value at the rbits scale: each
+		// digit multiplies the accumulator by 10 (in the value domain), which
+		// corresponds to multiplying the underlying integer K (where the
+		// fixpnt value = K * 2^-rbits) by 10 followed by adding the digit
+		// scaled by 2^rbits. Equivalently: accumulate K, then shift left by
+		// rbits at the end.
+		FP ten;
+		ten.setbits(static_cast<uint64_t>(10) << rbits);  // 10.0 in fixpnt rep
+		FP one_ulp;
+		one_ulp.setbits(static_cast<uint64_t>(1) << rbits);  // 1.0 in fixpnt rep
+		for (char c : body) {
+			if (!sp::is_decimal_digit(c)) return false;
+			value *= ten;
+			unsigned d = static_cast<unsigned>(c - '0');
+			FP digit;
+			digit.setbits(static_cast<uint64_t>(d) << rbits);
+			value += digit;
+			(void)one_ulp;  // reserved for B2 fractional-decimal path
+		}
+		break;
+	}
+	default:
+		return false;
+	}
+
+	if (negative) value = -value;
+	return true;
+}
+
 // istream input reads an ASCII format and assigns value to the fixed-point argument
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
 inline std::istream& operator>>(std::istream& istr, fixpnt<nbits, rbits, arithmetic, bt>& p) {
 	std::string txt;
 	istr >> txt;
 	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+		std::cerr << "unable to parse -" << txt << "- into a fixpnt value\n";
 	}
 	return istr;
 }

--- a/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
@@ -2106,13 +2106,19 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 	std::string_view body = pfx.body;
 	if (body.empty()) return false;
 
+	// Bit-pattern branches track digit_found so payloads of only separators or
+	// (theoretically) empty strings are rejected rather than silently yielding zero.
+	bool digit_found = false;
+
 	switch (pfx.base) {
 	case sp::number_base::binary: {
 		for (char c : body) {
 			if (!sp::is_binary_digit(c)) return false;
 			value <<= 1;
 			if (c == '1') value.setbit(0, true);
+			digit_found = true;
 		}
+		if (!digit_found) return false;
 		break;
 	}
 	case sp::number_base::octal: {
@@ -2123,7 +2129,9 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 			for (unsigned b = 0; b < 3; ++b) {
 				if ((digit >> b) & 1u) value.setbit(b, true);
 			}
+			digit_found = true;
 		}
+		if (!digit_found) return false;
 		break;
 	}
 	case sp::number_base::hex: {
@@ -2135,28 +2143,22 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 			for (unsigned b = 0; b < 4; ++b) {
 				if ((digit >> b) & 1u) value.setbit(b, true);
 			}
+			digit_found = true;
 		}
+		if (!digit_found) return false;
 		break;
 	}
 	case sp::number_base::decimal: {
-		// Accumulate the decimal as an integer value at the rbits scale: each
-		// digit multiplies the accumulator by 10 (in the value domain), which
-		// corresponds to multiplying the underlying integer K (where the
-		// fixpnt value = K * 2^-rbits) by 10 followed by adding the digit
-		// scaled by 2^rbits. Equivalently: accumulate K, then shift left by
-		// rbits at the end.
-		FP ten;
-		ten.setbits(static_cast<uint64_t>(10) << rbits);  // 10.0 in fixpnt rep
-		FP one_ulp;
-		one_ulp.setbits(static_cast<uint64_t>(1) << rbits);  // 1.0 in fixpnt rep
+		// Each digit multiplies the accumulator by 10 in the value domain
+		// and adds the digit (as an integer value). We use the fixpnt
+		// converting constructor from native int so Saturate / Modulo
+		// policy is respected, and so we never shift by rbits at runtime
+		// (which would be UB for instantiations with rbits >= 64).
+		const FP ten(10);
 		for (char c : body) {
 			if (!sp::is_decimal_digit(c)) return false;
 			value *= ten;
-			unsigned d = static_cast<unsigned>(c - '0');
-			FP digit;
-			digit.setbits(static_cast<uint64_t>(d) << rbits);
-			value += digit;
-			(void)one_ulp;  // reserved for B2 fractional-decimal path
+			value += FP(static_cast<int>(c - '0'));
 		}
 		break;
 	}
@@ -2168,13 +2170,15 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 	return true;
 }
 
-// istream input reads an ASCII format and assigns value to the fixed-point argument
+// istream input reads an ASCII format and assigns value to the fixed-point argument.
+// On parse failure, set failbit so callers (loops with `while (in >> x)`, etc.)
+// can detect the error without scraping stderr.
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
 inline std::istream& operator>>(std::istream& istr, fixpnt<nbits, rbits, arithmetic, bt>& p) {
 	std::string txt;
 	istr >> txt;
 	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a fixpnt value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
@@ -2092,7 +2092,7 @@ inline std::ostream& operator<<(std::ostream& ostr, const fixpnt<nbits, rbits, a
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
 bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& value) {
 	namespace sp = sw::universal::string_parse;
-	using FP = fixpnt<nbits, rbits, arithmetic, bt>;
+	using Fixpnt = fixpnt<nbits, rbits, arithmetic, bt>;
 
 	value.clear();
 	std::string_view s{number};
@@ -2154,11 +2154,11 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 		// converting constructor from native int so Saturate / Modulo
 		// policy is respected, and so we never shift by rbits at runtime
 		// (which would be UB for instantiations with rbits >= 64).
-		const FP ten(10);
+		const Fixpnt ten(10);
 		for (char c : body) {
 			if (!sp::is_decimal_digit(c)) return false;
 			value *= ten;
-			value += FP(static_cast<int>(c - '0'));
+			value += Fixpnt(static_cast<int>(c - '0'));
 		}
 		break;
 	}

--- a/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
@@ -2171,13 +2171,16 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 }
 
 // istream input reads an ASCII format and assigns value to the fixed-point argument.
-// On parse failure, set failbit so callers (loops with `while (in >> x)`, etc.)
-// can detect the error without scraping stderr.
+// On parse failure: log a diagnostic to std::cerr AND set failbit on the stream
+// so callers (loops with `while (in >> x)`, etc.) can detect the error without
+// scraping stderr. Both are useful: the message helps interactive debugging,
+// the failbit enables programmatic detection.
 template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
 inline std::istream& operator>>(std::istream& istr, fixpnt<nbits, rbits, arithmetic, bt>& p) {
 	std::string txt;
 	istr >> txt;
 	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a fixpnt value\n";
 		istr.setstate(std::ios::failbit);
 	}
 	return istr;

--- a/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt_impl.hpp
@@ -2094,7 +2094,12 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 	namespace sp = sw::universal::string_parse;
 	using Fixpnt = fixpnt<nbits, rbits, arithmetic, bt>;
 
-	value.clear();
+	// Build into a local temporary and only commit to `value` on a fully
+	// successful parse. This keeps malformed input from leaving the caller's
+	// object in a partially-mutated state.
+	Fixpnt tmp;
+	tmp.clear();
+
 	std::string_view s{number};
 
 	auto sg = sp::scan_sign(s);
@@ -2114,8 +2119,8 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 	case sp::number_base::binary: {
 		for (char c : body) {
 			if (!sp::is_binary_digit(c)) return false;
-			value <<= 1;
-			if (c == '1') value.setbit(0, true);
+			tmp <<= 1;
+			if (c == '1') tmp.setbit(0, true);
 			digit_found = true;
 		}
 		if (!digit_found) return false;
@@ -2124,10 +2129,10 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 	case sp::number_base::octal: {
 		for (char c : body) {
 			if (!sp::is_octal_digit(c)) return false;
-			value <<= 3;
+			tmp <<= 3;
 			unsigned digit = static_cast<unsigned>(c - '0');
 			for (unsigned b = 0; b < 3; ++b) {
-				if ((digit >> b) & 1u) value.setbit(b, true);
+				if ((digit >> b) & 1u) tmp.setbit(b, true);
 			}
 			digit_found = true;
 		}
@@ -2138,10 +2143,10 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 		for (char c : body) {
 			if (c == '\'') continue;
 			if (!sp::is_hex_digit(c)) return false;
-			value <<= 4;
+			tmp <<= 4;
 			unsigned digit = sp::hex_digit_value(c);
 			for (unsigned b = 0; b < 4; ++b) {
-				if ((digit >> b) & 1u) value.setbit(b, true);
+				if ((digit >> b) & 1u) tmp.setbit(b, true);
 			}
 			digit_found = true;
 		}
@@ -2157,8 +2162,8 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 		const Fixpnt ten(10);
 		for (char c : body) {
 			if (!sp::is_decimal_digit(c)) return false;
-			value *= ten;
-			value += Fixpnt(static_cast<int>(c - '0'));
+			tmp *= ten;
+			tmp += Fixpnt(static_cast<int>(c - '0'));
 		}
 		break;
 	}
@@ -2166,7 +2171,8 @@ bool parse(const std::string& number, fixpnt<nbits, rbits, arithmetic, bt>& valu
 		return false;
 	}
 
-	if (negative) value = -value;
+	if (negative) tmp = -tmp;
+	value = tmp;
 	return true;
 }
 

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -1683,7 +1683,12 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 	namespace sp = sw::universal::string_parse;
 	using Int = integer<nbits, BlockType, NumberType>;
 
-	value.clear();
+	// Build into a local temporary and only commit to `value` on a fully
+	// successful parse. This keeps malformed input from leaving the caller's
+	// object in a partially-mutated state.
+	Int tmp;
+	tmp.clear();
+
 	std::string_view s{number};
 
 	// Strip leading sign (if any).
@@ -1706,8 +1711,8 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 		// MSB-first: shift the accumulator left by 1 per character, OR in the bit.
 		for (char c : body) {
 			if (!sp::is_binary_digit(c)) return false;
-			value <<= 1;
-			if (c == '1') value.setbit(0, true);
+			tmp <<= 1;
+			if (c == '1') tmp.setbit(0, true);
 			digit_found = true;
 		}
 		if (!digit_found) return false;
@@ -1717,10 +1722,10 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 		// MSB-first: shift by 3, OR in the 3-bit digit.
 		for (char c : body) {
 			if (!sp::is_octal_digit(c)) return false;
-			value <<= 3;
+			tmp <<= 3;
 			unsigned digit = static_cast<unsigned>(c - '0');
 			for (unsigned b = 0; b < 3; ++b) {
-				if ((digit >> b) & 1u) value.setbit(b, true);
+				if ((digit >> b) & 1u) tmp.setbit(b, true);
 			}
 			digit_found = true;
 		}
@@ -1732,10 +1737,10 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 		for (char c : body) {
 			if (c == '\'') continue;
 			if (!sp::is_hex_digit(c)) return false;
-			value <<= 4;
+			tmp <<= 4;
 			unsigned digit = sp::hex_digit_value(c);
 			for (unsigned b = 0; b < 4; ++b) {
-				if ((digit >> b) & 1u) value.setbit(b, true);
+				if ((digit >> b) & 1u) tmp.setbit(b, true);
 			}
 			digit_found = true;
 		}
@@ -1749,9 +1754,9 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 		Int ten{10};
 		for (char c : body) {
 			if (!sp::is_decimal_digit(c)) return false;
-			value *= ten;
+			tmp *= ten;
 			Int digit{static_cast<unsigned>(c - '0')};
-			value += digit;
+			tmp += digit;
 			digit_found = true;
 		}
 		if (!digit_found) return false;
@@ -1761,7 +1766,8 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 		return false;
 	}
 
-	if (negative) value = -value;
+	if (negative) tmp = -tmp;
+	value = tmp;
 	return true;
 }
 

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -1697,6 +1697,10 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 	std::string_view body = pfx.body;
 	if (body.empty()) return false;
 
+	// Track whether any real digit was consumed so payloads of only separators
+	// (e.g. "0x'") are rejected rather than silently yielding zero.
+	bool digit_found = false;
+
 	switch (pfx.base) {
 	case sp::number_base::binary: {
 		// MSB-first: shift the accumulator left by 1 per character, OR in the bit.
@@ -1704,7 +1708,9 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 			if (!sp::is_binary_digit(c)) return false;
 			value <<= 1;
 			if (c == '1') value.setbit(0, true);
+			digit_found = true;
 		}
+		if (!digit_found) return false;
 		break;
 	}
 	case sp::number_base::octal: {
@@ -1716,7 +1722,9 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 			for (unsigned b = 0; b < 3; ++b) {
 				if ((digit >> b) & 1u) value.setbit(b, true);
 			}
+			digit_found = true;
 		}
+		if (!digit_found) return false;
 		break;
 	}
 	case sp::number_base::hex: {
@@ -1729,18 +1737,24 @@ bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& val
 			for (unsigned b = 0; b < 4; ++b) {
 				if ((digit >> b) & 1u) value.setbit(b, true);
 			}
+			digit_found = true;
 		}
+		if (!digit_found) return false;
 		break;
 	}
 	case sp::number_base::decimal: {
-		// MSB-first: multiply accumulator by 10, add digit.
+		// MSB-first: multiply accumulator by 10, add digit. is_decimal_digit
+		// gates the loop body so digit_found tracking is redundant here, but
+		// kept for symmetry.
 		Int ten{10};
 		for (char c : body) {
 			if (!sp::is_decimal_digit(c)) return false;
 			value *= ten;
 			Int digit{static_cast<unsigned>(c - '0')};
 			value += digit;
+			digit_found = true;
 		}
+		if (!digit_found) return false;
 		break;
 	}
 	default:

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -1884,13 +1884,17 @@ inline std::ostream& operator<<(std::ostream& ostr, const integer<nbits, BlockTy
 	return ostr << s;
 }
 
-// read an ASCII integer format
+// read an ASCII integer format.
+// On parse failure: log a diagnostic to std::cerr AND set failbit on the stream
+// so callers (loops with `while (in >> x)`, etc.) can detect the error without
+// scraping stderr. Symmetric with fixpnt's operator>>.
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
 inline std::istream& operator>>(std::istream& istr, integer<nbits, BlockType, NumberType>& p) {
 	std::string txt;
 	istr >> txt;
 	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+		std::cerr << "unable to parse -" << txt << "- into an integer value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -9,16 +9,16 @@
 #include <iostream>
 #include <iomanip>
 #include <algorithm>
-#include <regex>
+#include <string_view>
 #include <type_traits>  // for std::is_constant_evaluated() dispatch around mul128/addcarry
 #include <vector>
-#include <map>
 
 // supporting types and functions
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/number/shared/blocktype.hpp>
 #include <universal/native/integers.hpp> // just for printing native integers in binary form
 #include <universal/internal/blocktype/carry.hpp> // carry-detection intrinsics for uint64_t limbs
+#include <universal/utility/string_parse.hpp>   // shared constexpr scan_prefix / scan_sign / char classifiers
 
 /*
 the integer arithmetic can be configured to:
@@ -1658,139 +1658,97 @@ constexpr idiv_t<nbits, BlockType, NumberType> idiv(const integer<nbits, BlockTy
 
 /// stream operators
 
-// read a integer ASCII format and make a binary integer out of it
+// read an integer ASCII format and make a binary integer out of it
+//
+// Accepted syntax (Phase B1 of issue #835 -- shared string_parse foundation):
+//
+//   [+-]? ( 0[bB][01]+      |    // binary bit-pattern
+//           0[oO][0-7]+     |    // octal bit-pattern
+//           0[xX][0-9A-F']+ |    // hex bit-pattern (apostrophe allowed as digit separator)
+//           [0-9]+          )    // decimal integer
+//
+// Notes vs. the historical regex-based parser:
+//   - Octal now requires the explicit 0o/0O prefix (the previous code accepted
+//     C-style leading-zero octal but the conversion path was a `// TODO` that
+//     always returned false, so no real behavior change).
+//   - Binary 0b/0B is newly supported.
+//   - Decimal accepts a single optional leading +/- (the previous regex
+//     accepted multiple sign chars; functional difference is nil).
+//
+// All scanning is delegated to the constexpr primitives in
+// `<universal/utility/string_parse.hpp>`; the parser itself uses only
+// `integer`'s own arithmetic.
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>
 bool parse(const std::string& number, integer<nbits, BlockType, NumberType>& value) {
-	bool bSuccess = false;
+	namespace sp = sw::universal::string_parse;
+	using Int = integer<nbits, BlockType, NumberType>;
+
 	value.clear();
-	// check if the txt is an integer form: [0123456789]+
-	std::regex decimal_regex("^[-+]*[0-9]+");
-	std::regex octal_regex("^[-+]*0[1-7][0-7]*$");
-	std::regex hex_regex("^[-+]*0[xX][0-9a-fA-F']+");
-	// setup associative array to map chars to nibbles
-	static std::map<char, int> charLookup{
-		{ '0', 0 },
-		{ '1', 1 },
-		{ '2', 2 },
-		{ '3', 3 },
-		{ '4', 4 },
-		{ '5', 5 },
-		{ '6', 6 },
-		{ '7', 7 },
-		{ '8', 8 },
-		{ '9', 9 },
-		{ 'a', 10 },
-		{ 'b', 11 },
-		{ 'c', 12 },
-		{ 'd', 13 },
-		{ 'e', 14 },
-		{ 'f', 15 },
-		{ 'A', 10 },
-		{ 'B', 11 },
-		{ 'C', 12 },
-		{ 'D', 13 },
-		{ 'E', 14 },
-		{ 'F', 15 },
-	};
-	if (std::regex_match(number, octal_regex)) {
-		std::cout << "found an octal representation\n";
-		for (std::string::const_reverse_iterator r = number.rbegin();
-			r != number.rend();
-			++r) {
-			std::cout << "char = " << *r << std::endl;
+	std::string_view s{number};
+
+	// Strip leading sign (if any).
+	auto sg = sp::scan_sign(s);
+	const bool negative = sg.negative;
+	s = sg.rest;
+	if (s.empty()) return false;
+
+	// Detect base prefix; no prefix -> decimal.
+	auto pfx = sp::scan_prefix(s);
+	std::string_view body = pfx.body;
+	if (body.empty()) return false;
+
+	switch (pfx.base) {
+	case sp::number_base::binary: {
+		// MSB-first: shift the accumulator left by 1 per character, OR in the bit.
+		for (char c : body) {
+			if (!sp::is_binary_digit(c)) return false;
+			value <<= 1;
+			if (c == '1') value.setbit(0, true);
 		}
-		bSuccess = false; // TODO
+		break;
 	}
-	else if (std::regex_match(number, hex_regex)) {
-		//std::cout << "found a hexadecimal representation\n";
-		// each char is a nibble
-		int maxByteIndex = nbits / 8;
-		int byte = 0;
-		int byteIndex = 0;
-		bool odd = false;
-		for (std::string::const_reverse_iterator r = number.rbegin();
-			r != number.rend() && byteIndex < maxByteIndex;
-			++r) {
-			if (*r == '\'') {
-				// ignore
-			}
-			else if (*r == 'x' || *r == 'X') {
-				if (odd) {
-					// complete the most significant byte
-					value.setbyte(static_cast<unsigned>(byteIndex), static_cast<uint8_t>(byte));
-				}
-				// check that we have [-+]0[xX] format
-				++r;
-				if (r != number.rend()) {
-					if (*r == '0') {
-						// check if we have a sign
-						++r;
-						if (r == number.rend()) {
-							// no sign, thus by definition positive
-							bSuccess = true;
-						}
-						else if (*r == '+') {
-							// optional positive sign, no further action necessary
-							bSuccess = true;
-						}
-						else if (*r == '-') {
-							// negative sign, invert
-							value = -value;
-							bSuccess = true;
-						}
-						else {
-							// the regex will have filtered this out
-							return false;
-						}
-					}
-					else {
-						// we didn't find the obligatory '0', the regex should have filtered this out
-						return false;
-					}
-				}
-				else {
-					// we are missing the obligatory '0', the regex should have filtered this out
-					return false;
-				}
-				// we have reached the end of our parse
-				break;
-			}
-			else {
-				if (odd) {
-					byte += charLookup.at(*r) << 4;
-					value.setbyte(static_cast<unsigned>(byteIndex), static_cast<uint8_t>(byte));
-					++byteIndex;
-				}
-				else {
-					byte = charLookup.at(*r);
-				}
-				odd = !odd;
+	case sp::number_base::octal: {
+		// MSB-first: shift by 3, OR in the 3-bit digit.
+		for (char c : body) {
+			if (!sp::is_octal_digit(c)) return false;
+			value <<= 3;
+			unsigned digit = static_cast<unsigned>(c - '0');
+			for (unsigned b = 0; b < 3; ++b) {
+				if ((digit >> b) & 1u) value.setbit(b, true);
 			}
 		}
-		bSuccess = true;
+		break;
 	}
-	else if (std::regex_match(number, decimal_regex)) {
-		//std::cout << "found a decimal integer representation\n";
-		integer<nbits, BlockType, NumberType> scale = 1;
-		for (std::string::const_reverse_iterator r = number.rbegin();
-			r != number.rend();
-			++r) {
-			if (*r == '-') {
-				value = -value;
-			}
-			else if (*r == '+') {
-				break;
-			}
-			else {
-				integer<nbits, BlockType, NumberType> digit = charLookup.at(*r);
-				value += scale * digit;
-				scale *= 10;
+	case sp::number_base::hex: {
+		// MSB-first: shift by 4, OR in the nibble. Apostrophe is a separator.
+		for (char c : body) {
+			if (c == '\'') continue;
+			if (!sp::is_hex_digit(c)) return false;
+			value <<= 4;
+			unsigned digit = sp::hex_digit_value(c);
+			for (unsigned b = 0; b < 4; ++b) {
+				if ((digit >> b) & 1u) value.setbit(b, true);
 			}
 		}
-		bSuccess = true;
+		break;
+	}
+	case sp::number_base::decimal: {
+		// MSB-first: multiply accumulator by 10, add digit.
+		Int ten{10};
+		for (char c : body) {
+			if (!sp::is_decimal_digit(c)) return false;
+			value *= ten;
+			Int digit{static_cast<unsigned>(c - '0')};
+			value += digit;
+		}
+		break;
+	}
+	default:
+		return false;
 	}
 
-	return bSuccess;
+	if (negative) value = -value;
+	return true;
 }
 
 template<unsigned nbits, typename BlockType, IntegerNumberType NumberType>

--- a/static/fixpnt/binary/api/string_parse.cpp
+++ b/static/fixpnt/binary/api/string_parse.cpp
@@ -118,6 +118,8 @@ try {
 	check_parse_invalid<8, 4, Modulo, std::uint8_t>("dec w/letter", "12a");
 	check_parse_invalid<8, 4, Modulo, std::uint8_t>("bin w/2", "0b102");
 	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex no body", "0x");
+	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex only-sep '",  "0x'");
+	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex only-sep ''", "0x''");
 
 	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
 	          << " / " << sw::universal::g_total << " tests passed";

--- a/static/fixpnt/binary/api/string_parse.cpp
+++ b/static/fixpnt/binary/api/string_parse.cpp
@@ -1,0 +1,138 @@
+// string_parse.cpp: tests for fixpnt parse() (Phase B1 of issue #835)
+//
+// fixpnt::parse() was previously forward-declared but never defined; the
+// istream operator>> linked to a non-existent symbol. This test covers the
+// new implementation that uses the shared string_parse primitives.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <iostream>
+#include <string>
+#include <universal/utility/directives.hpp>
+#include <universal/number/fixpnt/fixpnt.hpp>
+
+namespace sw { namespace universal {
+
+	static int g_failures = 0;
+	static int g_total    = 0;
+
+	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
+	static void check_parse(const char* tag, const std::string& input,
+	                        const fixpnt<nbits, rbits, arithmetic, bt>& expected) {
+		++g_total;
+		fixpnt<nbits, rbits, arithmetic, bt> got;
+		bool ok = parse(input, got);
+		if (!ok || got != expected) {
+			++g_failures;
+			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
+			          << "got=" << double(got) << "  expected=" << double(expected) << '\n';
+		}
+	}
+
+	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
+	static void check_parse_invalid(const char* tag, const std::string& input) {
+		++g_total;
+		fixpnt<nbits, rbits, arithmetic, bt> got;
+		bool ok = parse(input, got);
+		if (ok) {
+			++g_failures;
+			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
+			             "parse should have rejected, got " << double(got) << '\n';
+		}
+	}
+
+}}  // namespace sw::universal
+
+int main()
+try {
+	using namespace sw::universal;
+	using FP8_4  = fixpnt<8,  4, Modulo, std::uint8_t>;
+	using FP16_8 = fixpnt<16, 8, Modulo, std::uint8_t>;
+
+	std::cout << "fixpnt parse() tests (Phase B1 of #835)\n\n";
+
+	// ----- decimal (integer-only in B1) -----
+	check_parse<8, 4, Modulo, std::uint8_t>("dec 0", "0", FP8_4(0));
+	check_parse<8, 4, Modulo, std::uint8_t>("dec 5", "5", FP8_4(5));
+	check_parse<8, 4, Modulo, std::uint8_t>("dec -1", "-1", FP8_4(-1));
+	check_parse<16, 8, Modulo, std::uint8_t>("dec 100 (rbits=8)", "100", FP16_8(100));
+
+	// ----- binary (bit-pattern fills storage MSB-first) -----
+	// fixpnt<8,4>(0b1010'0000) = 1010.0000 = value 10.0
+	{
+		FP8_4 expected;
+		expected.setbits(0b10100000);
+		check_parse<8, 4, Modulo, std::uint8_t>("bin 10100000 -> 10.0", "0b10100000", expected);
+	}
+	// fixpnt<8,4>(0b0000'1000) = 0000.1000 = value 0.5
+	{
+		FP8_4 expected;
+		expected.setbits(0b00001000);
+		check_parse<8, 4, Modulo, std::uint8_t>("bin 00001000 -> 0.5", "0b00001000", expected);
+	}
+
+	// ----- hex (bit-pattern fills storage; each nibble = 4 bits) -----
+	// fixpnt<8,4>(0xA0) = 1010.0000 = 10.0
+	{
+		FP8_4 expected;
+		expected.setbits(0xA0);
+		check_parse<8, 4, Modulo, std::uint8_t>("hex A0 -> 10.0", "0xA0", expected);
+	}
+	// fixpnt<16,8>(0xFF80) -> -0.5 (signed) or 65408/256 = 255.5 (modulo); we use Modulo
+	{
+		FP16_8 expected;
+		expected.setbits(0xFF80);
+		check_parse<16, 8, Modulo, std::uint8_t>("hex FF80", "0xFF80", expected);
+	}
+	// Apostrophe digit separator
+	{
+		FP16_8 expected;
+		expected.setbits(0xDEAD);
+		check_parse<16, 8, Modulo, std::uint8_t>("hex w/separator", "0xDE'AD", expected);
+	}
+
+	// ----- octal (bit-pattern; each digit = 3 bits) -----
+	// fixpnt<8,4>(0o250) = 010 101 000 truncated to 8 bits MSB = ... hmm tricky
+	// Use a width that's a multiple of 3 for clean semantics. fixpnt<9,4> -> 9 bits = 3 octal digits.
+	{
+		fixpnt<9, 4, Modulo, std::uint8_t> expected;
+		expected.setbits(0125);  // octal 125
+		check_parse<9, 4, Modulo, std::uint8_t>("oct 125", "0o125", expected);
+	}
+
+	// ----- sign on bit-pattern -----
+	{
+		FP8_4 expected;
+		expected.setbits(0xA0);
+		FP8_4 expected_neg = -expected;
+		check_parse<8, 4, Modulo, std::uint8_t>("hex w/leading -", "-0xA0", expected_neg);
+	}
+
+	// ----- invalid -----
+	check_parse_invalid<8, 4, Modulo, std::uint8_t>("empty", "");
+	check_parse_invalid<8, 4, Modulo, std::uint8_t>("just sign", "-");
+	check_parse_invalid<8, 4, Modulo, std::uint8_t>("dec w/letter", "12a");
+	check_parse_invalid<8, 4, Modulo, std::uint8_t>("bin w/2", "0b102");
+	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex no body", "0x");
+
+	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
+	          << " / " << sw::universal::g_total << " tests passed";
+	if (sw::universal::g_failures > 0) {
+		std::cout << "  (" << sw::universal::g_failures << " FAILED)\n";
+		return EXIT_FAILURE;
+	}
+	std::cout << "\n";
+	return EXIT_SUCCESS;
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/static/fixpnt/binary/api/string_parse.cpp
+++ b/static/fixpnt/binary/api/string_parse.cpp
@@ -10,153 +10,125 @@
 // This file is part of the universal numbers project, which is released under
 // an MIT Open Source license.
 
-#include <iostream>
-#include <string>
 #include <universal/utility/directives.hpp>
 #include <universal/number/fixpnt/fixpnt.hpp>
-
-namespace sw { namespace universal {
-
-	static int g_failures = 0;
-	static int g_total    = 0;
-
-	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-	static void check_parse(const char* tag, const std::string& input,
-	                        const fixpnt<nbits, rbits, arithmetic, bt>& expected) {
-		++g_total;
-		fixpnt<nbits, rbits, arithmetic, bt> got;
-		bool ok = parse(input, got);
-		if (!ok || got != expected) {
-			++g_failures;
-			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
-			          << "got=" << double(got) << "  expected=" << double(expected) << '\n';
-		}
-	}
-
-	template<unsigned nbits, unsigned rbits, bool arithmetic, typename bt>
-	static void check_parse_invalid(const char* tag, const std::string& input) {
-		++g_total;
-		fixpnt<nbits, rbits, arithmetic, bt> got;
-		bool ok = parse(input, got);
-		if (ok) {
-			++g_failures;
-			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
-			             "parse should have rejected, got " << double(got) << '\n';
-		}
-	}
-
-}}  // namespace sw::universal
+#include <universal/verification/test_reporters.hpp>
 
 int main()
 try {
 	using namespace sw::universal;
+
+	std::string test_suite  = "fixpnt<> parse() string-parsing test suite";
+	std::string test_tag    = "fixpnt<> parse()";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
 	using Fixpnt8_4  = fixpnt<8,  4, Modulo, std::uint8_t>;
+	using Fixpnt9_4  = fixpnt<9,  4, Modulo, std::uint8_t>;
 	using Fixpnt16_8 = fixpnt<16, 8, Modulo, std::uint8_t>;
 
-	std::cout << "fixpnt parse() tests (Phase B1 of #835)\n\n";
-
 	// ----- decimal (integer-only in B1) -----
-	check_parse<8, 4, Modulo, std::uint8_t>("dec 0", "0", Fixpnt8_4(0));
-	check_parse<8, 4, Modulo, std::uint8_t>("dec 5", "5", Fixpnt8_4(5));
-	check_parse<8, 4, Modulo, std::uint8_t>("dec -1", "-1", Fixpnt8_4(-1));
-	check_parse<16, 8, Modulo, std::uint8_t>("dec 100 (rbits=8)", "100", Fixpnt16_8(100));
+	{
+		int start = nrOfFailedTestCases;
+		Fixpnt8_4 a;
+		if (!parse(std::string("0"),  a) || a != Fixpnt8_4(0))  ++nrOfFailedTestCases;
+		if (!parse(std::string("5"),  a) || a != Fixpnt8_4(5))  ++nrOfFailedTestCases;
+		if (!parse(std::string("-1"), a) || a != Fixpnt8_4(-1)) ++nrOfFailedTestCases;
+		Fixpnt16_8 b;
+		if (!parse(std::string("100"), b) || b != Fixpnt16_8(100)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: decimal parsing\n";
+	}
 
 	// ----- binary (bit-pattern fills storage MSB-first) -----
 	// fixpnt<8,4>(0b1010'0000) = 1010.0000 = value 10.0
-	{
-		Fixpnt8_4 expected;
-		expected.setbits(0b10100000);
-		check_parse<8, 4, Modulo, std::uint8_t>("bin 10100000 -> 10.0", "0b10100000", expected);
-	}
 	// fixpnt<8,4>(0b0000'1000) = 0000.1000 = value 0.5
 	{
-		Fixpnt8_4 expected;
+		int start = nrOfFailedTestCases;
+		Fixpnt8_4 a, expected;
+		expected.setbits(0b10100000);
+		if (!parse(std::string("0b10100000"), a) || a != expected) ++nrOfFailedTestCases;
 		expected.setbits(0b00001000);
-		check_parse<8, 4, Modulo, std::uint8_t>("bin 00001000 -> 0.5", "0b00001000", expected);
+		if (!parse(std::string("0b00001000"), a) || a != expected) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: binary parsing\n";
 	}
 
 	// ----- hex (bit-pattern fills storage; each nibble = 4 bits) -----
-	// fixpnt<8,4>(0xA0) = 1010.0000 = 10.0
 	{
-		Fixpnt8_4 expected;
+		int start = nrOfFailedTestCases;
+		Fixpnt8_4 a, expected;
 		expected.setbits(0xA0);
-		check_parse<8, 4, Modulo, std::uint8_t>("hex A0 -> 10.0", "0xA0", expected);
-	}
-	// fixpnt<16,8>(0xFF80) -> -0.5 (signed) or 65408/256 = 255.5 (modulo); we use Modulo
-	{
-		Fixpnt16_8 expected;
-		expected.setbits(0xFF80);
-		check_parse<16, 8, Modulo, std::uint8_t>("hex FF80", "0xFF80", expected);
-	}
-	// Apostrophe digit separator
-	{
-		Fixpnt16_8 expected;
-		expected.setbits(0xDEAD);
-		check_parse<16, 8, Modulo, std::uint8_t>("hex w/separator", "0xDE'AD", expected);
-	}
-
-	// ----- octal (bit-pattern; each digit = 3 bits) -----
-	// fixpnt<8,4>(0o250) = 010 101 000 truncated to 8 bits MSB = ... hmm tricky
-	// Use a width that's a multiple of 3 for clean semantics. fixpnt<9,4> -> 9 bits = 3 octal digits.
-	{
-		fixpnt<9, 4, Modulo, std::uint8_t> expected;
-		expected.setbits(0125);  // octal 125
-		check_parse<9, 4, Modulo, std::uint8_t>("oct 125", "0o125", expected);
-	}
-
-	// ----- sign on bit-pattern -----
-	{
-		Fixpnt8_4 expected;
-		expected.setbits(0xA0);
+		if (!parse(std::string("0xA0"), a) || a != expected) ++nrOfFailedTestCases;
+		// Sign on hex bit-pattern: negate the parsed value
 		Fixpnt8_4 expected_neg = -expected;
-		check_parse<8, 4, Modulo, std::uint8_t>("hex w/leading -", "-0xA0", expected_neg);
+		if (!parse(std::string("-0xA0"), a) || a != expected_neg) ++nrOfFailedTestCases;
+		// Apostrophe digit separator on a wider type
+		Fixpnt16_8 b, expected16;
+		expected16.setbits(0xDEAD);
+		if (!parse(std::string("0xDE'AD"), b) || b != expected16) ++nrOfFailedTestCases;
+		// fixpnt<16,8>(0xFF80) with Modulo arithmetic
+		expected16.setbits(0xFF80);
+		if (!parse(std::string("0xFF80"), b) || b != expected16) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hex parsing\n";
 	}
 
-	// ----- invalid -----
-	check_parse_invalid<8, 4, Modulo, std::uint8_t>("empty", "");
-	check_parse_invalid<8, 4, Modulo, std::uint8_t>("just sign", "-");
-	check_parse_invalid<8, 4, Modulo, std::uint8_t>("dec w/letter", "12a");
-	check_parse_invalid<8, 4, Modulo, std::uint8_t>("bin w/2", "0b102");
-	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex no body", "0x");
-	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex only-sep '",  "0x'");
-	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex only-sep ''", "0x''");
-
-	// Commit-on-success: a failed parse must not modify the caller's value.
+	// ----- octal (bit-pattern; each digit = 3 bits, fixpnt<9,4> = 3 octal digits cleanly) -----
 	{
-		++sw::universal::g_total;
+		int start = nrOfFailedTestCases;
+		Fixpnt9_4 a, expected;
+		expected.setbits(0125);  // octal 125
+		if (!parse(std::string("0o125"), a) || a != expected) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: octal parsing\n";
+	}
+
+	// ----- invalid inputs must be rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		Fixpnt8_4 a;
+		if (parse(std::string(""),     a)) ++nrOfFailedTestCases;
+		if (parse(std::string("-"),    a)) ++nrOfFailedTestCases;
+		if (parse(std::string("12a"),  a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0b102"), a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0x"),   a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0x'"),  a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0x''"), a)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: invalid-input rejection\n";
+	}
+
+	// ----- commit-on-success: a failed parse must leave value untouched -----
+	{
+		int start = nrOfFailedTestCases;
 		Fixpnt8_4 v(5);
-		bool ok = parse(std::string("0x1G"), v);
-		if (ok || v != Fixpnt8_4(5)) {
-			++sw::universal::g_failures;
-			std::cout << "FAIL  commit-on-success: parse should fail and leave v unchanged; "
-			          << "ok=" << ok << "  v=" << double(v) << '\n';
-		}
-	}
-	{
-		++sw::universal::g_total;
-		Fixpnt16_8 v(-3);
-		bool ok = parse(std::string("12abc"), v);
-		if (ok || v != Fixpnt16_8(-3)) {
-			++sw::universal::g_failures;
-			std::cout << "FAIL  commit-on-success: decimal-then-garbage should leave v unchanged; "
-			          << "ok=" << ok << "  v=" << double(v) << '\n';
-		}
+		if (parse(std::string("0x1G"), v))   ++nrOfFailedTestCases;
+		if (v != Fixpnt8_4(5))               ++nrOfFailedTestCases;
+
+		Fixpnt16_8 w(-3);
+		if (parse(std::string("12abc"), w))  ++nrOfFailedTestCases;
+		if (w != Fixpnt16_8(-3))             ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: commit-on-success\n";
 	}
 
-	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
-	          << " / " << sw::universal::g_total << " tests passed";
-	if (sw::universal::g_failures > 0) {
-		std::cout << "  (" << sw::universal::g_failures << " FAILED)\n";
-		return EXIT_FAILURE;
-	}
-	std::cout << "\n";
-	return EXIT_SUCCESS;
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	std::cerr << msg << '\n';
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const std::exception& err) {
-	std::cerr << err.what() << '\n';
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception : " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }

--- a/static/fixpnt/binary/api/string_parse.cpp
+++ b/static/fixpnt/binary/api/string_parse.cpp
@@ -121,6 +121,28 @@ try {
 	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex only-sep '",  "0x'");
 	check_parse_invalid<8, 4, Modulo, std::uint8_t>("hex only-sep ''", "0x''");
 
+	// Commit-on-success: a failed parse must not modify the caller's value.
+	{
+		++sw::universal::g_total;
+		Fixpnt8_4 v(5);
+		bool ok = parse(std::string("0x1G"), v);
+		if (ok || v != Fixpnt8_4(5)) {
+			++sw::universal::g_failures;
+			std::cout << "FAIL  commit-on-success: parse should fail and leave v unchanged; "
+			          << "ok=" << ok << "  v=" << double(v) << '\n';
+		}
+	}
+	{
+		++sw::universal::g_total;
+		Fixpnt16_8 v(-3);
+		bool ok = parse(std::string("12abc"), v);
+		if (ok || v != Fixpnt16_8(-3)) {
+			++sw::universal::g_failures;
+			std::cout << "FAIL  commit-on-success: decimal-then-garbage should leave v unchanged; "
+			          << "ok=" << ok << "  v=" << double(v) << '\n';
+		}
+	}
+
 	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
 	          << " / " << sw::universal::g_total << " tests passed";
 	if (sw::universal::g_failures > 0) {

--- a/static/fixpnt/binary/api/string_parse.cpp
+++ b/static/fixpnt/binary/api/string_parse.cpp
@@ -50,27 +50,27 @@ namespace sw { namespace universal {
 int main()
 try {
 	using namespace sw::universal;
-	using FP8_4  = fixpnt<8,  4, Modulo, std::uint8_t>;
-	using FP16_8 = fixpnt<16, 8, Modulo, std::uint8_t>;
+	using Fixpnt8_4  = fixpnt<8,  4, Modulo, std::uint8_t>;
+	using Fixpnt16_8 = fixpnt<16, 8, Modulo, std::uint8_t>;
 
 	std::cout << "fixpnt parse() tests (Phase B1 of #835)\n\n";
 
 	// ----- decimal (integer-only in B1) -----
-	check_parse<8, 4, Modulo, std::uint8_t>("dec 0", "0", FP8_4(0));
-	check_parse<8, 4, Modulo, std::uint8_t>("dec 5", "5", FP8_4(5));
-	check_parse<8, 4, Modulo, std::uint8_t>("dec -1", "-1", FP8_4(-1));
-	check_parse<16, 8, Modulo, std::uint8_t>("dec 100 (rbits=8)", "100", FP16_8(100));
+	check_parse<8, 4, Modulo, std::uint8_t>("dec 0", "0", Fixpnt8_4(0));
+	check_parse<8, 4, Modulo, std::uint8_t>("dec 5", "5", Fixpnt8_4(5));
+	check_parse<8, 4, Modulo, std::uint8_t>("dec -1", "-1", Fixpnt8_4(-1));
+	check_parse<16, 8, Modulo, std::uint8_t>("dec 100 (rbits=8)", "100", Fixpnt16_8(100));
 
 	// ----- binary (bit-pattern fills storage MSB-first) -----
 	// fixpnt<8,4>(0b1010'0000) = 1010.0000 = value 10.0
 	{
-		FP8_4 expected;
+		Fixpnt8_4 expected;
 		expected.setbits(0b10100000);
 		check_parse<8, 4, Modulo, std::uint8_t>("bin 10100000 -> 10.0", "0b10100000", expected);
 	}
 	// fixpnt<8,4>(0b0000'1000) = 0000.1000 = value 0.5
 	{
-		FP8_4 expected;
+		Fixpnt8_4 expected;
 		expected.setbits(0b00001000);
 		check_parse<8, 4, Modulo, std::uint8_t>("bin 00001000 -> 0.5", "0b00001000", expected);
 	}
@@ -78,19 +78,19 @@ try {
 	// ----- hex (bit-pattern fills storage; each nibble = 4 bits) -----
 	// fixpnt<8,4>(0xA0) = 1010.0000 = 10.0
 	{
-		FP8_4 expected;
+		Fixpnt8_4 expected;
 		expected.setbits(0xA0);
 		check_parse<8, 4, Modulo, std::uint8_t>("hex A0 -> 10.0", "0xA0", expected);
 	}
 	// fixpnt<16,8>(0xFF80) -> -0.5 (signed) or 65408/256 = 255.5 (modulo); we use Modulo
 	{
-		FP16_8 expected;
+		Fixpnt16_8 expected;
 		expected.setbits(0xFF80);
 		check_parse<16, 8, Modulo, std::uint8_t>("hex FF80", "0xFF80", expected);
 	}
 	// Apostrophe digit separator
 	{
-		FP16_8 expected;
+		Fixpnt16_8 expected;
 		expected.setbits(0xDEAD);
 		check_parse<16, 8, Modulo, std::uint8_t>("hex w/separator", "0xDE'AD", expected);
 	}
@@ -106,9 +106,9 @@ try {
 
 	// ----- sign on bit-pattern -----
 	{
-		FP8_4 expected;
+		Fixpnt8_4 expected;
 		expected.setbits(0xA0);
-		FP8_4 expected_neg = -expected;
+		Fixpnt8_4 expected_neg = -expected;
 		check_parse<8, 4, Modulo, std::uint8_t>("hex w/leading -", "-0xA0", expected_neg);
 	}
 

--- a/static/integer/binary/api/string_parse.cpp
+++ b/static/integer/binary/api/string_parse.cpp
@@ -7,138 +7,139 @@
 // This file is part of the universal numbers project, which is released under
 // an MIT Open Source license.
 
-#include <iostream>
-#include <string>
 #include <universal/utility/directives.hpp>
+#define INTEGER_THROW_ARITHMETIC_EXCEPTION 1
 #include <universal/number/integer/integer.hpp>
-
-namespace sw { namespace universal {
-
-	// Tiny test bench: every check increments g_total and either passes silently
-	// or prints a FAIL line and increments g_failures.
-	static int g_failures = 0;
-	static int g_total    = 0;
-
-	template<unsigned nbits, typename Bt>
-	static void check_parse(const char* tag, const std::string& input,
-	                        const integer<nbits, Bt, IntegerNumberType::IntegerNumber>& expected) {
-		++g_total;
-		integer<nbits, Bt, IntegerNumberType::IntegerNumber> got;
-		bool ok = parse(input, got);
-		if (!ok || got != expected) {
-			++g_failures;
-			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
-			          << "got=" << static_cast<long long>(got) << "  expected=" << static_cast<long long>(expected) << '\n';
-		}
-	}
-
-	template<unsigned nbits, typename Bt>
-	static void check_parse_invalid(const char* tag, const std::string& input) {
-		++g_total;
-		integer<nbits, Bt, IntegerNumberType::IntegerNumber> got;
-		bool ok = parse(input, got);
-		if (ok) {
-			++g_failures;
-			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
-			             "parse should have rejected, got " << static_cast<long long>(got) << '\n';
-		}
-	}
-
-}}  // namespace sw::universal
+#include <universal/verification/test_reporters.hpp>
 
 int main()
 try {
 	using namespace sw::universal;
+
+	std::string test_suite  = "integer<> parse() string-parsing test suite";
+	std::string test_tag    = "integer<> parse()";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
 	using I8  = integer< 8, std::uint8_t,  IntegerNumberType::IntegerNumber>;
 	using I16 = integer<16, std::uint8_t,  IntegerNumberType::IntegerNumber>;
 	using I32 = integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>;
 	using I64 = integer<64, std::uint32_t, IntegerNumberType::IntegerNumber>;
 
-	std::cout << "integer parse() tests (Phase B1 of #835)\n\n";
-
 	// ----- decimal -----
-	check_parse<8, std::uint8_t>("dec 0",   "0",   I8(0));
-	check_parse<8, std::uint8_t>("dec 5",   "5",   I8(5));
-	check_parse<8, std::uint8_t>("dec 127", "127", I8(127));
-	check_parse<8, std::uint8_t>("dec -1",  "-1",  I8(-1));
-	check_parse<8, std::uint8_t>("dec -128","-128",I8(-128));
-	check_parse<8, std::uint8_t>("dec +42", "+42", I8(42));
-	check_parse<32, std::uint32_t>("dec 1_000_000", "1000000", I32(1000000));
-	check_parse<64, std::uint32_t>("dec 64-bit",   "1234567890123", I64(1234567890123LL));
+	{
+		int start = nrOfFailedTestCases;
+		I8 a;
+		if (!parse(std::string("0"),    a) || a != I8(0))    ++nrOfFailedTestCases;
+		if (!parse(std::string("5"),    a) || a != I8(5))    ++nrOfFailedTestCases;
+		if (!parse(std::string("127"),  a) || a != I8(127))  ++nrOfFailedTestCases;
+		if (!parse(std::string("-1"),   a) || a != I8(-1))   ++nrOfFailedTestCases;
+		if (!parse(std::string("-128"), a) || a != I8(-128)) ++nrOfFailedTestCases;
+		if (!parse(std::string("+42"),  a) || a != I8(42))   ++nrOfFailedTestCases;
+		I32 b;
+		if (!parse(std::string("1000000"), b) || b != I32(1000000)) ++nrOfFailedTestCases;
+		I64 c;
+		if (!parse(std::string("1234567890123"), c) || c != I64(1234567890123LL)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: decimal parsing\n";
+	}
 
 	// ----- binary -----
-	check_parse<8, std::uint8_t>("bin 1010",  "0b1010",     I8(10));
-	check_parse<8, std::uint8_t>("bin 0",     "0b0",        I8(0));
-	check_parse<8, std::uint8_t>("bin FF",    "0b11111111", I8(-1));  // 2s-complement for nbits=8
-	check_parse<32, std::uint32_t>("bin 32",  "0b10101010101010101010101010101010", I32(0xAAAAAAAA));
-	check_parse<8, std::uint8_t>("bin negative", "-0b1010", I8(-10));
-	check_parse<8, std::uint8_t>("bin 0B (uppercase)", "0B1010", I8(10));
+	{
+		int start = nrOfFailedTestCases;
+		I8 a;
+		if (!parse(std::string("0b1010"),     a) || a != I8(10)) ++nrOfFailedTestCases;
+		if (!parse(std::string("0b0"),        a) || a != I8(0))  ++nrOfFailedTestCases;
+		if (!parse(std::string("0b11111111"), a) || a != I8(-1)) ++nrOfFailedTestCases;
+		if (!parse(std::string("0B1010"),     a) || a != I8(10)) ++nrOfFailedTestCases;
+		if (!parse(std::string("-0b1010"),    a) || a != I8(-10)) ++nrOfFailedTestCases;
+		I32 b;
+		if (!parse(std::string("0b10101010101010101010101010101010"), b)
+		    || b != I32(0xAAAAAAAA)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: binary parsing\n";
+	}
 
 	// ----- octal -----
-	check_parse<16, std::uint8_t>("oct 17",   "0o17",   I16(15));
-	check_parse<16, std::uint8_t>("oct 100",  "0o100",  I16(64));
-	check_parse<8,  std::uint8_t>("oct 0",    "0o0",    I8(0));
-	check_parse<8,  std::uint8_t>("oct 0O upper", "0O17", I8(15));
+	{
+		int start = nrOfFailedTestCases;
+		I16 a;
+		if (!parse(std::string("0o17"),  a) || a != I16(15))  ++nrOfFailedTestCases;
+		if (!parse(std::string("0o100"), a) || a != I16(64))  ++nrOfFailedTestCases;
+		I8 b;
+		if (!parse(std::string("0o0"),   b) || b != I8(0))    ++nrOfFailedTestCases;
+		if (!parse(std::string("0O17"),  b) || b != I8(15))   ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: octal parsing\n";
+	}
 
 	// ----- hex -----
-	check_parse<8,  std::uint8_t>("hex FF",  "0xFF", I8(-1));  // saturates as 2s-complement
-	check_parse<16, std::uint8_t>("hex FF16","0xFF", integer<16, std::uint8_t, IntegerNumberType::IntegerNumber>(255));
-	check_parse<32, std::uint32_t>("hex DEADBEEF", "0xDEADBEEF", I32(0xDEADBEEF));
-	check_parse<32, std::uint32_t>("hex w/separator", "0xDEAD'BEEF", I32(0xDEADBEEF));
-	check_parse<8,  std::uint8_t>("hex 0X (uppercase prefix)", "0X1F", I8(31));
-	check_parse<8,  std::uint8_t>("hex mixed case digits", "0xaB", I8(0xAB));
-	check_parse<8,  std::uint8_t>("hex negative", "-0x05", I8(-5));
-
-	// ----- invalid -----
-	check_parse_invalid<8, std::uint8_t>("empty",       "");
-	check_parse_invalid<8, std::uint8_t>("just sign",   "-");
-	check_parse_invalid<8, std::uint8_t>("dec w/letter","12a");
-	check_parse_invalid<8, std::uint8_t>("bin w/2",     "0b102");
-	check_parse_invalid<8, std::uint8_t>("oct w/8",     "0o18");
-	check_parse_invalid<8, std::uint8_t>("hex w/z",     "0xZZ");
-	check_parse_invalid<8, std::uint8_t>("0b no body",  "0b");
-	check_parse_invalid<8, std::uint8_t>("0x no body",  "0x");
-	// Hex with only separator chars (no real digits) must be rejected.
-	check_parse_invalid<8,  std::uint8_t>("hex only-sep '",     "0x'");
-	check_parse_invalid<8,  std::uint8_t>("hex only-sep ''",    "0x''");
-	check_parse_invalid<32, std::uint32_t>("hex only-sep '''",  "0x'''");
-
-	// Commit-on-success: a failed parse must not modify the caller's value.
 	{
-		++sw::universal::g_total;
-		I32 v(42);                              // existing state
-		bool ok = parse(std::string("0x1G"), v); // malformed: 'G' is not hex
-		if (ok || v != I32(42)) {
-			++sw::universal::g_failures;
-			std::cout << "FAIL  commit-on-success: parse should fail and leave v unchanged; "
-			          << "ok=" << ok << "  v=" << static_cast<long long>(v) << '\n';
-		}
-	}
-	{
-		++sw::universal::g_total;
-		I32 v(-7);
-		bool ok = parse(std::string("123abc"), v); // decimal then garbage
-		if (ok || v != I32(-7)) {
-			++sw::universal::g_failures;
-			std::cout << "FAIL  commit-on-success: decimal-then-garbage should leave v unchanged; "
-			          << "ok=" << ok << "  v=" << static_cast<long long>(v) << '\n';
-		}
+		int start = nrOfFailedTestCases;
+		I8 a;
+		if (!parse(std::string("0xFF"), a) || a != I8(-1))    ++nrOfFailedTestCases;
+		if (!parse(std::string("0X1F"), a) || a != I8(31))    ++nrOfFailedTestCases;
+		if (!parse(std::string("0xaB"), a) || a != I8(0xAB))  ++nrOfFailedTestCases;
+		if (!parse(std::string("-0x05"), a) || a != I8(-5))   ++nrOfFailedTestCases;
+		I16 b;
+		if (!parse(std::string("0xFF"), b) || b != I16(255))  ++nrOfFailedTestCases;
+		I32 c;
+		if (!parse(std::string("0xDEADBEEF"),  c) || c != I32(0xDEADBEEF)) ++nrOfFailedTestCases;
+		if (!parse(std::string("0xDEAD'BEEF"), c) || c != I32(0xDEADBEEF)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hex parsing\n";
 	}
 
-	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
-	          << " / " << sw::universal::g_total << " tests passed";
-	if (sw::universal::g_failures > 0) {
-		std::cout << "  (" << sw::universal::g_failures << " FAILED)\n";
-		return EXIT_FAILURE;
+	// ----- invalid inputs must be rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		I8 a;
+		if (parse(std::string(""),      a)) ++nrOfFailedTestCases;
+		if (parse(std::string("-"),     a)) ++nrOfFailedTestCases;
+		if (parse(std::string("12a"),   a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0b102"), a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0o18"),  a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0xZZ"),  a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0b"),    a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0x"),    a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0x'"),   a)) ++nrOfFailedTestCases;
+		if (parse(std::string("0x''"),  a)) ++nrOfFailedTestCases;
+		I32 b;
+		if (parse(std::string("0x'''"), b)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: invalid-input rejection\n";
 	}
-	std::cout << "\n";
-	return EXIT_SUCCESS;
+
+	// ----- commit-on-success: a failed parse must leave value untouched -----
+	{
+		int start = nrOfFailedTestCases;
+		I32 v(42);
+		if (parse(std::string("0x1G"), v))  ++nrOfFailedTestCases;  // should fail
+		if (v != I32(42))                   ++nrOfFailedTestCases;  // unchanged
+
+		v = I32(-7);
+		if (parse(std::string("123abc"), v)) ++nrOfFailedTestCases;
+		if (v != I32(-7))                    ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: commit-on-success\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	std::cerr << msg << '\n';
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const std::exception& err) {
-	std::cerr << err.what() << '\n';
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception : " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }

--- a/static/integer/binary/api/string_parse.cpp
+++ b/static/integer/binary/api/string_parse.cpp
@@ -50,6 +50,7 @@ int main()
 try {
 	using namespace sw::universal;
 	using I8  = integer< 8, std::uint8_t,  IntegerNumberType::IntegerNumber>;
+	using I16 = integer<16, std::uint8_t,  IntegerNumberType::IntegerNumber>;
 	using I32 = integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>;
 	using I64 = integer<64, std::uint32_t, IntegerNumberType::IntegerNumber>;
 
@@ -74,8 +75,8 @@ try {
 	check_parse<8, std::uint8_t>("bin 0B (uppercase)", "0B1010", I8(10));
 
 	// ----- octal -----
-	check_parse<16, std::uint8_t>("oct 17",   "0o17",   I8(15) /*int16*/);
-	check_parse<16, std::uint8_t>("oct 100",  "0o100",  I8(64));
+	check_parse<16, std::uint8_t>("oct 17",   "0o17",   I16(15));
+	check_parse<16, std::uint8_t>("oct 100",  "0o100",  I16(64));
 	check_parse<8,  std::uint8_t>("oct 0",    "0o0",    I8(0));
 	check_parse<8,  std::uint8_t>("oct 0O upper", "0O17", I8(15));
 
@@ -97,6 +98,10 @@ try {
 	check_parse_invalid<8, std::uint8_t>("hex w/z",     "0xZZ");
 	check_parse_invalid<8, std::uint8_t>("0b no body",  "0b");
 	check_parse_invalid<8, std::uint8_t>("0x no body",  "0x");
+	// Hex with only separator chars (no real digits) must be rejected.
+	check_parse_invalid<8,  std::uint8_t>("hex only-sep '",     "0x'");
+	check_parse_invalid<8,  std::uint8_t>("hex only-sep ''",    "0x''");
+	check_parse_invalid<32, std::uint32_t>("hex only-sep '''",  "0x'''");
 
 	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
 	          << " / " << sw::universal::g_total << " tests passed";

--- a/static/integer/binary/api/string_parse.cpp
+++ b/static/integer/binary/api/string_parse.cpp
@@ -1,0 +1,117 @@
+// string_parse.cpp: tests for integer parse() migrated to string_parse primitives
+//                  (Phase B1 of issue #835)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <iostream>
+#include <string>
+#include <universal/utility/directives.hpp>
+#include <universal/number/integer/integer.hpp>
+
+namespace sw { namespace universal {
+
+	// Tiny test bench: every check increments g_total and either passes silently
+	// or prints a FAIL line and increments g_failures.
+	static int g_failures = 0;
+	static int g_total    = 0;
+
+	template<unsigned nbits, typename Bt>
+	static void check_parse(const char* tag, const std::string& input,
+	                        const integer<nbits, Bt, IntegerNumberType::IntegerNumber>& expected) {
+		++g_total;
+		integer<nbits, Bt, IntegerNumberType::IntegerNumber> got;
+		bool ok = parse(input, got);
+		if (!ok || got != expected) {
+			++g_failures;
+			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
+			          << "got=" << static_cast<long long>(got) << "  expected=" << static_cast<long long>(expected) << '\n';
+		}
+	}
+
+	template<unsigned nbits, typename Bt>
+	static void check_parse_invalid(const char* tag, const std::string& input) {
+		++g_total;
+		integer<nbits, Bt, IntegerNumberType::IntegerNumber> got;
+		bool ok = parse(input, got);
+		if (ok) {
+			++g_failures;
+			std::cout << "FAIL  " << tag << "  input=\"" << input << "\"  "
+			             "parse should have rejected, got " << static_cast<long long>(got) << '\n';
+		}
+	}
+
+}}  // namespace sw::universal
+
+int main()
+try {
+	using namespace sw::universal;
+	using I8  = integer< 8, std::uint8_t,  IntegerNumberType::IntegerNumber>;
+	using I32 = integer<32, std::uint32_t, IntegerNumberType::IntegerNumber>;
+	using I64 = integer<64, std::uint32_t, IntegerNumberType::IntegerNumber>;
+
+	std::cout << "integer parse() tests (Phase B1 of #835)\n\n";
+
+	// ----- decimal -----
+	check_parse<8, std::uint8_t>("dec 0",   "0",   I8(0));
+	check_parse<8, std::uint8_t>("dec 5",   "5",   I8(5));
+	check_parse<8, std::uint8_t>("dec 127", "127", I8(127));
+	check_parse<8, std::uint8_t>("dec -1",  "-1",  I8(-1));
+	check_parse<8, std::uint8_t>("dec -128","-128",I8(-128));
+	check_parse<8, std::uint8_t>("dec +42", "+42", I8(42));
+	check_parse<32, std::uint32_t>("dec 1_000_000", "1000000", I32(1000000));
+	check_parse<64, std::uint32_t>("dec 64-bit",   "1234567890123", I64(1234567890123LL));
+
+	// ----- binary -----
+	check_parse<8, std::uint8_t>("bin 1010",  "0b1010",     I8(10));
+	check_parse<8, std::uint8_t>("bin 0",     "0b0",        I8(0));
+	check_parse<8, std::uint8_t>("bin FF",    "0b11111111", I8(-1));  // 2s-complement for nbits=8
+	check_parse<32, std::uint32_t>("bin 32",  "0b10101010101010101010101010101010", I32(0xAAAAAAAA));
+	check_parse<8, std::uint8_t>("bin negative", "-0b1010", I8(-10));
+	check_parse<8, std::uint8_t>("bin 0B (uppercase)", "0B1010", I8(10));
+
+	// ----- octal -----
+	check_parse<16, std::uint8_t>("oct 17",   "0o17",   I8(15) /*int16*/);
+	check_parse<16, std::uint8_t>("oct 100",  "0o100",  I8(64));
+	check_parse<8,  std::uint8_t>("oct 0",    "0o0",    I8(0));
+	check_parse<8,  std::uint8_t>("oct 0O upper", "0O17", I8(15));
+
+	// ----- hex -----
+	check_parse<8,  std::uint8_t>("hex FF",  "0xFF", I8(-1));  // saturates as 2s-complement
+	check_parse<16, std::uint8_t>("hex FF16","0xFF", integer<16, std::uint8_t, IntegerNumberType::IntegerNumber>(255));
+	check_parse<32, std::uint32_t>("hex DEADBEEF", "0xDEADBEEF", I32(0xDEADBEEF));
+	check_parse<32, std::uint32_t>("hex w/separator", "0xDEAD'BEEF", I32(0xDEADBEEF));
+	check_parse<8,  std::uint8_t>("hex 0X (uppercase prefix)", "0X1F", I8(31));
+	check_parse<8,  std::uint8_t>("hex mixed case digits", "0xaB", I8(0xAB));
+	check_parse<8,  std::uint8_t>("hex negative", "-0x05", I8(-5));
+
+	// ----- invalid -----
+	check_parse_invalid<8, std::uint8_t>("empty",       "");
+	check_parse_invalid<8, std::uint8_t>("just sign",   "-");
+	check_parse_invalid<8, std::uint8_t>("dec w/letter","12a");
+	check_parse_invalid<8, std::uint8_t>("bin w/2",     "0b102");
+	check_parse_invalid<8, std::uint8_t>("oct w/8",     "0o18");
+	check_parse_invalid<8, std::uint8_t>("hex w/z",     "0xZZ");
+	check_parse_invalid<8, std::uint8_t>("0b no body",  "0b");
+	check_parse_invalid<8, std::uint8_t>("0x no body",  "0x");
+
+	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
+	          << " / " << sw::universal::g_total << " tests passed";
+	if (sw::universal::g_failures > 0) {
+		std::cout << "  (" << sw::universal::g_failures << " FAILED)\n";
+		return EXIT_FAILURE;
+	}
+	std::cout << "\n";
+	return EXIT_SUCCESS;
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/static/integer/binary/api/string_parse.cpp
+++ b/static/integer/binary/api/string_parse.cpp
@@ -103,6 +103,28 @@ try {
 	check_parse_invalid<8,  std::uint8_t>("hex only-sep ''",    "0x''");
 	check_parse_invalid<32, std::uint32_t>("hex only-sep '''",  "0x'''");
 
+	// Commit-on-success: a failed parse must not modify the caller's value.
+	{
+		++sw::universal::g_total;
+		I32 v(42);                              // existing state
+		bool ok = parse(std::string("0x1G"), v); // malformed: 'G' is not hex
+		if (ok || v != I32(42)) {
+			++sw::universal::g_failures;
+			std::cout << "FAIL  commit-on-success: parse should fail and leave v unchanged; "
+			          << "ok=" << ok << "  v=" << static_cast<long long>(v) << '\n';
+		}
+	}
+	{
+		++sw::universal::g_total;
+		I32 v(-7);
+		bool ok = parse(std::string("123abc"), v); // decimal then garbage
+		if (ok || v != I32(-7)) {
+			++sw::universal::g_failures;
+			std::cout << "FAIL  commit-on-success: decimal-then-garbage should leave v unchanged; "
+			          << "ok=" << ok << "  v=" << static_cast<long long>(v) << '\n';
+		}
+	}
+
 	std::cout << "\nResults: " << (sw::universal::g_total - sw::universal::g_failures)
 	          << " / " << sw::universal::g_total << " tests passed";
 	if (sw::universal::g_failures > 0) {


### PR DESCRIPTION
## Summary

- Migrates `integer::parse()` onto the shared `string_parse` foundation that landed in Phase A (#838) -- drops `std::regex` + `std::map`, fixes the previously-broken octal branch (was a `// TODO` returning false), and adds binary support.
- Implements `fixpnt::parse()` from scratch. **Discovery during this PR**: `fixpnt::parse()` was forward-declared in `fixpnt_fwd.hpp` and called by `operator>>` in `fixpnt_impl.hpp:2073`, but had no definition anywhere. A latent link error nobody had hit because no existing test exercises stream input on a fixpnt. This PR provides the definition.

Phase B1 explicitly excludes decimal-fraction parsing (`parse("3.14")` for fixpnt) -- that's the float-from-string problem and lands in Phase B2 alongside the analogous posit/cfloat work.

## Changes

| File | Change |
|------|--------|
| `include/sw/universal/number/integer/integer_impl.hpp` | Rewrites `parse()` body using `string_parse` primitives (~130 lines reduced to ~80, cleaner control flow). Implements binary + octal. Drops `<regex>` and `<map>` includes. |
| `include/sw/universal/number/fixpnt/fixpnt_impl.hpp` | Adds `parse()` definition (the dangling declaration finally has a body). Includes `<universal/utility/string_parse.hpp>`. |
| `static/integer/binary/api/string_parse.cpp` | **NEW** -- 33 assertions covering decimal/binary/octal/hex with sign handling and rejection of malformed inputs across integer<8,16,32,64>. |
| `static/fixpnt/binary/api/string_parse.cpp` | **NEW** -- 16 assertions covering bit-pattern fills (binary/octal/hex) and decimal-integer on fixpnt<8,4>, <9,4>, <16,8>. |

## Accepted syntax (both types)

```text
[+-]? ( 0[bB][01]+      |    // binary bit-pattern
        0[oO][0-7]+     |    // octal bit-pattern
        0[xX][0-9A-F']+ |    // hex bit-pattern (apostrophe allowed as separator)
        [0-9]+          )    // decimal integer
```

For fixpnt: bit-pattern parsers fill the underlying storage MSB-first (matches `setbits()`). Decimal parses as an integer and is stored at the rbits scale (`parse(\"5\")` on fixpnt<8,4> -> 5.0).

## Backward-compatibility notes

- **integer**: The previous octal branch was non-functional (`// TODO`). Real octal now requires the explicit `0o`/`0O` prefix (C-style leading-zero octal was never actually parsed).
- **integer**: Hex still accepts apostrophe as a digit separator (preserved from old behavior).
- **integer**: Decimal accepts a single optional leading `+` or `-` (previous regex permitted multiple sign chars -- a quirk; functional difference is nil).
- **fixpnt**: New function; no prior behavior to preserve.

## Test results

| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| `bint_string_parse` | OK | 33/33 PASS | OK | 33/33 PASS |
| `fixpnt_string_parse` | OK | 16/16 PASS | OK | 16/16 PASS |
| `bint_api` (existing regression) | OK | PASS | (not re-checked) | -- |

## Phase B roadmap (this is B1 of B)

| Step | Scope | Status |
|------|-------|--------|
| **B1 (this PR)** | integer + fixpnt: bit-pattern + decimal-integer parsing via string_parse | **shipping** |
| B2 | Decimal-FP value parsing (`parse(\"3.14\")` -> closest representable). Targets fixpnt + posit + cfloat. Float-from-string. | future |
| B3 (likely) | posit + cfloat: migrate existing bit-pattern parse onto string_parse | future |

## Test plan

- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit feedback addressed
- [ ] Promote to ready when satisfied: \`gh pr ready <NN>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced string parsing for fixed‑point and integer values: supports optional sign, base‑prefix detection (binary/octal/hex), decimal input, apostrophe digit separators, strict digit validation, and rejection of malformed/empty inputs.

* **Bug Fixes**
  * Stream extraction now sets failbit on parse failure and emits clearer diagnostics referencing fixpnt values.

* **Tests**
  * Added standalone test programs exercising parsing across formats and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->