### PR TITLE
feat(erational): extend parse to p/q, decimal, and scientific notation

### DIFF
--- a/elastic/rational/decimal/conversion/string_parse.cpp
+++ b/elastic/rational/decimal/conversion/string_parse.cpp
@@ -1,5 +1,5 @@
-// string_parse.cpp: regression tests for decimal-string parsing of erational
-//                  (Phase E of #835 -- operator>> hygiene)
+// string_parse.cpp: regression tests for string parsing of erational
+//                  (Phase E of #835 -- operator>> hygiene; #855 -- extended grammar)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -7,9 +7,10 @@
 // This file is part of the universal numbers project, which is released under
 // an MIT Open Source license.
 //
-// erational::parse currently accepts only integer-format input. Phase E
-// ships operator>> hygiene only; extension to p/q form and decimal/
-// scientific notation is tracked in issue #855.
+// erational::parse accepts integer, p/q rational, decimal-point, scientific,
+// and mixed-form (p/q with decimal sides) inputs.  Results are simplified to
+// lowest terms via GCD; q = 0 is rejected.  operator>> sets failbit on parse
+// failure (#835 Phase E).
 
 #include <universal/utility/directives.hpp>
 #include <iostream>
@@ -20,6 +21,7 @@
 #include <universal/verification/test_reporters.hpp>
 
 namespace {
+
 struct CerrSilencer {
 	std::ostringstream sink;
 	std::streambuf*    old;
@@ -28,26 +30,143 @@ struct CerrSilencer {
 	CerrSilencer(const CerrSilencer&)            = delete;
 	CerrSilencer& operator=(const CerrSilencer&) = delete;
 };
+
+int CheckParse(const char* input, const char* expected_pq, bool reportTestCases) {
+	using namespace sw::universal;
+	erational v;
+	if (!v.parse(input)) {
+		if (reportTestCases) std::cout << "FAIL parse rejected: '" << input << "'\n";
+		return 1;
+	}
+	std::ostringstream os;
+	os << v;
+	if (os.str() != std::string(expected_pq)) {
+		if (reportTestCases) {
+			std::cout << "FAIL parse('" << input << "') = "
+			          << os.str() << " expected " << expected_pq << '\n';
+		}
+		return 1;
+	}
+	return 0;
 }
+
+int CheckReject(const char* input, bool reportTestCases) {
+	using namespace sw::universal;
+	erational v;
+	if (v.parse(input)) {
+		if (reportTestCases) {
+			std::ostringstream os; os << v;
+			std::cout << "FAIL: '" << input << "' should be rejected, got " << os.str() << '\n';
+		}
+		return 1;
+	}
+	return 0;
+}
+
+}  // namespace
 
 int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite  = "erational decimal string parse (Phase E of #835)";
-	bool reportTestCases    = false;
+	std::string test_suite  = "erational string parse (issues #835 Phase E, #855)";
+	bool reportTestCases    = true;
 	int  nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// ----- integer-format inputs: assert parsed value, not just success -----
+	// ----- integer literals -> p/1 -----
 	{
 		int start = nrOfFailedTestCases;
-		erational p;
-		if (!p.parse("0")     || p != 0L)     ++nrOfFailedTestCases;
-		if (!p.parse("42")    || p != 42L)    ++nrOfFailedTestCases;
-		if (!p.parse("-1000") || p != -1000L) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: erational canonical integer parse\n";
+		nrOfFailedTestCases += CheckParse("0",       "0/1",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("42",      "42/1",      reportTestCases);
+		nrOfFailedTestCases += CheckParse("+7",      "7/1",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("-1000",   "-1000/1",   reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "integer parse", "erational parse");
+	}
+
+	// ----- p/q rational form with GCD simplification -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckParse("1/2",     "1/2",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("4/8",     "1/2",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("6/4",     "3/2",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("-22/7",   "-22/7",     reportTestCases);
+		nrOfFailedTestCases += CheckParse("355/113", "355/113",   reportTestCases);
+		// sign on either or both sides
+		nrOfFailedTestCases += CheckParse("22/-7",   "-22/7",     reportTestCases);
+		nrOfFailedTestCases += CheckParse("-22/-7",  "22/7",      reportTestCases);
+		nrOfFailedTestCases += CheckParse("+1/+2",   "1/2",       reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "p/q form (signs + simplification)", "erational parse");
+	}
+
+	// ----- decimal literals -> simplified rational -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckParse("3.14",    "157/50",    reportTestCases);
+		nrOfFailedTestCases += CheckParse("-3.14",   "-157/50",   reportTestCases);
+		nrOfFailedTestCases += CheckParse("0.25",    "1/4",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("-0.5",    "-1/2",      reportTestCases);
+		nrOfFailedTestCases += CheckParse("0.001",   "1/1000",    reportTestCases);
+		nrOfFailedTestCases += CheckParse("0.10",    "1/10",      reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "decimal -> rational", "erational parse");
+	}
+
+	// ----- scientific notation -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckParse("1e10",    "10000000000/1", reportTestCases);
+		nrOfFailedTestCases += CheckParse("1.5e2",   "150/1",         reportTestCases);
+		nrOfFailedTestCases += CheckParse("1.5e0",   "3/2",           reportTestCases);
+		nrOfFailedTestCases += CheckParse("1.5e-1",  "3/20",          reportTestCases);
+		nrOfFailedTestCases += CheckParse("-1e3",    "-1000/1",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("3.14e2",  "314/1",         reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "scientific notation", "erational parse");
+	}
+
+	// ----- mixed p/q where each side may be decimal or scientific -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckParse("3.14/2",  "157/100",   reportTestCases);
+		nrOfFailedTestCases += CheckParse("1/0.5",   "2/1",       reportTestCases);
+		nrOfFailedTestCases += CheckParse("1e2/2e1", "5/1",       reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "mixed p/q (decimal sides)", "erational parse");
+	}
+
+	// ----- division by zero must be rejected (no NaR encoding in erational) -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckReject("1/0",    reportTestCases);
+		nrOfFailedTestCases += CheckReject("5/0.0",  reportTestCases);
+		nrOfFailedTestCases += CheckReject("0/0",    reportTestCases);
+		nrOfFailedTestCases += CheckReject("1/0e10", reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "division by zero rejected", "erational parse");
+	}
+
+	// ----- malformed input must be rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckReject("",        reportTestCases);
+		nrOfFailedTestCases += CheckReject("abc",     reportTestCases);
+		nrOfFailedTestCases += CheckReject("/",       reportTestCases);
+		nrOfFailedTestCases += CheckReject("1/",      reportTestCases);
+		nrOfFailedTestCases += CheckReject("/2",      reportTestCases);
+		nrOfFailedTestCases += CheckReject("1/2/3",   reportTestCases);
+		nrOfFailedTestCases += CheckReject("3.14.15", reportTestCases);
+		nrOfFailedTestCases += CheckReject("1e",      reportTestCases);
+		nrOfFailedTestCases += CheckReject(".",       reportTestCases);
+		nrOfFailedTestCases += CheckReject("42x",     reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "malformed reject", "erational parse");
+	}
+
+	// ----- negative-zero collapses to +0 across all input forms -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckParse("-0",      "0/1", reportTestCases);
+		nrOfFailedTestCases += CheckParse("-0.0",    "0/1", reportTestCases);
+		nrOfFailedTestCases += CheckParse("-0/5",    "0/1", reportTestCases);
+		nrOfFailedTestCases += CheckParse("0/-5",    "0/1", reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "negative-zero collapse", "erational parse");
 	}
 
 	// ----- operator>> sets failbit on a bad token -----
