### PR TITLE
feat(efloat): implement parse() for decimal and scientific literals

### DIFF
--- a/elastic/efloat/conversion/string_parse.cpp
+++ b/elastic/efloat/conversion/string_parse.cpp
@@ -183,8 +183,15 @@ try {
 		// naive truncation (which would drop the round-up that took the
 		// 53-bit value from ...EB851E to ...EB851F to match native double).
 		efloat<2> v;
-		parse("3.14", v);
+		bool parsed = parse("3.14", v);
 		auto b = v.bits();
+		if (!parsed || b.size() < 2) {
+			std::cout << "FAIL 3.14: parsed=" << parsed
+			          << " limbs=" << b.size() << '\n';
+			++nrOfFailedTestCases;
+			ReportTestResult(nrOfFailedTestCases - start, "3.14 matches IEEE-754 double", "efloat parse");
+			return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+		}
 		std::uint64_t sig = (static_cast<std::uint64_t>(b[0]) << 32) | b[1];
 		const std::uint64_t expected = 0xC8F5C28F5C28F5C3ULL;
 		if (v.scale() != 1 || sig != expected) {

--- a/elastic/efloat/conversion/string_parse.cpp
+++ b/elastic/efloat/conversion/string_parse.cpp
@@ -1,5 +1,5 @@
-// string_parse.cpp: regression tests for decimal-string parsing of efloat
-//                  (Phase E of #835 -- operator>> hygiene only)
+// string_parse.cpp: regression tests for string parsing of efloat
+//                  (Phase E of #835 -- operator>> hygiene; #856 -- parse impl)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -7,20 +7,24 @@
 // This file is part of the universal numbers project, which is released under
 // an MIT Open Source license.
 //
-// efloat::parse is currently a stub that returns false unconditionally.
-// Phase E adds operator>> hygiene only: when parse() returns false, the
-// stream's failbit is now set (instead of just a cerr diagnostic).
-// Full parse() implementation is tracked in issue #856.
+// efloat::parse routes decimal / scientific literals through
+// sw::universal::decimal_to_binary::convert (Phase B2a), distills the
+// resulting mantissa + binary_scale into efloat's multi-limb representation,
+// and supports the "nan" / "inf" / "infinity" tokens.  operator>> sets
+// failbit on parse failure (#835 Phase E).
 
 #include <universal/utility/directives.hpp>
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #include <streambuf>
 #include <string>
+#include <cstdint>
 #include <universal/number/efloat/efloat.hpp>
 #include <universal/verification/test_reporters.hpp>
 
 namespace {
+
 struct CerrSilencer {
 	std::ostringstream sink;
 	std::streambuf*    old;
@@ -29,61 +33,286 @@ struct CerrSilencer {
 	CerrSilencer(const CerrSilencer&)            = delete;
 	CerrSilencer& operator=(const CerrSilencer&) = delete;
 };
+
+// Check the internal representation (state, sign, scale, top limb) against
+// expected values.  We assert on the top limb because efloat's to_string
+// for finite values is still a "TBD" stub -- the parse contract is what we
+// pin, not the round-trip-via-decimal.
+template<unsigned N>
+int CheckNormal(const char* input,
+                bool        expected_sign,
+                std::int64_t expected_scale,
+                std::uint32_t expected_lim0,
+                bool reportTestCases) {
+	using namespace sw::universal;
+	efloat<N> v;
+	if (!parse(input, v)) {
+		if (reportTestCases) std::cout << "FAIL parse rejected: '" << input << "'\n";
+		return 1;
+	}
+	if (v.iszero() || v.isnan() || v.isinf()) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' parsed as non-normal\n";
+		return 1;
+	}
+	bool sign_ok  = ((v.sign() == -1) == expected_sign);
+	bool scale_ok = (v.scale() == expected_scale);
+	auto bits = v.bits();
+	bool lim_ok = (!bits.empty() && bits[0] == expected_lim0);
+	if (!sign_ok || !scale_ok || !lim_ok) {
+		if (reportTestCases) {
+			std::cout << "FAIL '" << input << "': got sign=" << (v.sign() == -1 ? '-' : '+')
+			          << " scale=" << v.scale()
+			          << " lim0=0x" << std::hex << (bits.empty() ? 0u : bits[0]) << std::dec
+			          << " expected sign=" << (expected_sign ? '-' : '+')
+			          << " scale=" << expected_scale
+			          << " lim0=0x" << std::hex << expected_lim0 << std::dec << '\n';
+		}
+		return 1;
+	}
+	return 0;
 }
+
+template<unsigned N>
+int CheckZero(const char* input, bool expected_negative, bool reportTestCases) {
+	using namespace sw::universal;
+	efloat<N> v;
+	if (!parse(input, v)) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' rejected (expected zero)\n";
+		return 1;
+	}
+	if (!v.iszero()) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' not zero\n";
+		return 1;
+	}
+	if ((v.sign() == -1) != expected_negative) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' wrong zero sign\n";
+		return 1;
+	}
+	return 0;
+}
+
+template<unsigned N>
+int CheckNaN(const char* input, bool reportTestCases) {
+	using namespace sw::universal;
+	efloat<N> v;
+	if (!parse(input, v) || !v.isnan()) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' not nan\n";
+		return 1;
+	}
+	return 0;
+}
+
+template<unsigned N>
+int CheckInf(const char* input, bool expected_negative, bool reportTestCases) {
+	using namespace sw::universal;
+	efloat<N> v;
+	if (!parse(input, v) || !v.isinf()) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' not inf\n";
+		return 1;
+	}
+	if ((v.sign() == -1) != expected_negative) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' wrong inf sign\n";
+		return 1;
+	}
+	return 0;
+}
+
+template<unsigned N>
+int CheckReject(const char* input, bool reportTestCases) {
+	using namespace sw::universal;
+	efloat<N> v;
+	if (parse(input, v)) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' should reject\n";
+		return 1;
+	}
+	return 0;
+}
+
+}  // namespace
 
 int main()
 try {
 	using namespace sw::universal;
-	using Float = efloat<4>;
+	using Float = efloat<2>;  // 64-bit significand, lines up with native double layout
 
-	std::string test_suite  = "efloat decimal string parse (Phase E of #835)";
-	bool reportTestCases    = false;
+	std::string test_suite  = "efloat string parse (issues #835 Phase E, #856)";
+	bool reportTestCases    = true;
 	int  nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// ----- operator>> sets failbit when parse() returns false. Since
-	//       efloat::parse is currently a stub that always returns false,
-	//       any input drives failbit. This documents the current contract
-	//       and will continue to hold once parse() is implemented (#856) --
-	//       only the inputs that pass through parse will change. -----
+	// ----- canonical small values: bit-exact match against the hand-derived
+	//       normalized binary representation (MSB at bit 31 of _limb[0]) -----
 	{
 		int start = nrOfFailedTestCases;
-		std::istringstream is("1.0");
+		nrOfFailedTestCases += CheckNormal<2>("1",        false,  0, 0x80000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("-1",       true,   0, 0x80000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("2",        false,  1, 0x80000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("4",        false,  2, 0x80000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("0.5",      false, -1, 0x80000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("0.25",     false, -2, 0x80000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("1.5",      false,  0, 0xC0000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("-2.5",     true,   1, 0xA0000000u, reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "canonical normals", "efloat parse");
+	}
+
+	// ----- scientific notation with large |exponent| -----
+	{
+		int start = nrOfFailedTestCases;
+		// 1e10 = 0x9502F900_00000000 * 2^33 (verified against the d2b output;
+		// scale equals floor(log2(1e10)) = 33).
+		nrOfFailedTestCases += CheckNormal<2>("1e10",   false,   33, 0x9502F900u, reportTestCases);
+		// 1e-10 mantissa rounds to nearest at 64 bits; scale = -34.
+		nrOfFailedTestCases += CheckNormal<2>("1e-10",  false,  -34, 0xDBE6FECEu, reportTestCases);
+		// 1e100 scale = 332 (floor(log2(1e100)) = 332)
+		nrOfFailedTestCases += CheckNormal<2>("1e100",  false,  332, 0x924D692Cu, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("1e-100", false, -333, 0xDFF97724u, reportTestCases);
+		// 3.14e2 = 314 = 0b100111010 = 1.0011101 * 2^8
+		nrOfFailedTestCases += CheckNormal<2>("3.14e2", false,    8, 0x9D000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("-3.14e2", true,    8, 0x9D000000u, reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "scientific notation", "efloat parse");
+	}
+
+	// ----- 3.14 bit pattern matches the d2b output (64-bit RTNE) and
+	//       agrees with native double in the top 53 bits after rounding -----
+	{
+		int start = nrOfFailedTestCases;
+		// 3.14 normalized to 64 explicit bits with round-to-nearest-even:
+		//   sig = 0xC8F5C28F_5C28F5C3, scale = 1.
+		// Verify the full 64-bit pattern instead of extracting 53 bits via
+		// naive truncation (which would drop the round-up that took the
+		// 53-bit value from ...EB851E to ...EB851F to match native double).
+		efloat<2> v;
+		parse("3.14", v);
+		auto b = v.bits();
+		std::uint64_t sig = (static_cast<std::uint64_t>(b[0]) << 32) | b[1];
+		const std::uint64_t expected = 0xC8F5C28F5C28F5C3ULL;
+		if (v.scale() != 1 || sig != expected) {
+			std::cout << "FAIL 3.14 sig = 0x" << std::hex << sig
+			          << " scale=" << std::dec << v.scale()
+			          << " expected sig=0x" << std::hex << expected
+			          << " scale=1\n" << std::dec;
+			++nrOfFailedTestCases;
+		}
+		// Cross-check against native double: rounding the parsed 64-bit
+		// significand to 53 bits (round-half-to-even on bit 10) must match
+		// the bit pattern of 3.14 stored in an IEEE-754 double.
+		const std::uint64_t round_bias = 1ULL << 10;  // round half-up at bit 11 cut
+		std::uint64_t round_input = sig + round_bias;
+		// If exactly halfway (bottom 11 bits == 0x400) and result bit 11 == 0,
+		// strip the round bias for round-to-even.  3.14 is not exactly halfway,
+		// so this branch is not taken; we add the simplest check.
+		std::uint64_t top53 = round_input >> 11;
+		std::uint64_t double_bits = 0x40091EB851EB851FULL;
+		std::uint64_t double_sig  = (double_bits & 0x000FFFFFFFFFFFFFULL) | 0x0010000000000000ULL;
+		if (top53 != double_sig) {
+			std::cout << "FAIL 3.14 top53 = 0x" << std::hex << top53
+			          << " double_sig = 0x" << double_sig << std::dec << '\n';
+			++nrOfFailedTestCases;
+		}
+		ReportTestResult(nrOfFailedTestCases - start, "3.14 matches IEEE-754 double", "efloat parse");
+	}
+
+	// ----- signed zero (both sign-bearing inputs collapse to the same state) -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckZero<2>("0",       false, reportTestCases);
+		nrOfFailedTestCases += CheckZero<2>("+0",      false, reportTestCases);
+		nrOfFailedTestCases += CheckZero<2>("-0",      true,  reportTestCases);
+		nrOfFailedTestCases += CheckZero<2>("0.0",     false, reportTestCases);
+		nrOfFailedTestCases += CheckZero<2>("-0.0",    true,  reportTestCases);
+		nrOfFailedTestCases += CheckZero<2>("0e10",    false, reportTestCases);
+		nrOfFailedTestCases += CheckZero<2>("-0.0e5",  true,  reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "signed zero", "efloat parse");
+	}
+
+	// ----- nan / inf token routing -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckNaN<2>("nan",      reportTestCases);
+		nrOfFailedTestCases += CheckNaN<2>("NaN",      reportTestCases);
+		nrOfFailedTestCases += CheckNaN<2>("NAN",      reportTestCases);
+		nrOfFailedTestCases += CheckInf<2>("inf",      false, reportTestCases);
+		nrOfFailedTestCases += CheckInf<2>("Inf",      false, reportTestCases);
+		nrOfFailedTestCases += CheckInf<2>("-inf",     true,  reportTestCases);
+		nrOfFailedTestCases += CheckInf<2>("+inf",     false, reportTestCases);
+		nrOfFailedTestCases += CheckInf<2>("infinity", false, reportTestCases);
+		nrOfFailedTestCases += CheckInf<2>("-Infinity", true, reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "nan/inf tokens", "efloat parse");
+	}
+
+	// ----- malformed input must be rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckReject<2>("",       reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("abc",    reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("1.2.3",  reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("1e",     reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>(".",      reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("1e3.5",  reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("42x",    reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("0xFF",   reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("nann",   reportTestCases);
+		nrOfFailedTestCases += CheckReject<2>("inff",   reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "malformed reject", "efloat parse");
+	}
+
+	// ----- operator>> failbit on bad token -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("not-a-number");
 		Float p;
 		{
 			CerrSilencer silence;
 			is >> p;
 		}
 		if (!is.fail()) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: efloat operator>> failbit on stub parse\n";
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> failbit on bad", "efloat parse");
 	}
 
-	// ----- operator>> handles EOF without crashing -----
+	// ----- operator>> success on a valid scientific token in whitespace -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("  3.14e2  ");
+		Float p;
+		is >> p;
+		if (is.fail() || p.iszero() || p.isnan() || p.isinf()) ++nrOfFailedTestCases;
+		// scale should be 8 (314 normalized to 1.001110100 * 2^8)
+		if (p.scale() != 8) ++nrOfFailedTestCases;
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> scientific", "efloat parse");
+	}
+
+	// ----- operator>> on empty stream sets failbit -----
 	{
 		int start = nrOfFailedTestCases;
 		std::istringstream is("");
 		Float p;
-		{
-			CerrSilencer silence;
-			is >> p;
-		}
+		is >> p;
 		if (!is.fail()) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: efloat operator>> EOF handling\n";
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> empty stream", "efloat parse");
+	}
+
+	// ----- different nlimbs widths see the same scale and same top-limb pattern -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckNormal<1>("1.5",  false, 0, 0xC0000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<2>("1.5",  false, 0, 0xC0000000u, reportTestCases);
+		nrOfFailedTestCases += CheckNormal<4>("1.5",  false, 0, 0xC0000000u, reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "nlimbs parity (1/2/4)", "efloat parse");
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
 	return EXIT_FAILURE;
 }
 catch (const std::runtime_error& err) {
-	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	std::cerr << "Caught runtime exception: " << err.what() << '\n';
 	return EXIT_FAILURE;
 }
 catch (...) {
-	std::cerr << "Caught unknown exception" << std::endl;
+	std::cerr << "Caught unknown exception\n";
 	return EXIT_FAILURE;
 }

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -16,6 +16,8 @@
 // supporting types and functions
 #include <universal/native/ieee754.hpp>   // IEEE-754 decoders
 #include <universal/number/shared/specific_value_encoding.hpp>
+#include <universal/utility/string_parse.hpp>   // scan_decimal_float
+#include <universal/utility/decimal_to_binary.hpp>  // d2b convert (Phase B2a)
 
 /*
 The efloat arithmetic can be configured to:
@@ -159,6 +161,24 @@ public:
 		if (!std::is_constant_evaluated()) {
 			_limb.push_back(0);
 		}
+	}
+	constexpr void setinf(bool sign = false) noexcept {
+		_state = FloatingPointState::Infinite;
+		_sign = sign;
+		_exponent = 0;
+		_limb.clear();
+	}
+	constexpr void setnan(bool quiet = true) noexcept {
+		_state = quiet ? FloatingPointState::QuietNaN : FloatingPointState::SignalingNaN;
+		_sign = false;
+		_exponent = 0;
+		_limb.clear();
+	}
+	constexpr void setsign(bool sign) noexcept { _sign = sign; }
+	constexpr void setexponent(std::int64_t e) noexcept { _exponent = e; }
+	void setlimb(unsigned i, std::uint32_t value) {
+		if (i >= _limb.size()) _limb.resize(i + 1, 0u);
+		_limb[i] = value;
 	}
 
 	efloat& assign(const std::string& /* txt */) {
@@ -383,12 +403,110 @@ inline efloat<nlimbs> abs(const efloat<nlimbs>& a) {
 ////////////////////////////////////////////////////////////////////////////////
 /// stream operators
 
-// read a efloat ASCII format and make a binary efloat out of it
+// read an ASCII decimal literal and make a binary efloat out of it.
+// Supports:
+//   - "nan", "inf", "infinity" (case-insensitive, optional sign)
+//   - decimal / scientific literals routed through decimal_to_binary::convert
+//     ("1.5", "-3.14e2", "1e-100", "0x" is not accepted)
+// The d2b target_mantissa_bits is sized to fill efloat's available limb
+// storage, capped at 2040 bits (just under the d2b BigBits budget of 2048).
+// For larger nlimbs the parsed value uses 2040 explicit bits of precision
+// and lower limbs stay zero -- that is exact for any practical literal a
+// user types (a decimal exponent within ~+/-600).
 template<unsigned nlimbs>
 bool parse(const std::string& txt, efloat<nlimbs>& value) {
-	bool bSuccess = false;
 	value.clear();
-	return bSuccess;
+
+	std::string s = txt;
+	// trim ASCII whitespace
+	auto not_space = [](unsigned char c) { return !std::isspace(c); };
+	auto first = std::find_if(s.begin(), s.end(), not_space);
+	auto last  = std::find_if(s.rbegin(), s.rend(), not_space).base();
+	s = (first < last) ? std::string(first, last) : std::string{};
+	if (s.empty()) return false;
+
+	// nan / inf / infinity tokens (case-insensitive, optional leading sign).
+	{
+		bool neg = false;
+		std::size_t i = 0;
+		if (i < s.size() && (s[i] == '+' || s[i] == '-')) {
+			neg = (s[i] == '-');
+			++i;
+		}
+		std::string tok;
+		tok.reserve(s.size() - i);
+		for (std::size_t k = i; k < s.size(); ++k) {
+			tok.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(s[k]))));
+		}
+		if (tok == "nan") {
+			value.setnan(true);
+			return true;
+		}
+		if (tok == "inf" || tok == "infinity") {
+			value.setinf(neg);
+			return true;
+		}
+	}
+
+	// Decimal / scientific literal.
+	constexpr unsigned cap_bits  = sw::universal::decimal_to_binary::default_big_bits - 8u;
+	constexpr unsigned want_bits = static_cast<unsigned>(nlimbs) * 32u;
+	constexpr unsigned target_bits = (want_bits == 0u) ? 1u
+	                              : ((want_bits < cap_bits) ? want_bits : cap_bits);
+
+	auto r = sw::universal::decimal_to_binary::convert(s, target_bits);
+	if (!r.valid) return false;
+
+	if (r.is_zero) {
+		value.setzero();
+		if (r.negative) value.setsign(true);
+		return true;
+	}
+
+	// Round-to-nearest-even using d2b's guard/sticky.  If a carry escapes
+	// the top of the mantissa (now occupies bit `target_bits`), shift right
+	// by 1 and bump the binary scale.
+	auto mantissa = r.mantissa;
+	std::int64_t binary_scale = r.binary_scale;
+	bool round_up = r.guard_bit && (r.sticky_bit || mantissa.at(0));
+	if (round_up) {
+		using Big = sw::universal::decimal_to_binary::big_integer<>;
+		mantissa += Big(1);
+		if (mantissa.at(target_bits)) {
+			mantissa >>= 1;
+			++binary_scale;
+		}
+	}
+
+	value.setsign(r.negative);
+	value.setexponent(binary_scale);
+
+	// Pack the mantissa MSB-first into uint32 limbs: _limb[0] bit 31 = MSB,
+	// _limb[0] bit 0 = mantissa bit (target_bits - 32), _limb[1] bit 31 =
+	// mantissa bit (target_bits - 33), and so on.  Any leftover bits below
+	// the last full chunk go into the top of the next limb.
+	const unsigned full_limbs = target_bits / 32u;
+	const unsigned leftover   = target_bits % 32u;
+
+	for (unsigned i = 0; i < full_limbs; ++i) {
+		std::uint32_t v = 0;
+		const unsigned base = target_bits - 32u * (i + 1u);
+		for (unsigned b = 0; b < 32u; ++b) {
+			if (mantissa.at(base + b)) v |= (1u << b);
+		}
+		value.setlimb(i, v);
+	}
+	if (leftover > 0u) {
+		std::uint32_t v = 0;
+		for (unsigned b = 0; b < leftover; ++b) {
+			// mantissa.at(b) (a low mantissa bit) goes into the (32 - leftover + b)
+			// position of _limb[full_limbs] so the surviving bits stay packed
+			// against the top of the limb (MSB-first per-limb convention).
+			if (mantissa.at(b)) v |= (1u << (32u - leftover + b));
+		}
+		value.setlimb(full_limbs, v);
+	}
+	return true;
 }
 
 // generate an efloat format ASCII format


### PR DESCRIPTION
## Summary

\`efloat::parse\` was a stub that always returned false, so operator>>
extracted the token and immediately set failbit -- the elastic binary
float type couldn't ingest any literal at all.

This PR routes parse() through:
- the \"nan\" / \"inf\" / \"infinity\" tokens (case-insensitive, optional
  sign) into the matching \`FloatingPointState\`;
- every other input through \`decimal_to_binary::convert\` (Phase B2a,
  #841), then distills the resulting normalized mantissa + binary_scale
  into efloat's multi-limb representation -- the same approach #851
  used for the floatcascade family.

## Design

\`d2b::convert\` returns a normalized mantissa (MSB at bit
\`target_mantissa_bits - 1\`) plus a signed \`binary_scale\` and round
guard/sticky bits.  We:

1. Apply round-to-nearest-even using the guard/sticky.  If a carry
   escapes the top of the mantissa, shift right by 1 and bump
   \`binary_scale\`.
2. Pack the mantissa into efloat's \`std::vector<std::uint32_t>\`
   MSB-first: \`_limb[0]\` bit 31 = hidden bit (always 1 for normals);
   \`_limb[i]\` bit 0 = mantissa bit \`(target - 32(i+1))\`.
3. Set \`_exponent = binary_scale\`, \`_sign = result.negative\`.

\`target_mantissa_bits\` is sized to fill efloat's available limb
storage (\`nlimbs * 32\`) but capped at 2040 bits (just under d2b's
default BigBits = 2048).  For larger nlimbs the parsed value uses
2040 explicit bits and lower limbs stay zero -- exact for any
practical decimal literal a user would type.

## New efloat public modifiers

| | |
|---|---|
| \`setinf(bool sign = false)\` | set \`FloatingPointState::Infinite\` |
| \`setnan(bool quiet = true)\`  | set Quiet/SignalingNaN |
| \`setsign(bool)\`              | sign-only mutator |
| \`setexponent(std::int64_t)\`  | scale mutator |
| \`setlimb(unsigned, std::uint32_t)\` | limb mutator (grows the vector) |

\`parse()\` is a free function and uses only these public modifiers
plus \`clear()\` / \`setzero()\`, so no \`friend\` declaration is needed.

## Verified parses (excerpt)

| input | sign | scale | _limb[0] | _limb[1] |
|---|---|---|---|---|
| \"1\"        | + |  0 | 0x80000000 | 0 |
| \"2\"        | + |  1 | 0x80000000 | 0 |
| \"0.5\"      | + | -1 | 0x80000000 | 0 |
| \"1.5\"      | + |  0 | 0xC0000000 | 0 |
| \"3.14\"     | + |  1 | 0xC8F5C28F | 0x5C28F5C3 |
| \"3.14e2\"   | + |  8 | 0x9D000000 | 0 |
| \"1e10\"     | + | 33 | 0x9502F900 | 0 |
| \"1e-10\"    | + | -34 | 0xDBE6FECE | ... |
| \"1e100\"    | + | 332 | 0x924D692C | ... |
| \"1e-100\"   | + | -333 | 0xDFF97724 | ... |

3.14 cross-check: reducing the 64-bit RTNE significand to 53 bits with
RTNE yields exactly the IEEE-754 double bit pattern (0x191EB851EB851F).

## Out-of-scope

The ostream operator for finite values still emits \"TBD\"; implementing
a correct decimal printer (Dragon4 / Ryu for arbitrary-precision
binary float) is a separate effort and is not blocked by this PR.
Tests assert parse correctness via internal-state inspection, not via
round-trip-through-decimal.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_string_parse | OK | PASS (10/10 groups) | OK | PASS (10/10 groups) |
| efloat_api / constexpr / addition / pow | OK | exit 0 | OK | exit 0 |

## Test plan
- [ ] Fast CI (gcc + clang CI_LITE) passes
- [ ] Promote when satisfied: \`gh pr ready\`

Resolves #856

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full ASCII-decimal parser for efloat: decimal and scientific notation, signed zeros, NaN/Infinity variants, and correct rounding/representation across sizes.
  * New runtime state-manipulation helpers for efloat values to support setting special states and signs.

* **Tests**
  * Expanded regression test suite covering canonical decimals, large exponents, exact-significand cases, malformed tokens, and cross-width consistency.

* **Bug Fixes**
  * Replaced previous parsing stub with a working implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->