### PR TITLE
feat: API parity / implementation for decimal string parse in specialized FP (Phase D of #835)

### DIFF
--- a/elastic/unum/string_parse.cpp
+++ b/elastic/unum/string_parse.cpp
@@ -1,0 +1,119 @@
+// string_parse.cpp: regression tests for decimal-string parsing of unum (Type I)
+//                  (Phase D of #835 -- API parity)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/unum/unum.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+	using Unum = unum<3, 4>;  // a small unum Type I configuration
+
+	std::string test_suite  = "unum Type I decimal string parse (Phase D of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- canonical decimals match constructor (small inputs only;
+	//       the small unum<3,4> configuration has limited range/precision) -----
+	{
+		int start = nrOfFailedTestCases;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "0",       0.0     },
+			{ "1.0",     1.0     },
+			{ "-1.0",   -1.0     },
+			{ "1.5",     1.5     },
+			{ "-3.25",  -3.25    },
+			{ "0.5",     0.5     },
+			{ "2.0",     2.0     },
+		};
+		for (const auto& c : cases) {
+			Unum ours, ref(c.v);
+			if (!parse(c.s, ours)) ++nrOfFailedTestCases;
+			if (ours != ref)       ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: unum canonical decimals\n";
+	}
+
+	// ----- nan / inf token routing. unum Type I has no Inf encoding;
+	//       both nan and inf collapse to NaN, matching the existing
+	//       operator=(double) which also maps +/-inf to NaN. -----
+	{
+		int start = nrOfFailedTestCases;
+		Unum p;
+		for (const char* s : { "nan", "NaN", "+nan", "-nan",
+		                       "inf", "Inf", "infinity", "INFINITY",
+		                       "+inf", "-inf", "+infinity", "-infinity" }) {
+			p.setnan();
+			p = 0.0;  // reset to a known finite value
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isnan())   ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: unum nan/inf -> NaN routing\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		Unum p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: unum operator>> failbit\n";
+	}
+
+	// ----- malformed decimal inputs are rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		Unum p;
+		for (const char* s : { "1.5abc", "abc", "++1", "1.5e" }) {
+			if (parse(s, p)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  unexpectedly accepted: \"" << s << "\"\n";
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: unum malformed-input rejection\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cctype>
 #include <cstdint>
 #include <string>
 #include <sstream>
@@ -457,10 +458,38 @@ inline bfloat16 abs(bfloat16 a) {
 /// stream operators
 
 // parse a bfloat16 ASCII format and make a binary bfloat16 out of it
-inline bool parse(const std::string& /* number */, bfloat16& value) {
-	bool bSuccess = false;
-	value.zero();
-	return bSuccess;
+inline bool parse(const std::string& number, bfloat16& value) {
+	// Detect nan / inf / infinity tokens (case-insensitive, optional sign).
+	{
+		std::string t;
+		t.reserve(number.size());
+		for (char c : number) {
+			t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+		}
+		bool negative = !t.empty() && t.front() == '-';
+		std::string body = t;
+		if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+		if (body == "nan") {
+			value.setnan(NAN_TYPE_QUIET);
+			return true;
+		}
+		if (body == "inf" || body == "infinity") {
+			value.setinf(negative);
+			return true;
+		}
+	}
+	// Decimal floating-point: bfloat16 has only 7 explicit mantissa bits,
+	// so std::istringstream's double extraction is more than enough
+	// precision -- the value gets immediately rounded into the bfloat16
+	// encoding via convert_ieee754.
+	std::istringstream ss(number);
+	double d;
+	ss >> d;
+	if (ss.fail()) return false;
+	ss >> std::ws;
+	if (!ss.eof()) return false;
+	value = d;
+	return true;
 }
 
 // generate an bfloat16 format ASCII format
@@ -471,9 +500,13 @@ inline std::ostream& operator<<(std::ostream& ostr, bfloat16 bf) {
 // read an ASCII bfloat16 format
 inline std::istream& operator>>(std::istream& istr, bfloat16& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, p)) {
 		std::cerr << "unable to parse -" << txt << "- into a bfloat16 value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/posit1/posit_impl.hpp
+++ b/include/sw/universal/number/posit1/posit_impl.hpp
@@ -1743,9 +1743,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const posit<nbits, es>& p) {
 template<unsigned nbits, unsigned es>
 inline std::istream& operator>> (std::istream& istr, posit<nbits, es>& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, p)) {
 		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/posit1/posit_parse.hpp
+++ b/include/sw/universal/number/posit1/posit_parse.hpp
@@ -5,10 +5,12 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cctype>
 #include <iostream>
 #include <regex>
 #include <sstream>
 #include <cstdint>
+#include <string>
 #include <universal/number/posit1/posit_fwd.hpp>
 
 namespace sw { namespace universal {
@@ -17,6 +19,22 @@ namespace sw { namespace universal {
 template<unsigned nbits, unsigned es>
 bool parse(std::string& txt, posit<nbits, es>& p) {
 	bool bSuccess = false;
+	// Detect nan / inf / infinity tokens (case-insensitive, optional sign)
+	// before the regex / stod path; posit has only a single NaR encoding
+	// for any non-finite, so all spellings collapse to setnar().
+	{
+		std::string t;
+		t.reserve(txt.size());
+		for (char c : txt) {
+			t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+		}
+		std::string body = t;
+		if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+		if (body == "nan" || body == "inf" || body == "infinity") {
+			p.setnar();
+			return true;
+		}
+	}
 	// check if the txt is of the native posit form: nbits.esXhexvalue
 	std::regex posit_regex("[\\d]+\\.[0123456789][xX][\\w]+[p]*");
 	if (std::regex_match(txt, posit_regex)) {
@@ -56,6 +74,9 @@ bool parse(std::string& txt, posit<nbits, es>& p) {
 		std::istringstream ss(txt);
 		double d;
 		ss >> d;
+		if (ss.fail()) return false;
+		ss >> std::ws;
+		if (!ss.eof()) return false;
 		p = d;
 		bSuccess = true;
 	}

--- a/include/sw/universal/number/posito/posito_impl.hpp
+++ b/include/sw/universal/number/posito/posito_impl.hpp
@@ -1415,9 +1415,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const posito<nbits, es>& p) 
 template<unsigned nbits, unsigned es>
 inline std::istream& operator>> (std::istream& istr, posito<nbits, es>& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, p)) {
 		std::cerr << "unable to parse -" << txt << "- into a posito value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/posito/posito_parse.hpp
+++ b/include/sw/universal/number/posito/posito_parse.hpp
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cctype>
 #include <iostream>
 #include <regex>
 #include <sstream>
+#include <string>
 #include <universal/number/posito/posito_fwd.hpp>
 
 namespace sw { namespace universal {
@@ -16,6 +18,22 @@ namespace sw { namespace universal {
 template<unsigned nbits, unsigned es>
 bool parse(std::string& txt, posito<nbits, es>& p) {
 	bool bSuccess = false;
+	// Detect nan / inf / infinity tokens (case-insensitive, optional sign)
+	// before the regex / stod path; posito has only a single NaR encoding
+	// for any non-finite, so all spellings collapse to setnar().
+	{
+		std::string t;
+		t.reserve(txt.size());
+		for (char c : txt) {
+			t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+		}
+		std::string body = t;
+		if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+		if (body == "nan" || body == "inf" || body == "infinity") {
+			p.setnar();
+			return true;
+		}
+	}
 	// check if the txt is of the native posit form: nbits.esXhexvalue
 	std::regex posit_regex("[\\d]+\\.[0123456789][xX][\\w]+[p]*");
 	if (std::regex_match(txt, posit_regex)) {
@@ -55,6 +73,9 @@ bool parse(std::string& txt, posito<nbits, es>& p) {
 		std::istringstream ss(txt);
 		double d;
 		ss >> d;
+		if (ss.fail()) return false;
+		ss >> std::ws;
+		if (!ss.eof()) return false;
 		p = d;
 		bSuccess = true;
 	}

--- a/include/sw/universal/number/unum/unum_impl.hpp
+++ b/include/sw/universal/number/unum/unum_impl.hpp
@@ -32,11 +32,13 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cassert>
+#include <cctype>
 #include <cstdint>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <limits>
+#include <string>
 
 #include <universal/native/ieee754.hpp>
 #include <universal/native/extract_fields.hpp>
@@ -558,6 +560,22 @@ inline std::ostream& operator<<(std::ostream& ostr, const unum<esizesize, fsizes
 // parse a unum from a decimal floating-point string
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 bool parse(const std::string& txt, unum<esizesize, fsizesize, bt>& v) {
+	// Detect nan / inf / infinity tokens (case-insensitive, optional sign).
+	// unum Type I has no Inf encoding -- inf tokens collapse to NaN, matching
+	// the existing operator=(double) behavior which also maps +/-inf to NaN.
+	{
+		std::string t;
+		t.reserve(txt.size());
+		for (char c : txt) {
+			t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+		}
+		std::string body = t;
+		if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+		if (body == "nan" || body == "inf" || body == "infinity") {
+			v.setnan();
+			return true;
+		}
+	}
 	std::istringstream ss(txt);
 	double d;
 	ss >> d;
@@ -571,9 +589,13 @@ bool parse(const std::string& txt, unum<esizesize, fsizesize, bt>& v) {
 template<unsigned esizesize, unsigned fsizesize, typename bt>
 inline std::istream& operator>>(std::istream& istr, unum<esizesize, fsizesize, bt>& v) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, v)) {
 		std::cerr << "unable to parse -" << txt << "- into a unum value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/static/float/bfloat16/conversion/string_parse.cpp
+++ b/static/float/bfloat16/conversion/string_parse.cpp
@@ -1,0 +1,141 @@
+// string_parse.cpp: regression tests for decimal-string parsing of bfloat16
+//                  (Phase D of #835 -- parse() implementation + API parity)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// Before Phase D, bfloat16::parse() was a stub that returned false and set
+// value to zero unconditionally. This test exercises the new implementation.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "bfloat16 decimal string parse (Phase D of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- canonical decimals match bfloat16(double) constructor -----
+	{
+		int start = nrOfFailedTestCases;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "0",       0.0     },
+			{ "1.0",     1.0     },
+			{ "-1.0",   -1.0     },
+			{ "1.5",     1.5     },
+			{ "-3.25",  -3.25    },
+			{ "0.5",     0.5     },
+			{ "2.0",     2.0     },
+			{ "1.25e3",  1250.0  },
+			{ "0.0625",  0.0625  },
+		};
+		for (const auto& c : cases) {
+			bfloat16 ours, ref(c.v);
+			if (!parse(c.s, ours)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
+				continue;
+			}
+			if (ours != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  mismatch on \"" << c.s << "\":\n"
+					          << "    string -> " << to_binary(ours) << '\n'
+					          << "    ref    -> " << to_binary(ref)  << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 canonical decimals\n";
+	}
+
+	// ----- nan / inf token routing -----
+	{
+		int start = nrOfFailedTestCases;
+		bfloat16 p;
+		for (const char* s : { "nan", "NaN", "+nan", "-nan" }) {
+			p = bfloat16(0.0);
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isnan())   ++nrOfFailedTestCases;
+		}
+		for (const char* s : { "inf", "Inf", "infinity", "INFINITY",
+		                       "+inf", "+Inf", "+infinity", "+INFINITY" }) {
+			p = bfloat16(0.0);
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isinf())   ++nrOfFailedTestCases;
+			if (p.sign())     ++nrOfFailedTestCases;  // positive
+		}
+		for (const char* s : { "-inf", "-Inf", "-infinity", "-INFINITY" }) {
+			p = bfloat16(0.0);
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isinf())   ++nrOfFailedTestCases;
+			if (!p.sign())    ++nrOfFailedTestCases;  // negative
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 nan/inf token routing\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		bfloat16 p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 operator>> failbit\n";
+	}
+
+	// ----- malformed decimal inputs are rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		bfloat16 p;
+		for (const char* s : { "1.5abc", "abc", "++1", "1.5e" }) {
+			if (parse(s, p)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  unexpectedly accepted: \"" << s << "\"\n";
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 malformed-input rejection\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/posit1/conversion/string_parse.cpp
+++ b/static/tapered/posit1/conversion/string_parse.cpp
@@ -1,0 +1,118 @@
+// string_parse.cpp: regression tests for decimal-string parsing of posit (posit1)
+//                  (Phase D of #835 -- API parity for the older posit revision)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/posit1/posit1.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "posit1 decimal string parse (Phase D of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- canonical decimals match constructor for small configs -----
+	{
+		int start = nrOfFailedTestCases;
+		using Posit = posit<32, 2>;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "0",       0.0     },
+			{ "1.0",     1.0     },
+			{ "-1.0",   -1.0     },
+			{ "1.5",     1.5     },
+			{ "-3.25",  -3.25    },
+			{ "0.5",     0.5     },
+			{ "1.25e3",  1250.0  },
+		};
+		for (const auto& c : cases) {
+			Posit ours, ref(c.v);
+			std::string s(c.s);
+			if (!parse(s, ours)) ++nrOfFailedTestCases;
+			if (ours != ref)     ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit1<32,2> canonical decimals\n";
+	}
+
+	// ----- nan / inf token routing to NaR -----
+	{
+		int start = nrOfFailedTestCases;
+		posit<32, 2> p;
+		for (const char* s : { "nan", "NaN", "+nan", "-nan",
+		                       "inf", "Inf", "infinity", "INFINITY",
+		                       "+inf", "-inf", "+infinity", "-infinity" }) {
+			std::string t(s);
+			p.setzero();
+			if (!parse(t, p)) ++nrOfFailedTestCases;
+			if (!p.isnar())   ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit1 nan/inf -> NaR routing\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		posit<32, 2> p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit1 operator>> failbit\n";
+	}
+
+	// ----- malformed decimal inputs are rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		posit<32, 2> p;
+		for (const char* s : { "1.5abc", "abc", "++1", "1.5e" }) {
+			std::string t(s);
+			if (parse(t, p)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  unexpectedly accepted: \"" << s << "\"\n";
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posit1 malformed-input rejection\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/posito/conversion/string_parse.cpp
+++ b/static/tapered/posito/conversion/string_parse.cpp
@@ -1,0 +1,118 @@
+// string_parse.cpp: regression tests for decimal-string parsing of posit (posito)
+//                  (Phase D of #835 -- API parity for the older posit revision)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/posito/posito.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "posito decimal string parse (Phase D of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- canonical decimals match constructor for small configs -----
+	{
+		int start = nrOfFailedTestCases;
+		using Posit = posito<32, 2>;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "0",       0.0     },
+			{ "1.0",     1.0     },
+			{ "-1.0",   -1.0     },
+			{ "1.5",     1.5     },
+			{ "-3.25",  -3.25    },
+			{ "0.5",     0.5     },
+			{ "1.25e3",  1250.0  },
+		};
+		for (const auto& c : cases) {
+			Posit ours, ref(c.v);
+			std::string s(c.s);
+			if (!parse(s, ours)) ++nrOfFailedTestCases;
+			if (ours != ref)     ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posito<32,2> canonical decimals\n";
+	}
+
+	// ----- nan / inf token routing to NaR -----
+	{
+		int start = nrOfFailedTestCases;
+		posito<32, 2> p;
+		for (const char* s : { "nan", "NaN", "+nan", "-nan",
+		                       "inf", "Inf", "infinity", "INFINITY",
+		                       "+inf", "-inf", "+infinity", "-infinity" }) {
+			std::string t(s);
+			p.setzero();
+			if (!parse(t, p)) ++nrOfFailedTestCases;
+			if (!p.isnar())   ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posito nan/inf -> NaR routing\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		posito<32, 2> p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posito operator>> failbit\n";
+	}
+
+	// ----- malformed decimal inputs are rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		posito<32, 2> p;
+		for (const char* s : { "1.5abc", "abc", "++1", "1.5e" }) {
+			std::string t(s);
+			if (parse(t, p)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  unexpectedly accepted: \"" << s << "\"\n";
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: posito malformed-input rejection\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Phase D wraps up the remaining specialized FP family. Four types covered (posit1, posito, unum, bfloat16); one (hfloat) explicitly deferred to a tracking issue.

## Changes

### posit1, posito (older posit revisions sharing posit_parse.hpp style)
- nan / inf / infinity token detection (case-insensitive, optional sign). All non-finite spellings route to `setnar()` since posit has only one NaR encoding -- same convention as the current posit B2b path.
- Fix **latent bug**: stod fallback was returning `bSuccess=true` even when `istringstream` extraction failed. Now properly checks `ss.fail()` and trailing-junk via `!ss.eof()`.
- `operator>>`: extraction guard (return if `istr >> txt` fails) + `setstate(failbit)` on parse failure.

### unum (Type I)
- nan / inf / infinity token detection. unum has no Inf encoding, so inf tokens collapse to NaN -- matching the existing `operator=(double)` behavior that also maps +/-inf to NaN.
- `operator>>`: extraction guard + failbit.

### bfloat16
- **Implement `parse()`**. Previous body was a stub that returned false and set value to zero, ignoring input. New implementation:
  - nan / inf / infinity token routing to `setnan` / `setinf`
  - `std::istringstream` -> double fallback for decimal (bfloat16 has only 7 explicit mantissa bits; double precision is way more than enough)
  - `ss.fail()` and `!ss.eof()` guards reject malformed input
- `operator>>`: extraction guard + failbit.

### Tests (4 new files, ReportTestSuite pattern)
| Type | Test file |
|------|-----------|
| posit1   | \`static/tapered/posit1/conversion/string_parse.cpp\` |
| posito   | \`static/tapered/posito/conversion/string_parse.cpp\` |
| bfloat16 | \`static/float/bfloat16/conversion/string_parse.cpp\`  |
| unum     | \`elastic/unum/string_parse.cpp\`                      |

Each covers: canonical decimals, nan/inf token routing, `operator>>` failbit, malformed-input rejection.

## Not in this PR

hfloat. Its `parse()` is a stub like bfloat16's was, but the hfloat encoding (sign + biased hex exponent + ndigits hex fraction digits with truncation rounding) requires a substantial new conversion pipeline. Filed as #849.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| posit1_string_parse   | OK | PASS | OK | PASS |
| posito_string_parse   | OK | PASS | OK | PASS |
| bfloat16_string_parse | OK | PASS | OK | PASS |
| unum1_string_parse    | OK | PASS | OK | PASS |
| posit1_api            | OK | PASS | OK | PASS |
| posito_api            | OK | PASS | OK | PASS |
| bfloat16_api          | OK | PASS | OK | PASS |
| unum1_api             | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced decimal-string parsing for unum, bfloat16, posit1, and posito numeric types with recognition of NaN/Inf tokens (case-insensitive, with optional signs).

* **Bug Fixes**
  * Improved stream extraction failure handling and error reporting.
  * Stricter validation of malformed decimal strings.

* **Tests**
  * Added comprehensive regression test suites for string parsing across all numeric types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->