### PR TITLE
feat(posit): route decimal string parse through decimal_to_binary (Phase B2b of #835)

### DIFF
--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -30,6 +30,7 @@
 // #define POSIT_THROW_ARITHMETIC_EXCEPTION 1
 
 #include <universal/utility/find_msb.hpp>
+#include <universal/utility/decimal_to_binary.hpp>
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
@@ -2015,14 +2016,42 @@ bool parse(const std::string& txt, posit<nbits, es, bt>& p) {
 		return true;
 	}
 	else {
-		// assume it is a float/double/long double representation
-		std::istringstream ss(txt);
-		double d;
-		ss >> d;
-		if (ss.fail()) return false;
-		ss >> std::ws;
-		if (!ss.eof()) return false;
-		p = d;
+		// Decimal floating-point representation.
+		// Route through the high-precision decimal_to_binary utility so that
+		// wide posit configurations (nbits > 64) don't lose precision through
+		// an intermediate double. The utility delivers a normalized mantissa
+		// with target_mantissa_bits bits plus guard/sticky; we feed that
+		// directly into convert_<>() so rounding is done once in the posit
+		// encoding step.
+		// Special-value literals (nan / inf in any common spelling) map to NaR.
+		{
+			std::string t; t.reserve(txt.size());
+			for (char c : txt) t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+			std::string body = t;
+			if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+			if (body == "nan" || body == "inf" || body == "infinity") {
+				p.setnar();
+				return true;
+			}
+		}
+		constexpr unsigned extractBits         = nbits + 4;
+		constexpr unsigned target_mantissa_bits = extractBits + 1;
+		auto d = ::sw::universal::decimal_to_binary::convert(
+			std::string_view{txt}, target_mantissa_bits);
+		if (!d.valid) return false;
+		if (d.is_zero) {
+			p.setzero();
+			return true;
+		}
+		blocksignificand<extractBits, bt> frac;
+		for (unsigned i = 0; i < extractBits; ++i) {
+			if (d.mantissa.at(i)) frac.setbit(i, true);
+		}
+		// Fold d2b's residual guard/sticky into the lowest bit so convert_'s
+		// own sticky accumulator picks them up.
+		if (d.guard_bit || d.sticky_bit) frac.setbit(0, true);
+		convert_<nbits, es, bt, extractBits>(d.negative,
+			static_cast<int>(d.binary_scale), frac, p);
 		return true;
 	}
 }

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -7,10 +7,12 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cmath>
 #include <cassert>
+#include <cctype>
 #include <iostream>
 #include <iomanip>
 #include <limits>
 #include <regex>
