### PR TITLE
fix(einteger): operator>>= leaves spurious limb past the shift boundary

### DIFF
--- a/elastic/einteger/api/shift.cpp
+++ b/elastic/einteger/api/shift.cpp
@@ -1,0 +1,204 @@
+// shift.cpp: regression tests for einteger shift operators
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// Issue #862: einteger::operator>>= leaked a spurious limb when the shift
+// crossed more than half the limb count (uint8_t blocks were the trigger
+// in practice), and also left the input unchanged when shift == nbits()
+// instead of returning 0.  Both are pinned here.
+
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <cstdint>
+#include <universal/number/einteger/einteger.hpp>
+#include <universal/number/integer/integer.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+
+// Pack a little-endian byte payload into an einteger<Block>, regardless of the
+// chosen block width.  Bit i*8 of the integer is byte i of the payload.
+template<typename Block>
+sw::universal::einteger<Block> pack_le(const std::uint8_t* bytes, unsigned n) {
+	using namespace sw::universal;
+	einteger<Block> v;
+	for (unsigned i = 0; i < n; ++i) {
+		unsigned bit  = i * 8u;
+		unsigned limb = bit / (sizeof(Block) * 8u);
+		unsigned off  = bit % (sizeof(Block) * 8u);
+		Block existing = (limb < v.limbs()) ? v.block(limb) : Block{};
+		Block updated  = static_cast<Block>(existing
+		               | (static_cast<Block>(bytes[i]) << off));
+		v.setblock(limb, updated);
+	}
+	return v;
+}
+
+template<typename Block>
+int CheckShift(const char* tag, const std::uint8_t* bytes, unsigned n,
+               int shift, const char* expected_decimal, bool reportTestCases) {
+	auto v = pack_le<Block>(bytes, n);
+	v >>= shift;
+	std::ostringstream os;
+	os << v;
+	if (os.str() != std::string(expected_decimal)) {
+		if (reportTestCases) {
+			std::cout << "FAIL " << tag << " shift=" << shift
+			          << " got=" << os.str()
+			          << " expected=" << expected_decimal << '\n';
+		}
+		return 1;
+	}
+	return 0;
+}
+
+template<typename Block>
+int CheckShiftZero(const char* tag, const std::uint8_t* bytes, unsigned n,
+                   int shift, bool reportTestCases) {
+	auto v = pack_le<Block>(bytes, n);
+	v >>= shift;
+	if (!v.iszero()) {
+		if (reportTestCases) {
+			std::ostringstream os; os << v;
+			std::cout << "FAIL " << tag << " shift=" << shift
+			          << " got=" << os.str() << " expected=0\n";
+		}
+		return 1;
+	}
+	return 0;
+}
+
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "einteger shift operators (issue #862)";
+	bool reportTestCases   = true;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// 15-byte little-endian payload: 0x1921FB54442D17BD21B8D78573DE4E.
+	// This is the value that surfaced #862 (top bytes of pi * 10^15 << 100
+	// divided by 5^15, see #842).  We test it across all three block widths.
+	static const std::uint8_t payload15[15] = {
+		0x4e, 0xde, 0x73, 0x85, 0xd7, 0xb8, 0x21, 0xbd,
+		0x17, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x19
+	};
+
+	// >> 64: top 56 bits = 0x001921FB54442D17 = 7074237752028439
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckShift<std::uint8_t >(
+			"u8  15-limb >> 64", payload15, 15, 64,
+			"7074237752028439", reportTestCases);
+		nrOfFailedTestCases += CheckShift<std::uint16_t>(
+			"u16 8-limb  >> 64", payload15, 15, 64,
+			"7074237752028439", reportTestCases);
+		nrOfFailedTestCases += CheckShift<std::uint32_t>(
+			"u32 4-limb  >> 64", payload15, 15, 64,
+			"7074237752028439", reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start,
+			"15-byte payload >> 64", "einteger shift");
+	}
+
+	// >> 24: drop low 3 bytes, top 96 bits = 0x1921FB54442D17BD21B8D785
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckShift<std::uint8_t >(
+			"u8  >> 24", payload15, 15, 24,
+			"7778206666007220823048902533", reportTestCases);
+		nrOfFailedTestCases += CheckShift<std::uint16_t>(
+			"u16 >> 24", payload15, 15, 24,
+			"7778206666007220823048902533", reportTestCases);
+		nrOfFailedTestCases += CheckShift<std::uint32_t>(
+			"u32 >> 24", payload15, 15, 24,
+			"7778206666007220823048902533", reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start,
+			"15-byte payload >> 24", "einteger shift");
+	}
+
+	// shift == nbits boundary: every significant bit shifts out, so result = 0
+	{
+		int start = nrOfFailedTestCases;
+		{
+			einteger<std::uint32_t> v;
+			v.setblock(0, 0xFFFFFFFFu);
+			v >>= 32;
+			if (!v.iszero()) ++nrOfFailedTestCases;
+		}
+		{
+			einteger<std::uint8_t> v;
+			for (unsigned i = 0; i < 3; ++i) v.setblock(i, 0xFFu);
+			v >>= 24;
+			if (!v.iszero()) ++nrOfFailedTestCases;
+		}
+		{
+			einteger<std::uint16_t> v;
+			for (unsigned i = 0; i < 4; ++i) v.setblock(i, 0xFFFFu);
+			v >>= 64;
+			if (!v.iszero()) ++nrOfFailedTestCases;
+		}
+		ReportTestResult(nrOfFailedTestCases - start,
+			"shift == nbits boundary", "einteger shift");
+	}
+
+	// shift > nbits boundary (already-correct path, pinned here)
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckShiftZero<std::uint32_t>(
+			"u32 1-limb >> 64", payload15, 4, 64, reportTestCases);
+		nrOfFailedTestCases += CheckShiftZero<std::uint8_t >(
+			"u8  4-limb >> 200", payload15, 4, 200, reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start,
+			"shift > nbits boundary", "einteger shift");
+	}
+
+	// Multi-byte shift not aligned to a limb boundary (mixed block + in-block).
+	// Cross-check against an independent integer<2048> reference rather than
+	// a pre-baked literal -- avoids the test asserting an implementation
+	// echoes its own output.
+	{
+		int start = nrOfFailedTestCases;
+		using Big = integer<2048>;
+		Big ref(0);
+		for (int i = 14; i >= 0; --i) {
+			ref *= Big(256);
+			ref += Big(static_cast<int>(payload15[i]));
+		}
+		ref >>= 17;
+		std::ostringstream os; os << ref;
+		std::string expected = os.str();
+		nrOfFailedTestCases += CheckShift<std::uint8_t >(
+			"u8  >> 17", payload15, 15, 17, expected.c_str(), reportTestCases);
+		nrOfFailedTestCases += CheckShift<std::uint16_t>(
+			"u16 >> 17", payload15, 15, 17, expected.c_str(), reportTestCases);
+		nrOfFailedTestCases += CheckShift<std::uint32_t>(
+			"u32 >> 17", payload15, 15, 17, expected.c_str(), reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start,
+			"unaligned shift vs integer<2048>", "einteger shift");
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/einteger/einteger_impl.hpp
+++ b/include/sw/universal/number/einteger/einteger_impl.hpp
@@ -129,7 +129,11 @@ public:
 	einteger& operator>>=(int shift) {
 		if (shift == 0) return *this;
 		if (shift < 0) return operator>>=(-shift);
-		if (shift > static_cast<int>(nbits())) {
+		// shift == nbits shifts ALL significant bits out, so the result is
+		// 0.  The previous `>` test let this case fall through to the
+		// block-shift path with MSU < blockShift, where the inner copy
+		// loop is skipped and the original limbs survive unchanged.
+		if (shift >= static_cast<int>(nbits())) {
 			setzero();
 			return *this;
 		}
@@ -138,10 +142,19 @@ public:
 		if (shift >= static_cast<int>(bitsInBlock)) {
 			blockShift = shift / bitsInBlock;
 			if (MSU >= blockShift) {
-				// shift by blocks
+				// Shift down by whole limbs: copy [blockShift..MSU] into
+				// [0..MSU-blockShift], then zero all the high limbs that
+				// no longer have a source.  The previous implementation
+				// did the zeroing inline (`_block[i+blockShift] = 0`),
+				// which only covered positions [blockShift, MSU] -- when
+				// blockShift > (MSU+1)/2 the gap (MSU-blockShift,
+				// blockShift) was left untouched and the original limb
+				// value leaked through to the result.  Issue #862.
 				for (size_t i = 0; i <= MSU - blockShift; ++i) {
 					_block[i] = _block[i + blockShift];
-					_block[i + blockShift] = 0; // null the upper block
+				}
+				for (size_t i = MSU - blockShift + 1; i <= MSU; ++i) {
+					_block[i] = 0;
 				}
 			}
 			// adjust the shift


### PR DESCRIPTION
## Summary

Two latent bugs in einteger \`operator>>=\` surfaced while wiring the
regression test for #842:

1. **Spurious limb leak** when the shift covered more than half the
   limb vector.  The inline \`_block[i+blockShift] = 0\` inside the copy
   loop only zeroed positions \`[blockShift, MSU]\`; positions
   \`(MSU-blockShift, blockShift)\` were never touched and the original
   limb value leaked through.  Manifested with \`uint8_t\` blocks for
   any value tall enough to need a 15+-limb representation shifted by
   8 or more limbs.  The fix is a clean split: one pass to copy down,
   one pass to zero all high positions uniformly.

2. **\`shift == nbits()\` boundary**: the early-exit was \`> nbits()\`,
   so the exact-equality case fell through to the block-shift branch.
   With \`MSU < blockShift\` the inner copy loop is skipped (by design,
   since there is nothing to copy), and the original limbs survived
   unchanged.  Tightened to \`>=\`.

## Reproducer (pre-fix)

\`\`\`cpp
einteger<std::uint8_t> v;
std::uint8_t b[15] = {0x4e, 0xde, 0x73, 0x85, 0xd7, 0xb8, 0x21, 0xbd,
                      0x17, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x19};
for (unsigned i = 0; i < 15; ++i) v.setblock(i, b[i]);
v >>= 64;
// expected: 7074237752028439          (top 56 bits of 0x1921FB54442D17BD21B8D78573DE4E)
// actual:   13625959510920408343      (= 0xBD1921FB54442D17, byte 0xBD at position 7 leaked)
\`\`\`

\`\`\`cpp
einteger<std::uint32_t> v;
v.setblock(0, 0xFFFFFFFFu);
v >>= 32;
// expected: 0
// actual:   4294967295  (unchanged)
\`\`\`

## Changes

- \`include/sw/universal/number/einteger/einteger_impl.hpp\` -- split
  the copy loop in operator>>= into copy + zero passes, tightened the
  shift-out-of-range early-exit to \`>=\`.
- \`elastic/einteger/api/shift.cpp\` (new) -- regression suite covering
  the originally-reported case (uint8/16/32 blocks, shift = 24, 64),
  both boundary conditions (\`shift == nbits\`, \`shift > nbits\`), and
  an unaligned multi-byte shift that cross-checks against an
  independent \`integer<2048>\` reference (computed via \`*= 256 + +=\`,
  not via the \`integer<N>::setbyte\` path which has its own separate
  bug producing garbage output and is outside this PR's scope).

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| eint_shift (new) | OK | PASS | OK | PASS |
| eint_division | OK | PASS | OK | PASS |
| eint_string_parse | OK | PASS | OK | PASS |
| eint_addition / subtraction / multiplication | OK | PASS | OK | PASS |
| eint_api / assignment / comparison / constexpr / factorial | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: \`gh pr ready\`

## Related

- #842 (closed) -- the divide bug whose regression test exposed this
- #862 (this PR) -- the right-shift bug
- A separate \`integer<N>::setbyte\` bug noticed during this work
  (writes garbage instead of the requested byte value) is NOT addressed
  here; will file separately if it isn't already tracked.

Resolves #862

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect results when performing right-shift operations on large integers at boundary conditions, exact bit boundaries, and non-aligned shifts.

* **Tests**
  * Added comprehensive regression tests for shift operations, validating edge cases and cross-checking results against reference implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->