### PR TITLE
test(utility): adopt canonical ReportTestSuite pattern for string_parse foundation test

### DIFF
--- a/static/utility/test_string_parse.cpp
+++ b/static/utility/test_string_parse.cpp
@@ -7,31 +7,16 @@
 // This file is part of the universal numbers project, which is released under
 // an MIT Open Source license.
 
-#include <iostream>
-#include <iomanip>
+#include <universal/utility/directives.hpp>
 #include <string_view>
 #include <universal/utility/string_parse.hpp>
+#include <universal/verification/test_reporters.hpp>
 
 namespace sp = sw::universal::string_parse;
 
 // ============================================================================
-// Tiny test bench (no dependency on the regression framework -- this header
-// is a leaf utility and its tests should compile standalone).
-// ============================================================================
-
-static int g_failures = 0;
-static int g_total    = 0;
-
-static void report(bool condition, const char* what) {
-	++g_total;
-	if (!condition) {
-		++g_failures;
-		std::cout << "FAIL  " << what << '\n';
-	}
-}
-
-// ============================================================================
 // constexpr-correctness smoke tests: these have to compile, full stop.
+// Compile-time failure aborts the build before main() is reached.
 // ============================================================================
 
 namespace constexpr_tests {
@@ -66,316 +51,293 @@ static_assert(df.exp10 == 2,                  "exponent is 2");
 
 }  // namespace constexpr_tests
 
