### PR TITLE
feat(edecimal): extend parse to decimal-point and scientific notation

### DIFF
--- a/elastic/decimal/conversion/string_parse.cpp
+++ b/elastic/decimal/conversion/string_parse.cpp
@@ -1,5 +1,5 @@
-// string_parse.cpp: regression tests for decimal-string parsing of edecimal
-//                  (Phase E of #835 -- operator>> hygiene)
+// string_parse.cpp: regression tests for string parsing of edecimal
+//                  (Phase E of #835 -- operator>> hygiene; #854 -- extended grammar)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -7,9 +7,13 @@
 // This file is part of the universal numbers project, which is released under
 // an MIT Open Source license.
 //
-// edecimal::parse currently accepts only integer-format input. Phase E ships
-// operator>> hygiene only; extension to decimal/scientific notation is
-// tracked in issue #854.
+// edecimal::parse accepts integer, decimal-point, and scientific-notation
+// inputs.  Forms whose effective decimal exponent is negative (i.e. that
+// carry fractional digits with no matching positive exponent) are rejected
+// because edecimal is an integer-only number system and the issue spec
+// explicitly requires that we preserve the input digits exactly rather than
+// silently truncate them.  operator>> sets failbit on parse failure (#835
+// Phase E).
 
 #include <universal/utility/directives.hpp>
 #include <iostream>
