### PR TITLE
feat: exact d2b-based decimal parse via distillation for dd, qd, floatcascade

### DIFF
--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -8,14 +8,18 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
 // supporting types and functions
 #include <universal/utility/bit_cast.hpp>
+#include <universal/utility/decimal_to_binary.hpp>
 #include <universal/native/ieee754.hpp>
 #include <universal/numerics/error_free_ops.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
@@ -1769,92 +1773,30 @@ bool floatcascade<N>::parse(const std::string& number) {
     const char* p = number.c_str();
 
     // Skip any leading spaces
-    while (std::isspace(*p)) ++p;
+    while (std::isspace(static_cast<unsigned char>(*p))) ++p;
 
-    floatcascade<N> r;  // result accumulator
-    for (size_t i = 0; i < N; ++i) r[i] = 0.0;
+    // Route the decimal payload through decimal_to_binary + distill<N> for
+    // bit-exact correctly-rounded N-component cascade conversion. See
+    // issue #848. This replaces the legacy `r *= pown(10, exp)` step,
+    // which accumulated ULP-level error for large |exp|.
+    std::string_view payload(p);
+    auto d = ::sw::universal::decimal_to_binary::convert(
+        payload, static_cast<unsigned>(53u * N + 20u));
+    if (!d.valid) return false;
 
-    int nrDigits = 0;
-    int decimalPoint = -1;
-    int sign = 0, eSign = 1;
-    int exp = 0;
-    bool done = false, parsingMantissa = true;
-    char ch;
-
-    while (!done && (ch = *p) != '\0') {
-        if (std::isdigit(ch)) {
-            if (parsingMantissa) {
-                int digit = ch - '0';
-                r *= 10.0;
-                r += static_cast<double>(digit);
-                ++nrDigits;
-            }
-            else {
-                // parsing exponent section
-                int digit = ch - '0';
-                exp *= 10;
-                exp += digit;
-            }
-        }
-        else {
-            switch (ch) {
-            case '.':
-                if (decimalPoint >= 0) return false;  // multiple decimal points
-                decimalPoint = nrDigits;
-                break;
-
-            case '-':
-            case '+':
-                if (parsingMantissa) {
-                    if (sign != 0 || nrDigits > 0) return false;  // sign in wrong place
-                    sign = (ch == '-' ? -1 : 1);
-                }
-                else {
-                    eSign = (ch == '-' ? -1 : 1);
-                }
-                break;
-
-            case 'E':
-            case 'e':
-                parsingMantissa = false;
-                break;
-
-            default:
-                return false;  // invalid character
-            }
-        }
-
-        ++p;
+    if (d.is_zero) {
+        for (size_t i = 0; i < N; ++i) (*this)[i] = 0.0;
+        return true;
     }
 
-    // Reject inputs that produced zero mantissa digits (e.g. "", "   ",
-    // "+", ".", "e10"). Without this check the loop completes cleanly
-    // and returns 0, silently accepting malformed input.
-    if (nrDigits == 0) return false;
-
-    exp *= eSign;
-
-    // Adjust exponent based on decimal point position
-    if (decimalPoint >= 0) exp -= (nrDigits - decimalPoint);
-
-    // Apply exponent using power of 10
-    floatcascade<N> ten(10.0);
-    if (exp > 0) {
-        r *= pown(ten, exp);
-    }
-    else if (exp < 0) {
-        r /= pown(ten, -exp);
-    }
-
-    // Apply sign
-    if (sign == -1) {
-        for (size_t i = 0; i < N; ++i) {
-            r[i] = -r[i];
-        }
-    }
-
-    // Copy result to this
-    *this = r;
+    // Stack array of N doubles for distill output.
+    // distill takes a reference-to-array; size matches floatcascade<N>.
+    double comp[N];
+    for (size_t i = 0; i < N; ++i) comp[i] = 0.0;
+    ::sw::universal::decimal_to_binary::distill<
+        ::sw::universal::decimal_to_binary::default_big_bits,
+        static_cast<unsigned>(N)>(d, comp);
+    for (size_t i = 0; i < N; ++i) (*this)[i] = comp[i];
     return true;
 }
 

--- a/include/sw/universal/number/dd/dd_impl.hpp
+++ b/include/sw/universal/number/dd/dd_impl.hpp
@@ -13,6 +13,7 @@
 #include <cctype>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <iostream>
 #include <iomanip>
@@ -24,6 +25,7 @@
 
 // supporting types and functions
 #include <universal/utility/bit_cast.hpp>
+#include <universal/utility/decimal_to_binary.hpp>
 #include <universal/native/ieee754.hpp>
 #include <universal/numerics/error_free_ops.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
@@ -1433,72 +1435,20 @@ inline bool parse(const std::string& number, dd& value) {
 		}
 	}
 
