### PR TITLE
fix: IBM HFP clean-up

### DIFF
--- a/include/sw/universal/number/hfloat/hfloat.hpp
+++ b/include/sw/universal/number/hfloat/hfloat.hpp
@@ -68,6 +68,6 @@ namespace sw { namespace universal {
 // Standard IBM System/360 HFP formats
 using hfp32    = hfloat<6, 7, uint32_t>;    // 32-bit short precision
 using hfp64    = hfloat<14, 7, uint32_t>;   // 64-bit long precision
-using hfp128   = hfloat<28, 7, uint32_t>;   // 128-bit extended precision
+using hfp128   = hfloat<28, 7, uint32_t>;   // extended precision: 1+7+112 = 120 bits, stored in 128 bits
 
 }}  // namespace sw::universal

--- a/include/sw/universal/number/hfloat/hfloat.hpp
+++ b/include/sw/universal/number/hfloat/hfloat.hpp
@@ -66,8 +66,8 @@
 namespace sw { namespace universal {
 
 // Standard IBM System/360 HFP formats
-using hfloat_short    = hfloat<6, 7, uint32_t>;    // 32-bit short precision
-using hfloat_long     = hfloat<14, 7, uint32_t>;   // 64-bit long precision
-using hfloat_extended = hfloat<28, 7, uint32_t>;   // 128-bit extended precision
+using hfp32    = hfloat<6, 7, uint32_t>;    // 32-bit short precision
+using hfp64    = hfloat<14, 7, uint32_t>;   // 64-bit long precision
+using hfp128   = hfloat<28, 7, uint32_t>;   // 128-bit extended precision
 
 }}  // namespace sw::universal

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -969,13 +969,12 @@ inline std::string to_hex(const hfloat<ndigits, es, BlockType>& number) {
 	// the fraction as uint64_t, which loses bits for wide configs
 	// (hfloat_extended has fbits=112); the legacy `frac_val >> (i*4)` loop
 	// below also had UB for i*4 >= 64, producing wrapped/duplicated digits.
+	// MSB-first left-fold to assemble the exponent field; safe for any es.
 	using Hfloat = hfloat<ndigits, es, BlockType>;
 	unsigned exp_field = 0;
 	unsigned expStart  = Hfloat::nbits - 2;
 	for (unsigned i = 0; i < es; ++i) {
-		if (number.getbit(expStart - i)) {
-			exp_field |= (1u << (es - 1 - i));
-		}
+		exp_field = (exp_field << 1) | (number.getbit(expStart - i) ? 1u : 0u);
 	}
 	int exp_val = static_cast<int>(exp_field) - Hfloat::bias;
 

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -249,6 +249,52 @@ public:
 		return *this;
 	}
 
+	// Assign from a wide (target_mantissa_bits == fbits) decimal_to_binary
+	// result. Delivers full fbits of precision regardless of host integer
+	// width -- the whole point of routing decimal literals through d2b
+	// instead of through double. Used by parse() when fbits > 64; the
+	// uint64_t-based assign_from_mantissa64 above still serves the
+	// convert_ieee754 (double / long double) entry point, where the input
+	// is bounded to ~64 mantissa bits regardless.
+	template<unsigned BigBits>
+	constexpr hfloat& assign_from_wide_mantissa(bool negative, int bin_exp,
+	    const ::sw::universal::decimal_to_binary::basic_result<BigBits>& d) noexcept {
+		// d.mantissa is normalized with MSB at bit (fbits - 1). The hex-
+		// digit alignment within IBM HFP requires at most a 0..3 bit right
+		// shift relative to that normalization so the leading hex digit
+		// (bits [fbits-4, fbits-1]) ends up non-zero.
+		int hex_exp;
+		if (bin_exp > 0) hex_exp = (bin_exp + 3) / 4;
+		else             hex_exp = bin_exp / 4;  // C truncates toward zero == ceil for negative
+
+		if (hex_exp > emax) {
+			if (negative) maxneg(); else maxpos();
+			return *this;
+		}
+		if (hex_exp < emin) {
+			setzero();
+			return *this;
+		}
+
+		// shift = bin_exp - 4*hex_exp lies in [-3, 0]. Read fraction bit i
+		// from d.mantissa.at(i + right_shift); the low `right_shift` mantissa
+		// bits are dropped -- IBM HFP truncation rounding.
+		int shift = bin_exp - 4 * hex_exp;
+		unsigned right_shift = static_cast<unsigned>(-shift);
+
+		clear();
+		setbit(nbits - 1, negative);
+		unsigned biased_exp = static_cast<unsigned>(hex_exp + bias);
+		unsigned expStart = nbits - 2;
+		for (unsigned i = 0; i < es; ++i) {
+			setbit(expStart - i, (biased_exp >> (es - 1 - i)) & 1);
+		}
+		for (unsigned i = 0; i < fbits; ++i) {
+			if (d.mantissa.at(i + right_shift)) setbit(i, true);
+		}
+		return *this;
+	}
+
 	// prefix operators
 	constexpr hfloat operator-() const {
 		hfloat negated(*this);
@@ -1026,31 +1072,45 @@ bool parse(const std::string& number, hfloat<ndigits, es, BlockType>& value) {
 	}
 	if (pos != number.size()) return false;  // trailing junk
 
-	// Hand the trimmed payload (post-whitespace) to decimal_to_binary with
-	// 64 bits of precision -- enough to fill hfloat_long's 56 fbits exactly
-	// and a few extra for hfloat_short's 24 fbits to round correctly. For
-	// hfloat<28,*> (fbits=112) the result is the same lossy precision the
-	// pre-existing operator=(double) path already had, since 64 < 112.
+	// Hand the trimmed payload (post-whitespace) to decimal_to_binary.
+	// Request fbits of precision when fbits > 64 so wide-fraction configs
+	// (hfloat<28,*> with fbits=112) get bit-exact conversion through the
+	// d2b multi-limb mantissa instead of being clipped to double-precision
+	// like the legacy via-double path. For fbits <= 64 stay at 64 bits --
+	// that pinned the hfp64 0.1 truncation test under issue #849 and gives
+	// hfp32 a few guard bits for the d2b path's rounding to settle.
+	using H = hfloat<ndigits, es, BlockType>;
+	constexpr unsigned target_bits = (H::fbits > 64u) ? H::fbits : 64u;
 	std::string_view payload(number.data() + numeric_start, number.size() - numeric_start);
-	auto d = ::sw::universal::decimal_to_binary::convert(payload, 64u);
+	auto d = ::sw::universal::decimal_to_binary::convert(payload, target_bits);
 	if (!d.valid) return false;
 	if (d.is_zero) {
-		value = hfloat<ndigits, es, BlockType>(SpecificValue::zero);
+		value = H(SpecificValue::zero);
 		return true;
-	}
-
-	// Extract the 64-bit normalized mantissa (MSB at bit 63) from d2b's
-	// bigint. With target_mantissa_bits == 64, mantissa.bit[63] is the
-	// implicit-1 of the binary expansion and bits [0, 62] are the fraction.
-	std::uint64_t mantissa64 = 0;
-	for (unsigned i = 0; i < 64; ++i) {
-		if (d.mantissa.at(i)) mantissa64 |= (std::uint64_t{1} << i);
 	}
 
 	// d2b's binary_scale is the exponent of mantissa's MSB, so the
 	// "frexp" exponent (value = 1.frac * 2^(bin_exp - 1)) is binary_scale + 1.
 	int bin_exp = static_cast<int>(d.binary_scale) + 1;
-	value.assign_from_mantissa64(d.negative, bin_exp, mantissa64);
+
+	if constexpr (H::fbits > 64u) {
+		// Wide-fraction path: feed d2b's full multi-limb mantissa directly
+		// into the hex-aligned fraction. This is what makes parse() deliver
+		// precision beyond what double / long double can carry; the legacy
+		// uint64_t intermediate would truncate to ~64 bits and defeat the
+		// purpose of routing decimal literals through d2b in the first place.
+		value.assign_from_wide_mantissa(d.negative, bin_exp, d);
+	}
+	else {
+		// Extract the 64-bit normalized mantissa (MSB at bit 63) from d2b's
+		// bigint. With target_mantissa_bits == 64, mantissa.bit[63] is the
+		// implicit-1 of the binary expansion and bits [0, 62] are the fraction.
+		std::uint64_t mantissa64 = 0;
+		for (unsigned i = 0; i < 64; ++i) {
+			if (d.mantissa.at(i)) mantissa64 |= (std::uint64_t{1} << i);
+		}
+		value.assign_from_mantissa64(d.negative, bin_exp, mantissa64);
+	}
 	return true;
 }
 

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -947,15 +947,30 @@ inline std::string to_hex(const hfloat<ndigits, es, BlockType>& number) {
 	s << (number.sign() ? '-' : '+');
 	s << "0x0.";
 
-	// extract hex digits from fraction
-	bool sign_val; int exp_val; uint64_t frac_val;
-	number.unpack(sign_val, exp_val, frac_val);
+	// Read exponent and fraction directly from bit storage. unpack() returns
+	// the fraction as uint64_t, which loses bits for wide configs
+	// (hfloat_extended has fbits=112); the legacy `frac_val >> (i*4)` loop
+	// below also had UB for i*4 >= 64, producing wrapped/duplicated digits.
+	using Hfloat = hfloat<ndigits, es, BlockType>;
+	unsigned exp_field = 0;
+	unsigned expStart  = Hfloat::nbits - 2;
+	for (unsigned i = 0; i < es; ++i) {
+		if (number.getbit(expStart - i)) {
+			exp_field |= (1u << (es - 1 - i));
+		}
+	}
+	int exp_val = static_cast<int>(exp_field) - Hfloat::bias;
 
 	for (int i = static_cast<int>(ndigits) - 1; i >= 0; --i) {
-		unsigned hex_digit = (frac_val >> (i * 4)) & 0xF;
+		unsigned hex_digit = 0;
+		for (unsigned b = 0; b < 4u; ++b) {
+			if (number.getbit(static_cast<unsigned>(i) * 4u + b)) {
+				hex_digit |= (1u << b);
+			}
+		}
 		s << "0123456789ABCDEF"[hex_digit];
 	}
-	s << " * 16^" << (exp_val);
+	s << " * 16^" << exp_val;
 
 	return s.str();
 }

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -192,15 +192,47 @@ public:
 			// fraction's natural width exceeds 64 bits -- can't be held in
 			// uint64_t. This is unreachable for hfloat configs with fbits
 			// <= 64 (the standard hfloat_short / hfloat_long sizes) and is