@@ -20,6 +24,7 @@
 #include <universal/verification/test_reporters.hpp>
 
 namespace {
+
 struct CerrSilencer {
 	std::ostringstream sink;
 	std::streambuf*    old;
@@ -28,26 +33,138 @@ struct CerrSilencer {
 	CerrSilencer(const CerrSilencer&)            = delete;
 	CerrSilencer& operator=(const CerrSilencer&) = delete;
 };
+
+int CheckParse(const char* input, const char* expected_decimal, bool reportTestCases) {
+	using namespace sw::universal;
+	edecimal v;
+	if (!v.parse(input)) {
+		if (reportTestCases) std::cout << "FAIL parse rejected: '" << input << "'\n";
+		return 1;
+	}
+	std::ostringstream os;
+	os << v;
+	if (os.str() != std::string(expected_decimal)) {
+		if (reportTestCases) {
+			std::cout << "FAIL parse('" << input << "') = "
+			          << os.str() << " expected " << expected_decimal << '\n';
+		}
+		return 1;
+	}
+	return 0;
 }
+
+int CheckReject(const char* input, bool reportTestCases) {
+	using namespace sw::universal;
+	edecimal v;
+	if (v.parse(input)) {
+		if (reportTestCases) {
+			std::ostringstream os; os << v;
+			std::cout << "FAIL: '" << input << "' should be rejected, got " << os.str() << '\n';
+		}
+		return 1;
+	}
+	return 0;
+}
+
+}  // namespace
 
 int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite  = "edecimal decimal string parse (Phase E of #835)";
-	bool reportTestCases    = false;
+	std::string test_suite  = "edecimal string parse (issues #835 Phase E, #854)";
+	bool reportTestCases    = true;
 	int  nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// ----- integer-format inputs: assert parsed value, not just success -----
+	// ----- integer-format (canonical / pre-existing path) -----
 	{
 		int start = nrOfFailedTestCases;
-		edecimal p;
-		if (!p.parse("0")     || p != edecimal(0))     ++nrOfFailedTestCases;
-		if (!p.parse("42")    || p != edecimal(42))    ++nrOfFailedTestCases;
-		if (!p.parse("-1000") || p != edecimal(-1000)) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: edecimal canonical integer parse\n";
+		nrOfFailedTestCases += CheckParse("0",        "0",        reportTestCases);
+		nrOfFailedTestCases += CheckParse("42",       "42",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("+42",      "42",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("-1000",    "-1000",    reportTestCases);
+		nrOfFailedTestCases += CheckParse(
+			"1234567890123456789012345",
+			"1234567890123456789012345", reportTestCases);
+		nrOfFailedTestCases += CheckParse(
+			"-1234567890123456789012345",
+			"-1234567890123456789012345", reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "integer parse", "edecimal parse");
+	}
+
+	// ----- scientific notation that yields exact integers -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckParse("1e0",       "1",            reportTestCases);
+		nrOfFailedTestCases += CheckParse("1e10",      "10000000000",  reportTestCases);
+		nrOfFailedTestCases += CheckParse("-1e10",     "-10000000000", reportTestCases);
+		nrOfFailedTestCases += CheckParse("3e+2",      "300",          reportTestCases);
+		// 3.14e+200 -> 314 followed by 198 zeros: 200 digits total.
+		nrOfFailedTestCases += CheckParse(
+			"3.14e+200",
+			"314"
+			"000000000000000000000000000000000000000000000000000000000000000000000000000"
+			"000000000000000000000000000000000000000000000000000000000000000000000000000"
+			"000000000000000000000000000000000000000000000000",
+			reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "scientific exact", "edecimal parse");
+	}
+
+	// ----- decimal-point form: accepted iff effective exponent is non-negative -----
+	{
+		int start = nrOfFailedTestCases;
+		// Accept: the decimal point shifts the exponent, but the combined value
+		// is still an integer (no precision loss).
+		nrOfFailedTestCases += CheckParse("3.14e2",    "314",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("-2.5e1",    "-25",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("1.5e10",    "15000000000", reportTestCases);
+		nrOfFailedTestCases += CheckParse("-1.0e3",    "-1000",     reportTestCases);
+		// Edge syntax: trailing dot, leading dot
+		nrOfFailedTestCases += CheckParse("5.",        "5",         reportTestCases);
+		nrOfFailedTestCases += CheckParse(".5e1",      "5",         reportTestCases);
+		nrOfFailedTestCases += CheckParse("-.25e2",    "-25",       reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "decimal point (integer result)", "edecimal parse");
+	}
+
+	// ----- fractional / negative-exponent forms must be rejected -----
+	// edecimal cannot represent these without precision loss, and the spec
+	// requires preserving the input digits exactly.
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckReject("3.14",     reportTestCases);
+		nrOfFailedTestCases += CheckReject("-0.5",     reportTestCases);
+		nrOfFailedTestCases += CheckReject("0.001",    reportTestCases);
+		nrOfFailedTestCases += CheckReject("1.5e-100", reportTestCases);
+		// "3.0" has frac="0" and exp10=0 -> effective_exp = -1.  Reject as
+		// non-integer per the strict policy (use "3" or "3e0" instead).
+		nrOfFailedTestCases += CheckReject("3.0",      reportTestCases);
+		nrOfFailedTestCases += CheckReject("10.50e0",  reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "fractional input rejected", "edecimal parse");
+	}
+
+	// ----- malformed input must be rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckReject("",      reportTestCases);
+		nrOfFailedTestCases += CheckReject("abc",   reportTestCases);
+		nrOfFailedTestCases += CheckReject("1e",    reportTestCases);
+		nrOfFailedTestCases += CheckReject(".",     reportTestCases);
+		nrOfFailedTestCases += CheckReject("1.2.3", reportTestCases);
+		nrOfFailedTestCases += CheckReject("1e3.5", reportTestCases);
+		nrOfFailedTestCases += CheckReject("42x",   reportTestCases);
+		nrOfFailedTestCases += CheckReject("0x1F",  reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "malformed reject", "edecimal parse");
+	}
+
+	// ----- negative-zero collapses to +0 across all input forms -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckParse("-0",      "0", reportTestCases);
+		nrOfFailedTestCases += CheckParse("-0e10",   "0", reportTestCases);
+		nrOfFailedTestCases += CheckParse("-0.0e5",  "0", reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "negative-zero collapse", "edecimal parse");
 	}
 
 	// ----- operator>> sets failbit on a bad token -----
@@ -60,21 +177,41 @@ try {
 			is >> p;
 		}
 		if (!is.fail()) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: edecimal operator>> failbit\n";
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> failbit on bad", "edecimal parse");
+	}
+
+	// ----- operator>> succeeds on a good scientific token and consumes the value -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("  3.14e2  ");
+		edecimal p;
+		is >> p;
+		if (is.fail() || p != edecimal(314)) ++nrOfFailedTestCases;
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> scientific", "edecimal parse");
+	}
+
+	// ----- operator>> on empty stream sets failbit -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("");
+		edecimal p;
+		is >> p;
+		if (!is.fail()) ++nrOfFailedTestCases;
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> empty stream", "edecimal parse");
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
 	return EXIT_FAILURE;
 }
 catch (const std::runtime_error& err) {
-	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	std::cerr << "Caught runtime exception: " << err.what() << '\n';
 	return EXIT_FAILURE;
 }
 catch (...) {
-	std::cerr << "Caught unknown exception" << std::endl;
+	std::cerr << "Caught unknown exception\n";
 	return EXIT_FAILURE;
 }