-	dd r{ 0.0 };
-	int nrDigits{ 0 };
-	int decimalPoint{ -1 };
-	int sign{ 0 }, eSign{ 1 };
-	int e{ 0 };
-	bool done{ false }, parsingMantissa{ true };
-	char ch;
-	while (!done && (ch = *p) != '\0') {
-		if (std::isdigit(ch)) {
-			if (parsingMantissa) {
-				int digit = ch - '0';
-				r *= 10.0;
-				r += static_cast<double>(digit);
-				++nrDigits;
-			}
-			else { // parsing exponent section
-				int digit = ch - '0';
-				e *= 10;
-				e += digit;
-			}
-		}
-		else {
-			switch (ch) {
-			case '.':
-				if (decimalPoint >= 0) return false;
-				decimalPoint = nrDigits;
-				break;
-
-			case '-':
-			case '+':
-				if (parsingMantissa) {
-					if (sign != 0 || nrDigits > 0) return false;
-					sign = (ch == '-' ? -1 : 1);
-				}
-				else {
-					eSign = (ch == '-' ? -1 : 1);
-				}
-				break;
-
-			case 'E':
-			case 'e':
-				parsingMantissa = false;
-				break;
-
-			default:
-				return false;
-			}
-		}
-
-		++p;
+	// Route the decimal payload through decimal_to_binary + distill to get
+	// bit-exact correctly-rounded (hi, lo). This closes the residual ULP
+	// gap that the legacy `r *= pown(10, e)` exponent step accumulated for
+	// large |e|. See issue #848.
+	std::string_view payload(p);
+	auto d = ::sw::universal::decimal_to_binary::convert(payload, 53u * 2u + 20u);
+	if (!d.valid) return false;
+	if (d.is_zero) {
+		value = dd(0.0, 0.0);
+		return true;
 	}
-	// Reject inputs that produced zero mantissa digits (e.g. "", "   ",
-	// "+", ".", "e10"). Without this check the loop completes cleanly
-	// and returns 0, silently accepting malformed input.
-	if (nrDigits == 0) return false;
-	e *= eSign;
-
-	if (decimalPoint >= 0) e -= (nrDigits - decimalPoint);
-	dd _ten(10.0, 0.0);
-	if (e > 0) {
-		r *= pown(_ten, e);
-	}
-	else {
-		if (e < 0) r /= pown(_ten, -e);
-	}
-	value = (sign == -1) ? -r : r;
+	double hi_lo[2] = {0.0, 0.0};
+	::sw::universal::decimal_to_binary::distill(d, hi_lo);
+	value = dd(hi_lo[0], hi_lo[1]);
 	return true;
 }
 

--- a/include/sw/universal/number/qd/qd_impl.hpp
+++ b/include/sw/universal/number/qd/qd_impl.hpp
@@ -13,6 +13,7 @@
 #include <cctype>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <iostream>
 #include <iomanip>
@@ -24,6 +25,7 @@
 
 // supporting types and functions
 #include <universal/utility/bit_cast.hpp>
+#include <universal/utility/decimal_to_binary.hpp>
 #include <universal/native/ieee754.hpp>
 #include <universal/numerics/error_free_ops.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
@@ -1696,72 +1698,18 @@ inline bool parse(const std::string& number, qd& value) {
 		}
 	}
 
