### PR TITLE
ci: drop CodeQL pull_request trigger, switch c-cpp to manual CI_LITE build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,41 +1,28 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL Advanced"
+
+# Custom (advanced) CodeQL setup so the slow c-cpp scan does NOT run on every
+# pull request. With default-setup it ran on every PR for >20 minutes on this
+# template-heavy codebase; here it runs only:
+#   - weekly against main (drift detection)
+#   - on direct pushes to main (post-merge verification)
+#   - on demand via workflow_dispatch
+# It deliberately omits a `pull_request:` trigger.
 
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '27 16 * * 3'
+  workflow_dispatch:
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
     permissions:
-      # required for all workflows
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
       packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
 
@@ -43,63 +30,36 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: c-cpp
-          build-mode: autobuild
-        - language: javascript-typescript
-          build-mode: none
-        - language: python
-          build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+          - language: actions
+            build-mode: none
+          - language: c-cpp
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Manual build for c-cpp: CI_LITE compiles a representative subset, which
+      # is enough for CodeQL's extractor without paying for a full BUILD_ALL.
+      - name: Configure (c-cpp)
+        if: matrix.language == 'c-cpp'
+        run: cmake -B build -DUNIVERSAL_BUILD_CI_LITE=ON
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      - name: Build (c-cpp)
+        if: matrix.language == 'c-cpp'
+        run: cmake --build build -j 4
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

#844 committed the GitHub default CodeQL template, but it still triggers on every \`pull_request\` (>20 min c-cpp scan per PR on this template-heavy codebase) and uses \`autobuild\` for c-cpp which doesn't understand a header-only library.

This PR fixes both.

## Changes (`.github/workflows/codeql.yml`)

- **Drop \`pull_request:\` from the trigger list.** CodeQL now runs only on push to main (post-merge verification), the weekly schedule (drift detection), and on demand.
- **Add \`workflow_dispatch:\`** so security-relevant changes can be re-scanned on demand without waiting for the schedule.
- **Switch c-cpp to \`build-mode: manual\`** with an explicit cmake configure + build using \`UNIVERSAL_BUILD_CI_LITE=ON\` — the same minimal-build flag the regular CI matrix already uses.
- Drop the placeholder "Run manual build steps" block that called \`exit 1\` on any manual-mode language.
- Drop the \`runs-on:\` swift conditional since swift isn't in the matrix.

## Effect on the PR workflow

Before: every PR shows \`Analyze (c-cpp)\` taking 20+ minutes; user has been ignoring it manually.
After: PRs no longer show that check at all. Weekly Wednesday 16:27 UTC run + post-merge run + manual trigger remain.

## Test plan

- [ ] On merge, watch the next push-to-main fire the workflow and confirm c-cpp build succeeds with CI_LITE
- [ ] Confirm the next PR after merge does NOT show \`Analyze (c-cpp)\` in checks
- [ ] If c-cpp build needs more time, raise the \`timeout-minutes:\` cap

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* CodeQL Advanced scanning now triggers exclusively on pushes to the main branch, scheduled weekly runs, and manual dispatch—pull request scanning has been disabled
* C/C++ build configuration for code analysis updated to use explicit setup with enhanced parameters, replacing the previous autobuild approach

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->