--- a/elastic/decimal/conversion/string_parse.cpp
+++ b/elastic/decimal/conversion/string_parse.cpp
@@ -158,6 +158,19 @@ try {
 		ReportTestResult(nrOfFailedTestCases - start, "malformed reject", "edecimal parse");
 	}
 
+	// ----- defensive cap on the resulting digit count (~2 billion zeros
+	//       would otherwise allocate ~2 GiB during parse, so reject it) ----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckReject("1e2000000000", reportTestCases);
+		nrOfFailedTestCases += CheckReject("1e2147483647", reportTestCases); // INT32_MAX
+		nrOfFailedTestCases += CheckReject("1e10000000",   reportTestCases); // 10^7 digits
+		// The 1 MiB cap is exclusive: 1e1048576 -> 1,048,577 digits -> reject;
+		// 1e1048575 -> 1,048,576 digits -> still accepted.
+		nrOfFailedTestCases += CheckReject("1e1048576",    reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "expansion cap (DoS guard)", "edecimal parse");
+	}
+
 	// ----- negative-zero collapses to +0 across all input forms -----
 	{
 		int start = nrOfFailedTestCases;

--- a/include/sw/universal/number/edecimal/edecimal.hpp
+++ b/include/sw/universal/number/edecimal/edecimal.hpp
@@ -47,6 +47,7 @@
 /// support functions
 #include <universal/native/ieee754.hpp>
 #include <universal/string/strmanip.hpp>
+#include <universal/utility/string_parse.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library

--- a/include/sw/universal/number/edecimal/edecimal_impl.hpp
+++ b/include/sw/universal/number/edecimal/edecimal_impl.hpp
@@ -381,6 +381,15 @@ public:
 	//   "3.14"        -> rejected (would lose the .14)
 	//   "1.5e-100"    -> rejected
 	bool parse(const std::string& _digits) {
+		// Defensive cap on the resulting digit count.  scan_decimal_float
+		// returns an int32 exponent, so an input like "1e2000000000" would
+		// otherwise expand to two billion zeros (~2 GB of vector storage)
+		// inside a parse call.  This bound caps the post-expansion size at
+		// ~1 MiB of digit storage and keeps parse a cheap operation.  The
+		// limit is far above any practical decimal literal a user would
+		// type by hand or generate from a roundtrip.
+		constexpr std::size_t MAX_DIGITS = 1u << 20;  // 1,048,576
+
 		std::string digits(_digits);
 		trim(digits);
 		if (digits.empty()) return false;
@@ -394,14 +403,23 @@ public:
 		                     - static_cast<std::int64_t>(scan.frac_part.size());
 		if (eff_exp < 0) return false;
 
+		// Total digit count after expansion = int + frac + eff_exp trailing
+		// zeros.  Reject if this would exceed the cap.  Use uint64 math so
+		// the sum cannot overflow when eff_exp approaches INT32_MAX.
+		std::uint64_t total_digits = static_cast<std::uint64_t>(scan.int_part.size())
+		                           + static_cast<std::uint64_t>(scan.frac_part.size())
+		                           + static_cast<std::uint64_t>(eff_exp);
+		if (total_digits > MAX_DIGITS) return false;
+
 		clear();
+		reserve(static_cast<std::size_t>(total_digits));
 		// Push significand digits in high-to-low order (matches the
 		// pre-existing pattern), then reverse so _digits[0] holds 10^0.
 		for (char c : scan.int_part)  push_back(static_cast<std::uint8_t>(c - '0'));
 		for (char c : scan.frac_part) push_back(static_cast<std::uint8_t>(c - '0'));
 		// Trailing zeros from the exponent: "1.5e10" with eff_exp = 9
 		// becomes "15" + 9 zeros = "15000000000".
-		for (std::int64_t i = 0; i < eff_exp; ++i) push_back(0);
+		insert(end(), static_cast<std::size_t>(eff_exp), std::uint8_t{0});
 
 		// Empty significand (defensive; scan_decimal_float requires at least
 		// one digit somewhere, so this shouldn't fire on valid output).

--- a/include/sw/universal/number/edecimal/edecimal_impl.hpp
+++ b/include/sw/universal/number/edecimal/edecimal_impl.hpp
@@ -369,66 +369,52 @@ public:
 		}
 	}
 