-	qd r{ 0.0 };
-	int nrDigits{ 0 };
-	int decimalPoint{ -1 };
-	int sign{ 0 }, eSign{ 1 };
-	int e{ 0 };
-	bool done{ false }, parsingMantissa{ true };
-	char ch;
-	while (!done && (ch = *p) != '\0') {
-		if (std::isdigit(ch)) {
-			if (parsingMantissa) {
-				int digit = ch - '0';
-				r *= 10.0;
-				r += static_cast<double>(digit);
-				++nrDigits;
-			}
-			else { // parsing exponent section
-				int digit = ch - '0';
-				e *= 10;
-				e += digit;
-			}
-		}
-		else {
-			switch (ch) {
-			case '.':
-				if (decimalPoint >= 0) return false;
-				decimalPoint = nrDigits;
-				break;
-
-			case '-':
-			case '+':
-				if (parsingMantissa) {
-					if (sign != 0 || nrDigits > 0) return false;
-					sign = (ch == '-' ? -1 : 1);
-				}
-				else {
-					eSign = (ch == '-' ? -1 : 1);
-				}
-				break;
-
-			case 'E':
-			case 'e':
-				parsingMantissa = false;
-				break;
-
-			default:
-				return false;
-			}
-		}
-
-		++p;
+	// Route the decimal payload through decimal_to_binary + distill<4> for
+	// bit-exact correctly-rounded quad-double conversion. See issue #848.
+	std::string_view payload(p);
+	auto d = ::sw::universal::decimal_to_binary::convert(payload, 53u * 4u + 20u);
+	if (!d.valid) return false;
+	if (d.is_zero) {
+		value = qd(0.0, 0.0, 0.0, 0.0);
+		return true;
 	}
-	// Reject inputs that produced zero mantissa digits (e.g. "", "   ",
-	// "+", ".", "e10"). Without this check the loop completes cleanly
-	// and returns 0, silently accepting malformed input.
-	if (nrDigits == 0) return false;
-	e *= eSign;
-
-	if (decimalPoint >= 0) e -= (nrDigits - decimalPoint);
-	qd _ten(10.0, 0.0);
-	if (e > 0) {
-		r *= pown(_ten, e);
-	}
-	else {
-		if (e < 0) r /= pown(_ten, -e);
-	}
-	value = (sign == -1) ? -r : r;
+	double comp[4] = {0.0, 0.0, 0.0, 0.0};
+	::sw::universal::decimal_to_binary::distill(d, comp);
+	value = qd(comp[0], comp[1], comp[2], comp[3]);
 	return true;
 }
 

--- a/include/sw/universal/utility/decimal_to_binary.hpp
+++ b/include/sw/universal/utility/decimal_to_binary.hpp
@@ -384,18 +384,44 @@ inline void distill(const basic_result<BigBits>& d, double (&out)[N]) {
 		}
 
 		// Construct the component as chunk * 2^(lsb_weight + extract_lo).
-		const int exp_ldexp = static_cast<int>(lsb_weight + extract_lo);
-		double comp = std::ldexp(static_cast<double>(chunk), exp_ldexp);
+		// Clamp the std::ldexp exponent to the int range. For all realistic
+		// inputs (|decimal exponent| <= ~308 for IEEE-double-range values)
+		// the sum stays well within int, but defending against the extreme
+		// case keeps the cast safe under any caller's target_mantissa_bits.
+		const std::int64_t exp_check = lsb_weight + static_cast<std::int64_t>(extract_lo);
+		double comp;
+		{
+			constexpr std::int64_t INT_MAX_V = static_cast<std::int64_t>((std::numeric_limits<int>::max)());
+			constexpr std::int64_t INT_MIN_V = static_cast<std::int64_t>((std::numeric_limits<int>::min)());
+			if (exp_check > INT_MAX_V) {
+				comp = std::numeric_limits<double>::infinity();
+			} else if (exp_check < INT_MIN_V) {
+				comp = 0.0;
+			} else {
+				comp = std::ldexp(static_cast<double>(chunk), static_cast<int>(exp_check));
+			}
+		}
 		if (neg) comp = -comp;
 		out[i] = comp;
 
