### PR TITLE
feat(cfloat): route decimal string parse through decimal_to_binary (Phase B2c of #835)

### DIFF
--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -21,12 +21,16 @@
 // number system include file <universal/number/cfloat/cfloat.hpp>
 // 
 // supporting types and functions
+#include <cctype>
 #include <limits>
 #include <regex>
+#include <sstream>
+#include <string_view>
 #include <type_traits>
 #include <universal/native/ieee754.hpp>
 #include <universal/native/subnormal.hpp>
 #include <universal/utility/find_msb.hpp>
+#include <universal/utility/decimal_to_binary.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/shared/infinite_encoding.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
@@ -3623,14 +3627,64 @@ bool parse(const std::string& txt, cfloat<nbits,es,bt,hasSubnormals,hasMaxExpVal
 		return true;
 	}
 	else {
-		// assume it is a float/double/long double representation
-		std::istringstream ss(txt);
-		double d;
-		ss >> d;
-		if (ss.fail()) return false;
-		ss >> std::ws;
-		if (!ss.eof()) return false;
-		v = d;
+		// Decimal floating-point representation.
+		// Route through the high-precision decimal_to_binary utility so that
+		// wide cfloat configurations (nbits > 64, including IEEE quad and
+		// posit-killer formats) don't lose precision through an intermediate
+		// double. The utility delivers a normalized mantissa with
+		// target_mantissa_bits bits plus guard/sticky; we package that as a
+		// blocktriple and hand it to convert(blocktriple, cfloat), which
+		// handles all IEEE-754 edge cases (subnormals, saturation, etc.).
+		// Special-value tokens (nan / inf in any common spelling) are
+		// recognised directly so callers don't depend on locale-sensitive
+		// std::istringstream parsing of those literals.
+		using Cfloat = cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>;
+		{
+			std::string t; t.reserve(txt.size());
+			for (char c : txt) t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+			bool negative = !t.empty() && t.front() == '-';
+			std::string body = t;
+			if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+			if (body == "nan") {
+				v.setnan(NAN_TYPE_QUIET);
+				return true;
+			}
+			if (body == "inf" || body == "infinity") {
+				v.setinf(negative);
+				return true;
+			}
+		}
+		// We pack the d2b result into a blocktriple<fbits, MUL, bt>. The MUL
+		// layout has bfbits = 2*fbits + 2 and radix = 2*fbits, which gives us
+		// exactly fbits of headroom below the cfloat fraction for guard/
+		// sticky -- enough room for cfloat's convert() to make a correct
+		// round-to-nearest-even decision. (The REP layout has no such
+		// headroom: its fraction is exactly cfloat::fbits wide.)
+		using BT = blocktriple<Cfloat::fbits, BlockTripleOperator::MUL, bt>;
+		constexpr unsigned radix_pos          = static_cast<unsigned>(BT::radix);
+		constexpr unsigned target_mantissa_bits = radix_pos + 1u;
+		auto d = ::sw::universal::decimal_to_binary::convert(
+			std::string_view{txt}, target_mantissa_bits);
+		if (!d.valid) return false;
+		if (d.is_zero) {
+			v.setzero();
+			v.setsign(d.negative);
+			return true;
+		}
+		BT bt_val;
+		bt_val.setnormal();
+		bt_val.setsign(d.negative);
+		bt_val.setscale(static_cast<int>(d.binary_scale));
+		// d2b mantissa has its MSB at position radix_pos (the hidden bit);
+		// below it are radix_pos extra precision bits. Copy bit-for-bit
+		// into the blocktriple significand aligned to the same radix.
+		for (unsigned i = 0; i <= radix_pos; ++i) {
+			if (d.mantissa.at(i)) bt_val.setbit(i, true);
+		}
+		// Fold d2b's residual guard/sticky into the lowest bit so cfloat's
+		// own rounding decision picks them up as sticky tail.
+		if (d.guard_bit || d.sticky_bit) bt_val.setbit(0, true);
+		convert(bt_val, v);
 		return true;
 	}
 }
