### PR TITLE
feat(utility): high-precision decimal-to-binary converter (Phase B2a of #835)

### DIFF
--- a/include/sw/universal/utility/decimal_to_binary.hpp
+++ b/include/sw/universal/utility/decimal_to_binary.hpp
@@ -1,0 +1,273 @@
+#pragma once
+// decimal_to_binary.hpp: high-precision decimal-string to binary-mantissa converter
+//                       (Phase B2a of issue #835)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// -----------------------------------------------------------------------------
+// What this does
+// -----------------------------------------------------------------------------
+//
+// Takes a decimal floating-point literal (via `string_parse::scan_decimal_float`)
+// and produces an integer mantissa + binary scale + round/sticky bits with
+// enough precision that any Universal number system can encode the result with
+// correct round-to-nearest-even rounding.
+//
+// Specifically, given input "[+-]?int.frac[eE][+-]?exp" the converter
+// produces a result satisfying
+//
+//     value = (-1)^negative * mantissa * 2^(binary_scale - target_mantissa_bits + 1)
+//
+// where `mantissa` is an integer whose MSB sits at bit position
+// (target_mantissa_bits - 1) when the value is non-zero, plus a guard_bit and
+// sticky_bit summarising the discarded tail. The caller -- posit, cfloat,
+// fixpnt, dd, qd, ... -- applies its own encoding-specific rounding using
+// these primitives.
+//
+// Algorithm
+// ---------
+// Build the input as an exact rational p/q (or just an integer p when the
+// decimal exponent is non-negative) using multi-limb integer arithmetic
+// (`einteger`). Then convert to the form (mantissa * 2^k) with rounding
+// information by shifting and dividing in the bigint domain.
+//
+// For decimal exponent E >= 0:
+//     V = M * 10^E = M * 2^E * 5^E
+//     mantissa_unrounded = M * 5^E
+//     binary_scale_of_LSB = E
+//
+// For decimal exponent E < 0:
+//     V = M / 10^|E| = M / (2^|E| * 5^|E|)
+//     We pick a shift K large enough that the precision-preserving quotient
+//     (M << K) / 5^|E| has target_mantissa_bits + 2 valid bits. Then
+//     mantissa_unrounded = (M << K) / 5^|E|,
+//     binary_scale_of_LSB = -(K + |E|),
+//     and the remainder of that division feeds the sticky bit.
+//
+// Normalize: shift the mantissa so its MSB sits at position
+// (target_mantissa_bits - 1). Bits shifted off below feed the guard and
+// sticky outputs.
+//
+// Limitations of this header
+// --------------------------
+// - Inputs producing more than INT64_MAX/INT64_MIN binary_scale saturate.
+// - Empty mantissa (e.g. ".") is rejected upstream by scan_decimal_float.
+// - "inf" / "nan" string literals are NOT handled here. Callers route them
+//   separately if they want stream-extraction parity with native floats.
+
+#include <cstdint>
+#include <string_view>
+#include <universal/utility/string_parse.hpp>
+#include <universal/number/integer/integer.hpp>
+
+namespace sw { namespace universal { namespace decimal_to_binary {
+
+// Internal big-integer width used for the decimal-to-binary computation.
+//
+// 2048 bits comfortably covers all IEEE double-range decimal exponents
+// (the bigint can reach ~ headroom + 3 * |E| bits during the shift+divide,
+// which for |E| <= ~500 stays well under the budget). For higher-precision
+// targets (e.g., posit<256,*>) with extreme exponents, the public template
+// overload below lets callers raise the budget.
+//
+// einteger<> (the elastic integer) is intentionally NOT used here: it
+// currently produces incorrect results for certain large-operand division
+// patterns this code path exercises (a separate issue, not in scope for
+// this header). The fixed-width `integer<N>` path is bit-exact under both
+// gcc and clang.
+constexpr unsigned default_big_bits = 2048;
+
+template<unsigned BigBits = default_big_bits>
+using big_integer = sw::universal::integer<BigBits, std::uint32_t,
+                                            sw::universal::IntegerNumberType::IntegerNumber>;
+
+// Result of the conversion. See header doc for the contract.
+//
+// `mantissa` is stored as a wide fixed-size `integer<>` because that's the
+// type the internal arithmetic uses; callers that only need a few-dozen
+// significant bits can read them out via `mantissa.test(i)` or extract a
+// uint64_t.
+template<unsigned BigBits = default_big_bits>
+struct basic_result {
+	bool                       valid;        // input parsed and produced a finite value
+	bool                       negative;     // sign bit
+	bool                       is_zero;      // value is exactly zero (other fields then meaningless)
+	std::int64_t               binary_scale; // 2^binary_scale = the MSB weight of `mantissa`
+	big_integer<BigBits>       mantissa;     // normalized: MSB at position (target_mantissa_bits - 1)
+	bool                       guard_bit;    // bit just below the LSB of mantissa
+	bool                       sticky_bit;   // OR of every bit below the guard
+};
+
+// Default alias for the common case.
+using result = basic_result<default_big_bits>;
+
+namespace detail {
+
+// Build the bigint M = int_digits || frac_digits (concatenated as a single
+// integer value).
+template<unsigned BigBits>
+inline big_integer<BigBits>
+collect_digits(std::string_view int_part, std::string_view frac_part) {
+	using Big = big_integer<BigBits>;
+	Big M(0);
+	const Big ten(10);
+	for (char c : int_part) {
+		M *= ten;
+		M += Big(static_cast<int>(c - '0'));
+	}
+	for (char c : frac_part) {
+		M *= ten;
+		M += Big(static_cast<int>(c - '0'));
+	}
+	return M;
+}
+
+// Multiply x in place by 5^e via repeated *= 5. O(e) bigint multiplications
+// by the single-limb constant 5; each step is fast.
+template<unsigned BigBits>
+inline void multiply_by_5_to_the_e(big_integer<BigBits>& x, std::int64_t e) {
+	if (e <= 0) return;
+	using Big = big_integer<BigBits>;
+	const Big five(5);
+	for (std::int64_t i = 0; i < e; ++i) x *= five;
+}
+
+}  // namespace detail
+
+// Convert the components of a decimal-float scan into a normalized
+// (sign, mantissa, binary_scale, guard, sticky) result with at least
+// target_mantissa_bits significant bits of mantissa.
+//
+// `d` must be a successful `scan_decimal_float` result (d.valid == true).
+// target_mantissa_bits is the count of explicit mantissa bits the caller
+// wants (e.g., 24 for IEEE float, 53 for IEEE double, fbits+1 for a cfloat
+// or fbits+regime+1 for a posit).
+template<unsigned BigBits = default_big_bits>
+inline basic_result<BigBits>
+convert(const sw::universal::string_parse::decimal_float_scan& d,
+        unsigned target_mantissa_bits) {
+	using Big = big_integer<BigBits>;
+	basic_result<BigBits> out;
+	out.valid       = false;
+	out.negative    = d.negative;
+	out.is_zero     = false;
+	out.binary_scale = 0;
+	out.mantissa    = Big(0);
+	out.guard_bit   = false;
+	out.sticky_bit  = false;
+
+	if (!d.valid) return out;
+
+	// Build M as an integer; compute the effective decimal exponent E.
+	Big M = detail::collect_digits<BigBits>(d.int_part, d.frac_part);
+	{
+		Big zero(0);
+		if (M == zero) {
+			// Zero value.
+			out.is_zero = true;
+			out.valid   = true;
+			return out;
+		}
+	}
+	// Effective base-10 exponent after concatenating fractional digits:
+	//   value = M * 10^(d.exp10 - len(d.frac_part))
+	std::int64_t E = static_cast<std::int64_t>(d.exp10)
+	               - static_cast<std::int64_t>(d.frac_part.size());
+
+	// Headroom: ask for target_mantissa_bits + 2 useful bits so the round
+	// (just below the cut) and sticky (everything further below) bits are
+	// reliable.
+	const unsigned headroom = target_mantissa_bits + 2u;
+
+	// Build value*2^scale as an integer in `num` (numerator).
+	Big num = M;
+	std::int64_t lsb_scale = 0;  // 2^lsb_scale = unit of LSB of `num`
+
+	if (E >= 0) {
+		// value = M * 10^E = M * 2^E * 5^E
+		// num = M * 5^E,  lsb_scale = E.
+		detail::multiply_by_5_to_the_e<BigBits>(num, E);
+		lsb_scale = E;
+	} else {
+		// value = M / 10^|E| = M / (2^|E| * 5^|E|).
+		//
+		// We want num/denom = value * 2^K for some K large enough that the
+		// quotient carries at least `headroom` precision bits AFTER dividing
+		// by 5^|E| (which consumes ~|E| * log2(5) ~= |E| * 2.322 bits).
+		//     value * 2^K = M * 2^K / (2^|E| * 5^|E|) = M * 2^(K - |E|) / 5^|E|
+		// Choosing K = headroom + |E| * 4 overshoots log2(5) ~= 2.32 with
+		// generous margin; cost is O(|E|) extra bigint bits, negligible vs
+		// the O(|E|) work of computing 5^|E|.
+		std::int64_t neg_E = -E;
+		const std::int64_t shift_amount = static_cast<std::int64_t>(headroom)
+		                                + 3 * neg_E;
+		const std::int64_t K            = static_cast<std::int64_t>(headroom)
+		                                + 4 * neg_E;
+		num <<= static_cast<int>(shift_amount);
+		Big denom(1);
+		detail::multiply_by_5_to_the_e<BigBits>(denom, neg_E);
+		Big rem = num;
+		rem %= denom;
+		num /= denom;
+		Big zero(0);
+		const bool divide_residual = (rem != zero);
+		lsb_scale = -K;
+		out.sticky_bit = divide_residual;
+	}
+
+	// Normalize: shift num so its MSB sits at position
+	// (target_mantissa_bits - 1). Bits dropped off the bottom go into
+	// guard and sticky.
+	// Find MSB by linear scan from the top (integer<> doesn't expose a
+	// dedicated findMsb in the same form as einteger; this is simple and
+	// sufficient).
+	int msb = -1;
+	for (int i = static_cast<int>(BigBits) - 1; i >= 0; --i) {
+		if (num.at(static_cast<unsigned>(i))) { msb = i; break; }
+	}
+	int top = static_cast<int>(target_mantissa_bits) - 1;
+
+	if (msb > top) {
+		// Need to shift right by (msb - top). The bit at position
+		// (msb - top - 1) is the guard; the OR of bits below is sticky.
+		int rshift = msb - top;
+		int guard_pos = rshift - 1;
+		bool sticky = out.sticky_bit;
+		for (int i = 0; i < guard_pos; ++i) {
+			if (num.at(static_cast<unsigned>(i))) { sticky = true; break; }
+		}
+		bool guard = (guard_pos >= 0) ? num.at(static_cast<unsigned>(guard_pos)) : false;
+		num >>= rshift;
+		out.guard_bit  = guard;
+		out.sticky_bit = sticky;
+		lsb_scale += rshift;
+	} else if (msb < top) {
+		int lshift = top - msb;
+		num <<= lshift;
+		lsb_scale -= lshift;
+	}
+
+	out.mantissa     = num;
+	out.binary_scale = lsb_scale + static_cast<std::int64_t>(target_mantissa_bits - 1);
+	out.valid        = true;
+	return out;
+}
+
+// Convenience overload: parse the string in one call.
+template<unsigned BigBits = default_big_bits>
+inline basic_result<BigBits>
+convert(std::string_view s, unsigned target_mantissa_bits) {
+	auto scan = sw::universal::string_parse::scan_decimal_float(s);
+	if (!scan.valid) {
+		basic_result<BigBits> out{};
+		out.valid = false;
+		return out;
+	}
+	return convert<BigBits>(scan, target_mantissa_bits);
+}
+
+}}}  // namespace sw::universal::decimal_to_binary

--- a/include/sw/universal/utility/decimal_to_binary.hpp
+++ b/include/sw/universal/utility/decimal_to_binary.hpp
@@ -162,6 +162,12 @@ convert(const sw::universal::string_parse::decimal_float_scan& d,
 
 	if (!d.valid) return out;
 
+	// target_mantissa_bits == 0 is meaningless (no bits to populate). Values
+	// above the internal bigint width can't be reached by normalization
+	// without overflowing the storage. Either case is rejected up front so
+	// the rest of the routine can assume target_mantissa_bits in [1, BigBits].
+	if (target_mantissa_bits == 0u || target_mantissa_bits > BigBits) return out;
+
 	// Build M as an integer; compute the effective decimal exponent E.
 	Big M = detail::collect_digits<BigBits>(d.int_part, d.frac_part);
 	{

--- a/static/utility/test_decimal_to_binary.cpp
+++ b/static/utility/test_decimal_to_binary.cpp
@@ -205,6 +205,28 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: stod oracle comparison\n";
 	}
 
+	// ----- target_mantissa_bits bounds validation -----
+	{
+		int start = nrOfFailedTestCases;
+		// 0 mantissa bits is meaningless: must reject.
+		{
+			auto r = d2b::convert("1.0", 0);
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		// Above the internal bigint width is unreachable: must reject.
+		{
+			auto r = d2b::convert("1.0", d2b::default_big_bits + 1u);
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		// Largest valid target_mantissa_bits should still succeed for a
+		// trivially-representable value.
+		{
+			auto r = d2b::convert("1.0", d2b::default_big_bits);
+			if (!r.valid || r.is_zero) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: target_mantissa_bits bounds\n";
+	}
+
 	// ----- the classic 0.1 (non-terminating binary): match stod -----
 	{
 		int start = nrOfFailedTestCases;

--- a/static/utility/test_decimal_to_binary.cpp
+++ b/static/utility/test_decimal_to_binary.cpp
@@ -1,0 +1,243 @@
+// test_decimal_to_binary.cpp: tests for the high-precision decimal-to-binary
+//                            converter utility (Phase B2a of issue #835)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <cstring>      // std::memcpy
+#include <string>
+#include <universal/utility/decimal_to_binary.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace sw { namespace universal { namespace decimal_to_binary {
+
+// Encode a successful decimal_to_binary::result as IEEE-754 binary64 with
+// round-half-to-even semantics. Returns the encoded double bit-pattern as
+// uint64_t (so callers can compare bit-for-bit).
+//
+// Convention: convert() was called with target_mantissa_bits = 53, so
+// `r.mantissa` has its MSB at position 52 (the IEEE double mantissa width).
+// The MSB is the implicit-leading-1 bit.
+//
+// Returns false on overflow / underflow into denormals / extreme cases so the
+// caller knows to skip those (we still set out_bits to something reasonable).
+inline bool encode_as_double(const result& r, std::uint64_t& out_bits) {
+	const std::uint64_t sign_bit = r.negative ? (std::uint64_t(1) << 63) : 0;
+	if (r.is_zero) {
+		out_bits = sign_bit;  // signed zero
+		return true;
+	}
+	// mantissa is in [2^52, 2^53).
+	// Lift out the low 53 bits as uint64_t.
+	std::uint64_t mant = 0;
+	for (int i = 52; i >= 0; --i) {
+		mant <<= 1;
+		if (r.mantissa.test(static_cast<unsigned>(i))) mant |= 1u;
+	}
+	// Round-half-to-even using guard + sticky.
+	bool round_up = false;
+	if (r.guard_bit) {
+		if (r.sticky_bit) round_up = true;
+		else              round_up = (mant & 1u) != 0;  // tie -> round to even
+	}
+	std::int64_t scale = r.binary_scale;
+	if (round_up) {
+		mant += 1;
+		if (mant == (std::uint64_t(1) << 53)) {
+			mant >>= 1;
+			scale += 1;
+		}
+	}
+	// IEEE bias.
+	std::int64_t biased_exp = scale + 1023;
+	if (biased_exp >= 2047) {
+		// Overflow -> infinity.
+		out_bits = sign_bit | (std::uint64_t(2047) << 52);
+		return false;
+	}
+	if (biased_exp <= 0) {
+		// Subnormal or underflow; not covered by this simple encoder.
+		out_bits = sign_bit;  // best-effort: signed zero
+		return false;
+	}
+	// Strip the implicit leading 1.
+	std::uint64_t frac52 = mant & ((std::uint64_t(1) << 52) - 1);
+	out_bits = sign_bit | (std::uint64_t(biased_exp) << 52) | frac52;
+	return true;
+}
+
+inline std::uint64_t double_to_bits(double d) {
+	std::uint64_t bits;
+	std::memcpy(&bits, &d, sizeof(bits));
+	return bits;
+}
+
+}}}  // namespace sw::universal::decimal_to_binary
+
+namespace sp = sw::universal::string_parse;
+namespace d2b = sw::universal::decimal_to_binary;
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "decimal_to_binary high-precision converter (Phase B2a of #835)";
+	std::string test_tag    = "decimal_to_binary";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- direct output checks for hand-computable values (53-bit target) -----
+	{
+		int start = nrOfFailedTestCases;
+
+		// 1.0 -> mantissa = 2^52, binary_scale = 0, no guard/sticky
+		{
+			auto r = d2b::convert("1.0", 53);
+			if (!r.valid || r.negative || r.is_zero
+			    || r.binary_scale != 0
+			    || r.guard_bit || r.sticky_bit
+			    || !r.mantissa.test(52) || r.mantissa.test(53)) ++nrOfFailedTestCases;
+		}
+		// 2.0 -> mantissa = 2^52, binary_scale = 1
+		{
+			auto r = d2b::convert("2.0", 53);
+			if (!r.valid || r.binary_scale != 1
+			    || !r.mantissa.test(52) || r.mantissa.test(53)
+			    || r.guard_bit || r.sticky_bit) ++nrOfFailedTestCases;
+		}
+		// 0.5 -> mantissa = 2^52, binary_scale = -1
+		{
+			auto r = d2b::convert("0.5", 53);
+			if (!r.valid || r.binary_scale != -1
+			    || !r.mantissa.test(52) || r.mantissa.test(53)
+			    || r.guard_bit || r.sticky_bit) ++nrOfFailedTestCases;
+		}
+		// 3.0 = 1.1b * 2^1 -> mantissa has bits 52 and 51 set, binary_scale = 1
+		{
+			auto r = d2b::convert("3.0", 53);
+			if (!r.valid || r.binary_scale != 1
+			    || !r.mantissa.test(52) || !r.mantissa.test(51)
+			    || r.mantissa.test(53)
+			    || r.guard_bit || r.sticky_bit) ++nrOfFailedTestCases;
+		}
+		// -1.0
+		{
+			auto r = d2b::convert("-1.0", 53);
+			if (!r.valid || !r.negative || r.binary_scale != 0
+			    || !r.mantissa.test(52)) ++nrOfFailedTestCases;
+		}
+		// 0 (and variants)
+		{
+			auto r = d2b::convert("0", 53);
+			if (!r.valid || !r.is_zero) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = d2b::convert("0.0", 53);
+			if (!r.valid || !r.is_zero) ++nrOfFailedTestCases;
+		}
+		{
+			auto r = d2b::convert("-0.0", 53);
+			if (!r.valid || !r.is_zero || !r.negative) ++nrOfFailedTestCases;
+		}
+		// Empty -> invalid
+		{
+			auto r = d2b::convert("", 53);
+			if (r.valid) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hand-computable cases\n";
+	}
+
+	// ----- bit-for-bit comparison against std::stod for canonical doubles -----
+	{
+		int start = nrOfFailedTestCases;
+		const char* cases[] = {
+			"1.0",
+			"2.0",
+			"3.0",
+			"0.5",
+			"-1.0",
+			"1.5",
+			"3.14",
+			"3.141592653589793",
+			"1e0",
+			"1e10",
+			"1e-10",
+			"42",
+			"100",
+			"1000000",
+			"-3.14e2",
+			"123456789",
+			"1.23456789e+15",
+			// Powers of 2 are exact in both decimal and binary
+			"4",
+			"8",
+			"16",
+			"1024",
+			"4503599627370496",  // 2^52
+			// Powers of 10 -- non-trivial decimal-to-binary
+			"10",
+			"100000",
+			"1e100",
+			"1e-100",
+		};
+		for (const char* s : cases) {
+			auto r = d2b::convert(s, 53);
+			std::uint64_t ours = 0;
+			bool encoded = d2b::encode_as_double(r, ours);
+			std::uint64_t theirs = d2b::double_to_bits(std::stod(s));
+			if (!encoded) continue;  // skip overflow / denormal cases for this oracle test
+			if (ours != theirs) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  mismatch on \"" << s << "\":\n"
+					          << "    ours   = 0x" << std::hex << ours   << '\n'
+					          << "    stod() = 0x" << std::hex << theirs << '\n' << std::dec;
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: stod oracle comparison\n";
+	}
+
+	// ----- the classic 0.1 (non-terminating binary): match stod -----
+	{
+		int start = nrOfFailedTestCases;
+		auto r = d2b::convert("0.1", 53);
+		std::uint64_t ours = 0;
+		bool encoded = d2b::encode_as_double(r, ours);
+		std::uint64_t theirs = d2b::double_to_bits(0.1);
+		if (!encoded || ours != theirs) ++nrOfFailedTestCases;
+		// 0.2
+		r = d2b::convert("0.2", 53);
+		encoded = d2b::encode_as_double(r, ours);
+		theirs = d2b::double_to_bits(0.2);
+		if (!encoded || ours != theirs) ++nrOfFailedTestCases;
+		// 0.3
+		r = d2b::convert("0.3", 53);
+		encoded = d2b::encode_as_double(r, ours);
+		theirs = d2b::double_to_bits(0.3);
+		if (!encoded || ours != theirs) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: non-terminating-binary cases\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/utility/test_decimal_to_binary.cpp
+++ b/static/utility/test_decimal_to_binary.cpp
@@ -192,7 +192,18 @@ try {
 			std::uint64_t ours = 0;
 			bool encoded = d2b::encode_as_double(r, ours);
 			std::uint64_t theirs = d2b::double_to_bits(std::stod(s));
-			if (!encoded) continue;  // skip overflow / denormal cases for this oracle test
+			// None of the cases in this list should overflow or underflow
+			// into denormals when encoded as IEEE double. If encode_as_double
+			// returns false, that's a real regression -- a converter bug, a
+			// changed encoder, or a misclassified case -- not something to
+			// silently skip.
+			if (!encoded) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  encode_as_double returned false on \"" << s << "\"\n";
+				}
+				continue;
+			}
 			if (ours != theirs) {
 				++nrOfFailedTestCases;
 				if (reportTestCases) {


### PR DESCRIPTION
## Summary

Adds `include/sw/universal/utility/decimal_to_binary.hpp` -- the shared bigint-based foundation that Phase B2b (posit) and B2c (cfloat) will consume to implement correctly-rounded `parse(\"3.14159\")`-style decimal-value parsing at any precision width.

This PR is utility + validation only. Wiring posit and cfloat through it lands in B2b/B2c.

## Algorithm

Given `string_parse::scan_decimal_float` output (sign, int_part, frac_part, exp10):

```text
E = exp10 - len(frac_part)
M = (int_part || frac_part) parsed as a bigint

E >= 0:  mantissa = M * 5^E,  binary scale = E
E <  0:  let neg_E = |E|, K = headroom + 4 * neg_E.
         mantissa = floor((M << (K - neg_E)) / 5^neg_E)
         binary scale = -K
```

Then normalize the mantissa so its MSB sits at `target_mantissa_bits - 1`. Bits dropped during the right-shift feed `guard_bit`; bits below feed `sticky_bit`. The bigint divide remainder also OR's into `sticky_bit`.

The `K = headroom + 4*neg_E` choice overshoots `log2(5) ~= 2.32` with generous margin: the post-divide quotient retains `target_mantissa_bits + 2` useful bits regardless of `|E|`.

## API

```cpp
namespace sw::universal::decimal_to_binary {
    template<unsigned BigBits = default_big_bits /* = 2048 */>
    struct basic_result {
        bool valid, negative, is_zero;
        std::int64_t binary_scale;
        big_integer<BigBits> mantissa;    // normalized: MSB at (target_mantissa_bits - 1)
        bool guard_bit, sticky_bit;
    };

    template<unsigned BigBits = default_big_bits>
    basic_result<BigBits> convert(const string_parse::decimal_float_scan& d,
                                   unsigned target_mantissa_bits);

    template<unsigned BigBits = default_big_bits>
    basic_result<BigBits> convert(std::string_view s, unsigned target_mantissa_bits);
}
```

Callers pass `target_mantissa_bits` matching their target type (e.g., 53 for IEEE double, fbits+1 for cfloat, fbits+regime+1 for posit) and read off `mantissa.test(i)` to extract bit i.

## Notable implementation choice: integer<2048>, NOT einteger<>

The internal bigint is `integer<2048, std::uint32_t, IntegerNumberType::IntegerNumber>`, not the elastic `einteger<>`. Reason: `einteger<>` currently produces bit-exact wrong results for the division path this code path exercises. Concrete reproducer:

```cpp
einteger<> M = 3141592653589793, num = M;
num <<= 100;
einteger<> denom = 1; for (int i = 0; i < 15; ++i) denom *= 5LL;
auto q = num; q /= denom;
auto top53 = q; top53 >>= 64;
// einteger gives top53 = 7074237752028440 (off by one ULP).
// integer<2048> gives the correct floor: 7074237752028439.
```

That's a separate `einteger<>` bug to be tracked independently; not in scope here. `integer<N>` is bit-exact under both gcc and clang.

## Tests

`static/utility/test_decimal_to_binary.cpp`:

- **Direct-output checks** for hand-computable values: 1.0, 2.0, 0.5, 3.0, -1.0, 0, 0.0, -0.0, "" (invalid)
- **25-case stod oracle comparison** spanning normal decimals, powers of 2, powers of 10, 17-digit values, scientific notation, and very large/small magnitudes (1e100 / 1e-100)
- **Non-terminating-binary** cases 0.1, 0.2, 0.3 (classic IEEE rounding boundaries)

All cases pass **bit-for-bit** against `std::stod` on gcc and clang.

## What's not covered yet

- IEEE subnormals (the test's `encode_as_double` helper skips those)
- `inf` / `nan` string literals (callers route those separately if they want stream-extraction parity with native floats)

## Roadmap

| Phase | Status |
|-------|--------|
| **B2a -- decimal-to-binary utility (this PR)** | **shipping** |
| B2b -- wire posit::parse() through the utility | next |
| B2c -- wire cfloat::parse() through the utility | after B2b |

## Test plan

- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] CodeRabbit feedback addressed
- [ ] Promote to ready: \`gh pr ready <NN>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a high‑precision decimal→binary conversion utility that returns normalized mantissa and binary exponent, detects zero/invalid inputs, and includes rounding support to improve numeric fidelity across conversions.

* **Tests**
  * Added a standalone test executable that verifies conversion correctness, rounding behavior, bounds handling, and bitwise agreement with IEEE‑754 double results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->