-		// Subtract the rounded value from rem exactly.
+		// Subtract the rounded value from rem exactly. Skip the subtraction
+		// if any bit position would exceed the bigint's storage; this only
+		// triggers when chunk overflow during round-up pushed the MSB past
+		// BigBits-1, which means subsequent components were going to be
+		// dominated by an already-saturating value anyway.
 		Big sub_val(0);
+		bool out_of_range = false;
 		for (int k = 0; k < 64; ++k) {
 			if (chunk & (std::uint64_t{1} << k)) {
-				sub_val.setbit(static_cast<unsigned>(extract_lo + k), true);
+				const std::int64_t bit_idx = static_cast<std::int64_t>(extract_lo) + k;
+				if (bit_idx < 0 || bit_idx >= static_cast<std::int64_t>(BigBits)) {
+					out_of_range = true;
+					break;
+				}
+				sub_val.setbit(static_cast<unsigned>(bit_idx), true);
 			}
 		}
+		if (out_of_range) return;  // further components would be zero anyway
 		if (neg) sub_val = -sub_val;
 		rem -= sub_val;
 	}

--- a/include/sw/universal/utility/decimal_to_binary.hpp
+++ b/include/sw/universal/utility/decimal_to_binary.hpp
@@ -59,6 +59,7 @@
 // - "inf" / "nan" string literals are NOT handled here. Callers route them
 //   separately if they want stream-extraction parity with native floats.
 
+#include <cmath>     // std::ldexp
 #include <cstdint>
 #include <string_view>
 #include <universal/utility/string_parse.hpp>
@@ -274,6 +275,130 @@ convert(std::string_view s, unsigned target_mantissa_bits) {
 		return out;
 	}
 	return convert<BigBits>(scan, target_mantissa_bits);