@@ -60,21 +179,42 @@ try {
 			is >> p;
 		}
 		if (!is.fail()) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: erational operator>> failbit\n";
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> failbit on bad", "erational parse");
+	}
+
+	// ----- operator>> succeeds on a p/q token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("  -22/7  ");
+		erational p;
+		is >> p;
+		std::ostringstream os; os << p;
+		if (is.fail() || os.str() != "-22/7") ++nrOfFailedTestCases;
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> p/q", "erational parse");
+	}
+
+	// ----- operator>> on empty stream sets failbit -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("");
+		erational p;
+		is >> p;
+		if (!is.fail()) ++nrOfFailedTestCases;
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> empty stream", "erational parse");
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
 	return EXIT_FAILURE;
 }
 catch (const std::runtime_error& err) {
-	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	std::cerr << "Caught runtime exception: " << err.what() << '\n';
 	return EXIT_FAILURE;
 }
 catch (...) {
-	std::cerr << "Caught unknown exception" << std::endl;
+	std::cerr << "Caught unknown exception\n";
 	return EXIT_FAILURE;
 }

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -233,66 +233,111 @@ public:
 	void setbits(uint64_t v) { *this = v; } // API to be consistent with the other number systems
 
 	// read a erational ASCII format and make a erational type out of it
+	// Parse a rational literal in any of these forms:
+	//   integer:     "42",   "-1000"            -> 42/1, -1000/1
+	//   p/q:         "1/2",  "-22/7", "355/113" -> simplified to lowest terms
+	//   decimal:     "3.14", "-0.5"             -> 157/50, -1/2
+	//   scientific:  "1.5e2", "1.5e-1"          -> 150/1, 3/20
+	//   mixed p/q:   "3.14/2"                   -> 157/100
+	// Rejects malformed input, division by zero ("1/0"), and inputs whose
+	// expansion would exceed the underlying edecimal parse cap.
 	bool parse(const std::string& _digits) {
-		bool bSuccess = false;
 		std::string digits(_digits);
 		trim(digits);
-		// check if the txt is an erational form:[+-]*[0123456789]+
-		std::regex erational_regex("[+-]*[0123456789]+");
-		if (std::regex_match(digits, erational_regex)) {
-			// found a erational representation
-			numerator.clear();
-			auto it = digits.begin();
-			if (*it == '-') {
-				setneg();
-				++it;
-			}
-			else if (*it == '+') {
-				++it;
-			}
-			for (; it != digits.end(); ++it) {
-				uint8_t v;
-				switch (*it) {
-				case '0':
-					v = 0;
-					break;
-				case '1':
-					v = 1;
-					break;
-				case '2':
-					v = 2;
-					break;
-				case '3':
-					v = 3;
-					break;
-				case '4':
-					v = 4;
-					break;
-				case '5':
-					v = 5;
-					break;
-				case '6':
-					v = 6;
-					break;
-				case '7':
-					v = 7;
-					break;
-				case '8':
-					v = 8;
-					break;
-				case '9':
-					v = 9;
-					break;
-				default:
-					v = 0;
-				}
-				numerator.push_back(v);
-			}
-			std::reverse(numerator.begin(), numerator.end());
-			bSuccess = true;
+		if (digits.empty()) return false;
+
+		// Detect rational p/q split. A single '/' divides the input; any
+		// further '/' is rejected by the per-half scan_decimal_float check.
+		auto slash = digits.find('/');
+		if (slash != std::string::npos) {
+			std::string p_str = digits.substr(0, slash);
+			std::string q_str = digits.substr(slash + 1);
+			edecimal p_num, p_den, q_num, q_den;
+			bool p_neg = false, q_neg = false;
+			if (!parse_decimal_to_fraction(p_str, p_num, p_den, p_neg)) return false;
+			if (!parse_decimal_to_fraction(q_str, q_num, q_den, q_neg)) return false;
+			// q == 0 (e.g. "1/0", "1/0.0") is rejected: erational has no
+			// NaR encoding, and silently representing infinity would mask
+			// downstream divide-by-zero detection.
+			if (q_num.iszero()) return false;
+			// (p_num/p_den) / (q_num/q_den) = (p_num*q_den)/(p_den*q_num)
+			numerator   = p_num * q_den;
+			denominator = p_den * q_num;
+			negative    = p_neg ^ q_neg;
 		}
-		return bSuccess;
+		else {
+			edecimal num, den;
+			bool neg = false;
+			if (!parse_decimal_to_fraction(digits, num, den, neg)) return false;
+			numerator   = num;
+			denominator = den;
+			negative    = neg;
+		}
+
+		// Reduce to lowest terms via GCD.
+		normalize();
+		// No negative zero.
+		if (numerator.iszero()) negative = false;
+		return true;
 	}
+
+private:
+	// Tokenize a decimal/scientific literal and split it into a (numerator,
+	// denominator) edecimal pair without precision loss.  Returns false on
+	// malformed input or if expansion would exceed the safe digit cap.
+	static bool parse_decimal_to_fraction(const std::string& s,
+	                                      edecimal& num,
+	                                      edecimal& den,
+	                                      bool& neg) {
+		// Same defensive cap as edecimal::parse uses internally.  We pre-check
+		// here so we never allocate a giant intermediate string before
+		// handing it off.
+		constexpr std::size_t MAX_DIGITS = 1u << 20;  // 1,048,576
+
+		std::string trimmed = s;
+		trim(trimmed);
+		if (trimmed.empty()) return false;
+
+		auto scan = sw::universal::string_parse::scan_decimal_float(trimmed);
+		if (!scan.valid) return false;
+		neg = scan.negative;
+
+		// Combined significand = int_part || frac_part (high-to-low digits).
+		std::string sig;
+		sig.reserve(scan.int_part.size() + scan.frac_part.size());
+		sig.append(scan.int_part);
+		sig.append(scan.frac_part);
+		if (sig.empty()) return false;  // defensive: scan requires >=1 digit
+
+		// Effective exponent: positive means trailing zeros on the numerator,
+		// negative means the denominator is 10^|eff|.
+		std::int64_t eff_exp = static_cast<std::int64_t>(scan.exp10)
+		                     - static_cast<std::int64_t>(scan.frac_part.size());
+
+		if (eff_exp >= 0) {
+			std::uint64_t total = static_cast<std::uint64_t>(sig.size())
+			                    + static_cast<std::uint64_t>(eff_exp);
+			if (total > MAX_DIGITS) return false;
+			sig.append(static_cast<std::size_t>(eff_exp), '0');
+			if (!num.parse(sig)) return false;
+			den = edecimal(1);
+		}
+		else {
+			// numerator = sig (no expansion);
+			// denominator = 10^|eff_exp| (a single 1 followed by |eff| zeros).
+			std::uint64_t den_digits = static_cast<std::uint64_t>(-eff_exp) + 1u;
+			if (sig.size() > MAX_DIGITS || den_digits > MAX_DIGITS) return false;
+			if (!num.parse(sig)) return false;
+			std::string den_str;
+			den_str.reserve(static_cast<std::size_t>(den_digits));
+			den_str.push_back('1');
+			den_str.append(static_cast<std::size_t>(-eff_exp), '0');
+			if (!den.parse(den_str)) return false;
+		}
+		return true;
+	}
+
+public:
 
 protected:
 	// HELPER methods


### PR DESCRIPTION
## Summary

\`erational::parse\` previously matched only \`[+-]*[0-9]+\` via
\`std::regex_match\` and left the denominator unset (so reusing an
erational with a non-default denominator silently kept stale state).
This PR routes parse through \`sw::universal::string_parse::scan_decimal_float\`
(the foundation from #838) and now accepts every form a rational
literal can naturally take.

## Design

A private static helper \`parse_decimal_to_fraction(s, num, den, neg)\`
tokenizes any decimal / scientific literal into an exact
(numerator, denominator) edecimal pair:

| input        | numerator | denominator |
|--------------|-----------|-------------|
| \`\"42\"\`       | 42        | 1           |
| \`\"3.14\"\`     | 314       | 100         |
| \`\"1.5e2\"\`    | 150       | 1           |
| \`\"1.5e-1\"\`   | 15        | 10          |
| \`\"3.14e+200\"\` | 314 * 10^198 | 1   |

\`parse()\` itself first detects a \`'/'\` separator. If present, both
sides are parsed through the helper and combined as
\`(p_num * q_den) / (p_den * q_num)\` with sign = \`p_neg ^ q_neg\`.
\`normalize()\` then reduces to lowest terms via GCD.

\`q_num.iszero()\` (across all flavors: \`\"1/0\"\`, \`\"5/0.0\"\`,
\`\"1/0e10\"\`) is rejected -- erational has no NaR encoding and
silently representing infinity would mask downstream divide-by-zero
detection.

## Defensive cap

The helper rejects inputs whose significand or denominator would
exceed 1,048,576 digits, mirroring the DoS protection that #854 added
to \`edecimal::parse\`.  \`scan_decimal_float\` returns an int32
exponent, so without this guard \`\"1e2000000000\"\` would expand to a
~2 GB string before reaching edecimal.

## Examples

\`\`\`
\"0\"         -> 0/1
\"-1000\"     -> -1000/1
\"1/2\"       -> 1/2
\"4/8\"       -> 1/2          (GCD simplification)
\"-22/7\"     -> -22/7
\"22/-7\"     -> -22/7        (sign normalization)
\"3.14\"      -> 157/50       (decimal -> rational)
\"-0.5\"      -> -1/2
\"1.5e-1\"    -> 3/20         (scientific -> rational)
\"3.14/2\"    -> 157/100      (mixed: decimal numerator)
\"1e2/2e1\"   -> 5/1
\"-0.0\"      -> 0/1          (negative-zero collapse)
\"1/0\"       -> REJECT
\"1/2/3\"     -> REJECT
\"\"          -> REJECT
\"3.14.15\"   -> REJECT
\`\`\`

## Changes

- \`include/sw/universal/number/erational/erational_impl.hpp\` --
  replace parse() with the routing logic; add the private
  parse_decimal_to_fraction helper; the integer path now also resets
  denominator to 1 (previously a latent bug when reusing an erational).
- \`elastic/rational/decimal/conversion/string_parse.cpp\` -- extend the
  test from 2 groups to 11.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| erat_string_parse | OK | PASS (11/11 groups) | OK | PASS (11/11 groups) |
| erat_api / logic / exceptions | OK | exit 0 | OK | exit 0 |
| erat_addition / subtraction / multiplication / division / sqrt | OK | exit 0 | OK | exit 0 |

## Test plan
- [ ] Fast CI (gcc + clang CI_LITE) passes
- [ ] Promote when satisfied: \`gh pr ready\`

Resolves #855

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Significantly expanded regression test coverage for rational number parsing across integers, ratios, decimals, and scientific notation.

* **New Features**
  * Enhanced parser to support scientific notation and mixed rational/decimal expressions.

* **Bug Fixes**
  * Improved validation for invalid inputs including division-by-zero and malformed tokens.
  * Standardized negative-zero handling across all input forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->