+#include <string_view>
 #include <type_traits>
 
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
@@ -2063,6 +2065,7 @@ inline std::istream& operator>> (std::istream& istr, posit<nbits, es, bt>& p) {
 	istr >> txt;
 	if (!parse(txt, p)) {
 		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -12,6 +12,7 @@
 #include <iomanip>
 #include <limits>
 #include <regex>
+#include <sstream>
 #include <string_view>
 #include <type_traits>
 

--- a/static/tapered/posit/conversion/string_parse.cpp
+++ b/static/tapered/posit/conversion/string_parse.cpp
@@ -1,0 +1,211 @@
+// string_parse.cpp: regression tests for decimal-string parsing of posit
+//                  (Phase B2b of #835)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+#include <sstream>
+#include <string>
+#include <universal/number/posit/posit.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "posit decimal string parse (Phase B2b of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- small posit: bit-exact match against double constructor -----
+	// For posit<32,2> and below the legacy double-precision parse path
+	// already had enough precision, so the new path must produce identical
+	// results.
+	{
+		int start = nrOfFailedTestCases;
+		using Posit = posit<32, 2>;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "0",                 0.0          },
+			{ "0.0",               0.0          },
+			{ "-0.0",              0.0          },
+			{ "1.0",               1.0          },
+			{ "-1.0",             -1.0          },
+			{ "2.0",               2.0          },
+			{ "0.5",               0.5          },
+			{ "3.14",              3.14         },
+			{ "3.141592653589793", 3.141592653589793 },
+			{ "1.5",               1.5          },
+			{ "-3.25",            -3.25         },
+			{ "1.25e3",            1250.0       },
+			{ "1e0",               1.0          },
+			{ "1e10",              1e10         },
+			{ "1e-10",             1e-10        },
+			{ "1234567.8901234",   1234567.8901234 },
+		};
+		for (const auto& c : cases) {
+			Posit ours, ref(c.v);
+			if (!parse(c.s, ours)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
+				continue;
+			}
+			if (ours != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  mismatch on \"" << c.s << "\":\n"
+					          << "    string  -> " << to_binary(ours) << " = " << double(ours) << '\n'
+					          << "    double  -> " << to_binary(ref)  << " = " << double(ref)  << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit<32,2> decimal vs double constructor\n";
+	}
+
+	// ----- narrow posit also round-trips -----
+	{
+		int start = nrOfFailedTestCases;
+		using Posit = posit<16, 2>;
+		Posit a, b;
+		if (!parse("2.5", a)) ++nrOfFailedTestCases;
+		b = 2.5;
+		if (a != b) ++nrOfFailedTestCases;
+		if (!parse("-0.125", a)) ++nrOfFailedTestCases;
+		b = -0.125;
+		if (a != b) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit<16,2> basic decimals\n";
+	}
+
+	// ----- native posit hex format still works -----
+	{
+		int start = nrOfFailedTestCases;
+		posit<8, 0> p, expected;
+		if (!parse("8.0x40p", p)) ++nrOfFailedTestCases;
+		expected = 1.0;
+		if (p != expected) ++nrOfFailedTestCases;
+		// mismatched nbits.es must fail
+		if (parse("16.2x40p", p)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: native posit hex format\n";
+	}
+
+	// ----- nan / inf literals route to NaR -----
+	{
+		int start = nrOfFailedTestCases;
+		posit<32, 2> p;
+		for (const char* s : { "nan", "NaN", "+nan", "-nan",
+		                       "inf", "Inf", "+inf", "-inf",
+		                       "infinity", "INFINITY" }) {
+			p.setzero();
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isnar())   ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: nan/inf -> NaR routing\n";
+	}
+
+	// ----- operator>> failure path sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		posit<32, 2> p;
+		std::streambuf* oldbuf = std::cerr.rdbuf(nullptr); // mute diagnostic
+		is >> p;
+		std::cerr.rdbuf(oldbuf);
+		// operator>> doesn't currently set failbit on posit (it just emits to cerr).
+		// We only check that the call completes without crash and p is a defined
+		// value. If operator>> is later updated to setstate(failbit), the
+		// assertion below becomes the meaningful check.
+		(void)is.fail();
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: operator>> bad-token handling\n";
+	}
+
+	// ----- wide posit: decimal-string parse must MATCH bits delivered by
+	//       the double-constructor route for inputs that ARE EXACT in
+	//       double. Inputs that aren't exact (e.g. 1e-6, 0.1) will legally
+	//       diverge -- posit<64,3> has ~56 fraction bits, more than double's
+	//       52, so the new path captures precision the old double-funnel
+	//       lost. Those cases belong in the precision-win check below.
+	{
+		int start = nrOfFailedTestCases;
+		using Posit = posit<64, 3>;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "1.0",              1.0    },
+			{ "-2.5",            -2.5    },
+			{ "0.25",             0.25   },
+			{ "100",              100.0  },
+			{ "1024",             1024.0 },
+			{ "0.0625",           0.0625 },  // 2^-4
+		};
+		for (const auto& c : cases) {
+			Posit ours, ref(c.v);
+			if (!parse(c.s, ours)) ++nrOfFailedTestCases;
+			if (ours != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  mismatch on \"" << c.s << "\":\n"
+					          << "    string  -> " << to_binary(ours) << '\n'
+					          << "    double  -> " << to_binary(ref)  << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit<64,3> sanity (exact-in-double inputs)\n";
+	}
+
+	// ----- precision-win demonstration: a value that's not exact in
+	//       double should round differently in posit<64,3> when parsed
+	//       via the new high-precision path vs the legacy double funnel.
+	{
+		int start = nrOfFailedTestCases;
+		using Posit = posit<64, 3>;
+		Posit via_string, via_double(1e-6);
+		if (!parse("1e-6", via_string)) ++nrOfFailedTestCases;
+		if (via_string == via_double) {
+			// Not necessarily a failure -- if your posit happens to have
+			// fewer fraction bits than double for this exponent, equality
+			// is fine. But for posit<64,3> at scale ~-20, fbits > 52, so
+			// the two paths SHOULD differ.
+			++nrOfFailedTestCases;
+			if (reportTestCases) {
+				std::cout << "  expected precision divergence for 1e-6 in posit<64,3>; got identity\n";
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit<64,3> precision-win\n";
+	}
+
+	// ----- wide posit precision win: a value with more decimal digits
+	//       than double can hold should still parse to a defined value.
+	//       We don't compare against an oracle here -- the comparison
+	//       framework for that lives in the future Phase C tooling --
+	//       but we exercise the code path on a wide configuration.
+	{
+		int start = nrOfFailedTestCases;
+		posit<128, 4> p;
+		if (!parse("3.14159265358979323846264338327950288419716939937510", p))
+			++nrOfFailedTestCases;
+		if (p.iszero())          ++nrOfFailedTestCases;
+		if (p.isnar())           ++nrOfFailedTestCases;
+		if (sign(p))             ++nrOfFailedTestCases;  // positive
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit<128,4> wide decimal\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/posit/conversion/string_parse.cpp
+++ b/static/tapered/posit/conversion/string_parse.cpp
@@ -108,7 +108,7 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: nan/inf -> NaR routing\n";
 	}
 
-	// ----- operator>> failure path sets failbit on a bad token -----
+	// ----- operator>> sets failbit on a bad token -----
 	{
 		int start = nrOfFailedTestCases;
 		std::istringstream is("not-a-number");
@@ -116,11 +116,7 @@ try {
 		std::streambuf* oldbuf = std::cerr.rdbuf(nullptr); // mute diagnostic
 		is >> p;
 		std::cerr.rdbuf(oldbuf);
-		// operator>> doesn't currently set failbit on posit (it just emits to cerr).
-		// We only check that the call completes without crash and p is a defined
-		// value. If operator>> is later updated to setstate(failbit), the
-		// assertion below becomes the meaningful check.
-		(void)is.fail();
+		if (!is.fail()) ++nrOfFailedTestCases;
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: operator>> bad-token handling\n";
 	}
 
@@ -157,19 +153,31 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit<64,3> sanity (exact-in-double inputs)\n";
 	}
 
-	// ----- precision-win demonstration: a value that's not exact in
-	//       double should round differently in posit<64,3> when parsed
-	//       via the new high-precision path vs the legacy double funnel.
+	// ----- precision-win demonstration: pin the expected posit<64,3> bit
+	//       pattern for "1e-6" via the new high-precision path. The legacy
+	//       double-funnel result is also computed for comparison; the two
+	//       must differ (because posit<64,3> has ~56 fraction bits, more
+	//       than double's 52). Pinning the exact bit pattern means any
+	//       future rounding regression in the new path is caught directly,
+	//       not just by inequality.
 	{
 		int start = nrOfFailedTestCases;
 		using Posit = posit<64, 3>;
 		Posit via_string, via_double(1e-6);
 		if (!parse("1e-6", via_string)) ++nrOfFailedTestCases;
+		// Expected bit pattern of the high-precision parse for 1e-6 in
+		// posit<64,3>: sign=0, regime=0001, exp=100, fraction=56 bits.
+		const std::string expected_bits =
+		    "0b0.0001.100.00001100011011110111101000001011010111101101100011010011";
+		if (to_binary(via_string) != expected_bits) {
+			++nrOfFailedTestCases;
+			if (reportTestCases) {
+				std::cout << "  pinned bit mismatch for 1e-6 in posit<64,3>:\n"
+				          << "    got      " << to_binary(via_string) << '\n'
+				          << "    expected " << expected_bits          << '\n';
+			}
+		}
 		if (via_string == via_double) {
-			// Not necessarily a failure -- if your posit happens to have
-			// fewer fraction bits than double for this exponent, equality
-			// is fine. But for posit<64,3> at scale ~-20, fbits > 52, so
-			// the two paths SHOULD differ.
 			++nrOfFailedTestCases;
 			if (reportTestCases) {
 				std::cout << "  expected precision divergence for 1e-6 in posit<64,3>; got identity\n";


### PR DESCRIPTION
## Summary

Replace the `std::istringstream >> double` funnel in `posit::parse()` with a direct call into the high-precision `decimal_to_binary` utility shipped in Phase B2a (#841). For posit configurations whose fraction precision exceeds double's 52 bits (roughly `posit<nbits, *>` with `nbits > 60`), this captures the trailing decimal precision that the legacy path silently truncated.

## Changes

- `include/sw/universal/number/posit/posit_impl.hpp`
  - Add `#include <universal/utility/decimal_to_binary.hpp>`
  - Decimal branch of `parse()`:
    * Routes `nan` / `inf` / `infinity` tokens (any case, optional sign) to `setnar()`
    * Calls `decimal_to_binary::convert` with `target_mantissa_bits = nbits + 5`
    * Copies `nbits+4` mantissa bits into a `blocksignificand<extractBits>`, folds d2b's residual guard/sticky into bit[0], and hands off to `convert_<>()` so all rounding happens once in posit's encoding step
  - Hex format path (regex match on `nbits.esxHEXVALUEp`) is unchanged
- `static/tapered/posit/conversion/string_parse.cpp` (new)
  - 7 test groups using the canonical `ReportTestSuite` pattern

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| posit_string_parse | OK | PASS | OK | PASS |
| posit_api          | OK | PASS | OK | PASS |
| posit_assignment   | OK | PASS | OK | PASS |
| posit_conversion   | OK | PASS | OK | PASS |

## Notable behavior change

For `posit<64, 3>` parsing `"1e-6"`, the new and legacy paths legally diverge by 3 ULPs:
- Legacy: `1e-6` -> stod -> double (52-bit rounded) -> posit (rounded to ~56 bits)
- New:    `1e-6` -> d2b at 68 bits -> posit (rounded to ~56 bits)

The new path is strictly more accurate; the test asserts the divergence is observed.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate decimal-to-binary parsing for posit values, improved handling of special literals (NaN, Infinity), and operator>> now flags stream failure on invalid input.

* **Tests**
  * Added a regression test executable covering decimal/hex parsing, round-trips, edge cases, precision regressions, and parsing across multiple posit sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->