+}
+
+// ---------------------------------------------------------------------------
+// distill: split a d2b conversion into N IEEE-754 doubles.
+// ---------------------------------------------------------------------------
+//
+// Given a d2b conversion result (sign + bigint mantissa + binary_scale +
+// guard/sticky), produces N doubles `out[0..N-1]` forming a canonical
+// non-overlapping expansion whose sum equals the parsed value (rounded to
+// the cumulative precision of the cascade, using round-to-nearest-even at
+// each step).
+//
+// This is the bit-exact conversion path used by dd / qd / floatcascade
+// parse() routines. It replaces the legacy `r *= pown(10, e)` step, whose
+// pown computation accumulates ULP-level error for large |e|.
+//
+// Preconditions:
+//   - d.valid == true (caller must check)
+//   - convert() was called with target_mantissa_bits >= 53 * N + 10
+//     so the bigint mantissa has enough explicit bits to feed N rounds
+//     plus headroom for round/sticky. distill itself doesn't enforce this;
+//     callers select target_mantissa_bits when calling convert().
+//
+// Postconditions:
+//   - When d.is_zero: out[0..N-1] are all 0.0.
+//   - Otherwise: out[0] is the round-to-nearest-double of the full value;
+//     out[1] is the round-to-nearest-double of the residual; ...
+//     out[N-1] is the round-to-nearest-double of the deepest residual.
+//     Each out[i+1] is either 0 or satisfies |out[i+1]| <= ulp(out[i]) / 2.
+//   - Components after the value has been exactly expressed are 0.0.
+//
+// Internal representation: we work with a SIGNED bigint residual. After
+// each round-up at extraction, the residual can flip sign briefly; the
+// next iteration's component then takes the opposite sign. This is the
+// standard cascade canonicalization invariant.
+template<unsigned BigBits, unsigned N>
+inline void distill(const basic_result<BigBits>& d, double (&out)[N]) {
+	for (unsigned i = 0; i < N; ++i) out[i] = 0.0;
+	if (d.is_zero) return;
+	using Big = big_integer<BigBits>;
+
+	// Find MSB position of the magnitude mantissa to anchor the binary scale.
+	// The d2b normalization places the mantissa MSB at the bit position that
+	// has weight 2^binary_scale.
+	int top_msb = -1;
+	for (int i = static_cast<int>(BigBits) - 1; i >= 0; --i) {
+		if (d.mantissa.at(static_cast<unsigned>(i))) { top_msb = i; break; }
+	}
+	if (top_msb < 0) return;  // is_zero should have caught this
+
+	// mantissa.bit[k] has weight 2^(binary_scale - top_msb + k).
+	const std::int64_t lsb_weight = d.binary_scale - static_cast<std::int64_t>(top_msb);
+
+	// Initialize residual as the signed bigint magnitude.
+	Big rem = d.mantissa;
+	if (d.negative) rem = -rem;
+
+	const Big zero(0);
+
+	for (unsigned i = 0; i < N; ++i) {
+		// Magnitude + sign of the current residual.
+		bool neg = (rem < zero);
+		Big abs_rem = neg ? -rem : rem;
+		int msb = -1;
+		for (int k = static_cast<int>(BigBits) - 1; k >= 0; --k) {
+			if (abs_rem.at(static_cast<unsigned>(k))) { msb = k; break; }
+		}
+		if (msb < 0) return;  // residual is exactly zero -- remaining out[] stay 0.0
+
+		// Extract top up-to-53 bits of abs_rem at positions [extract_lo, msb].
+		int extract_lo = (msb >= 52) ? (msb - 52) : 0;
+		const int chunk_bits = msb - extract_lo + 1;  // in [1, 53]
+		std::uint64_t chunk = 0;
+		for (int k = 0; k < chunk_bits; ++k) {
+			if (abs_rem.at(static_cast<unsigned>(extract_lo + k))) {
+				chunk |= (std::uint64_t{1} << k);
+			}
+		}
+
+		// Round-to-nearest-even: round_bit is the bit just below the cut;
+		// sticky is the OR of all bits further below (in the bigint).
+		bool round_bit = (extract_lo > 0)
+			? abs_rem.at(static_cast<unsigned>(extract_lo - 1))
+			: false;
+		bool sticky = false;
+		for (int k = 0; k < extract_lo - 1; ++k) {
+			if (abs_rem.at(static_cast<unsigned>(k))) { sticky = true; break; }
+		}
+		// On the first iteration the d2b residual guard/sticky bits live
+		// logically BELOW position 0 in the bigint, so they only contribute
+		// to sticky. Subsequent iterations track the exact integer residual
+		// and the d2b guard/sticky are already discarded -- they're
+		// captured by whether the previous round-up flipped rem's sign.
+		if (i == 0) {
+			sticky = sticky || d.guard_bit || d.sticky_bit;
+		}
+		const bool lsb_set = (chunk & 1u) != 0;
+		const bool round_up = round_bit && (sticky || lsb_set);
+		if (round_up) {
+			++chunk;
+			if (chunk == (std::uint64_t{1} << 53)) {
+				// Mantissa overflowed: renormalize to 1.0 * 2^(exp+1).
+				chunk = std::uint64_t{1} << 52;
+				++msb;
+				++extract_lo;
+			}
+		}
+
+		// Construct the component as chunk * 2^(lsb_weight + extract_lo).
+		const int exp_ldexp = static_cast<int>(lsb_weight + extract_lo);
+		double comp = std::ldexp(static_cast<double>(chunk), exp_ldexp);
+		if (neg) comp = -comp;
+		out[i] = comp;
+
+		// Subtract the rounded value from rem exactly.
+		Big sub_val(0);
+		for (int k = 0; k < 64; ++k) {
+			if (chunk & (std::uint64_t{1} << k)) {
+				sub_val.setbit(static_cast<unsigned>(extract_lo + k), true);
+			}
+		}
+		if (neg) sub_val = -sub_val;
+		rem -= sub_val;
+	}
 }
 
 }}}  // namespace sw::universal::decimal_to_binary

--- a/static/highprecision/dd/conversion/string_parse.cpp
+++ b/static/highprecision/dd/conversion/string_parse.cpp
@@ -101,6 +101,36 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dd nan/inf token routing\n";
 	}
 
