### PR TITLE
feat: operator>> hygiene + ereal nan/inf for decimal/elastic family (Phase E of #835)

### DIFF
--- a/elastic/decimal/conversion/string_parse.cpp
+++ b/elastic/decimal/conversion/string_parse.cpp
@@ -1,0 +1,80 @@
+// string_parse.cpp: regression tests for decimal-string parsing of edecimal
+//                  (Phase E of #835 -- operator>> hygiene)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// edecimal::parse currently accepts only integer-format input. Phase E ships
+// operator>> hygiene only; extension to decimal/scientific notation is
+// tracked in issue #854.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/edecimal/edecimal.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "edecimal decimal string parse (Phase E of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- integer-format inputs (existing parse path) -----
+	{
+		int start = nrOfFailedTestCases;
+		edecimal p;
+		if (!p.parse("0"))      ++nrOfFailedTestCases;
+		if (!p.parse("42"))     ++nrOfFailedTestCases;
+		if (!p.parse("-1000"))  ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: edecimal canonical integer parse\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		edecimal p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: edecimal operator>> failbit\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/elastic/decimal/conversion/string_parse.cpp
+++ b/elastic/decimal/conversion/string_parse.cpp
@@ -40,13 +40,13 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// ----- integer-format inputs (existing parse path) -----
+	// ----- integer-format inputs: assert parsed value, not just success -----
 	{
 		int start = nrOfFailedTestCases;
 		edecimal p;
-		if (!p.parse("0"))      ++nrOfFailedTestCases;
-		if (!p.parse("42"))     ++nrOfFailedTestCases;
-		if (!p.parse("-1000"))  ++nrOfFailedTestCases;
+		if (!p.parse("0")     || p != edecimal(0))     ++nrOfFailedTestCases;
+		if (!p.parse("42")    || p != edecimal(42))    ++nrOfFailedTestCases;
+		if (!p.parse("-1000") || p != edecimal(-1000)) ++nrOfFailedTestCases;
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: edecimal canonical integer parse\n";
 	}
 

--- a/elastic/efloat/conversion/string_parse.cpp
+++ b/elastic/efloat/conversion/string_parse.cpp
@@ -1,0 +1,89 @@
+// string_parse.cpp: regression tests for decimal-string parsing of efloat
+//                  (Phase E of #835 -- operator>> hygiene only)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// efloat::parse is currently a stub that returns false unconditionally.
+// Phase E adds operator>> hygiene only: when parse() returns false, the
+// stream's failbit is now set (instead of just a cerr diagnostic).
+// Full parse() implementation is tracked in issue #856.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+	using Float = efloat<4>;
+
+	std::string test_suite  = "efloat decimal string parse (Phase E of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- operator>> sets failbit when parse() returns false. Since
+	//       efloat::parse is currently a stub that always returns false,
+	//       any input drives failbit. This documents the current contract
+	//       and will continue to hold once parse() is implemented (#856) --
+	//       only the inputs that pass through parse will change. -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("1.0");
+		Float p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: efloat operator>> failbit on stub parse\n";
+	}
+
+	// ----- operator>> handles EOF without crashing -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("");
+		Float p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: efloat operator>> EOF handling\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/elastic/einteger/conversion/string_parse.cpp
+++ b/elastic/einteger/conversion/string_parse.cpp
@@ -41,13 +41,13 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// ----- canonical decimals (existing parse path) -----
+	// ----- canonical decimals (existing parse path): assert parsed value, not just success -----
 	{
 		int start = nrOfFailedTestCases;
 		Int p;
-		if (!parse("0", p))     ++nrOfFailedTestCases;
-		if (!parse("42", p))    ++nrOfFailedTestCases;
-		if (!parse("-1000", p)) ++nrOfFailedTestCases;
+		if (!parse("0", p)     || p != Int(0))     ++nrOfFailedTestCases;
+		if (!parse("42", p)    || p != Int(42))    ++nrOfFailedTestCases;
+		if (!parse("-1000", p) || p != Int(-1000)) ++nrOfFailedTestCases;
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: einteger canonical decimals\n";
 	}
 

--- a/elastic/einteger/conversion/string_parse.cpp
+++ b/elastic/einteger/conversion/string_parse.cpp
@@ -1,0 +1,81 @@
+// string_parse.cpp: regression tests for decimal-string parsing of einteger
+//                  (Phase E of #835 -- operator>> hygiene)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// einteger::parse currently supports decimal and hex paths; binary and octal
+// branches are placeholders. Phase E ships operator>> hygiene only; full
+// parse coverage is tracked in issue #853.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/einteger/einteger.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+	using Int = einteger<std::uint32_t>;
+
+	std::string test_suite  = "einteger decimal string parse (Phase E of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- canonical decimals (existing parse path) -----
+	{
+		int start = nrOfFailedTestCases;
+		Int p;
+		if (!parse("0", p))     ++nrOfFailedTestCases;
+		if (!parse("42", p))    ++nrOfFailedTestCases;
+		if (!parse("-1000", p)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: einteger canonical decimals\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		Int p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: einteger operator>> failbit\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/elastic/ereal/conversion/string_parse.cpp
+++ b/elastic/ereal/conversion/string_parse.cpp
@@ -8,6 +8,7 @@
 // an MIT Open Source license.
 
 #include <universal/utility/directives.hpp>
+#include <cmath>
 #include <iostream>
 #include <sstream>
 #include <streambuf>
@@ -64,6 +65,9 @@ try {
 		for (const char* s : { "-inf", "-Inf", "-infinity" }) {
 			if (!parse(s, p)) ++nrOfFailedTestCases;
 			if (!p.isinf())   ++nrOfFailedTestCases;
+			// -inf must have negative sign; std::signbit works for ereal
+			// since its leading limb is a regular IEEE double.
+			if (std::signbit(static_cast<double>(p)) != true) ++nrOfFailedTestCases;
 		}
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: ereal nan/inf token routing\n";
 	}

--- a/elastic/ereal/conversion/string_parse.cpp
+++ b/elastic/ereal/conversion/string_parse.cpp
@@ -1,0 +1,98 @@
+// string_parse.cpp: regression tests for decimal-string parsing of ereal
+//                  (Phase E of #835 -- nan/inf + operator>> hygiene)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/ereal/ereal.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+	using Real = ereal<4>;
+
+	std::string test_suite  = "ereal decimal string parse (Phase E of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- canonical decimals (existing digit-accumulate parse path) -----
+	{
+		int start = nrOfFailedTestCases;
+		Real p;
+		if (!parse("0", p))      ++nrOfFailedTestCases;
+		if (!parse("1.0", p))    ++nrOfFailedTestCases;
+		if (!parse("-3.25", p))  ++nrOfFailedTestCases;
+		if (!parse("1.25e3", p)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: ereal canonical decimals\n";
+	}
+
+	// ----- nan / inf token routing -----
+	{
+		int start = nrOfFailedTestCases;
+		Real p;
+		for (const char* s : { "nan", "NaN", "+nan", "-nan" }) {
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isnan())   ++nrOfFailedTestCases;
+		}
+		for (const char* s : { "inf", "Inf", "infinity", "INFINITY",
+		                       "+inf", "+infinity" }) {
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isinf())   ++nrOfFailedTestCases;
+		}
+		for (const char* s : { "-inf", "-Inf", "-infinity" }) {
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isinf())   ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: ereal nan/inf token routing\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		Real p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: ereal operator>> failbit\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/elastic/rational/decimal/conversion/string_parse.cpp
+++ b/elastic/rational/decimal/conversion/string_parse.cpp
@@ -40,13 +40,13 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// ----- integer-format inputs (existing parse path) -----
+	// ----- integer-format inputs: assert parsed value, not just success -----
 	{
 		int start = nrOfFailedTestCases;
 		erational p;
-		if (!p.parse("0"))      ++nrOfFailedTestCases;
-		if (!p.parse("42"))     ++nrOfFailedTestCases;
-		if (!p.parse("-1000"))  ++nrOfFailedTestCases;
+		if (!p.parse("0")     || p != 0L)     ++nrOfFailedTestCases;
+		if (!p.parse("42")    || p != 42L)    ++nrOfFailedTestCases;
+		if (!p.parse("-1000") || p != -1000L) ++nrOfFailedTestCases;
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: erational canonical integer parse\n";
 	}
 

--- a/elastic/rational/decimal/conversion/string_parse.cpp
+++ b/elastic/rational/decimal/conversion/string_parse.cpp
@@ -1,0 +1,80 @@
+// string_parse.cpp: regression tests for decimal-string parsing of erational
+//                  (Phase E of #835 -- operator>> hygiene)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// erational::parse currently accepts only integer-format input. Phase E
+// ships operator>> hygiene only; extension to p/q form and decimal/
+// scientific notation is tracked in issue #855.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/erational/erational.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "erational decimal string parse (Phase E of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- integer-format inputs (existing parse path) -----
+	{
+		int start = nrOfFailedTestCases;
+		erational p;
+		if (!p.parse("0"))      ++nrOfFailedTestCases;
+		if (!p.parse("42"))     ++nrOfFailedTestCases;
+		if (!p.parse("-1000"))  ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: erational canonical integer parse\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
+		erational p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: erational operator>> failbit\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/dfloat/dfloat_impl.hpp
+++ b/include/sw/universal/number/dfloat/dfloat_impl.hpp
@@ -1422,9 +1422,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const dfloat<ndigits, es, En
 template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
 inline std::istream& operator>>(std::istream& istr, dfloat<ndigits, es, Encoding, BlockType>& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, p)) {
 		std::cerr << "unable to parse -" << txt << "- into a dfloat value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/dfloat/dfloat_impl.hpp
+++ b/include/sw/universal/number/dfloat/dfloat_impl.hpp
@@ -1439,6 +1439,78 @@ inline std::istream& operator>>(std::istream& istr, dfloat<ndigits, es, Encoding
 template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
 bool parse(const std::string& number, dfloat<ndigits, es, Encoding, BlockType>& value) {
 	if (number.empty()) return false;
+	// Pre-validate: the input must match the dfloat grammar. Without this
+	// guard, assign() silently accepts garbage and produces zero, so the
+	// operator>> path would never set failbit on inputs like "not-a-number"
+	// or "1.5abc".
+	{
+		std::size_t pos = 0;
+		while (pos < number.size() && std::isspace(static_cast<unsigned char>(number[pos]))) ++pos;
+		if (pos >= number.size()) return false;
+		if (number[pos] == '+' || number[pos] == '-') ++pos;
+		if (pos >= number.size()) return false;
+
+		// Branch on first character (after sign): special-value token or
+		// a decimal floating-point literal.
+		const char c0 = number[pos];
+		if (c0 == 'i' || c0 == 'I' || c0 == 'n' || c0 == 'N') {
+			// Expect "inf" / "infinity" / "nan" (case-insensitive). assign()
+			// only inspects the first 3 letters; we tolerate trailing letters
+			// only when they spell "infinity" or are absent.
+			auto lc = [&number](std::size_t i) {
+				return static_cast<char>(std::tolower(static_cast<unsigned char>(number[i])));
+			};
+			if (pos + 3 > number.size()) return false;
+			const char a = lc(pos), b = lc(pos + 1), c = lc(pos + 2);
+			const bool is_inf = (a == 'i' && b == 'n' && c == 'f');
+			const bool is_nan = (a == 'n' && b == 'a' && c == 'n');
+			if (!is_inf && !is_nan) return false;
+			// After the 3 letters, allow nothing (nan/inf), or the rest of "infinity".
+			std::size_t after = pos + 3;
+			if (after < number.size()) {
+				if (is_inf
+				 && after + 5 == number.size()
+				 && lc(after) == 'i' && lc(after + 1) == 'n' && lc(after + 2) == 'i'
+				 && lc(after + 3) == 't' && lc(after + 4) == 'y') {
+					// "infinity" -- ok
+				}
+				else {
+					return false;
+				}
+			}
+		}
+		else if ((c0 >= '0' && c0 <= '9') || c0 == '.') {
+			// Decimal floating-point literal: digits . digits [eE [+-] digits]
+			bool seen_digit = false;
+			bool seen_dot   = false;
+			while (pos < number.size()) {
+				char ch = number[pos];
+				if (ch >= '0' && ch <= '9') { seen_digit = true; ++pos; continue; }
+				if (ch == '.') {
+					if (seen_dot) return false;
+					seen_dot = true;
+					++pos;
+					continue;
+				}
+				break;
+			}
+			if (!seen_digit) return false;
+			if (pos < number.size() && (number[pos] == 'e' || number[pos] == 'E')) {
+				++pos;
+				if (pos < number.size() && (number[pos] == '+' || number[pos] == '-')) ++pos;
+				bool seen_exp_digit = false;
+				while (pos < number.size() && number[pos] >= '0' && number[pos] <= '9') {
+					seen_exp_digit = true;
+					++pos;
+				}
+				if (!seen_exp_digit) return false;
+			}
+			if (pos != number.size()) return false;  // trailing junk
+		}
+		else {
+			return false;
+		}
+	}
 	value.assign(number);
 	return true;
 }

--- a/include/sw/universal/number/edecimal/edecimal_impl.hpp
+++ b/include/sw/universal/number/edecimal/edecimal_impl.hpp
@@ -636,9 +636,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const edecimal& d) {
 // read an ASCII edecimal format from an istream
 inline std::istream& operator>>(std::istream& istr, edecimal& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!p.parse(txt)) {
-		std::cerr << "unable to parse -" << txt << "- into a edecimal value\n";
+		std::cerr << "unable to parse -" << txt << "- into an edecimal value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -423,9 +423,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const efloat<nlimbs>& rhs) {
 template<unsigned nlimbs>
 inline std::istream& operator>>(std::istream& istr, efloat<nlimbs>& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a floating-point value\n";
+		std::cerr << "unable to parse -" << txt << "- into an efloat value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/einteger/einteger_impl.hpp
+++ b/include/sw/universal/number/einteger/einteger_impl.hpp
@@ -1114,9 +1114,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const einteger<BlockType>& i
 template<typename BlockType>
 inline std::istream& operator>>(std::istream& istr, einteger<BlockType>& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+		std::cerr << "unable to parse -" << txt << "- into an einteger value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -425,9 +425,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const erational& d) {
 // read an ASCII erational format from an istream
 inline std::istream& operator>>(std::istream& istr, erational& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!p.parse(txt)) {
-		std::cerr << "unable to parse -" << txt << "- into a erational value\n";
+		std::cerr << "unable to parse -" << txt << "- into an erational value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cctype>
 #include <string>
 #include <sstream>
 #include <iostream>
@@ -323,13 +324,30 @@ public:
 		int exponent = 0;
 
 		// Skip leading whitespace
-		while (pos < str.length() && std::isspace(str[pos])) ++pos;
+		while (pos < str.length() && std::isspace(static_cast<unsigned char>(str[pos]))) ++pos;
 		if (pos >= str.length()) return false;
 
 		// Parse optional sign
 		if (str[pos] == '+' || str[pos] == '-') {
 			negative = (str[pos] == '-');
 			++pos;
+		}
+
+		// Detect nan / inf / infinity tokens (case-insensitive). The digit
+		// loop below would otherwise reject any alphabetic character.
+		{
+			std::string lower;
+			for (size_t q = pos; q < str.length(); ++q) {
+				lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(str[q]))));
+			}
+			if (lower == "nan") {
+				this->setnan();
+				return true;
+			}
+			if (lower == "inf" || lower == "infinity") {
+				this->setinf(negative);
+				return true;
+			}
 		}
 
 		// Parse mantissa digits
@@ -865,9 +883,13 @@ inline std::ostream& operator<<(std::ostream& ostr, const ereal<nlimbs>& rhs) {
 template<unsigned nlimbs>
 inline std::istream& operator>>(std::istream& istr, ereal<nlimbs>& p) {
 	std::string txt;
-	istr >> txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
 	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a floating-point value\n";
+		std::cerr << "unable to parse -" << txt << "- into an ereal value\n";
+		istr.setstate(std::ios::failbit);
 	}
 	return istr;
 }

--- a/static/float/dfloat/conversion/string_parse.cpp
+++ b/static/float/dfloat/conversion/string_parse.cpp
@@ -53,22 +53,54 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat canonical decimals\n";
 	}
 
-	// ----- nan / inf token routing (assign handles these) -----
+	// ----- nan / inf token routing: assert resulting state, not just success -----
 	{
 		int start = nrOfFailedTestCases;
 		Dfloat p;
-		for (const char* s : { "nan", "NaN", "inf", "Inf",
-		                       "+nan", "-inf", "infinity" }) {
+		for (const char* s : { "nan", "NaN", "+nan" }) {
 			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isnan())   ++nrOfFailedTestCases;
 		}
+		for (const char* s : { "inf", "Inf", "infinity" }) {
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+			if (!p.isinf())   ++nrOfFailedTestCases;
+		}
+		// "-inf" should be negative infinity. dfloat's assign routes the sign.
+		if (!parse("-inf", p)) ++nrOfFailedTestCases;
+		if (!p.isinf())        ++nrOfFailedTestCases;
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat nan/inf token parsing\n";
+	}
+
+	// ----- malformed input is rejected (CR round-1) -----
+	{
+		int start = nrOfFailedTestCases;
+		Dfloat p;
+		for (const char* s : { "not-a-number", "abc", "1.5abc", "++1",
+		                       "1.5.0", "1e", "1ea" }) {
+			if (parse(s, p)) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "  unexpectedly accepted: \"" << s << "\"\n";
+			}
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat malformed input rejection\n";
 	}
 
 	// ----- operator>> sets failbit on a bad token -----
 	{
 		int start = nrOfFailedTestCases;
-		// dfloat's assign() is permissive; use a clearly invalid token by
-		// using an empty-after-extraction case via a stream at EOF.
+		std::istringstream is("not-a-number");
+		Dfloat p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat operator>> failbit\n";
+	}
+
+	// ----- operator>> handles EOF (empty stream) -----
+	{
+		int start = nrOfFailedTestCases;
 		std::istringstream is("");
 		Dfloat p;
 		{
@@ -76,7 +108,7 @@ try {
 			is >> p;
 		}
 		if (!is.fail()) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat operator>> EOF failbit\n";
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat operator>> EOF\n";
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/static/float/dfloat/conversion/string_parse.cpp
+++ b/static/float/dfloat/conversion/string_parse.cpp
@@ -1,0 +1,96 @@
+// string_parse.cpp: regression tests for decimal-string parsing of dfloat
+//                  (Phase E of #835 -- API parity)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// dfloat::assign() already implements a complete decimal parser with nan/inf
+// token handling. The Phase E scope here is just operator>> hygiene
+// (extraction guard + failbit). Full parse coverage is tracked separately
+// in issue #852.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <sstream>
+#include <streambuf>
+#include <string>
+#include <universal/number/dfloat/dfloat.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+struct CerrSilencer {
+	std::ostringstream sink;
+	std::streambuf*    old;
+	CerrSilencer() : old(std::cerr.rdbuf(sink.rdbuf())) {}
+	~CerrSilencer() { std::cerr.rdbuf(old); }
+	CerrSilencer(const CerrSilencer&)            = delete;
+	CerrSilencer& operator=(const CerrSilencer&) = delete;
+};
+}
+
+int main()
+try {
+	using namespace sw::universal;
+	using Dfloat = decimal64;
+
+	std::string test_suite  = "dfloat decimal string parse (Phase E of #835)";
+	bool reportTestCases    = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----- canonical decimals (already handled by assign) -----
+	{
+		int start = nrOfFailedTestCases;
+		Dfloat p;
+		if (!parse("0", p))      ++nrOfFailedTestCases;
+		if (!parse("1.0", p))    ++nrOfFailedTestCases;
+		if (!parse("-3.25", p))  ++nrOfFailedTestCases;
+		if (!parse("1.25e3", p)) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat canonical decimals\n";
+	}
+
+	// ----- nan / inf token routing (assign handles these) -----
+	{
+		int start = nrOfFailedTestCases;
+		Dfloat p;
+		for (const char* s : { "nan", "NaN", "inf", "Inf",
+		                       "+nan", "-inf", "infinity" }) {
+			if (!parse(s, p)) ++nrOfFailedTestCases;
+		}
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat nan/inf token parsing\n";
+	}
+
+	// ----- operator>> sets failbit on a bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		// dfloat's assign() is permissive; use a clearly invalid token by
+		// using an empty-after-extraction case via a stream at EOF.
+		std::istringstream is("");
+		Dfloat p;
+		{
+			CerrSilencer silence;
+			is >> p;
+		}
+		if (!is.fail()) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: dfloat operator>> EOF failbit\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Phase E wraps up the decimal/elastic family with minimal API-parity work. Six types covered (dfloat, einteger, edecimal, erational, efloat, ereal). The full-implementation work for each was found to vary significantly per type, so each is captured in a dedicated tracking issue (#852-#857).

## Changes per type

| Type | What ships | Why bounded | Tracking issue |
|------|-----------|-------------|---------------|
| dfloat    | operator>> extraction guard + failbit | \`assign()\` already implements full nan/inf-aware decimal parse | #852 (verify full surface + tests) |
| einteger  | operator>> hygiene + fix "posit value" typo | parse() works for decimal/hex; binary/octal stubs deferred | #853 |
| edecimal  | operator>> hygiene | parse() only accepts integer-format input; decimal/sci extension deferred | #854 |
| erational | operator>> hygiene | parse() only accepts integer-format input; p/q form + decimal/sci deferred | #855 |
| efloat    | operator>> hygiene | parse() is a stub returning false; full implementation deferred | #856 |
| ereal     | nan / inf token routing + operator>> hygiene | digit-accumulate parse already works; distillation upgrade deferred | #857 |

## Tests (6 new files, ReportTestSuite pattern)

| Type | Test |
|------|------|
| dfloat    | \`static/float/dfloat/conversion/string_parse.cpp\` |
| einteger  | \`elastic/einteger/conversion/string_parse.cpp\` |
| edecimal  | \`elastic/decimal/conversion/string_parse.cpp\` |
| erational | \`elastic/rational/decimal/conversion/string_parse.cpp\` |
| efloat    | \`elastic/efloat/conversion/string_parse.cpp\` |
| ereal     | \`elastic/ereal/conversion/string_parse.cpp\` |

Each covers: canonical parse where supported, nan/inf token routing where supported, operator>> failbit on a bad token. Tests intentionally stay narrow -- broader coverage will land with the per-type implementations in #852-#857.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| dfloat_string_parse  | OK | PASS | OK | PASS |
| eint_string_parse    | OK | PASS | OK | PASS |
| edec_string_parse    | OK | PASS | OK | PASS |
| erat_string_parse    | OK | PASS | OK | PASS |
| efloat_string_parse  | OK | PASS | OK | PASS |
| er_conv_string_parse | OK | PASS | OK | PASS |
| dfloat_api / eint_api / edec_api / efloat_api / er_api_api | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: \`gh pr ready <PR>\`

Relates to #835

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression test executables exercising decimal-string parsing and stream extraction hygiene for multiple numeric types.

* **Bug Fixes**
  * Stream extraction now verifies input read success and sets stream failbit on parse failures.
  * Parsing validation improved and special values (NaN/Infinity) recognized case-insensitively.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->