-			// the hfloat_extended (fbits=112) edge case. Best-effort: cap
-			// fraction at the max representable in fbits so normalize_and_pack
-			// has something non-zero to encode. Full bit-exact conversion
-			// for fbits > 64 would need a multi-limb intermediate; left as
-			// future work.
-			if constexpr (fbits < 64) {
-				fraction = (uint64_t(1) << fbits) - 1u;
-			} else {
+			// the hfloat_extended (fbits=112) path: the 64-bit mantissa must
+			// be placed at offset `mantissa_shift` within the fbits-wide
+			// fraction (its low `mantissa_shift` bits are truncated to zero
+			// -- IBM HFP truncation). Check overflow/underflow first (the
+			// usual normalize_and_pack route can't see the wide fraction),
+			// then pack sign + exponent and setbit() the mantissa bits at
+			// their target high positions. Full bit-exact fbits>64
+			// conversion needs a wider intermediate (e.g. __uint128_t) and
+			// is left as future work; this delivers hfp64-precision in an
+			// hfp128 container.
+			if constexpr (fbits >= 64) {
+				if (hex_exp > emax) {
+					if (negative) maxneg(); else maxpos();
+					return *this;
+				}
+				if (hex_exp < emin) {
+					setzero();
+					return *this;
+				}
+				if (static_cast<unsigned>(mantissa_shift) < 64u) {
+					pack(negative, hex_exp, 0);
+					unsigned offset = static_cast<unsigned>(mantissa_shift);
+					unsigned upper = (offset + 64u <= fbits) ? 64u : (fbits - offset);
+					for (unsigned i = 0; i < upper; ++i) {
+						if ((mantissa64 >> i) & 1) setbit(offset + i, true);
+					}
+					return *this;
+				}
+				// mantissa_shift >= 64: entire 64-bit mantissa lies beyond
+				// bit 63 of the fraction. Saturating to maxpos keeps the
+				// exponent meaningful while signaling unrepresentable
+				// precision; rare for normal-magnitude inputs.
 				fraction = ~uint64_t(0);
+			}
+			else {
+				// fbits < 64 with mantissa_shift > 0 is mathematically
+				// unreachable (shift = bin_exp - 4*hex_exp + fbits with
+				// (bin_exp - 4*hex_exp) in [0,3], so mantissa_shift =
+				// shift - 64 <= fbits + 3 - 64 < 0 when fbits < 61), but
+				// keep a defensive fallback for very narrow configs.
+				fraction = (uint64_t(1) << fbits) - 1u;
 			}
 		}
 		else if (-mantissa_shift < 64) {
@@ -468,19 +500,30 @@ public:
 		if (iszero()) return 0;
 		bool s; int e; uint64_t f;
 		unpack(s, e, f);
-		// IBM HFP: value = 0.f * 16^e
-		// Scale in terms of powers of 2: scale = 4*e + leading_bit_position_of_f - fbits
-		// But conceptually: scale = 4 * (e - bias_already_removed)
-		// Find the leading 1 bit of the fraction. unpack() caps the
-		// fraction at 64 useful bits, so we only need to scan up to bit 63.
-		// Indices >= 64 would make `f >> i` UB.
+		(void)s;
+		// IBM HFP: value = 0.f * 16^e. unpack() returns the fraction's
+		// low 64 bits (for fbits < 64, that's the entire fraction). For
+		// fbits >= 64 the leading hex digit lives in bits [fbits-4, fbits-1]
+		// of the full fraction -- unpack's low-64-bit view sees only the
+		// truncated tail, not the leading bit, so we read the top 64
+		// fraction bits directly (bits [fbits-64, fbits-1]).
+		uint64_t top = 0;
+		if constexpr (fbits >= 64) {
+			for (unsigned i = 0; i < 64u; ++i) {
+				if (getbit(fbits - 64u + i)) top |= (uint64_t(1) << i);
+			}
+		}
+		else {
+			top = f;
+		}
 		constexpr int read_iter = (fbits < 64) ? static_cast<int>(fbits) : 64;
 		int leading = -1;
 		for (int i = read_iter - 1; i >= 0; --i) {
-			if ((f >> i) & 1) { leading = i; break; }
+			if ((top >> i) & 1) { leading = i; break; }
 		}
 		if (leading < 0) return 0;
-		return 4 * e + leading - static_cast<int>(fbits);
+		constexpr int frac_msb_weight = (fbits < 64) ? static_cast<int>(fbits) : 64;
+		return 4 * e + leading - frac_msb_weight;
 	}
 
 	// convert to string
@@ -709,8 +752,23 @@ protected:
 		bool s; int e; uint64_t f;
 		unpack(s, e, f);
 