@@ -3642,6 +3696,7 @@ inline std::istream& operator>>(std::istream& istr, cfloat<nbits,es,bt,hasSubnor
 	istr >> txt;
 	if (!parse(txt, v)) {
 		std::cerr << "unable to parse -" << txt << "- into a cfloat value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/static/float/cfloat/conversion/string_parse.cpp
+++ b/static/float/cfloat/conversion/string_parse.cpp
@@ -74,7 +74,11 @@ try {
 		};
 		for (const auto& c : cases) {
 			single ours, ref(c.v);
-			if (!parse(c.s, ours)) ++nrOfFailedTestCases;
+			if (!parse(c.s, ours)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
+				continue;
+			}
 			if (ours != ref) {
 				++nrOfFailedTestCases;
 				if (reportTestCases) {
@@ -102,13 +106,32 @@ try {
 		};
 		for (const auto& c : cases) {
 			duble ours, ref(c.v);
-			if (!parse(c.s, ours)) ++nrOfFailedTestCases;
-			if (ours != ref) ++nrOfFailedTestCases;
+			if (!parse(c.s, ours)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
+				continue;
+			}
+			if (ours != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  mismatch on \"" << c.s << "\":\n"
+					          << "    string -> " << to_binary(ours) << '\n'
+					          << "    ref    -> " << to_binary(ref)  << '\n';
+				}
+			}
 		}
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: duble (cfloat<64,11>) exact-in-double\n";
 	}
 
 	// ----- nan / inf literals route to the corresponding encodings -----
+	//
+	// Note on NaN sign: cfloat's encoding only has two NaN patterns -- QUIET
+	// (sign=0) and SIGNALLING (sign=1). It does NOT separately encode the
+	// IEEE-style sign bit on NaN. Our parse routes every "nan" spelling to
+	// QUIET (sign=0), matching the policy already established by
+	// convert_ieee754: a negative IEEE qNaN is also mapped to QUIET there,
+	// dropping the input sign. We exercise +nan / -nan as tokens here only
+	// to confirm they parse and produce A NaN, not to assert sign preservation.
 	{
 		int start = nrOfFailedTestCases;
 		single p;

--- a/static/float/cfloat/conversion/string_parse.cpp
+++ b/static/float/cfloat/conversion/string_parse.cpp
@@ -8,10 +8,25 @@
 // an MIT Open Source license.
 
 #include <universal/utility/directives.hpp>
+#include <iostream>
 #include <sstream>
+#include <streambuf>
 #include <string>
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/verification/test_reporters.hpp>
+
+// RAII guard: redirects std::cerr to nullptr (silencing diagnostics) for the
+// scope of a test block, and restores the original buffer in the destructor
+// so the stream stays consistent even if the body throws.
+namespace {
+struct CerrSilencer {
+	std::streambuf* old;
+	CerrSilencer() : old(std::cerr.rdbuf(nullptr)) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
 
 int main()
 try {
@@ -140,7 +155,8 @@ try {
 			if (!parse(s, p))      ++nrOfFailedTestCases;
 			if (!p.isnan())        ++nrOfFailedTestCases;
 		}
-		for (const char* s : { "inf", "Inf", "infinity", "INFINITY" }) {
+		for (const char* s : { "inf", "Inf", "infinity", "INFINITY",
+		                       "+inf", "+Inf", "+infinity", "+INFINITY" }) {
 			p.setzero();
 			if (!parse(s, p)) ++nrOfFailedTestCases;
 			if (!p.isinf())   ++nrOfFailedTestCases;
@@ -173,9 +189,10 @@ try {
 		int start = nrOfFailedTestCases;
 		std::istringstream is("not-a-number");
 		single p;
-		std::streambuf* oldbuf = std::cerr.rdbuf(nullptr);
-		is >> p;
-		std::cerr.rdbuf(oldbuf);
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
 		if (!is.fail()) ++nrOfFailedTestCases;
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: operator>> bad-token failbit\n";
 	}

--- a/static/float/cfloat/conversion/string_parse.cpp
+++ b/static/float/cfloat/conversion/string_parse.cpp
@@ -15,13 +15,17 @@
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/verification/test_reporters.hpp>
 
-// RAII guard: redirects std::cerr to nullptr (silencing diagnostics) for the
-// scope of a test block, and restores the original buffer in the destructor
-// so the stream stays consistent even if the body throws.
+// RAII guard: redirects std::cerr to a throwaway sink for the scope of a
+// test block, and restores the original buffer in the destructor so the
+// stream stays consistent even if the body throws. We use an
+// ostringstream-backed sink rather than nullptr -- a nullptr buffer can
+// leave std::cerr in a badbit state after writes, which would persist
+// across subsequent unrelated tests.
 namespace {
 struct CerrSilencer {
-	std::streambuf* old;
-	CerrSilencer() : old(std::cerr.rdbuf(nullptr)) {}
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
 	~CerrSilencer() { std::cerr.rdbuf(old); }
 	CerrSilencer(const CerrSilencer&)            = delete;
 	CerrSilencer& operator=(const CerrSilencer&) = delete;
@@ -162,7 +166,7 @@ try {
 			if (!p.isinf())   ++nrOfFailedTestCases;
 			if (p.sign())     ++nrOfFailedTestCases;  // positive
 		}
-		for (const char* s : { "-inf", "-Inf", "-infinity" }) {
+		for (const char* s : { "-inf", "-Inf", "-infinity", "-INFINITY" }) {
 			p.setzero();
 			if (!parse(s, p)) ++nrOfFailedTestCases;
 			if (!p.isinf())   ++nrOfFailedTestCases;

--- a/static/float/cfloat/conversion/string_parse.cpp
+++ b/static/float/cfloat/conversion/string_parse.cpp
@@ -1,0 +1,210 @@
+// string_parse.cpp: regression tests for decimal-string parsing of cfloat
+//                  (Phase B2c of #835)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+#include <sstream>
+#include <string>
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "cfloat decimal string parse (Phase B2c of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- half: bit-exact match against cfloat constructor -----
+	{
+		int start = nrOfFailedTestCases;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "0",      0.0 },
+			{ "0.0",    0.0 },
+			{ "1.0",    1.0 },
+			{ "-1.0", -1.0 },
+			{ "1.5",    1.5 },
+			{ "-3.25", -3.25 },
+			{ "2.0",    2.0 },
+			{ "0.5",    0.5 },
+			{ "1.25e3", 1250.0 },
+			{ "65504",  65504.0 },  // maxpos for half
+		};
+		for (const auto& c : cases) {
+			half ours, ref(c.v);
+			if (!parse(c.s, ours)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
+				continue;
+			}
+			if (ours != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  mismatch on \"" << c.s << "\":\n"
+					          << "    string -> " << to_binary(ours) << '\n'
+					          << "    ref    -> " << to_binary(ref)  << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: half (cfloat<16,5>) decimal vs constructor\n";
+	}
+
+	// ----- single (IEEE float): match the float constructor for exact-in-float values -----
+	{
+		int start = nrOfFailedTestCases;
+		struct Case { const char* s; float v; };
+		Case cases[] = {
+			{ "0",       0.0f },
+			{ "1.0",     1.0f },
+			{ "-1.0",   -1.0f },
+			{ "0.5",     0.5f },
+			{ "0.25",    0.25f },
+			{ "100",     100.0f },
+			{ "1e10",    1e10f },
+			{ "1.5",     1.5f },
+		};
+		for (const auto& c : cases) {
+			single ours, ref(c.v);
+			if (!parse(c.s, ours)) ++nrOfFailedTestCases;
+			if (ours != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  mismatch on \"" << c.s << "\":\n"
+					          << "    string -> " << to_binary(ours) << '\n'
+					          << "    ref    -> " << to_binary(ref)  << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: single (cfloat<32,8>)\n";
+	}
+
+	// ----- duble (IEEE double): match the double constructor for exact inputs -----
+	{
+		int start = nrOfFailedTestCases;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "1.0",        1.0 },
+			{ "-2.5",      -2.5 },
+			{ "0.25",       0.25 },
+			{ "100",        100.0 },
+			{ "1024",       1024.0 },
+			{ "0.0625",     0.0625 },  // 2^-4
+			{ "4503599627370496",   4503599627370496.0 },  // 2^52
+		};
+		for (const auto& c : cases) {
+			duble ours, ref(c.v);
+			if (!parse(c.s, ours)) ++nrOfFailedTestCases;
+			if (ours != ref) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: duble (cfloat<64,11>) exact-in-double\n";
+	}
+
+	// ----- nan / inf literals route to the corresponding encodings -----
+	{
+		int start = nrOfFailedTestCases;
+		single p;
+		for (const char* s : { "nan", "NaN", "+nan", "-nan" }) {
+			p.setzero();
+			if (!parse(s, p))      ++nrOfFailedTestCases;
+			if (!p.isnan())        ++nrOfFailedTestCases;
+		}
+		for (const char* s : { "inf", "Inf", "infinity", "INFINITY" }) {
+			p.setzero();
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isinf())   ++nrOfFailedTestCases;
+			if (p.sign())     ++nrOfFailedTestCases;  // positive
+		}
+		for (const char* s : { "-inf", "-Inf", "-infinity" }) {
+			p.setzero();
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isinf())   ++nrOfFailedTestCases;
+			if (!p.sign())    ++nrOfFailedTestCases;  // negative
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: nan/inf token routing\n";
+	}
+
+	// ----- native cfloat hex format still works (with and without 0x prefix) -----
+	{
+		int start = nrOfFailedTestCases;
+		half p;
+		if (!parse("16.5x3C00c", p))   ++nrOfFailedTestCases;
+		if (p != half(1.0))            ++nrOfFailedTestCases;
+		if (!parse("16.5x0x3C00c", p)) ++nrOfFailedTestCases;
+		if (p != half(1.0))            ++nrOfFailedTestCases;
+		// mismatched nbits.es must fail
+		if (parse("32.8x12345678c", p)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: native cfloat hex format\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		single p;
+		std::streambuf* oldbuf = std::cerr.rdbuf(nullptr);
+		is >> p;
+		std::cerr.rdbuf(oldbuf);
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: operator>> bad-token failbit\n";
+	}
+
+	// ----- trailing junk is rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		single p;
+		if (parse("1.5abc", p)) ++nrOfFailedTestCases;
+		if (parse("3.14xyz", p)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: trailing-junk rejection\n";
+	}
+
+	// ----- signed zero -----
+	{
+		int start = nrOfFailedTestCases;
+		half p;
+		if (!parse("0", p)) ++nrOfFailedTestCases;
+		if (p.sign())       ++nrOfFailedTestCases;  // +0
+		if (!parse("-0", p)) ++nrOfFailedTestCases;
+		if (!p.sign())      ++nrOfFailedTestCases;  // -0
+		if (!parse("-0.0", p)) ++nrOfFailedTestCases;
+		if (!p.sign())      ++nrOfFailedTestCases;  // -0.0
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: signed zero handling\n";
+	}
+
+	// ----- precision-win check: a value that's not exact in double should
+	//       round differently in cfloat<128,15> (quad, ~112 fbits) vs the
+	//       legacy double funnel.
+	{
+		int start = nrOfFailedTestCases;
+		quad via_string, via_double(1e-6);
+		if (!parse("1e-6", via_string)) ++nrOfFailedTestCases;
+		if (via_string == via_double) {
+			++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "  expected precision divergence for 1e-6 in cfloat<128,15>\n";
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: quad precision-win\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/posit/conversion/string_parse.cpp
+++ b/static/tapered/posit/conversion/string_parse.cpp
@@ -15,13 +15,17 @@
 #include <universal/number/posit/posit.hpp>
 #include <universal/verification/test_reporters.hpp>
 
-// RAII guard: redirects std::cerr to nullptr (silencing diagnostics) for the
-// scope of a test block, and restores the original buffer in the destructor
-// so the stream stays consistent even if the body throws.
+// RAII guard: redirects std::cerr to a throwaway sink for the scope of a
+// test block, and restores the original buffer in the destructor so the
+// stream stays consistent even if the body throws. We use an
+// ostringstream-backed sink rather than nullptr -- a nullptr buffer can
+// leave std::cerr in a badbit state after writes, which would persist
+// across subsequent unrelated tests.
 namespace {
 struct CerrSilencer {
-	std::streambuf* old;
-	CerrSilencer() : old(std::cerr.rdbuf(nullptr)) {}
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
 	~CerrSilencer() { std::cerr.rdbuf(old); }
 	CerrSilencer(const CerrSilencer&)            = delete;
 	CerrSilencer& operator=(const CerrSilencer&) = delete;

--- a/static/tapered/posit/conversion/string_parse.cpp
+++ b/static/tapered/posit/conversion/string_parse.cpp
@@ -8,10 +8,25 @@
 // an MIT Open Source license.
 
 #include <universal/utility/directives.hpp>
+#include <iostream>
 #include <sstream>
+#include <streambuf>
 #include <string>
 #include <universal/number/posit/posit.hpp>
 #include <universal/verification/test_reporters.hpp>
+
+// RAII guard: redirects std::cerr to nullptr (silencing diagnostics) for the
+// scope of a test block, and restores the original buffer in the destructor
+// so the stream stays consistent even if the body throws.
+namespace {
+struct CerrSilencer {
+	std::streambuf* old;
+	CerrSilencer() : old(std::cerr.rdbuf(nullptr)) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
 
 int main()
 try {
@@ -113,9 +128,10 @@ try {
 		int start = nrOfFailedTestCases;
 		std::istringstream is("not-a-number");
 		posit<32, 2> p;
-		std::streambuf* oldbuf = std::cerr.rdbuf(nullptr); // mute diagnostic
-		is >> p;
-		std::cerr.rdbuf(oldbuf);
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
 		if (!is.fail()) ++nrOfFailedTestCases;
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: operator>> bad-token handling\n";
 	}


### PR DESCRIPTION
## Summary

Replace the \`std::istringstream >> double\` funnel in \`cfloat::parse()\` with a direct call into the high-precision \`decimal_to_binary\` utility (Phase B2a, #841). For wide cfloat configurations (IEEE quad, extended, and beyond) this captures the trailing decimal precision the legacy path silently truncated.

## Changes

- \`include/sw/universal/number/cfloat/cfloat_impl.hpp\`
  - Add direct \`<cctype>\`, \`<sstream>\`, \`<string_view>\`, and \`<universal/utility/decimal_to_binary.hpp>\` includes (no more transitive-include reliance)
  - Decimal branch of \`parse()\`:
    * \`nan\` / \`inf\` / \`infinity\` tokens (any case, optional sign) route to \`setnan\` / \`setinf\` with proper sign handling
    * \`decimal_to_binary::convert\` with \`target_mantissa_bits\` sized to \`blocktriple<Cfloat::fbits, MUL, bt>::radix + 1\` for bit-aligned packing
    * MUL-op blocktriple gives 2\*fbits of headroom below the cfloat fraction so cfloat's existing \`convert(blocktriple, cfloat)\` consumes guard/sticky correctly
    * d2b's residual guard/sticky fold into the blocktriple's lowest bit
  - Hex format path (\`nbits.esxHEXVALUEc\`, with or without \`0x\` prefix) is unchanged
  - \`operator>>\` now sets \`std::ios::failbit\` on parse failure (matches the symmetry pattern from posit / integer / fixpnt)
- \`static/float/cfloat/conversion/string_parse.cpp\` (new)
  - 9 test groups using the canonical \`ReportTestSuite\` pattern

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| cfloat_string_parse        | OK | PASS | OK | PASS |
| cfloat_api                 | OK | PASS | OK | PASS |
| cfloat_assignment          | OK | PASS | OK | PASS |
| cfloat_float_conversion    | OK | PASS | OK | PASS |
| cfloat_double_conversion   | OK | PASS | OK | PASS |

## Notable behavior change

For \`cfloat<128, 15>\` (IEEE quad) parsing \`1e-6\`, the new and legacy paths legally diverge:
- Legacy: \`1e-6\` -> stod -> double (52-bit rounded) -> quad (rounded to 112 fbits)
- New:    \`1e-6\` -> d2b at radix+1 bits -> quad (rounded directly to 112 fbits)

The new path is strictly more accurate; the test asserts the divergence is observed.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal-string parsing: direct handling of NaN/Inf spellings, normalized decimal-to-binary conversion, and proper handling of guard/sticky rounding.
  * Stream extraction now reliably sets the stream failbit on parse failures.

* **Tests**
  * Added a standalone regression test executable covering decimal parsing, hex parsing, signed zeros, and precision edge cases.
  * Tests now mute noisy diagnostic output using an RAII-based silencer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->