+	// ----- large-|e| precision: hi component matches std::stod (round-to-double)
+	//       for exponents where the legacy pown(10,e) path accumulated visible
+	//       ULP error. Post-#848 the hi component is bit-exact round-to-nearest
+	//       regardless of |e|. -----
+	{
+		int start = nrOfFailedTestCases;
+		const char* cases[] = {
+			"1.0e100",
+			"1.0e200",
+			"1.0e300",
+			"3.141592653589793e150",
+			"-2.718281828459045e-200",
+			"1.7976931348623157e308",   // near max double
+			"2.2250738585072014e-308",  // near min normal double
+		};
+		for (const char* s : cases) {
+			dd p;
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			double ref = std::stod(s);
+			if (p.high() != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  hi != stod for \"" << s << "\": got "
+					          << p.high() << " stod=" << ref << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dd large-|e| hi matches stod (issue #848)\n";
+	}
+
 	// ----- parse rejects malformed inputs that produce no mantissa digits -----
 	{
 		int start = nrOfFailedTestCases;

--- a/static/utility/test_distill.cpp
+++ b/static/utility/test_distill.cpp
@@ -1,0 +1,218 @@
+// test_distill.cpp: unit tests for decimal_to_binary::distill<N>
+//                  (issue #848 -- exact decimal-to-(hi,lo,...) conversion)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// distill produces a canonical non-overlapping IEEE-754 expansion equivalent
+// to the original parsed value. The invariants checked here are:
+//   - Sum of components reconstructs the value (within target precision)
+//   - Components are canonical: |out[i+1]| <= ulp(out[i]) / 2 (or zero)
+//   - Exact-in-double inputs yield a single non-zero component and zeros
+//   - Sign handling for both positive and negative input
+
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <universal/utility/decimal_to_binary.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace d2b = sw::universal::decimal_to_binary;
+
+namespace {
+
+// |out[i+1]| <= ulp(out[i]) / 2 -- canonical cascade invariant.
+// Implemented via std::ldexp(0.5, exponent_of(out[i])) bound.
+bool canonical_cascade(const double* arr, unsigned n) {
+	for (unsigned i = 0; i + 1 < n; ++i) {
+		if (arr[i] == 0.0) {
+			if (arr[i + 1] != 0.0) return false;
+			continue;
+		}
+		int e;
+		std::frexp(arr[i], &e);  // arr[i] = (mantissa in [0.5, 1)) * 2^e
+		// ulp(arr[i]) = 2^(e - 53) for normal doubles (53-bit significand including hidden)
+		// |arr[i+1]| <= 2^(e - 53) / 2 = 2^(e - 54)
+		double limit = std::ldexp(1.0, e - 54);
+		if (std::fabs(arr[i + 1]) > limit) return false;
+	}
+	return true;
+}
+
+}  // namespace
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite  = "decimal_to_binary::distill (issue #848)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- exact-in-double inputs distill to one component + zeros -----
+	{
+		int start = nrOfFailedTestCases;
+		struct Case { const char* s; double v; };
+		Case cases[] = {
+			{ "0",     0.0   },
+			{ "1.0",   1.0   },
+			{ "-1.0", -1.0   },
+			{ "0.5",   0.5   },
+			{ "2.0",   2.0   },
+			{ "1.5",   1.5   },
+			{ "1024",  1024.0 },
+		};
+		for (const auto& c : cases) {
+			auto r = d2b::convert(c.s, 64);
+			double out[4] = {0, 0, 0, 0};
+			d2b::distill(r, out);
+			if (out[0] != c.v) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  exact-in-double \"" << c.s << "\": got " << out[0]
+					          << " expected " << c.v << '\n';
+				}
+				continue;
+			}
+			if (out[1] != 0.0 || out[2] != 0.0 || out[3] != 0.0) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  exact-in-double \"" << c.s
+					          << "\": expected residuals all zero, got "
+					          << out[1] << " / " << out[2] << " / " << out[3] << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: exact-in-double cases\n";
+	}
+
+	// ----- 0.1 (non-terminating binary): N=2 distillation matches double -----
+	// double(0.1) is a specific rounded value; out[0] should equal it; out[1]
+	// captures the residual (could be small positive or negative). Sum
+	// reconstructs the parsed value to within target precision.
+	{
+		int start = nrOfFailedTestCases;
+		auto r = d2b::convert("0.1", 64);
+		double out[2] = {0, 0};
+		d2b::distill(r, out);
+		if (out[0] != 0.1) {
+			++nrOfFailedTestCases;
+			if (reportTestCases) {
+				std::cout << "  0.1 hi mismatch: got " << out[0] << " expected 0.1\n";
+			}
+		}
+		if (!canonical_cascade(out, 2)) {
+			++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "  0.1 cascade not canonical\n";
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: 0.1 N=2 distillation\n";
+	}
+
+	// ----- 3.141592653589793 (16 decimal digits): N=3 distillation -----
+	// hi should be the IEEE double of pi; the residual captures the trailing
+	// bits beyond double's 52-bit mantissa.
+	{
+		int start = nrOfFailedTestCases;
+		auto r = d2b::convert("3.141592653589793238462643383279502884197", 256);
+		double out[3] = {0, 0, 0};
+		d2b::distill(r, out);
+		// out[0] is round-to-nearest-double of full pi expansion
+		double pi_double = 0;
+		{
+			// Build pi_double from its standard bit pattern.
+			std::uint64_t pi_bits = 0x400921FB54442D18ULL;
+			std::memcpy(&pi_double, &pi_bits, sizeof(double));
+		}
+		if (out[0] != pi_double) {
+			++nrOfFailedTestCases;
+			if (reportTestCases) {
+				std::cout << "  pi hi mismatch: got " << out[0] << '\n';
+			}
+		}
+		if (!canonical_cascade(out, 3)) {
+			++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "  pi cascade not canonical\n";
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: pi N=3 distillation\n";
+	}
+
+	// ----- canonical-cascade invariant under many representative inputs -----
+	{
+		int start = nrOfFailedTestCases;
+		const char* cases[] = {
+			"1.0", "2.0", "0.5", "0.1", "0.2", "0.3",
+			"1.25e3", "1e10", "1e-10", "1.5e100", "1.5e-100",
+			"3.14159265358979323846", "-2.71828182845904523536",
+			"1.7976931348623157e308",  // near max double
+			"2.2250738585072014e-308", // near min normal
+		};
+		for (const char* s : cases) {
+			auto r = d2b::convert(s, 256);
+			if (!r.valid) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  parse failed: " << s << '\n';
+				continue;
+			}
+			double out2[2] = {0, 0};
+			double out3[3] = {0, 0, 0};
+			double out4[4] = {0, 0, 0, 0};
+			d2b::distill(r, out2);
+			d2b::distill(r, out3);
+			d2b::distill(r, out4);
+			if (!canonical_cascade(out2, 2)
+			 || !canonical_cascade(out3, 3)
+			 || !canonical_cascade(out4, 4)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  cascade not canonical: " << s << '\n';
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: canonical-cascade invariant\n";
+	}
+
+	// ----- hi component agrees with std::stod for in-range inputs -----
+	// stod gives a single round-to-nearest-double. distill[0] should match.
+	{
+		int start = nrOfFailedTestCases;
+		const char* cases[] = {
+			"1.0", "2.0", "0.5", "0.1", "0.2", "0.3", "3.14",
+			"1.25e3", "1e10", "1e-10", "1e100", "1e-100",
+			"3.141592653589793",
+			"-2.5", "-0.625",
+		};
+		for (const char* s : cases) {
+			auto r = d2b::convert(s, 256);
+			double out[4] = {0, 0, 0, 0};
+			d2b::distill(r, out);
+			double ref = std::stod(s);
+			if (out[0] != ref) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  stod oracle mismatch \"" << s << "\": got "
+					          << out[0] << " stod=" << ref << '\n';
+				}
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: stod oracle agreement\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/utility/test_distill.cpp
+++ b/static/utility/test_distill.cpp
@@ -68,8 +68,10 @@ try {
 			{ "1.5",   1.5   },
 			{ "1024",  1024.0 },
 		};
+		// 256-bit target satisfies distill's documented precondition of
+		// target_mantissa_bits >= 53 * N + 10 for N=4.
 		for (const auto& c : cases) {
-			auto r = d2b::convert(c.s, 64);
+			auto r = d2b::convert(c.s, 256);
 			double out[4] = {0, 0, 0, 0};
 			d2b::distill(r, out);
 			if (out[0] != c.v) {


### PR DESCRIPTION
## Summary

Replace the legacy \`r *= pown(10, e)\` decimal-exponent step in \`dd::parse\`, \`qd::parse\`, and \`floatcascade<N>::parse\` with an exact route through \`decimal_to_binary\`, distilled into N IEEE-754 doubles forming a canonical non-overlapping cascade. Closes the residual ULP-level error the pown path accumulated for large \`|e|\`.

## New utility

\`include/sw/universal/utility/decimal_to_binary.hpp\` gains \`distill<N>(result, double[N])\`:
- Tracks a **signed** bigint residual (allows round-up to flip sign; next component compensates)
- For each iteration:
  1. find MSB of residual
  2. extract top 53 bits with round-to-nearest-even (uses bigint sticky)
  3. convert to double via \`std::ldexp\`
  4. subtract back exactly from the residual
- Cascade canonicality: \`|out[i+1]| <= ulp(out[i]) / 2\` by construction
- Caller chooses \`target_mantissa_bits\` when calling \`convert()\` to give distill enough explicit bigint precision (\`53*N + 20\` is sufficient)

## Migrations

| Type | Path | Distill width |
|------|------|---------------|
| \`dd::parse\`               | \`d2b::convert(payload, 126)\` -> \`distill<2>\` -> \`dd(hi, lo)\`             | 2 components |
| \`qd::parse\`               | \`d2b::convert(payload, 232)\` -> \`distill<4>\` -> \`qd(x0, x1, x2, x3)\`     | 4 components |
| \`floatcascade<N>::parse\`  | \`d2b::convert(payload, 53*N + 20)\` -> \`distill<N>\` -> componentwise assign | N components (dd_cascade=2, td_cascade=3, qd_cascade=4) |

\`nan\` / \`inf\` / \`infinity\` token routing is preserved; \`operator>>\` failbit unchanged.

## Tests

**New**: \`static/utility/test_distill.cpp\`
- Exact-in-double inputs produce single component + zeros
- 0.1 cascade matches \`double(0.1)\`
- pi cascade matches the standard pi-bit pattern at hi
- Canonical-cascade invariant verified across 14 representative inputs
- stod oracle agreement for the hi component over 15 cases

**Modified**: \`static/highprecision/dd/conversion/string_parse.cpp\` gains a large-\`|e|\` group that verifies \`p.high() == std::stod(s)\` for \`|e|\` up to 308 (near double's range limits). These cases would expose pown-accumulated drift on the legacy path.

**Existing tests**: all 5 string_parse + 5 api_api regressions still PASS.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| utility_test_distill   | OK | PASS | OK | PASS |
| dd_conv_string_parse   | OK | PASS | OK | PASS |
| qd_conv_string_parse   | OK | PASS | OK | PASS |
| ddc_conv_string_parse  | OK | PASS | OK | PASS |
| tdc_conv_string_parse  | OK | PASS | OK | PASS |
| qdc_conv_string_parse  | OK | PASS | OK | PASS |
| dd_api_api             | OK | PASS | OK | PASS |
| qd_api_api             | OK | PASS | OK | PASS |
| ddc_api_api            | OK | PASS | OK | PASS |
| tdc_api_api            | OK | PASS | OK | PASS |
| qdc_api_api            | OK | PASS | OK | PASS |

## Implementation notes

- The signed-bigint residual is what made canonical-cascade output natural: after round-up at iteration i, the residual flips sign and the next component is negative, which is exactly what cascades require.
- \`integer<2048, uint32_t, IntegerNumberType::IntegerNumber>\` supports negation, subtraction, and \`operator<\` against another \`integer\`, so the residual-tracking math works out of the box.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Resolves #848

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a decimal-to-binary distillation pipeline to produce precise multi-component floating-point cascades.

* **Bug Fixes**
  * Reworked decimal string parsing to use the new conversion pipeline, improving accuracy and robustness for large exponents, zeros, and invalid inputs.

* **Tests**
  * Added regression and unit tests covering decimal parsing and cascade distillation across multiple precisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->