-		// value = 0.f * 16^e = f * 2^(-fbits) * 16^e = f * 2^(4*e - fbits)
-		int shift = 4 * e - static_cast<int>(fbits);
+		// value = 0.f * 16^e. For fbits < 64 the unpack'd f IS the full
+		// fraction and value = f * 2^(-fbits) * 16^e = f * 2^(4*e - fbits).
+		// For fbits >= 64 the leading hex digit lives in the TOP 64 fraction
+		// bits, which unpack's low-64 view doesn't see; read them directly
+		// and treat f as representing fraction's bits [fbits-64, fbits-1],
+		// so value = f * 2^(-64) * 16^e = f * 2^(4*e - 64).
+		int shift;
+		if constexpr (fbits >= 64) {
+			f = 0;
+			for (unsigned i = 0; i < 64u; ++i) {
+				if (getbit(fbits - 64u + i)) f |= (uint64_t(1) << i);
+			}
+			shift = 4 * e - 64;
+		}
+		else {
+			shift = 4 * e - static_cast<int>(fbits);
+		}
 		double result = static_cast<double>(f);
 		if (std::is_constant_evaluated()) {
 			// Power-of-2 scaling: 2.0 and 0.5 are exactly representable

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -456,27 +456,37 @@ public:
 
 	// create specific number system values of interest
 	//
-	// The `max_frac` computations below cap at uint64_t max for fbits >= 64:
-	// `1ull << 64` and wider are UB. For hfloat configs with fbits > 64
-	// (hfloat_extended at fbits=112), the high fraction bits stay zero
-	// since pack()'s fraction parameter is also uint64_t; full-width
-	// fbits > 64 saturation is future work pending a multi-limb fraction
-	// path through pack / normalize_and_pack.
+	// IBM HFP has no subnormals (has_denorm == denorm_absent), so minpos
+	// and denorm_min coincide at the smallest normalized positive value:
+	// leading hex digit = 1, smallest exponent. maxpos sets every fraction
+	// bit (all 28 hex digits = F for hfp128). For fbits >= 64 the pack()
+	// uint64_t parameter cannot carry the full fraction; we fall back to
+	// setbit() to populate bits beyond position 63.
 	constexpr hfloat& maxpos() noexcept {
 		clear();
 		unsigned biased_exp = (1u << es) - 1u;
-		uint64_t max_frac;
+		int max_exp = static_cast<int>(biased_exp) - bias;
 		if constexpr (fbits < 64) {
-			max_frac = (uint64_t(1) << fbits) - 1u;
-		} else {
-			max_frac = ~uint64_t(0);
+			uint64_t max_frac = (uint64_t(1) << fbits) - 1u;
+			pack(false, max_exp, max_frac);
 		}
-		pack(false, static_cast<int>(biased_exp) - bias, max_frac);
+		else {
+			pack(false, max_exp, 0);
+			for (unsigned i = 0; i < fbits; ++i) setbit(i, true);
+		}
 		return *this;
 	}
 	constexpr hfloat& minpos() noexcept {
 		clear();
-		pack(false, emin, 1);
+		// Smallest normalized positive: leading hex digit = 1, i.e. bit
+		// (fbits - 4) set, all other fraction bits zero. Value = 16^(emin-1).
+		if constexpr (fbits < 64) {
+			pack(false, emin, uint64_t(1) << (fbits - 4));
+		}
+		else {
+			pack(false, emin, 0);
+			setbit(fbits - 4, true);
+		}
 		return *this;
 	}
 	constexpr hfloat& zero() noexcept {
@@ -485,19 +495,27 @@ public:
 	}
 	constexpr hfloat& minneg() noexcept {
 		clear();
-		pack(true, emin, 1);
+		if constexpr (fbits < 64) {
+			pack(true, emin, uint64_t(1) << (fbits - 4));
+		}
+		else {
+			pack(true, emin, 0);
+			setbit(fbits - 4, true);
+		}
 		return *this;
 	}
 	constexpr hfloat& maxneg() noexcept {
 		clear();
 		unsigned biased_exp = (1u << es) - 1u;
-		uint64_t max_frac;
+		int max_exp = static_cast<int>(biased_exp) - bias;
 		if constexpr (fbits < 64) {
-			max_frac = (uint64_t(1) << fbits) - 1u;
-		} else {
-			max_frac = ~uint64_t(0);
+			uint64_t max_frac = (uint64_t(1) << fbits) - 1u;
+			pack(true, max_exp, max_frac);
 		}
-		pack(true, static_cast<int>(biased_exp) - bias, max_frac);
+		else {
+			pack(true, max_exp, 0);
+			for (unsigned i = 0; i < fbits; ++i) setbit(i, true);
+		}
 		return *this;
 	}
 

--- a/include/sw/universal/number/hfloat/manipulators.hpp
+++ b/include/sw/universal/number/hfloat/manipulators.hpp
@@ -79,27 +79,34 @@ namespace sw { namespace universal {
 	template<unsigned ndigits, unsigned es, typename bt>
 	std::string components(const hfloat<ndigits, es, bt>& number) {
 		std::stringstream s;
-		bool sign; int exp; uint64_t frac;
-		number.unpack(sign, exp, frac);
+		bool sign = number.sign();
 		s << "sign: " << (sign ? '-' : '+');
 		if (number.iszero()) {
 			s << ", zero";
 		}
 		else {
-			s << ", hex scale: " << exp << ", hex fraction: 0x0.";
-			// Guard: frac is uint64_t so we can only extract up to 16 hex digits (64 bits).
-			// For hfloat_extended (ndigits=28) the fraction exceeds 64 bits;
-			// print only the digits that fit and mark truncation.
-			constexpr int max_hex_digits = 16; // 64 / 4
-			int printable = (static_cast<int>(ndigits) <= max_hex_digits)
-			              ? static_cast<int>(ndigits)
-			              : max_hex_digits;
-			for (int i = printable - 1; i >= 0; --i) {
-				unsigned hex_digit = (frac >> (i * 4)) & 0xF;
-				s << "0123456789ABCDEF"[hex_digit];
+			// Read sign + exponent the same way unpack() does, but iterate
+			// fraction hex digits directly from storage so wide configs
+			// (hfloat_extended at ndigits=28) print all 28 digits instead of
+			// the uint64_t-limited first 16.
+			unsigned exp_field = 0;
+			using Hfloat = hfloat<ndigits, es, bt>;
+			unsigned expStart = Hfloat::nbits - 2;
+			for (unsigned i = 0; i < es; ++i) {
+				if (number.getbit(expStart - i)) {
+					exp_field |= (1u << (es - 1 - i));
+				}
 			}
-			if (static_cast<int>(ndigits) > max_hex_digits) {
-				s << "... (truncated, " << ndigits << " hex digits exceed uint64_t)";
+			int exp = static_cast<int>(exp_field) - Hfloat::bias;
+			s << ", hex scale: " << exp << ", hex fraction: 0x0.";
+			for (int i = static_cast<int>(ndigits) - 1; i >= 0; --i) {
+				unsigned hex_digit = 0;
+				for (unsigned b = 0; b < 4u; ++b) {
+					if (number.getbit(static_cast<unsigned>(i) * 4u + b)) {
+						hex_digit |= (1u << b);
+					}
+				}
+				s << "0123456789ABCDEF"[hex_digit];
 			}
 		}
 		return s.str();

--- a/include/sw/universal/number/hfloat/manipulators.hpp
+++ b/include/sw/universal/number/hfloat/manipulators.hpp
@@ -48,22 +48,29 @@ namespace sw { namespace universal {
 		using Hfloat = hfloat<ndigits, es, bt>;
 		std::stringstream s;
 
-		// sign in red
-		s << "\033[31m" << (number.sign() ? '1' : '0') << "\033[0m" << '.';
+		Color red(ColorCode::FG_RED);
+	    Color yellow(ColorCode::FG_YELLOW);
+	    //Color blue(ColorCode::FG_BLUE);
+	    Color magenta(ColorCode::FG_MAGENTA);
+	    Color cyan(ColorCode::FG_CYAN);
+	    //Color white(ColorCode::FG_WHITE);
+	    Color def(ColorCode::FG_DEFAULT);
 
-		// exponent in blue
-		s << "\033[34m";
+		// sign bit
+		s << red << (number.sign() ? '1' : '0') << def;
+
+		// exponent bits
 		unsigned expStart = Hfloat::nbits - 2;
 		for (unsigned i = 0; i < es; ++i) {
-			s << (number.getbit(expStart - i) ? '1' : '0');
+			s << cyan << (number.getbit(expStart - i) ? '1' : '0');
 		}
-		s << "\033[0m" << '.';
 
-		// fraction in default color (with hex-digit separators)
+		// fraction bits
 		for (int i = static_cast<int>(Hfloat::fbits) - 1; i >= 0; --i) {
-			s << (number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
-			if (nibbleMarker && i > 0 && (i % 4 == 0)) s << '\'';
+			s << magenta << (number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
+			if (nibbleMarker && i > 0 && (i % 4 == 0)) s << yellow << '\'';
 		}
+	    s << def;
 
 		return s.str();
 	}

--- a/include/sw/universal/number/hfloat/manipulators.hpp
+++ b/include/sw/universal/number/hfloat/manipulators.hpp
@@ -50,10 +50,8 @@ namespace sw { namespace universal {
 
 		Color red(ColorCode::FG_RED);
 	    Color yellow(ColorCode::FG_YELLOW);
-	    //Color blue(ColorCode::FG_BLUE);
 	    Color magenta(ColorCode::FG_MAGENTA);
 	    Color cyan(ColorCode::FG_CYAN);
-	    //Color white(ColorCode::FG_WHITE);
 	    Color def(ColorCode::FG_DEFAULT);
 
 		// sign bit
@@ -87,15 +85,16 @@ namespace sw { namespace universal {
 		else {
 			// Read sign + exponent the same way unpack() does, but iterate
 			// fraction hex digits directly from storage so wide configs
-			// (hfloat_extended at ndigits=28) print all 28 digits instead of
-			// the uint64_t-limited first 16.
-			unsigned exp_field = 0;
+			// (hfp128 at ndigits=28) print all 28 digits instead of the
+			// uint64_t-limited first 16. Use a left-fold to assemble
+			// exp_field MSB-first; this is safe even if es approaches the
+			// width of unsigned (the legacy `1u << (es - 1 - i)` is UB once
+			// es exceeds the width of unsigned).
 			using Hfloat = hfloat<ndigits, es, bt>;
+			unsigned exp_field = 0;
 			unsigned expStart = Hfloat::nbits - 2;
 			for (unsigned i = 0; i < es; ++i) {
-				if (number.getbit(expStart - i)) {
-					exp_field |= (1u << (es - 1 - i));
-				}
+				exp_field = (exp_field << 1) | (number.getbit(expStart - i) ? 1u : 0u);
 			}
 			int exp = static_cast<int>(exp_field) - Hfloat::bias;
 			s << ", hex scale: " << exp << ", hex fraction: 0x0.";

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -178,7 +178,6 @@ try {
 	// parsing
 	std::cout << "+---------    parsing\n";
 	{
-		using Real = hfp64;
 		hfp32 a;
 		hfp64 b;
 		hfp128 c;
@@ -193,11 +192,11 @@ try {
 		// high-precision constants to seed high-precision HFPs
 		constexpr char pi_str[] = "3.141592653589793238462643383279502884197169";
 		parse(pi_str, a);
-		ReportValue(a, "parsed pi");
+		ReportValue(a, "parsed pi", 20, 7);
 		parse(pi_str, b);
-		ReportValue(b, "parsed pi");
+		ReportValue(b, "parsed pi", 20, 14);
 		parse(pi_str, c);
-		ReportValue(c, "parsed pi");
+		ReportValue(c, "parsed pi", 20, 28);
 	}
 
 	// printing

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -225,7 +225,7 @@ try {
 		using Real = hfp64;
 		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
 		std::cout << "values print : " << a << ", " << b << '\n';
-		std::cout << "hex print    : " << to_hex(a) << "\n" << to_hex(b) << '\n';
+		std::cout << "hex print    : " << to_hex(a) << "\n             : " << to_hex(b) << '\n';
 		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
 		std::cout << "color print  : " << color_print(a, true) << "\n             : " << color_print(b, true) << '\n';
 		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
@@ -235,7 +235,7 @@ try {
 		using Real = hfp128;
 		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
 		std::cout << "values print : " << a << ", " << b << '\n';
-		std::cout << "hex print    : " << to_hex(a) << "\n" << to_hex(b) << '\n';
+		std::cout << "hex print    : " << to_hex(a) << "\n             : " << to_hex(b) << '\n';
 		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
 		std::cout << "color print  : " << color_print(a, true) << "\n             : " << color_print(b, true) << '\n';
 		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -25,8 +25,7 @@ try {
 
 	// important behavioral traits
 	{
-		using Hpf24_7 = hfloat<6, 7>;
-		ReportTrivialityOfType<Hpf24_7>();
+		ReportTrivialityOfType<hfp32>();
 	}
 
 	// IBM HFP short precision

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -12,6 +12,20 @@
 #include <universal/verification/test_suite.hpp>
 #include <universal/number/cfloat/cfloat.hpp>
 
+#include <iostream>
+#include <iomanip>
+#include <strstream>
+
+namespace sw::universal {
+	template<unsigned _ndigits, unsigned _es, typename bt>
+	const std::string hfp_pair(const hfloat<_ndigits, _es, bt>& a, unsigned precision = 7) {
+		std::stringstream s;
+		s << std::setprecision(precision) << a << " : ";
+		s << to_binary(a, true);
+		return s.str();
+	}
+}
+
 int main()
 try {
 	using namespace sw::universal;
@@ -146,13 +160,42 @@ try {
 	std::cout << "+---------    numeric_limits\n";
 	{
 		using Real = hfp32;
-		std::cout << "hfp32 radix           : " << std::numeric_limits<Real>::radix << '\n';
-		std::cout << "hfp32 digits (binary) : " << std::numeric_limits<Real>::digits << '\n';
-		std::cout << "hfp32 has_infinity    : " << std::numeric_limits<Real>::has_infinity << '\n';
-		std::cout << "hfp32 has_quiet_NaN   : " << std::numeric_limits<Real>::has_quiet_NaN << '\n';
-		std::cout << "hfp32 round_style     : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
-		std::cout << "hfp32 max             : " << std::numeric_limits<Real>::max() << '\n';
-		std::cout << "hfp32 min             : " << std::numeric_limits<Real>::min() << '\n';
+		Real maxval = std::numeric_limits<Real>::max();
+		Real minval = std::numeric_limits<Real>::min();
+		std::cout << "hfp32 radix            : " << std::numeric_limits<Real>::radix << '\n';
+		std::cout << "hfp32 digits (binary)  : " << std::numeric_limits<Real>::digits << '\n';
+		std::cout << "hfp32 has_infinity     : " << (std::numeric_limits<Real>::has_infinity ? "yes" : "no") << '\n';
+		std::cout << "hfp32 has_quiet_NaN    : " << (std::numeric_limits<Real>::has_quiet_NaN ? "yes" : "no") << '\n';
+		std::cout << "hfp32 round_style      : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
+		std::cout << "hfp32 max              : " << hfp_pair(maxval, 7u) << '\n';
+		std::cout << "hfp32 min              : " << hfp_pair(minval, 7u) << '\n';
+		std::cout << '\n';
+	}
+	{
+		using Real = hfp64;
+		Real maxval = std::numeric_limits<Real>::max();
+		Real minval = std::numeric_limits<Real>::min();
+		std::cout << "hfp64 radix            : " << std::numeric_limits<Real>::radix << '\n';
+		std::cout << "hfp64 digits (binary)  : " << std::numeric_limits<Real>::digits << '\n';
+		std::cout << "hfp64 has_infinity     : " << (std::numeric_limits<Real>::has_infinity ? "yes" : "no") << '\n';
+		std::cout << "hfp64 has_quiet_NaN    : " << (std::numeric_limits<Real>::has_quiet_NaN ? "yes" : "no") << '\n';
+		std::cout << "hfp64 round_style      : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
+		std::cout << "hfp64 max              : " << hfp_pair(maxval, 14u) << '\n';
+		std::cout << "hfp64 min              : " << hfp_pair(minval, 14u) << '\n';
+		std::cout << '\n';
+	}
+	{
+		using Real = hfp128;
+		Real maxval = std::numeric_limits<Real>::max();
+		Real minval = std::numeric_limits<Real>::min();
+		std::cout << "hfp128 radix           : " << std::numeric_limits<Real>::radix << '\n';
+		std::cout << "hfp128 digits (binary) : " << std::numeric_limits<Real>::digits << '\n';
+		std::cout << "hfp128 has_infinity    : " << (std::numeric_limits<Real>::has_infinity ? "yes" : "no") << '\n';
+		std::cout << "hfp128 has_quiet_NaN   : " << (std::numeric_limits<Real>::has_quiet_NaN ? "yes" : "no") << '\n';
+		std::cout << "hfp128 round_style     : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
+		std::cout << "hfp128 max             : " << hfp_pair(maxval, 24u) << '\n';
+		std::cout << "hfp128 min             : " << hfp_pair(minval, 24u) << '\n';
+		std::cout << '\n';
 	}
 
 	// truncation rounding verification
@@ -191,11 +234,11 @@ try {
 		// high-precision constants to seed high-precision HFPs
 		constexpr char pi_str[] = "3.141592653589793238462643383279502884197169";
 		parse(pi_str, a);
-		ReportValue(a, "parsed pi", 20, 7);
+		ReportValue(a, "parsed pi", 21, 7);
 		parse(pi_str, b);
-		ReportValue(b, "parsed pi", 20, 14);
+		ReportValue(b, "parsed pi", 21, 14);
 		parse(pi_str, c);
-		ReportValue(c, "parsed pi", 20, 28);
+		ReportValue(c, "parsed pi", 21, 28);
 	}
 
 	// printing

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -175,6 +175,31 @@ try {
 		}
 	}
 
+	// parsing
+	std::cout << "+---------    parsing\n";
+	{
+		using Real = hfp64;
+		hfp32 a;
+		hfp64 b;
+		hfp128 c;
+
+		parse("1.23456789e-10", a);
+		ReportValue(a, "parsed 1.23456789e-10");
+		parse("1.23456789e-10", b);
+		ReportValue(b, "parsed 1.23456789e-10");
+		parse("1.23456789e-10", c);
+		ReportValue(c, "parsed 1.23456789e-10");
+
+		// high-precision constants to seed high-precision HFPs
+		constexpr char pi_str[] = "3.141592653589793238462643383279502884197169";
+		parse(pi_str, a);
+		ReportValue(a, "parsed pi");
+		parse(pi_str, b);
+		ReportValue(b, "parsed pi");
+		parse(pi_str, c);
+		ReportValue(c, "parsed pi");
+	}
+
 	// printing
 	std::cout << "+---------    I/O and printing\n";
 	{

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -10,22 +10,7 @@
 #define HFLOAT_THROW_ARITHMETIC_EXCEPTION 0
 #include <universal/number/hfloat/hfloat.hpp>
 #include <universal/verification/test_suite.hpp>
-
-// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
-#define MANUAL_TESTING 0
-// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
-// It is the responsibility of the regression test to organize the tests in a quartile progression.
-//#undef REGRESSION_LEVEL_OVERRIDE
-#ifndef REGRESSION_LEVEL_OVERRIDE
-#undef REGRESSION_LEVEL_1
-#undef REGRESSION_LEVEL_2
-#undef REGRESSION_LEVEL_3
-#undef REGRESSION_LEVEL_4
-#define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
-#endif
+#include <universal/number/cfloat/cfloat.hpp>
 
 int main()
 try {
@@ -38,25 +23,16 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-#if MANUAL_TESTING
-	// generate individual testcases to hand trace/debug
-
-	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
-	return EXIT_SUCCESS;   // ignore errors
-#else
-
-#if REGRESSION_LEVEL_1
-
 	// important behavioral traits
 	{
-		using TestType = hfloat<6, 7>;
-		ReportTrivialityOfType<TestType>();
+		using Hpf24_7 = hfloat<6, 7>;
+		ReportTrivialityOfType<Hpf24_7>();
 	}
 
 	// IBM HFP short precision
 	std::cout << "+---------    IBM System/360 Hexadecimal Floating-Point tests\n";
 	{
-		using Real = hfloat_short;
+		using Real = hfp32;
 		std::cout << "type : " << type_tag(Real{}) << '\n';
 
 		Real a(1.0f), b(0.5f);
@@ -66,7 +42,7 @@ try {
 	// basic value construction and conversion
 	std::cout << "+---------    Basic value construction and conversion\n";
 	{
-		using Real = hfloat_short;
+		using Real = hfp32;
 
 		Real zero(0);
 		Real one(1);
@@ -98,7 +74,7 @@ try {
 	// IBM HFP properties: no NaN, no infinity
 	std::cout << "+---------    IBM HFP properties: no NaN, no infinity\n";
 	{
-		using Real = hfloat_short;
+		using Real = hfp32;
 
 		Real a(1.0f);
 		std::cout << "isnan(1.0)  : " << a.isnan() << " (should be 0)\n";
@@ -118,7 +94,7 @@ try {
 	// arithmetic operations
 	std::cout << "+---------    Arithmetic operations\n";
 	{
-		using Real = hfloat_short;
+		using Real = hfp32;
 
 		Real a(100), b(3);
 		Real sum = a + b;
@@ -135,7 +111,7 @@ try {
 	// wobbling precision demonstration
 	std::cout << "+---------    Wobbling precision (IBM HFP characteristic)\n";
 	{
-		using Real = hfloat_short;
+		using Real = hfp32;
 
 		// 1.0 and 8.0 have different effective precision due to hex alignment
 		Real one(1.0f), eight(8.0f);
@@ -147,7 +123,7 @@ try {
 	// special values
 	std::cout << "+---------    Special values\n";
 	{
-		using Real = hfloat_short;
+		using Real = hfp32;
 
 		Real maxp(SpecificValue::maxpos);
 		Real minp(SpecificValue::minpos);
@@ -163,27 +139,27 @@ try {
 	// dynamic range
 	std::cout << "+---------    Dynamic range\n";
 	{
-		hfloat_short s;
+		hfp32 s;
 		std::cout << dynamic_range(s) << '\n';
 	}
 
 	// numeric_limits
 	std::cout << "+---------    numeric_limits\n";
 	{
-		using Real = hfloat_short;
-		std::cout << "hfloat_short radix          : " << std::numeric_limits<Real>::radix << '\n';
-		std::cout << "hfloat_short digits (binary) : " << std::numeric_limits<Real>::digits << '\n';
-		std::cout << "hfloat_short has_infinity    : " << std::numeric_limits<Real>::has_infinity << '\n';
-		std::cout << "hfloat_short has_quiet_NaN   : " << std::numeric_limits<Real>::has_quiet_NaN << '\n';
-		std::cout << "hfloat_short round_style     : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
-		std::cout << "hfloat_short max             : " << std::numeric_limits<Real>::max() << '\n';
-		std::cout << "hfloat_short min             : " << std::numeric_limits<Real>::min() << '\n';
+		using Real = hfp32;
+		std::cout << "hfp32 radix           : " << std::numeric_limits<Real>::radix << '\n';
+		std::cout << "hfp32 digits (binary) : " << std::numeric_limits<Real>::digits << '\n';
+		std::cout << "hfp32 has_infinity    : " << std::numeric_limits<Real>::has_infinity << '\n';
+		std::cout << "hfp32 has_quiet_NaN   : " << std::numeric_limits<Real>::has_quiet_NaN << '\n';
+		std::cout << "hfp32 round_style     : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
+		std::cout << "hfp32 max             : " << std::numeric_limits<Real>::max() << '\n';
+		std::cout << "hfp32 min             : " << std::numeric_limits<Real>::min() << '\n';
 	}
 
 	// truncation rounding verification
 	std::cout << "+---------    Truncation rounding (never rounds up)\n";
 	{
-		using Real = hfloat_short;
+		using Real = hfp32;
 
 		// 1/3 should truncate, not round
 		Real one(1), three(3);
@@ -199,21 +175,51 @@ try {
 		}
 	}
 
-#endif
-
-#if REGRESSION_LEVEL_2
-#endif
-
-#if REGRESSION_LEVEL_3
-#endif
-
-#if REGRESSION_LEVEL_4
-#endif
+	// printing
+	std::cout << "+---------    I/O and printing\n";
+	{
+		std::cout << "\ncfloat<32, 8> reference\n";
+		using Real = single;
+		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
+		std::cout << "values print : " << a << ", " << b << '\n';
+		std::cout << "hex print    : " << to_hex(a) << ", " << to_hex(b) << '\n';
+		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
+		std::cout << "color print  : " << color_print(a) << "\n             : " << color_print(b, true) << '\n';
+		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
+	}
+	{
+		std::cout << "\nhfp32 reference\n";
+		using Real = hfp32;
+		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
+		std::cout << "values print : " << a << ", " << b << '\n';
+		std::cout << "hex print    : " << to_hex(a) << ", " << to_hex(b) << '\n';
+		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
+		std::cout << "color print  : " << color_print(a) << "\n             : " << color_print(b, true) << '\n';
+		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
+	}
+	{
+		std::cout << "\nhfp64 reference\n";
+		using Real = hfp64;
+		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
+		std::cout << "values print : " << a << ", " << b << '\n';
+		std::cout << "hex print    : " << to_hex(a) << "\n" << to_hex(b) << '\n';
+		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
+		std::cout << "color print  : " << color_print(a, true) << "\n             : " << color_print(b, true) << '\n';
+		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
+	}
+	{
+		std::cout << "\nhfp128 reference\n";
+		using Real = hfp128;
+		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
+		std::cout << "values print : " << a << ", " << b << '\n';
+		std::cout << "hex print    : " << to_hex(a) << "\n" << to_hex(b) << '\n';
+		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
+		std::cout << "color print  : " << color_print(a, true) << "\n             : " << color_print(b, true) << '\n';
+		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
+	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
-
-#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;

--- a/static/float/hfloat/api/constexpr.cpp
+++ b/static/float/hfloat/api/constexpr.cpp
@@ -198,16 +198,16 @@ try {
 	}
 
 	// ----------------------------------------------------------------------------
-	// hfloat_long smoke (wider exponent range, 56 fraction bits)
+	// hfp64 smoke (wider exponent range, 56 fraction bits)
 	// ----------------------------------------------------------------------------
 	{
 		constexpr hfp64 a(2.0);
 		constexpr hfp64 b(3.0);
 		constexpr auto cx_sum = a + b;
-		static_assert((cx_sum - hfp64(5.0)).iszero(), "constexpr hfloat_long +");
+		static_assert((cx_sum - hfp64(5.0)).iszero(), "constexpr hfp64 +");
 
 		constexpr auto cx_prod = a * b;
-		static_assert((cx_prod - hfp64(6.0)).iszero(), "constexpr hfloat_long *");
+		static_assert((cx_prod - hfp64(6.0)).iszero(), "constexpr hfp64 *");
 	}
 
 	// ----------------------------------------------------------------------------
@@ -223,7 +223,7 @@ try {
 
 	// ----------------------------------------------------------------------------
 	// Integer construction precision (CodeRabbit follow-up).
-	// hfloat_long has a 56-bit fraction so values above 2^53 (the IEEE 754
+	// hfp64 has a 56-bit fraction so values above 2^53 (the IEEE 754
 	// double mantissa width) must be packed directly from the integer
 	// without round-tripping through double.
 	//
@@ -231,7 +231,7 @@ try {
 	// 9007199254740993  = 2^53 + 1  (NOT representable in double; rounds
 	//                                to 2^53 under any double round-trip)
 	//
-	// Both values fit in hfloat_long's 56-bit fraction, so direct integer
+	// Both values fit in hfp64's 56-bit fraction, so direct integer
 	// packing must keep them distinct.  The previous double round-trip
 	// implementation failed this contract -- the new pack_uint64() path
 	// satisfies it.  We verify via tuple-based comparison (which is itself
@@ -241,20 +241,20 @@ try {
 	{
 		constexpr hfp64 a(9007199254740992LL);   // 2^53
 		constexpr hfp64 b(9007199254740993LL);   // 2^53 + 1
-		static_assert(a != b, "constexpr: hfloat_long preserves 2^53 + 1 distinct from 2^53");
-		static_assert(a < b,  "constexpr: hfloat_long 2^53 < 2^53 + 1 (tuple compare)");
-		static_assert(b > a,  "constexpr: hfloat_long 2^53 + 1 > 2^53");
+		static_assert(a != b, "constexpr: hfp64 preserves 2^53 + 1 distinct from 2^53");
+		static_assert(a < b,  "constexpr: hfp64 2^53 < 2^53 + 1 (tuple compare)");
+		static_assert(b > a,  "constexpr: hfp64 2^53 + 1 > 2^53");
 
 		// Same witness via the unsigned conversion path.
 		constexpr hfp64 au(9007199254740992ULL);
 		constexpr hfp64 bu(9007199254740993ULL);
-		static_assert(au != bu, "constexpr: hfloat_long unsigned preserves 2^53 + 1");
+		static_assert(au != bu, "constexpr: hfp64 unsigned preserves 2^53 + 1");
 
 		// INT64_MIN: |v| computed via -(v+1)+1 identity, no overflow.
 		constexpr long long llmin = (-9223372036854775807LL) - 1LL;  // INT64_MIN
 		constexpr hfp64 smin(llmin);
-		static_assert(smin.sign(), "constexpr: hfloat_long INT64_MIN is negative");
-		static_assert(!smin.iszero(), "constexpr: hfloat_long INT64_MIN is non-zero");
+		static_assert(smin.sign(), "constexpr: hfp64 INT64_MIN is negative");
+		static_assert(!smin.iszero(), "constexpr: hfp64 INT64_MIN is non-zero");
 	}
 
 	std::cout << "hfloat constexpr verification: "

--- a/static/float/hfloat/api/constexpr.cpp
+++ b/static/float/hfloat/api/constexpr.cpp
@@ -28,21 +28,19 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// hfloat_short = hfloat<6, 7> = 32-bit IBM HFP short.
-	// hfloat_long  = hfloat<14, 7> = 64-bit IBM HFP long.
+	// hfp32 = hfloat<6, 7> = 32-bit IBM HFP short.
+	// hfp64  = hfloat<14, 7> = 64-bit IBM HFP long.
 	// IBM HFP has NO NaN, NO infinity, NO subnormals; truncation rounding
 	// only.  The constexpr suite focuses on these invariants in addition
 	// to the standard arithmetic / comparison contract.
-	using HShort = hfloat_short;
-	using HLong  = hfloat_long;
 
 	// ----------------------------------------------------------------------------
 	// Native int construction (smoke test)
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort a(0);
-		constexpr HShort b(1);
-		constexpr HShort c(-3);
+		constexpr hfp32 a(0);
+		constexpr hfp32 b(1);
+		constexpr hfp32 c(-3);
 		(void)a; (void)b; (void)c;
 	}
 
@@ -52,10 +50,10 @@ try {
 	// (and analogous for *, -, /, +=, <)
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort a(2.0);
-		constexpr HShort b(3.0);
+		constexpr hfp32 a(2.0);
+		constexpr hfp32 b(3.0);
 		constexpr auto cx_sum = a + b;            // 2 + 3 = 5
-		static_assert((cx_sum - HShort(5.0)).iszero(), "issue #732 acceptance: a + b");
+		static_assert((cx_sum - hfp32(5.0)).iszero(), "issue #732 acceptance: a + b");
 	}
 
 	// ----------------------------------------------------------------------------
@@ -67,54 +65,54 @@ try {
 	// don't cause spurious failures.
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort a(4.5);
-		constexpr HShort b(1.5);
+		constexpr hfp32 a(4.5);
+		constexpr hfp32 b(1.5);
 		constexpr auto cx_sum  = a + b;          // 4.5 + 1.5 = 6.0
 		constexpr auto cx_diff = a - b;          // 4.5 - 1.5 = 3.0
 		constexpr auto cx_prod = a * b;          // 4.5 * 1.5 = 6.75
 		constexpr auto cx_quot = a / b;          // 4.5 / 1.5 = 3.0
 		constexpr auto cx_neg  = -a;             // -4.5
-		static_assert((cx_sum  - HShort(6.0)).iszero(),  "constexpr +  failed");
-		static_assert((cx_diff - HShort(3.0)).iszero(),  "constexpr -  failed");
-		static_assert((cx_prod - HShort(6.75)).iszero(), "constexpr *  failed");
-		static_assert((cx_quot - HShort(3.0)).iszero(),  "constexpr /  failed");
-		static_assert((cx_neg  - HShort(-4.5)).iszero(), "constexpr unary - failed");
+		static_assert((cx_sum  - hfp32(6.0)).iszero(),  "constexpr +  failed");
+		static_assert((cx_diff - hfp32(3.0)).iszero(),  "constexpr -  failed");
+		static_assert((cx_prod - hfp32(6.75)).iszero(), "constexpr *  failed");
+		static_assert((cx_quot - hfp32(3.0)).iszero(),  "constexpr /  failed");
+		static_assert((cx_neg  - hfp32(-4.5)).iszero(), "constexpr unary - failed");
 
 		// Compound assignment via lambda (constexpr lambdas are C++20)
-		constexpr HShort cx_addeq = []() { HShort t(1.5); t += HShort(3.0); return t; }();
-		constexpr HShort cx_subeq = []() { HShort t(4.5); t -= HShort(1.5); return t; }();
-		constexpr HShort cx_muleq = []() { HShort t(1.5); t *= HShort(3.0); return t; }();
-		constexpr HShort cx_diveq = []() { HShort t(4.5); t /= HShort(1.5); return t; }();
-		static_assert((cx_addeq - HShort(4.5)).iszero(), "constexpr += failed");
-		static_assert((cx_subeq - HShort(3.0)).iszero(), "constexpr -= failed");
-		static_assert((cx_muleq - HShort(4.5)).iszero(), "constexpr *= failed");
-		static_assert((cx_diveq - HShort(3.0)).iszero(), "constexpr /= failed");
+		constexpr hfp32 cx_addeq = []() { hfp32 t(1.5); t += hfp32(3.0); return t; }();
+		constexpr hfp32 cx_subeq = []() { hfp32 t(4.5); t -= hfp32(1.5); return t; }();
+		constexpr hfp32 cx_muleq = []() { hfp32 t(1.5); t *= hfp32(3.0); return t; }();
+		constexpr hfp32 cx_diveq = []() { hfp32 t(4.5); t /= hfp32(1.5); return t; }();
+		static_assert((cx_addeq - hfp32(4.5)).iszero(), "constexpr += failed");
+		static_assert((cx_subeq - hfp32(3.0)).iszero(), "constexpr -= failed");
+		static_assert((cx_muleq - hfp32(4.5)).iszero(), "constexpr *= failed");
+		static_assert((cx_diveq - hfp32(3.0)).iszero(), "constexpr /= failed");
 	}
 
 	// ----------------------------------------------------------------------------
 	// Constexpr comparison (issue acceptance: <)
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort a(1.5);
-		constexpr HShort b(3.0);
-		static_assert(a < b,     "constexpr: HShort(1.5) < HShort(3.0)");
-		static_assert(b > a,     "constexpr: HShort(3.0) > HShort(1.5)");
-		static_assert(a <= b,    "constexpr: HShort(1.5) <= HShort(3.0)");
-		static_assert(b >= a,    "constexpr: HShort(3.0) >= HShort(1.5)");
-		static_assert(!(a == b), "constexpr: HShort(1.5) != HShort(3.0)");
+		constexpr hfp32 a(1.5);
+		constexpr hfp32 b(3.0);
+		static_assert(a < b,     "constexpr: hfp32(1.5) < hfp32(3.0)");
+		static_assert(b > a,     "constexpr: hfp32(3.0) > hfp32(1.5)");
+		static_assert(a <= b,    "constexpr: hfp32(1.5) <= hfp32(3.0)");
+		static_assert(b >= a,    "constexpr: hfp32(3.0) >= hfp32(1.5)");
+		static_assert(!(a == b), "constexpr: hfp32(1.5) != hfp32(3.0)");
 		static_assert(a != b,    "constexpr: != operator");
-		static_assert(a == a,    "constexpr: HShort(1.5) == HShort(1.5)");
+		static_assert(a == a,    "constexpr: hfp32(1.5) == hfp32(1.5)");
 	}
 
 	// ----------------------------------------------------------------------------
 	// Conversion-out: operator double() / float() are now constexpr
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort a(0.5);
+		constexpr hfp32 a(0.5);
 		constexpr double d = double(a);
 		static_assert(d == 0.5, "constexpr operator double()");
 
-		constexpr HShort b(2.5);
+		constexpr hfp32 b(2.5);
 		constexpr float f = float(b);
 		static_assert(f == 2.5f, "constexpr operator float()");
 	}
@@ -125,14 +123,14 @@ try {
 	// the array aggregate to zero, which IS legal in a constant expression.)
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort cx_zero{};
-		static_assert(cx_zero.iszero(), "constexpr HShort{} is zero");
+		constexpr hfp32 cx_zero{};
+		static_assert(cx_zero.iszero(), "constexpr hfp32{} is zero");
 
 		// ++0 -> next representable value; --0 -> previous representable value
-		constexpr HShort cx_inc_zero = []() { HShort t{}; ++t; return t; }();
-		constexpr HShort cx_dec_zero = []() { HShort t{}; --t; return t; }();
-		static_assert(cx_inc_zero > HShort(0.0), "constexpr ++0 > 0");
-		static_assert(cx_dec_zero < HShort(0.0), "constexpr --0 < 0");
+		constexpr hfp32 cx_inc_zero = []() { hfp32 t{}; ++t; return t; }();
+		constexpr hfp32 cx_dec_zero = []() { hfp32 t{}; --t; return t; }();
+		static_assert(cx_inc_zero > hfp32(0.0), "constexpr ++0 > 0");
+		static_assert(cx_dec_zero < hfp32(0.0), "constexpr --0 < 0");
 	}
 
 	// ----------------------------------------------------------------------------
@@ -143,19 +141,19 @@ try {
 	// constant-evaluation time as well as runtime.
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort zero(SpecificValue::zero);
-		constexpr HShort maxp(SpecificValue::maxpos);
-		constexpr HShort minp(SpecificValue::minpos);
-		constexpr HShort minn(SpecificValue::minneg);
-		constexpr HShort maxn(SpecificValue::maxneg);
-		constexpr HShort infp(SpecificValue::infpos);
-		constexpr HShort infn(SpecificValue::infneg);
-		constexpr HShort qn(SpecificValue::qnan);
-		static_assert(zero == HShort(0.0), "constexpr SpecificValue::zero");
-		static_assert(maxp > HShort(0.0),  "constexpr SpecificValue::maxpos > 0");
-		static_assert(minp > HShort(0.0),  "constexpr SpecificValue::minpos > 0");
-		static_assert(minn < HShort(0.0),  "constexpr SpecificValue::minneg < 0");
-		static_assert(maxn < HShort(0.0),  "constexpr SpecificValue::maxneg < 0");
+		constexpr hfp32 zero(SpecificValue::zero);
+		constexpr hfp32 maxp(SpecificValue::maxpos);
+		constexpr hfp32 minp(SpecificValue::minpos);
+		constexpr hfp32 minn(SpecificValue::minneg);
+		constexpr hfp32 maxn(SpecificValue::maxneg);
+		constexpr hfp32 infp(SpecificValue::infpos);
+		constexpr hfp32 infn(SpecificValue::infneg);
+		constexpr hfp32 qn(SpecificValue::qnan);
+		static_assert(zero == hfp32(0.0), "constexpr SpecificValue::zero");
+		static_assert(maxp > hfp32(0.0),  "constexpr SpecificValue::maxpos > 0");
+		static_assert(minp > hfp32(0.0),  "constexpr SpecificValue::minpos > 0");
+		static_assert(minn < hfp32(0.0),  "constexpr SpecificValue::minneg < 0");
+		static_assert(maxn < hfp32(0.0),  "constexpr SpecificValue::maxneg < 0");
 		static_assert(maxp > minp,         "constexpr maxpos > minpos");
 
 		// HFP saturation of infinity: infpos == maxpos, infneg == maxneg
@@ -171,9 +169,9 @@ try {
 	// no NaN -- core IBM System/360 HFP property).
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort zero(0.0);
-		constexpr HShort one(1.0);
-		constexpr HShort maxp(SpecificValue::maxpos);
+		constexpr hfp32 zero(0.0);
+		constexpr hfp32 one(1.0);
+		constexpr hfp32 maxp(SpecificValue::maxpos);
 		static_assert(!zero.isinf(),  "constexpr: HFP zero is not inf");
 		static_assert(!zero.isnan(),  "constexpr: HFP zero is not nan");
 		static_assert(!one.isinf(),   "constexpr: HFP one is not inf");
@@ -188,8 +186,8 @@ try {
 	//   (no NaN/inf available; this is the closest constexpr-safe behavior).
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort zero(0.0);
-		constexpr HShort one(1.0);
+		constexpr hfp32 zero(0.0);
+		constexpr hfp32 one(1.0);
 		// 1/0 -> zero (HFP has no infinity; constexpr divide-by-zero contract)
 		constexpr auto cx_div_zero = one / zero;
 		static_assert(cx_div_zero.iszero(), "constexpr 1/0 -> zero (HFP saturation)");
@@ -203,24 +201,24 @@ try {
 	// hfloat_long smoke (wider exponent range, 56 fraction bits)
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HLong a(2.0);
-		constexpr HLong b(3.0);
+		constexpr hfp64 a(2.0);
+		constexpr hfp64 b(3.0);
 		constexpr auto cx_sum = a + b;
-		static_assert((cx_sum - HLong(5.0)).iszero(), "constexpr hfloat_long +");
+		static_assert((cx_sum - hfp64(5.0)).iszero(), "constexpr hfloat_long +");
 
 		constexpr auto cx_prod = a * b;
-		static_assert((cx_prod - HLong(6.0)).iszero(), "constexpr hfloat_long *");
+		static_assert((cx_prod - hfp64(6.0)).iszero(), "constexpr hfloat_long *");
 	}
 
 	// ----------------------------------------------------------------------------
 	// abs / fabs free functions are constexpr
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HShort negv(-3.5);
-		constexpr HShort posv = abs(negv);
-		static_assert(posv == HShort(3.5), "constexpr abs(-3.5) == 3.5");
-		constexpr HShort posv2 = fabs(negv);
-		static_assert(posv2 == HShort(3.5), "constexpr fabs(-3.5) == 3.5");
+		constexpr hfp32 negv(-3.5);
+		constexpr hfp32 posv = abs(negv);
+		static_assert(posv == hfp32(3.5), "constexpr abs(-3.5) == 3.5");
+		constexpr hfp32 posv2 = fabs(negv);
+		static_assert(posv2 == hfp32(3.5), "constexpr fabs(-3.5) == 3.5");
 	}
 
 	// ----------------------------------------------------------------------------
@@ -241,20 +239,20 @@ try {
 	// lose the very bit we're checking).
 	// ----------------------------------------------------------------------------
 	{
-		constexpr HLong a(9007199254740992LL);   // 2^53
-		constexpr HLong b(9007199254740993LL);   // 2^53 + 1
+		constexpr hfp64 a(9007199254740992LL);   // 2^53
+		constexpr hfp64 b(9007199254740993LL);   // 2^53 + 1
 		static_assert(a != b, "constexpr: hfloat_long preserves 2^53 + 1 distinct from 2^53");
 		static_assert(a < b,  "constexpr: hfloat_long 2^53 < 2^53 + 1 (tuple compare)");
 		static_assert(b > a,  "constexpr: hfloat_long 2^53 + 1 > 2^53");
 
 		// Same witness via the unsigned conversion path.
-		constexpr HLong au(9007199254740992ULL);
-		constexpr HLong bu(9007199254740993ULL);
+		constexpr hfp64 au(9007199254740992ULL);
+		constexpr hfp64 bu(9007199254740993ULL);
 		static_assert(au != bu, "constexpr: hfloat_long unsigned preserves 2^53 + 1");
 
 		// INT64_MIN: |v| computed via -(v+1)+1 identity, no overflow.
 		constexpr long long llmin = (-9223372036854775807LL) - 1LL;  // INT64_MIN
-		constexpr HLong smin(llmin);
+		constexpr hfp64 smin(llmin);
 		static_assert(smin.sign(), "constexpr: hfloat_long INT64_MIN is negative");
 		static_assert(!smin.iszero(), "constexpr: hfloat_long INT64_MIN is non-zero");
 	}

--- a/static/float/hfloat/conversion/string_parse.cpp
+++ b/static/float/hfloat/conversion/string_parse.cpp
@@ -177,15 +177,15 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfp64 precision-win for 0.1\n";
 	}
 
-	// ----- hfloat_extended smoke test. With fbits=112 the uint64 fraction
-	//       intermediate can't hold the full hex significand; we accept
-	//       reduced precision and the `if constexpr (fbits < 64)` guards
-	//       in normalize_and_pack / pack / maxpos / maxneg ensure the
-	//       paths don't UB-out on `1ULL << 112`. Verify: parse and the
-	//       via-double constructor produce IDENTICAL results (both go
-	//       through assign_from_mantissa64) and the result is non-zero
-	//       for a normal-magnitude input. Bit-exact hfloat_extended
-	//       conversion is future work pending a multi-limb fraction. -----
+	// ----- hfloat_extended (hfp128) parse correctness. fbits=112 exceeds
+	//       the 64-bit mantissa intermediate, so parse delivers hfp64-level
+	//       precision in an hfp128 container: the 64-bit mantissa lands at
+	//       the top of the 112-bit fraction and the low 48 fraction bits
+	//       are zero. Issue #870 documented the prior bug where the
+	//       mantissa_shift>0 path saturated to all-ones in the LOW 64 bits
+	//       of the fraction -- producing 8.27e-25 instead of ~1.23e-10
+	//       for parse("1.23456789e-10", ...). Full bit-exact 112-bit
+	//       conversion needs a multi-limb intermediate and is future work. -----
 	{
 		int start = nrOfFailedTestCases;
 		using ExtH = hfloat<28, 7, std::uint32_t>;
@@ -196,7 +196,50 @@ try {
 		// Saturation still works for hfloat_extended
 		if (!parse("1e1000", via_parse)) ++nrOfFailedTestCases;
 		if (via_parse != ExtH(SpecificValue::maxpos)) ++nrOfFailedTestCases;
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat_extended smoke + saturation\n";
+
+		// Issue #870 regression: hfp128 must parse small-magnitude decimals
+		// to approximately the right value, NOT to the all-ones-saturation
+		// garbage in the low fraction bits.
+		ExtH ext_small;
+		if (!parse("1.23456789e-10", ext_small)) ++nrOfFailedTestCases;
+		if (ext_small.iszero())                  ++nrOfFailedTestCases;
+		if (ext_small == ExtH(SpecificValue::maxpos)) ++nrOfFailedTestCases;
+		// Round-trip via double: with hfp64-precision in an hfp128 container
+		// the result must be within hfp64's relative resolution (~16^-14) of
+		// the intended value. The pre-fix bug produced 8.27e-25, which is
+		// off by ~15 orders of magnitude -- the 1e-3 tolerance below catches
+		// it decisively while leaving headroom for legitimate truncation.
+		{
+			double d = double(ext_small);
+			double expected = 1.23456789e-10;
+			double rel_err  = (d - expected) / expected;
+			if (rel_err < 0) rel_err = -rel_err;
+			if (rel_err > 1.0e-3) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  hfp128 parse(\"1.23456789e-10\") = " << d
+					          << " (expected ~" << expected
+					          << ", rel_err=" << rel_err << ")\n";
+				}
+			}
+		}
+		// hfp128 unbiased exponent must agree with hfp64's for the same
+		// input (the bug case had the right exponent but garbage fraction;
+		// keep this invariant pinned to catch fraction-corruption regressions
+		// that happen to land in a valid exponent slot).
+		{
+			hfp64 ref;
+			parse("1.23456789e-10", ref);
+			if (ext_small.scale() != ref.scale()) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  hfp128 scale " << ext_small.scale()
+					          << " differs from hfp64 scale " << ref.scale() << '\n';
+				}
+			}
+		}
+
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat_extended smoke + saturation + #870\n";
 	}
 
 	// ----- scientific notation across a wide |e| range. Verify parse

--- a/static/float/hfloat/conversion/string_parse.cpp
+++ b/static/float/hfloat/conversion/string_parse.cpp
@@ -83,7 +83,7 @@ try {
 
 #if REGRESSION_LEVEL_1
 
-	// ----- hfloat_short: canonical decimals match constructor -----
+	// ----- hfp32: canonical decimals match constructor -----
 	{
 		int start = nrOfFailedTestCases;
 		struct Case { const char* s; double v; };
@@ -115,7 +115,7 @@ try {
 				}
 			}
 		}
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat_short canonical decimals\n";
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfp32 canonical decimals\n";
 	}
 
 	// ----- hfp64: canonical decimals match constructor -----
@@ -177,7 +177,7 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfp64 precision-win for 0.1\n";
 	}
 
-	// ----- hfloat_extended (hfp128) parse correctness. fbits=112; parse()
+	// ----- hfp128 parse correctness. fbits=112; parse()
 	//       routes the decimal payload through decimal_to_binary requesting
 	//       fbits of precision and feeds the multi-limb mantissa straight
 	//       into the hex-aligned fraction. The whole point of parse() is to
@@ -198,7 +198,7 @@ try {
 		// the wide d2b path now LEGITIMATELY diverges from via_double --
 		// parse delivers full 112 bits, via_double only ~53.
 		if (via_parse != via_double)  ++nrOfFailedTestCases;
-		// Saturation still works for hfloat_extended
+		// Saturation still works for hfp128
 		if (!parse("1e1000", via_parse)) ++nrOfFailedTestCases;
 		if (via_parse != ExtH(SpecificValue::maxpos)) ++nrOfFailedTestCases;
 
@@ -266,7 +266,7 @@ try {
 			}
 		}
 
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat_extended smoke + saturation + #870\n";
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfp128 smoke + saturation + #870\n";
 	}
 
 	// ----- scientific notation across a wide |e| range. Verify parse
@@ -340,7 +340,7 @@ try {
 	{
 		int start = nrOfFailedTestCases;
 		hfp32 p, maxpos(SpecificValue::maxpos), maxneg(SpecificValue::maxneg);
-		// hfloat_short max is 16^63 ~ 7.24e75. Use a value well above that.
+		// hfp32 max is 16^63 ~ 7.24e75. Use a value well above that.
 		if (!parse("1e100", p)) ++nrOfFailedTestCases;
 		if (p != maxpos)        ++nrOfFailedTestCases;
 		if (!parse("-1e100", p)) ++nrOfFailedTestCases;

--- a/static/float/hfloat/conversion/string_parse.cpp
+++ b/static/float/hfloat/conversion/string_parse.cpp
@@ -177,44 +177,48 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfp64 precision-win for 0.1\n";
 	}
 
-	// ----- hfloat_extended (hfp128) parse correctness. fbits=112 exceeds
-	//       the 64-bit mantissa intermediate, so parse delivers hfp64-level
-	//       precision in an hfp128 container: the 64-bit mantissa lands at
-	//       the top of the 112-bit fraction and the low 48 fraction bits
-	//       are zero. Issue #870 documented the prior bug where the
-	//       mantissa_shift>0 path saturated to all-ones in the LOW 64 bits
-	//       of the fraction -- producing 8.27e-25 instead of ~1.23e-10
-	//       for parse("1.23456789e-10", ...). Full bit-exact 112-bit
-	//       conversion needs a multi-limb intermediate and is future work. -----
+	// ----- hfloat_extended (hfp128) parse correctness. fbits=112; parse()
+	//       routes the decimal payload through decimal_to_binary requesting
+	//       fbits of precision and feeds the multi-limb mantissa straight
+	//       into the hex-aligned fraction. The whole point of parse() is to
+	//       deliver precision beyond what double / long double can carry --
+	//       a value like 1.23456789e-10 in hfp128 has 112 meaningful fraction
+	//       bits, far past double's 53. Issue #870 documented the prior bug
+	//       where parse() clipped through a uint64_t intermediate, producing
+	//       either 8.27e-25 (saturation) or hfp64-precision-in-hfp128 (the
+	//       first fix attempt) instead of the full 112 bits. -----
 	{
 		int start = nrOfFailedTestCases;
 		using ExtH = hfloat<28, 7, std::uint32_t>;
 		ExtH via_parse, via_double(1.0);
 		if (!parse("1.0", via_parse)) ++nrOfFailedTestCases;
 		if (via_parse.iszero())       ++nrOfFailedTestCases;
+		// 1.0 happens to land in a single fraction bit (bit 108) for both
+		// paths, so via_parse == via_double here. For non-trivial decimals
+		// the wide d2b path now LEGITIMATELY diverges from via_double --
+		// parse delivers full 112 bits, via_double only ~53.
 		if (via_parse != via_double)  ++nrOfFailedTestCases;
 		// Saturation still works for hfloat_extended
 		if (!parse("1e1000", via_parse)) ++nrOfFailedTestCases;
 		if (via_parse != ExtH(SpecificValue::maxpos)) ++nrOfFailedTestCases;
 
 		// Issue #870 regression: hfp128 must parse small-magnitude decimals
-		// to approximately the right value, NOT to the all-ones-saturation
-		// garbage in the low fraction bits.
+		// to the correct value, NOT to the all-ones-saturation garbage in
+		// the low fraction bits that the pre-fix code produced.
 		ExtH ext_small;
 		if (!parse("1.23456789e-10", ext_small)) ++nrOfFailedTestCases;
 		if (ext_small.iszero())                  ++nrOfFailedTestCases;
 		if (ext_small == ExtH(SpecificValue::maxpos)) ++nrOfFailedTestCases;
-		// Round-trip via double: with hfp64-precision in an hfp128 container
-		// the result must be within hfp64's relative resolution (~16^-14) of
-		// the intended value. The pre-fix bug produced 8.27e-25, which is
-		// off by ~15 orders of magnitude -- the 1e-3 tolerance below catches
-		// it decisively while leaving headroom for legitimate truncation.
+		// Round-trip via double catches the original bug decisively: pre-fix
+		// produced 8.27e-25 (15 orders of magnitude off); the post-fix value
+		// is bounded by double's 53-bit window on the parsed bits, hence the
+		// generous tolerance below relative to the round-trip's true error.
 		{
 			double d = double(ext_small);
 			double expected = 1.23456789e-10;
 			double rel_err  = (d - expected) / expected;
 			if (rel_err < 0) rel_err = -rel_err;
-			if (rel_err > 1.0e-3) {
+			if (rel_err > 1.0e-6) {
 				++nrOfFailedTestCases;
 				if (reportTestCases) {
 					std::cout << "  hfp128 parse(\"1.23456789e-10\") = " << d
@@ -235,6 +239,29 @@ try {
 				if (reportTestCases) {
 					std::cout << "  hfp128 scale " << ext_small.scale()
 					          << " differs from hfp64 scale " << ref.scale() << '\n';
+				}
+			}
+		}
+		// parse() must deliver precision past double's 53 bits -- the very
+		// reason for routing decimal literals through d2b instead of a
+		// double round-trip. Pin this by parsing a long pi literal and
+		// checking that the fraction bits below position (fbits - 53) =
+		// (112 - 53) = 59 are not all zero. If parse() ever regresses to
+		// a uint64_t intermediate this assertion fires.
+		{
+			ExtH ext_pi;
+			const char* pi_str = "3.141592653589793238462643383279502884197169";
+			if (!parse(pi_str, ext_pi)) ++nrOfFailedTestCases;
+			bool any_low_bit_set = false;
+			for (unsigned i = 0; i < 59u; ++i) {
+				if (ext_pi.getbit(i)) { any_low_bit_set = true; break; }
+			}
+			if (!any_low_bit_set) {
+				++nrOfFailedTestCases;
+				if (reportTestCases) {
+					std::cout << "  hfp128 parse(pi) populated only bits >= 59 --"
+					             " parse() regressed to double-precision intermediate\n"
+					          << "  bits: " << to_binary(ext_pi) << '\n';
 				}
 			}
 		}

--- a/static/float/hfloat/conversion/string_parse.cpp
+++ b/static/float/hfloat/conversion/string_parse.cpp
@@ -18,8 +18,27 @@
 #include <sstream>
 #include <streambuf>
 #include <string>
+// Configure the hfloat template environment
+#define HFLOAT_THROW_ARITHMETIC_EXCEPTION 0
 #include <universal/number/hfloat/hfloat.hpp>
-#include <universal/verification/test_reporters.hpp>
+#include <universal/verification/test_suite.hpp>
+
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+// #undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
 
 namespace {
 struct CerrSilencer {
@@ -42,6 +61,28 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+	// generate individual testcases to hand trace/debug
+
+	hfp32 a, b, c;
+	parse("0.1", a);
+	parse("0.0625", b);
+	c = a + b;
+	ReportValue(a, "a");
+	ReportValue(b, "b");
+	ReportValue(c, "a + b");
+
+	a.setbits(0x7FFF'FFFF);
+	ReportValue(a, "0x7FFF'FFFF");
+	b.maxpos();
+	ReportValue(b, "maxpos");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;  // ignore errors
+#else
+
+#if REGRESSION_LEVEL_1
+
 	// ----- hfloat_short: canonical decimals match constructor -----
 	{
 		int start = nrOfFailedTestCases;
@@ -54,11 +95,12 @@ try {
 			{ "-3.25", -3.25 },
 			{ "0.5",   0.5   },
 			{ "16.0",  16.0  },  // exact in hex-float (one hex digit)
-			{ "256.0", 256.0 },
-			{ "1.25e3", 1250.0 },
+		    { "256.0", 256.0}, 
+			{ "1.25e3", 1250.0}, 
+			{ "7.237005e+75", 7.237005e+75},
 		};
 		for (const auto& c : cases) {
-			hfloat_short ours, ref(c.v);
+			hfp32 ours, ref(c.v);
 			if (!parse(c.s, ours)) {
 				++nrOfFailedTestCases;
 				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
@@ -76,7 +118,7 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat_short canonical decimals\n";
 	}
 
-	// ----- hfloat_long: canonical decimals match constructor -----
+	// ----- hfp64: canonical decimals match constructor -----
 	{
 		int start = nrOfFailedTestCases;
 		struct Case { const char* s; double v; };
@@ -90,7 +132,7 @@ try {
 			{ "1e10",       1e10     },
 		};
 		for (const auto& c : cases) {
-			hfloat_long ours, ref(c.v);
+			hfp64 ours, ref(c.v);
 			if (!parse(c.s, ours)) {
 				++nrOfFailedTestCases;
 				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
@@ -101,16 +143,16 @@ try {
 				if (reportTestCases) std::cout << "  mismatch on \"" << c.s << "\"\n";
 			}
 		}
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat_long canonical decimals\n";
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfp64 canonical decimals\n";
 	}
 
-	// ----- precision-win: hfloat_long has 56 fbits, which is MORE than double's
-	//       53. The new d2b-based parse delivers a 56-bit-exact result, while
-	//       the legacy via-double path inherited IEEE round-to-nearest plus a
-	//       trailing-zero pad. Pin both bit patterns to lock the contract. -----
+	// precision-win: hfp64 has 56 fbits, which is MORE than double's 53 bits.
+	// The new d2b-based parse delivers a 56-bit-exact result, while
+	// the legacy via-double path inherited IEEE round-to-nearest plus a
+	// trailing-zero pad. Pin both bit patterns to lock the contract.
 	{
 		int start = nrOfFailedTestCases;
-		hfloat_long via_string, via_double(0.1);
+		hfp64 via_string, via_double(0.1);
 		if (!parse("0.1", via_string)) ++nrOfFailedTestCases;
 		// Direct d2b + truncation rounding yields ...01100110011001 (the last
 		// hex digit is 9, truncated from the 0.1 repeating pattern). The via-
@@ -132,7 +174,7 @@ try {
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "  expected divergence vs via-double; got identity\n";
 		}
-		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat_long precision-win for 0.1\n";
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfp64 precision-win for 0.1\n";
 	}
 
 	// ----- hfloat_extended smoke test. With fbits=112 the uint64 fraction
@@ -161,7 +203,7 @@ try {
 	//       succeeds and the result has the expected sign + non-zero
 	//       (or properly saturated) shape. For non-exact-in-double
 	//       inputs the direct d2b path legally diverges from
-	//       hfloat_long(double_val) -- the precision-win pinned for
+	//       hfp64(double_val) -- the precision-win pinned for
 	//       parse("0.1", ...) above generalizes here, so we don't
 	//       compare against via-double. -----
 	{
@@ -178,7 +220,7 @@ try {
 			{ "-1.5e30",    true  },
 		};
 		for (const auto& c : cases) {
-			hfloat_long p;
+			hfp64 p;
 			if (!parse(c.s, p)) {
 				++nrOfFailedTestCases;
 				if (reportTestCases) std::cout << "  parse failed: " << c.s << '\n';
@@ -201,7 +243,7 @@ try {
 	//       spellings parse to that same zero (no signed zero) -----
 	{
 		int start = nrOfFailedTestCases;
-		hfloat_long p;
+		hfp64 p;
 		for (const char* s : { "0", "0.0", "-0", "-0.0", "+0", "+0.0" }) {
 			if (!parse(s, p)) ++nrOfFailedTestCases;
 			if (!p.iszero()) ++nrOfFailedTestCases;
@@ -212,7 +254,7 @@ try {
 	// ----- nan / inf tokens are REJECTED (hfloat has no NaN/Inf encoding) -----
 	{
 		int start = nrOfFailedTestCases;
-		hfloat_short p;
+		hfp32 p;
 		for (const char* s : { "nan", "NaN", "+nan", "-nan",
 		                       "inf", "Inf", "infinity", "INFINITY",
 		                       "+inf", "-inf", "-infinity" }) {
@@ -227,7 +269,7 @@ try {
 	// ----- overflow saturates to maxpos / maxneg (no Inf) -----
 	{
 		int start = nrOfFailedTestCases;
-		hfloat_short p, maxpos(SpecificValue::maxpos), maxneg(SpecificValue::maxneg);
+		hfp32 p, maxpos(SpecificValue::maxpos), maxneg(SpecificValue::maxneg);
 		// hfloat_short max is 16^63 ~ 7.24e75. Use a value well above that.
 		if (!parse("1e100", p)) ++nrOfFailedTestCases;
 		if (p != maxpos)        ++nrOfFailedTestCases;
@@ -239,7 +281,7 @@ try {
 	// ----- malformed input is rejected -----
 	{
 		int start = nrOfFailedTestCases;
-		hfloat_short p;
+		hfp32 p;
 		for (const char* s : { "", "+", "-", ".", "e10",
 		                       "not-a-number", "abc", "1.5abc",
 		                       "1.5.0", "1e", "1ea" }) {
@@ -255,7 +297,7 @@ try {
 	{
 		int start = nrOfFailedTestCases;
 		std::istringstream is("not-a-number");
-		hfloat_short p;
+		hfp32 p;
 		{
 			CerrSilencer silence;
 			is >> p;
@@ -268,7 +310,7 @@ try {
 	{
 		int start = nrOfFailedTestCases;
 		std::istringstream is("");
-		hfloat_short p;
+		hfp32 p;
 		{
 			CerrSilencer silence;
 			is >> p;
@@ -277,8 +319,21 @@ try {
 		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: hfloat operator>> EOF\n";
 	}
 
+#	endif
+
+#	if REGRESSION_LEVEL_2
+#	endif
+
+#	if REGRESSION_LEVEL_3
+#	endif
+
+#	if REGRESSION_LEVEL_4
+#	endif
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;


### PR DESCRIPTION
the parse and printing APIs needed some TLC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed internal hexadecimal floating-point type aliases to clearer names.

* **Improvements**
  * Enhanced colorized diagnostics for clearer, correctly reset bit-field visualization.
  * Improved parsing/printing logic to produce consistent hex/exponent/fraction output.

* **Bug Fixes**
  * Fixed scaling, conversion, and formatting for very-wide fractional formats to ensure accurate high-precision behavior.
  * Removed truncation artifacts and improved nibble/separator handling.

* **Tests**
  * Updated and expanded test suites and regression harnesses to exercise new aliases and extended precision scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->