-// ============================================================================
-// scan_prefix
-// ============================================================================
-
-static void test_scan_prefix() {
-	// Lowercase prefixes
-	{
-		auto r = sp::scan_prefix("0b1010");
-		report(r.base == sp::number_base::binary,  "scan_prefix 0b -> binary");
-		report(r.body == "1010",                    "scan_prefix 0b body");
-	}
-	{
-		auto r = sp::scan_prefix("0o777");
-		report(r.base == sp::number_base::octal,   "scan_prefix 0o -> octal");
-		report(r.body == "777",                     "scan_prefix 0o body");
-	}
-	{
-		auto r = sp::scan_prefix("0xDEADBEEF");
-		report(r.base == sp::number_base::hex,     "scan_prefix 0x -> hex");
-		report(r.body == "DEADBEEF",                "scan_prefix 0x body");
-	}
-	// Uppercase prefixes
-	{
-		auto r = sp::scan_prefix("0B11");
-		report(r.base == sp::number_base::binary,  "scan_prefix 0B -> binary");
-	}
-	{
-		auto r = sp::scan_prefix("0O77");
-		report(r.base == sp::number_base::octal,   "scan_prefix 0O -> octal");
-	}
-	{
-		auto r = sp::scan_prefix("0X1F");
-		report(r.base == sp::number_base::hex,     "scan_prefix 0X -> hex");
-	}
-	// No prefix -> decimal
-	{
-		auto r = sp::scan_prefix("123");
-		report(r.base == sp::number_base::decimal, "scan_prefix bare -> decimal");
-		report(r.body == "123",                     "scan_prefix bare body unchanged");
-	}
-	// Leading '0' without prefix char -> decimal (just "0" or "012")
-	{
-		auto r = sp::scan_prefix("0");
-		report(r.base == sp::number_base::decimal, "scan_prefix \"0\" -> decimal");
-		report(r.body == "0",                       "scan_prefix \"0\" body unchanged");
-	}
-	{
-		auto r = sp::scan_prefix("012");
-		report(r.base == sp::number_base::decimal, "scan_prefix \"012\" -> decimal (no octal default)");
-	}
-	// Empty
-	{
-		auto r = sp::scan_prefix("");
-		report(r.base == sp::number_base::decimal, "scan_prefix empty -> decimal");
-		report(r.body.empty(),                       "scan_prefix empty body empty");
-	}
-}
-
-// ============================================================================
-// scan_sign
-// ============================================================================
-
-static void test_scan_sign() {
-	{
-		auto r = sp::scan_sign("-42");
-		report(r.negative,           "scan_sign '-' negative");
-		report(r.rest == "42",       "scan_sign '-' rest");
-	}
-	{
-		auto r = sp::scan_sign("+42");
-		report(!r.negative,          "scan_sign '+' not negative");
-		report(r.rest == "42",       "scan_sign '+' rest");
-	}
-	{
-		auto r = sp::scan_sign("42");
-		report(!r.negative,          "scan_sign no sign positive");
-		report(r.rest == "42",       "scan_sign no sign rest unchanged");
-	}
-	{
-		auto r = sp::scan_sign("");
-		report(!r.negative,          "scan_sign empty positive");
-		report(r.rest.empty(),       "scan_sign empty rest");
-	}
-	{
-		// Only first character consumed; "--7" -> negative, rest "-7"
-		auto r = sp::scan_sign("--7");
-		report(r.negative,           "scan_sign '--' first char only");
-		report(r.rest == "-7",       "scan_sign '--' rest is \"-7\"");
-	}
-}
-
-// ============================================================================
-// parse_binary / parse_octal / parse_hex
-// ============================================================================
-
-static void test_parse_binary() {
-	{
-		auto r = sp::parse_binary("1010");
-		report(r.value == 10u && r.digits == 4 && !r.overflow && r.valid,
-		       "parse_binary 1010");
-	}
-	{
-		auto r = sp::parse_binary("0");
-		report(r.value == 0u && r.digits == 1 && r.valid, "parse_binary 0");
-	}
-	{
-		// 64 ones = 2^64 - 1, no overflow
-		auto r = sp::parse_binary("1111111111111111111111111111111111111111111111111111111111111111");
-		report(r.value == 0xFFFFFFFFFFFFFFFFull && r.digits == 64 && !r.overflow && r.valid,
-		       "parse_binary 64 ones");
-	}
-	{
-		// 65 bits => overflow
-		auto r = sp::parse_binary("10000000000000000000000000000000000000000000000000000000000000000");
-		report(r.overflow && r.digits == 65, "parse_binary 65-bit overflow");
-	}
-	{
-		// Stops at invalid char
-		auto r = sp::parse_binary("101z01");
-		report(r.value == 5u && r.digits == 3 && !r.valid, "parse_binary stops at 'z'");
-	}
-	{
-		auto r = sp::parse_binary("");
-		report(!r.valid && r.digits == 0, "parse_binary empty -> invalid");
-	}
-}
-
-static void test_parse_octal() {
-	{
-		auto r = sp::parse_octal("777");
-		report(r.value == 0777u && r.valid && r.digits == 3 && !r.overflow,
-		       "parse_octal 777");
-	}
-	{
-		auto r = sp::parse_octal("01234567");
-		report(r.value == 01234567u && r.valid && r.digits == 8 && !r.overflow,
-		       "parse_octal 01234567");
-	}
-	{
-		// '8' is not octal
-		auto r = sp::parse_octal("128");
-		report(r.value == 012u && r.digits == 2 && !r.valid, "parse_octal stops at '8'");
-	}
-	{
-		auto r = sp::parse_octal("");
-		report(!r.valid, "parse_octal empty -> invalid");
-	}
-}
-
-static void test_parse_hex() {
-	{
-		auto r = sp::parse_hex("FF");
-		report(r.value == 0xFFu && r.valid && r.digits == 2, "parse_hex FF");
-	}
-	{
-		auto r = sp::parse_hex("DEADBEEF");
-		report(r.value == 0xDEADBEEFu && r.valid && r.digits == 8, "parse_hex DEADBEEF");
-	}
-	{
-		// Lowercase and uppercase mixed
-		auto r = sp::parse_hex("DeAdC0De");
-		report(r.value == 0xDEADC0DEu && r.valid, "parse_hex mixed case");
-	}
-	{
-		// 16 hex digits = 64 bits, no overflow
-		auto r = sp::parse_hex("FFFFFFFFFFFFFFFF");
-		report(r.value == 0xFFFFFFFFFFFFFFFFull && r.valid && !r.overflow,
-		       "parse_hex 16 F's");
-	}
-	{
-		// 17 hex digits => overflow
-		auto r = sp::parse_hex("10000000000000000");
-		report(r.overflow && r.digits == 17, "parse_hex 17-digit overflow");
-	}
-	{
-		// Stops at invalid
-		auto r = sp::parse_hex("FF.AA");
-		report(r.value == 0xFFu && r.digits == 2 && !r.valid, "parse_hex stops at '.'");
-	}
-}
-
-// ============================================================================
-// scan_decimal_float
-// ============================================================================
-
-static void test_scan_decimal_float() {
-	// Integer only
-	{
-		auto r = sp::scan_decimal_float("42");
-		report(r.valid && !r.negative && r.int_part == "42" && r.frac_part.empty() && r.exp10 == 0,
-		       "scan_decimal_float \"42\"");
-	}
-	// Negative integer
-	{
-		auto r = sp::scan_decimal_float("-7");
-		report(r.valid && r.negative && r.int_part == "7", "scan_decimal_float \"-7\"");
-	}
-	// Explicit positive
-	{
-		auto r = sp::scan_decimal_float("+5");
-		report(r.valid && !r.negative && r.int_part == "5", "scan_decimal_float \"+5\"");
-	}
-	// Integer + fraction
-	{
-		auto r = sp::scan_decimal_float("3.14");
-		report(r.valid && r.int_part == "3" && r.frac_part == "14" && r.exp10 == 0,
-		       "scan_decimal_float \"3.14\"");
-	}
-	// Fraction only
-	{
-		auto r = sp::scan_decimal_float(".5");
-		report(r.valid && r.int_part.empty() && r.frac_part == "5",
-		       "scan_decimal_float \".5\"");
-	}
-	// Integer only with trailing dot
-	{
-		auto r = sp::scan_decimal_float("5.");
-		report(r.valid && r.int_part == "5" && r.frac_part.empty(),
-		       "scan_decimal_float \"5.\"");
-	}
-	// Exponent
-	{
-		auto r = sp::scan_decimal_float("1e10");
-		report(r.valid && r.int_part == "1" && r.exp10 == 10, "scan_decimal_float \"1e10\"");
-	}
-	{
-		auto r = sp::scan_decimal_float("1E-5");
-		report(r.valid && r.exp10 == -5, "scan_decimal_float \"1E-5\"");
-	}
-	// All the things
-	{
-		auto r = sp::scan_decimal_float("-3.14159e+2");
-		report(r.valid && r.negative && r.int_part == "3" && r.frac_part == "14159" && r.exp10 == 2,
-		       "scan_decimal_float \"-3.14159e+2\"");
-	}
-	// Just a dot
-	{
-		auto r = sp::scan_decimal_float(".");
-		report(!r.valid, "scan_decimal_float \".\" should fail");
-	}
-	// Empty
-	{
-		auto r = sp::scan_decimal_float("");
-		report(!r.valid, "scan_decimal_float empty should fail");
-	}
-	// Trailing garbage
-	{
-		auto r = sp::scan_decimal_float("3.14x");
-		report(!r.valid, "scan_decimal_float \"3.14x\" should reject trailing garbage");
-	}
-	// Bad exponent
-	{
-		auto r = sp::scan_decimal_float("1e");
-		report(!r.valid, "scan_decimal_float \"1e\" should fail (no exp digits)");
-	}
-	{
-		auto r = sp::scan_decimal_float("1ex");
-		report(!r.valid, "scan_decimal_float \"1ex\" should fail");
-	}
-	// Long fraction (constexpr-friendly: views point into input)
-	{
-		auto r = sp::scan_decimal_float("3.14159265358979323846264338327950288419716939937510");
-		report(r.valid && r.frac_part.size() == 50,
-		       "scan_decimal_float 50-digit fraction");
-	}
-	// int32 exponent boundary (positive max) -- exp parser must accept INT32_MAX
-	{
-		auto r = sp::scan_decimal_float("1e2147483647");
-		report(r.valid && r.exp10 == 2147483647,
-		       "scan_decimal_float exp=INT32_MAX");
-	}
-	// int32 exponent boundary (negative min) -- exp parser must accept INT32_MIN.
-	// Regression: an earlier version rejected this because the magnitude check
-	// (v > INT32_MAX) fired before the sign was applied.
-	{
-		auto r = sp::scan_decimal_float("1e-2147483648");
-		report(r.valid && r.exp10 == (-2147483647 - 1),
-		       "scan_decimal_float exp=INT32_MIN");
-	}
-	// One past int32 max on positive side -- exp parser must reject.
-	{
-		auto r = sp::scan_decimal_float("1e2147483648");
-		report(!r.valid, "scan_decimal_float exp=INT32_MAX+1 rejected");
-	}
-}
-
 int main()
 try {
-	std::cout << "string_parse primitives (Phase A of #835): test suite\n\n";
+	using namespace sw::universal;
 
-	test_scan_prefix();
-	test_scan_sign();
-	test_parse_binary();
-	test_parse_octal();
-	test_parse_hex();
-	test_scan_decimal_float();
+	std::string test_suite  = "string_parse primitives (Phase A of #835) test suite";
+	std::string test_tag    = "string_parse";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
 
-	std::cout << "\nResults: " << (g_total - g_failures) << " / " << g_total << " tests passed";
-	if (g_failures > 0) {
-		std::cout << "  (" << g_failures << " FAILED)\n";
-		return EXIT_FAILURE;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- scan_prefix -----
+	{
+		int start = nrOfFailedTestCases;
+		// Lowercase prefixes
+		{
+			auto r = sp::scan_prefix("0b1010");
+			if (r.base != sp::number_base::binary || r.body != "1010") ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_prefix("0o777");
+			if (r.base != sp::number_base::octal || r.body != "777")   ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_prefix("0xDEADBEEF");
+			if (r.base != sp::number_base::hex || r.body != "DEADBEEF") ++nrOfFailedTestCases;
+		}
+		// Uppercase prefixes
+		{
+			auto r = sp::scan_prefix("0B11");
+			if (r.base != sp::number_base::binary) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_prefix("0O77");
+			if (r.base != sp::number_base::octal)  ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_prefix("0X1F");
+			if (r.base != sp::number_base::hex)    ++nrOfFailedTestCases;
+		}
+		// No prefix or bare leading zero -> decimal
+		{
+			auto r = sp::scan_prefix("123");
+			if (r.base != sp::number_base::decimal || r.body != "123") ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_prefix("0");
+			if (r.base != sp::number_base::decimal || r.body != "0")   ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_prefix("012");  // no C-style octal default
+			if (r.base != sp::number_base::decimal) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_prefix("");
+			if (r.base != sp::number_base::decimal || !r.body.empty()) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: scan_prefix\n";
 	}
-	std::cout << "\n";
-	return EXIT_SUCCESS;
+
+	// ----- scan_sign -----
+	{
+		int start = nrOfFailedTestCases;
+		{
+			auto r = sp::scan_sign("-42");
+			if (!r.negative || r.rest != "42") ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_sign("+42");
+			if (r.negative || r.rest != "42")  ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_sign("42");
+			if (r.negative || r.rest != "42")  ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_sign("");
+			if (r.negative || !r.rest.empty()) ++nrOfFailedTestCases;
+		}
+		{
+			// Only first char consumed; "--7" -> negative, rest "-7"
+			auto r = sp::scan_sign("--7");
+			if (!r.negative || r.rest != "-7") ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: scan_sign\n";
+	}
+
+	// ----- parse_binary -----
+	{
+		int start = nrOfFailedTestCases;
+		{
+			auto r = sp::parse_binary("1010");
+			if (r.value != 10u || r.digits != 4 || r.overflow || !r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::parse_binary("0");
+			if (r.value != 0u || r.digits != 1 || !r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			// 64 ones = 2^64 - 1, no overflow
+			auto r = sp::parse_binary("1111111111111111111111111111111111111111111111111111111111111111");
+			if (r.value != 0xFFFFFFFFFFFFFFFFull || r.digits != 64 || r.overflow || !r.valid)
+				++nrOfFailedTestCases;
+		}
+		{
+			// 65 bits -> overflow
+			auto r = sp::parse_binary("10000000000000000000000000000000000000000000000000000000000000000");
+			if (!r.overflow || r.digits != 65) ++nrOfFailedTestCases;
+		}
+		{
+			// Stops at invalid char
+			auto r = sp::parse_binary("101z01");
+			if (r.value != 5u || r.digits != 3 || r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::parse_binary("");
+			if (r.valid || r.digits != 0) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: parse_binary\n";
+	}
+
+	// ----- parse_octal -----
+	{
+		int start = nrOfFailedTestCases;
+		{
+			auto r = sp::parse_octal("777");
+			if (r.value != 0777u || !r.valid || r.digits != 3 || r.overflow) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::parse_octal("01234567");
+			if (r.value != 01234567u || !r.valid || r.digits != 8 || r.overflow) ++nrOfFailedTestCases;
+		}
+		{
+			// '8' is not octal -- stops at it
+			auto r = sp::parse_octal("128");
+			if (r.value != 012u || r.digits != 2 || r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::parse_octal("");
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: parse_octal\n";
+	}
+
+	// ----- parse_hex -----
+	{
+		int start = nrOfFailedTestCases;
+		{
+			auto r = sp::parse_hex("FF");
+			if (r.value != 0xFFu || !r.valid || r.digits != 2) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::parse_hex("DEADBEEF");
+			if (r.value != 0xDEADBEEFu || !r.valid || r.digits != 8) ++nrOfFailedTestCases;
+		}
+		{
+			// Lowercase + uppercase mixed
+			auto r = sp::parse_hex("DeAdC0De");
+			if (r.value != 0xDEADC0DEu || !r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			// 16 hex digits = 64 bits, no overflow
+			auto r = sp::parse_hex("FFFFFFFFFFFFFFFF");
+			if (r.value != 0xFFFFFFFFFFFFFFFFull || !r.valid || r.overflow) ++nrOfFailedTestCases;
+		}
+		{
+			// 17 hex digits -> overflow
+			auto r = sp::parse_hex("10000000000000000");
+			if (!r.overflow || r.digits != 17) ++nrOfFailedTestCases;
+		}
+		{
+			// Stops at invalid
+			auto r = sp::parse_hex("FF.AA");
+			if (r.value != 0xFFu || r.digits != 2 || r.valid) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: parse_hex\n";
+	}
+
+	// ----- scan_decimal_float -----
+	{
+		int start = nrOfFailedTestCases;
+		// Integer only
+		{
+			auto r = sp::scan_decimal_float("42");
+			if (!r.valid || r.negative || r.int_part != "42" || !r.frac_part.empty() || r.exp10 != 0)
+				++nrOfFailedTestCases;
+		}
+		// Negative integer
+		{
+			auto r = sp::scan_decimal_float("-7");
+			if (!r.valid || !r.negative || r.int_part != "7") ++nrOfFailedTestCases;
+		}
+		// Explicit positive
+		{
+			auto r = sp::scan_decimal_float("+5");
+			if (!r.valid || r.negative || r.int_part != "5") ++nrOfFailedTestCases;
+		}
+		// Integer + fraction
+		{
+			auto r = sp::scan_decimal_float("3.14");
+			if (!r.valid || r.int_part != "3" || r.frac_part != "14" || r.exp10 != 0)
+				++nrOfFailedTestCases;
+		}
+		// Fraction only
+		{
+			auto r = sp::scan_decimal_float(".5");
+			if (!r.valid || !r.int_part.empty() || r.frac_part != "5") ++nrOfFailedTestCases;
+		}
+		// Integer only with trailing dot
+		{
+			auto r = sp::scan_decimal_float("5.");
+			if (!r.valid || r.int_part != "5" || !r.frac_part.empty()) ++nrOfFailedTestCases;
+		}
+		// Exponent (positive)
+		{
+			auto r = sp::scan_decimal_float("1e10");
+			if (!r.valid || r.int_part != "1" || r.exp10 != 10) ++nrOfFailedTestCases;
+		}
+		// Exponent (negative)
+		{
+			auto r = sp::scan_decimal_float("1E-5");
+			if (!r.valid || r.exp10 != -5) ++nrOfFailedTestCases;
+		}
+		// All the things
+		{
+			auto r = sp::scan_decimal_float("-3.14159e+2");
+			if (!r.valid || !r.negative || r.int_part != "3" || r.frac_part != "14159" || r.exp10 != 2)
+				++nrOfFailedTestCases;
+		}
+		// Malformed
+		{
+			auto r = sp::scan_decimal_float(".");
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_decimal_float("");
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_decimal_float("3.14x");
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_decimal_float("1e");
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = sp::scan_decimal_float("1ex");
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		// Long fraction (constexpr-friendly: views point into input)
+		{
+			auto r = sp::scan_decimal_float("3.14159265358979323846264338327950288419716939937510");
+			if (!r.valid || r.frac_part.size() != 50) ++nrOfFailedTestCases;
+		}
+		// int32 exponent boundary (positive max) -- exp parser must accept INT32_MAX
+		{
+			auto r = sp::scan_decimal_float("1e2147483647");
+			if (!r.valid || r.exp10 != 2147483647) ++nrOfFailedTestCases;
+		}
+		// int32 exponent boundary (negative min) -- exp parser must accept INT32_MIN.
+		// Regression: an earlier version rejected this because the magnitude check
+		// (v > INT32_MAX) fired before the sign was applied.
+		{
+			auto r = sp::scan_decimal_float("1e-2147483648");
+			if (!r.valid || r.exp10 != (-2147483647 - 1)) ++nrOfFailedTestCases;
+		}
+		// One past int32 max on positive side -- must reject
+		{
+			auto r = sp::scan_decimal_float("1e2147483648");
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: scan_decimal_float\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	std::cerr << msg << '\n';
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const std::exception& err) {
-	std::cerr << err.what() << '\n';
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
## Summary

Follow-on cleanup for the Phase A foundation that landed via #838. The foundation test (`static/utility/test_string_parse.cpp`) used a homegrown `g_total`/`g_failures` bench instead of the `ReportTestSuiteHeader` / scope-block / `ReportTestSuiteResults` idiom that the rest of the regression suite (hundreds of tests in `static/*/api/*`) uses. PR #839 applied the same fix to the integer and fixpnt parse() tests; this PR brings the foundation in line.

## Changes

- `static/utility/test_string_parse.cpp` -- replaces the custom bench with the canonical pattern:
  - `ReportTestSuiteHeader` at entry, `ReportTestSuiteResults` at exit
  - One scope block per primitive (`scan_prefix` / `scan_sign` / `parse_binary` / `parse_octal` / `parse_hex` / `scan_decimal_float`), each with `int start = nrOfFailedTestCases;` at the top, per-assertion `++nrOfFailedTestCases`, trailing `if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: <group>\n";` diagnostic.
  - Standard catch footer (ad-hoc / runtime / unknown).

The `static_assert` smoke tests at file scope (proving `constexpr` evaluation) are kept verbatim -- they verify a different invariant (compile-time evaluation) that no runtime block can.

## Test coverage

Identical to the pre-refactor version:
- `scan_prefix`: 0b/0B/0o/0O/0x/0X, decimal default, leading-0-without-prefix, empty
- `scan_sign`: +/-, no sign, empty, double-sign
- `parse_binary/octal/hex`: valid, partial-stop-at-invalid, 64-bit boundary, 65/17-digit overflow, empty -> invalid
- `scan_decimal_float`: integer-only, fraction-only, signs, exponent variants, malformed (bare dot, trailing garbage, empty exponent), 50-digit fraction, int32 boundary exponents (INT32_MAX, INT32_MIN, INT32_MAX+1)

## Test results

| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| `utility_test_string_parse` | OK | PASS | OK | PASS |

Output now reads `string_parse primitives (Phase A of #835) test suite: PASS` matching the rest of the suite.

## Test plan

- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] CodeRabbit feedback addressed
- [x] Promote to ready: \`gh pr ready <NN>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Tests**
* Improved internal test infrastructure and reporting for string parsing validation.
* Enhanced test coverage with more comprehensive edge case verification.

**Note:** No user-facing changes in this release. This update focuses on test quality improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->