### PR TITLE
fix(ereal): reject trailing garbage in parse + comprehensive test coverage

### DIFF
--- a/elastic/ereal/conversion/string_parse.cpp
+++ b/elastic/ereal/conversion/string_parse.cpp
@@ -1,11 +1,17 @@
 // string_parse.cpp: regression tests for decimal-string parsing of ereal
-//                  (Phase E of #835 -- nan/inf + operator>> hygiene)
+//                  (Phase E of #835 -- nan/inf + operator>> hygiene;
+//                   #857 -- coverage + trailing-garbage fix)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under
 // an MIT Open Source license.
+//
+// ereal::parse accepts integer, decimal, scientific, and nan/inf literals;
+// operator>> sets failbit on parse failure with an extraction guard.  Issue
+// #857 also tightened the parse to reject trailing garbage after the
+// mantissa or exponent ("1e", "1e3.5", "42x").
 
 #include <universal/utility/directives.hpp>
 #include <cmath>
@@ -17,6 +23,7 @@
 #include <universal/verification/test_reporters.hpp>
 
 namespace {
+
 struct CerrSilencer {
 	std::ostringstream sink;
 	std::streambuf*    old;
@@ -25,54 +32,156 @@ struct CerrSilencer {
 	CerrSilencer(const CerrSilencer&)            = delete;
 	CerrSilencer& operator=(const CerrSilencer&) = delete;
 };
+
+// Parse `input` and compare the parsed value (as a double) against `expected`
+// with a tight tolerance.  ereal's leading limb is an IEEE double, so any
+// finite value that fits in double precision must compare equal here.
+template<unsigned N>
+int CheckValue(const char* input, double expected, bool reportTestCases) {
+	using namespace sw::universal;
+	ereal<N> v;
+	if (!parse(input, v)) {
+		if (reportTestCases) std::cout << "FAIL parse rejected: '" << input << "'\n";
+		return 1;
+	}
+	double got = static_cast<double>(v);
+	// ereal's digit-accumulate path may drift sub-ulp from the exact value
+	// for sub-1-ulp inputs; allow a small relative tolerance.
+	double diff = std::fabs(got - expected);
+	double tol  = std::fabs(expected) * 1e-12;
+	if (tol < 1e-300) tol = 1e-300;
+	if (diff > tol) {
+		if (reportTestCases) {
+			std::cout << "FAIL '" << input << "' got=" << got
+			          << " expected=" << expected
+			          << " diff=" << diff << '\n';
+		}
+		return 1;
+	}
+	return 0;
 }
+
+template<unsigned N>
+int CheckReject(const char* input, bool reportTestCases) {
+	using namespace sw::universal;
+	ereal<N> v;
+	if (parse(input, v)) {
+		if (reportTestCases) {
+			std::cout << "FAIL '" << input << "' should reject, got "
+			          << static_cast<double>(v) << '\n';
+		}
+		return 1;
+	}
+	return 0;
+}
+
+template<unsigned N>
+int CheckNaN(const char* input, bool reportTestCases) {
+	using namespace sw::universal;
+	ereal<N> v;
+	if (!parse(input, v) || !v.isnan()) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' not nan\n";
+		return 1;
+	}
+	return 0;
+}
+
+template<unsigned N>
+int CheckInf(const char* input, bool expected_negative, bool reportTestCases) {
+	using namespace sw::universal;
+	ereal<N> v;
+	if (!parse(input, v) || !v.isinf()) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' not inf\n";
+		return 1;
+	}
+	if (std::signbit(static_cast<double>(v)) != expected_negative) {
+		if (reportTestCases) std::cout << "FAIL '" << input << "' wrong inf sign\n";
+		return 1;
+	}
+	return 0;
+}
+
+}  // namespace
 
 int main()
 try {
 	using namespace sw::universal;
 	using Real = ereal<4>;
 
-	std::string test_suite  = "ereal decimal string parse (Phase E of #835)";
-	bool reportTestCases    = false;
+	std::string test_suite  = "ereal string parse (issues #835 Phase E, #857)";
+	bool reportTestCases    = true;
 	int  nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// ----- canonical decimals (existing digit-accumulate parse path) -----
+	// ----- canonical decimals: assert parsed value, not just success -----
 	{
 		int start = nrOfFailedTestCases;
-		Real p;
-		if (!parse("0", p))      ++nrOfFailedTestCases;
-		if (!parse("1.0", p))    ++nrOfFailedTestCases;
-		if (!parse("-3.25", p))  ++nrOfFailedTestCases;
-		if (!parse("1.25e3", p)) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: ereal canonical decimals\n";
+		nrOfFailedTestCases += CheckValue<4>("0",       0.0,    reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1",       1.0,    reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("-1",     -1.0,    reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("+42",     42.0,   reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("-1000", -1000.0,  reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("3.14",    3.14,   reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("-3.25",  -3.25,   reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("0.001",   0.001,  reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "canonical decimals", "ereal parse");
 	}
 
-	// ----- nan / inf token routing -----
+	// ----- scientific notation across +/-100 decimal exponent -----
 	{
 		int start = nrOfFailedTestCases;
-		Real p;
-		for (const char* s : { "nan", "NaN", "+nan", "-nan" }) {
-			if (!parse(s, p)) ++nrOfFailedTestCases;
-			if (!p.isnan())   ++nrOfFailedTestCases;
-		}
-		for (const char* s : { "inf", "Inf", "infinity", "INFINITY",
-		                       "+inf", "+infinity" }) {
-			if (!parse(s, p)) ++nrOfFailedTestCases;
-			if (!p.isinf())   ++nrOfFailedTestCases;
-		}
-		for (const char* s : { "-inf", "-Inf", "-infinity" }) {
-			if (!parse(s, p)) ++nrOfFailedTestCases;
-			if (!p.isinf())   ++nrOfFailedTestCases;
-			// -inf must have negative sign; std::signbit works for ereal
-			// since its leading limb is a regular IEEE double.
-			if (std::signbit(static_cast<double>(p)) != true) ++nrOfFailedTestCases;
-		}
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: ereal nan/inf token routing\n";
+		nrOfFailedTestCases += CheckValue<4>("1e0",     1.0,        reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1e10",    1e10,       reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1.5e2",   150.0,      reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1.25e3",  1250.0,     reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("-3.14e2", -314.0,     reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1e-10",   1e-10,      reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1e100",   1e100,      reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1e-100",  1e-100,     reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("1E+10",   1e10,       reportTestCases);  // capital E + explicit '+'
+		ReportTestResult(nrOfFailedTestCases - start, "scientific notation", "ereal parse");
 	}
 
-	// ----- operator>> sets failbit on a bad token -----
+	// ----- nan / inf / infinity token routing (case-insensitive, signed inf) -----
+	{
+		int start = nrOfFailedTestCases;
+		for (const char* s : { "nan", "NaN", "NAN", "+nan", "-nan" }) {
+			nrOfFailedTestCases += CheckNaN<4>(s, reportTestCases);
+		}
+		for (const char* s : { "inf", "Inf", "INF", "infinity", "Infinity", "INFINITY",
+		                       "+inf", "+Infinity" }) {
+			nrOfFailedTestCases += CheckInf<4>(s, false, reportTestCases);
+		}
+		for (const char* s : { "-inf", "-Inf", "-infinity", "-INFINITY" }) {
+			nrOfFailedTestCases += CheckInf<4>(s, true, reportTestCases);
+		}
+		ReportTestResult(nrOfFailedTestCases - start, "nan/inf tokens", "ereal parse");
+	}
+
+	// ----- malformed input must be rejected -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckReject<4>("",        reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("  ",      reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("abc",     reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("1.2.3",   reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>(".",       reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("42x",     reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("0xFF",    reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("1 2",     reportTestCases);
+		// Trailing 'e' with no digits, decimal point inside exponent:
+		// both formerly accepted; #857 tightens the parse.
+		nrOfFailedTestCases += CheckReject<4>("1e",      reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("1e3.5",   reportTestCases);
+		// Almost-token forms that must NOT be misread as nan/inf
+		nrOfFailedTestCases += CheckReject<4>("nann",    reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("innf",    reportTestCases);
+		nrOfFailedTestCases += CheckReject<4>("infi",    reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "malformed reject", "ereal parse");
+	}
+
+	// ----- operator>> failbit on bad token -----
 	{
 		int start = nrOfFailedTestCases;
 		std::istringstream is("not-a-number");
@@ -82,21 +191,57 @@ try {
 			is >> p;
 		}
 		if (!is.fail()) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: ereal operator>> failbit\n";
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> failbit on bad", "ereal parse");
+	}
+
+	// ----- operator>> success on a scientific token in whitespace -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("  3.14e2  ");
+		Real p;
+		is >> p;
+		if (is.fail() || std::fabs(static_cast<double>(p) - 314.0) > 1e-12) {
+			++nrOfFailedTestCases;
+		}
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> scientific", "ereal parse");
+	}
+
+	// ----- operator>> on empty stream sets failbit -----
+	{
+		int start = nrOfFailedTestCases;
+		std::istringstream is("");
+		Real p;
+		is >> p;
+		if (!is.fail()) ++nrOfFailedTestCases;
+		ReportTestResult(nrOfFailedTestCases - start, "operator>> empty stream", "ereal parse");
+	}
+
+	// ----- block-width parity: ereal<1>, ereal<2>, ereal<4> match for the
+	//       same input -----
+	{
+		int start = nrOfFailedTestCases;
+		nrOfFailedTestCases += CheckValue<1>("3.14e2", 314.0, reportTestCases);
+		nrOfFailedTestCases += CheckValue<2>("3.14e2", 314.0, reportTestCases);
+		nrOfFailedTestCases += CheckValue<4>("3.14e2", 314.0, reportTestCases);
+		nrOfFailedTestCases += CheckNaN<1>("nan", reportTestCases);
+		nrOfFailedTestCases += CheckNaN<2>("nan", reportTestCases);
+		nrOfFailedTestCases += CheckInf<1>("-inf", true, reportTestCases);
+		nrOfFailedTestCases += CheckInf<2>("-inf", true, reportTestCases);
+		ReportTestResult(nrOfFailedTestCases - start, "nlimbs parity", "ereal parse");
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
-	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
 	return EXIT_FAILURE;
 }
 catch (const std::runtime_error& err) {
-	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	std::cerr << "Caught runtime exception: " << err.what() << '\n';
 	return EXIT_FAILURE;
 }
 catch (...) {
-	std::cerr << "Caught unknown exception" << std::endl;
+	std::cerr << "Caught unknown exception\n";
 	return EXIT_FAILURE;
 }

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -352,6 +352,7 @@ public:
 
 		// Parse mantissa digits
 		bool found_digit = false;
+		bool saw_exponent_marker = false;
 		ereal<maxlimbs> ten(10.0);
 
 		while (pos < str.length()) {
@@ -373,6 +374,7 @@ public:
 				decimal_point_seen = true;
 			}
 			else if (c == 'e' || c == 'E') {
+				saw_exponent_marker = true;
 				++pos;  // Move past 'e'/'E'
 				break;  // Start exponent parsing
 			}
@@ -385,17 +387,20 @@ public:
 
 		if (!found_digit) return false;
 
-		// Parse optional exponent
-		if (pos < str.length() && (str[pos - 1] == 'e' || str[pos - 1] == 'E')) {
+		// Parse exponent digits when the mantissa loop stopped on an 'e'/'E'
+		// marker.  Tracking saw_exponent_marker (instead of inspecting
+		// str[pos-1]) is the only correct signal because the mantissa loop
+		// may have reached end-of-string normally.  A trailing 'e' with no
+		// digits ("1e") and a non-digit after the exponent ("1e3.5") both
+		// reject below.
+		if (saw_exponent_marker) {
 			bool exp_negative = false;
 
-			// Parse exponent sign
 			if (pos < str.length() && (str[pos] == '+' || str[pos] == '-')) {
 				exp_negative = (str[pos] == '-');
 				++pos;
 			}
 
-			// Parse exponent digits
 			bool found_exp_digit = false;
 			while (pos < str.length() && std::isdigit(str[pos])) {
 				found_exp_digit = true;
@@ -406,6 +411,11 @@ public:
 			if (!found_exp_digit) return false;
 			if (exp_negative) exponent = -exponent;
 		}
+
+		// Reject trailing garbage: any character left over after the
+		// mantissa + optional exponent run means the input wasn't a
+		// valid decimal literal.
+		if (pos != str.length()) return false;
 
 		// Apply decimal point adjustment
 		if (decimal_point_seen) {


### PR DESCRIPTION
## Summary

Items 1 and 2 of #857 (nan/inf token routing + operator>> failbit/extraction
guard) shipped via #858 / Phase E of #835.  Two latent parse bugs surfaced
while writing the comprehensive test the issue's acceptance criteria
requires:

- \`\"1e\"\` was accepted as 1.0.  The exponent block guarded on
  \`pos < str.length() && str[pos - 1] == 'e'\`, which is false at end-
  of-string, so the missing-exponent-digit check never ran.
- \`\"1e3.5\"\` was accepted as 1000.  The exponent parser consumed
  \`\"3\"\` and never verified that \`pos == str.length()\`, letting
  trailing garbage through silently.

Fix: track \`saw_exponent_marker\` explicitly when the mantissa loop
stops on \`'e'\`/\`'E'\`, and require \`pos == str.length()\` at the end
of parse.

## Test extension

\`elastic/ereal/conversion/string_parse.cpp\` grew from 3 groups (just
\"parse returned true\") to 8 groups that assert parsed values via the
double-extraction path (1e-12 relative tolerance for finite values)
and pin every malformed-input case in the issue's acceptance
criteria:

| Group | Coverage |
|-------|----------|
| canonical decimals | \"0\", \"1\", \"-1\", \"+42\", \"-1000\", \"3.14\", \"-3.25\", \"0.001\" |
| scientific notation | 1e0 .. 1e+/-100, \"-3.14e2\", \"1E+10\" |
| nan/inf tokens | \"nan\"/\"NaN\"/\"NAN\", \"+nan\", \"-nan\"; inf/Inf/INF/infinity, signed |
| malformed reject | empty, alpha, 1.2.3, \".\", 42x, 0xFF, \"1 2\", **\"1e\", \"1e3.5\"**, nann, innf, infi |
| operator>> failbit on bad | re-asserts #858 hygiene |
| operator>> scientific | reads \"3.14e2\" in whitespace, 314.0 within 1e-12 |
| operator>> empty stream | EOF sets failbit cleanly |
| nlimbs parity | ereal<1>/<2>/<4> agree on \"3.14e2\", \"nan\", \"-inf\" |

## Out of scope

Item 3 of the issue (replace the digit-accumulate + \`pown(10, e)\`
exponent path with the distill algorithm from #851) is explicitly
deferred per the issue body (\"may warrant its own follow-up issue\").
Not addressed here.

## Test Results

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_conv_string_parse | OK | PASS (8/8 groups) | OK | PASS (8/8 groups) |
| er_api_api | OK | exit 0 | OK | exit 0 |
| er_arith_addition / subtraction / multiplication / division | OK | exit 0 | OK | exit 0 |

## Test plan
- [ ] Fast CI (gcc + clang CI_LITE) passes
- [ ] Promote when satisfied: \`gh pr ready\`

Resolves #857

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of decimal-string parsing for `ereal` numbers to properly reject malformed input with trailing garbage and invalid exponent markers.

* **Tests**
  * Expanded test coverage with comprehensive checks for canonical decimals, scientific notation, special values (NaN/Inf), and malformed input rejection.
  * Added cross-width consistency assertions for `ereal` parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->