-	// read a edecimal ASCII format and make a edecimal type out of it
+	// read an ASCII decimal literal and make an edecimal value out of it.
+	// Accepts integer, decimal-point, and scientific-notation forms:
+	//   "42"          -> 42
+	//   "-1000"       -> -1000
+	//   "3.14e2"      -> 314
+	//   "1.5e10"      -> 15'000'000'000
+	//   "-3.14e+200"  -> -314 * 10^198
+	// Rejects forms whose effective exponent is negative -- those carry
+	// fractional digits that cannot be represented exactly as an integer.
+	//   "3.14"        -> rejected (would lose the .14)
+	//   "1.5e-100"    -> rejected
 	bool parse(const std::string& _digits) {
-		bool bSuccess = false;
 		std::string digits(_digits);
 		trim(digits);
-		// check if the txt is an edecimal form:[+-]*[0123456789]+
-		std::regex edecimal_regex("[+-]*[0123456789]+");
-		if (std::regex_match(digits, edecimal_regex)) {
-			// found a edecimal representation
-			clear();
-			auto it = digits.begin();
-			if (*it == '-') {
-				setneg();
-				++it;
-			}
-			else if (*it == '+') {
-				++it;
-			}
-			for (; it != digits.end(); ++it) {
-				uint8_t v;
-				switch (*it) {
-				case '0':
-					v = 0;
-					break;
-				case '1':
-					v = 1;
-					break;
-				case '2':
-					v = 2;
-					break;
-				case '3':
-					v = 3;
-					break;
-				case '4':
-					v = 4;
-					break;
-				case '5':
-					v = 5;
-					break;
-				case '6':
-					v = 6;
-					break;
-				case '7':
-					v = 7;
-					break;
-				case '8':
-					v = 8;
-					break;
-				case '9':
-					v = 9;
-					break;
-				default:
-					v = 0;
-				}
-				push_back(v);
-			}
-			std::reverse(begin(), end());
-			bSuccess = true;
-		}
-		return bSuccess;
+		if (digits.empty()) return false;
+
+		auto scan = sw::universal::string_parse::scan_decimal_float(digits);
+		if (!scan.valid) return false;
+
+		// Combined significand digits are the integer part followed by the
+		// fractional part; the decimal point's position shifts the exponent.
+		std::int64_t eff_exp = static_cast<std::int64_t>(scan.exp10)
+		                     - static_cast<std::int64_t>(scan.frac_part.size());
+		if (eff_exp < 0) return false;
+
+		clear();
+		// Push significand digits in high-to-low order (matches the
+		// pre-existing pattern), then reverse so _digits[0] holds 10^0.
+		for (char c : scan.int_part)  push_back(static_cast<std::uint8_t>(c - '0'));
+		for (char c : scan.frac_part) push_back(static_cast<std::uint8_t>(c - '0'));
+		// Trailing zeros from the exponent: "1.5e10" with eff_exp = 9
+		// becomes "15" + 9 zeros = "15000000000".
+		for (std::int64_t i = 0; i < eff_exp; ++i) push_back(0);
+
+		// Empty significand (defensive; scan_decimal_float requires at least
+		// one digit somewhere, so this shouldn't fire on valid output).
+		if (empty()) push_back(0);
+
+		std::reverse(begin(), end());
+		// Strip high-order zeros so "0042" / "0.0042e4" stay normalized,
+		// and any all-zero representation collapses to a single [0].
+		unpad();
+		setsign(scan.negative);
+		// No negative zero: "-0", "-0.0e5", etc. all parse to +0.
+		if (size() == 1 && operator[](0) == 0) setpos();
+		return true;
 	}
 
 #if EDECIMAL_OPERATIONS_COUNT


### PR DESCRIPTION
## Summary

\`edecimal::parse\` previously matched only \`[+-]*[0-9]+\` via
\`std::regex_match\`, rejecting every form with a decimal point or an
exponent suffix.  This PR routes parse through
\`sw::universal::string_parse::scan_decimal_float\` (the foundation from
#838) and now accepts decimal-point and scientific-notation inputs that
yield an exact integer.

## Design

\`scan_decimal_float\` returns \`int_part\`, \`frac_part\`, and a signed
\`exp10\`.  The value's effective decimal exponent is
\`exp10 - frac_part.size()\`.

- **eff_exp >= 0**: the value is an exact integer.  Concatenate
  \`int_part || frac_part\`, append \`eff_exp\` trailing zeros, store
  the digits in edecimal's LSB-first vector.  Examples:
  \`\"3.14e2\" -> 314\`, \`\"1.5e10\" -> 15000000000\`, \`\"3.14e+200\" ->
  314 followed by 198 zeros\`.
- **eff_exp < 0**: the value carries fractional digits that edecimal
  (an integer-only number system) cannot represent without precision
  loss.  Reject.  Examples: \`\"3.14\"\`, \`\"-0.5\"\`, \`\"1.5e-100\"\`,
  \`\"3.0\"\` (eff_exp = -1), \`\"10.50e0\"\` (eff_exp = -2).

The strict rejection matches the issue spec's \"preserve those digits
exactly\" rule.

## Changes

- \`include/sw/universal/number/edecimal/edecimal.hpp\` -- include
  \`utility/string_parse.hpp\` (provides \`scan_decimal_float\`).
- \`include/sw/universal/number/edecimal/edecimal_impl.hpp\` -- rewrite
  \`parse()\` against \`scan_decimal_float\`; call \`unpad()\` so leading
  zeros do not survive in the digit vector; collapse negative zero to
  +0 across all accepted forms.
- \`elastic/decimal/conversion/string_parse.cpp\` -- extend the test
  suite to 9 groups covering the new grammar, the strict rejection,
  and the pre-existing operator>> hygiene (shipped in #858).

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| edec_string_parse | OK | PASS (9/9 groups) | OK | PASS (9/9 groups) |
| edec_api | OK | exit 0 | OK | exit 0 |
| edec_assignment | OK | exit 0 | OK | exit 0 |
| edec_comparison | OK | exit 0 | OK | exit 0 |
| edec_constexpr | OK | exit 0 | OK | exit 0 |
| edec_addition / subtraction / multiplication / division | OK | exit 0 | OK | exit 0 |

## Test plan
- [x] Fast CI (gcc + clang CI_LITE) passes
- [x] Promote when satisfied: \`gh pr ready\`

Resolves #854

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced decimal parsing: supports scientific notation, decimal points with fractional parts, and signed literals; enforces limits to prevent overly large expansions and rejects inputs that would require fractional loss.

* **Tests**
  * Expanded regression suite with structured per-case reporting and helpers to validate successful parses and expected rejection/fail behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->