### PR TITLE
fix(dfloat): parsing and printing embellishment

### DIFF
--- a/include/sw/universal/number/dfloat/manipulators.hpp
+++ b/include/sw/universal/number/dfloat/manipulators.hpp
@@ -11,6 +11,27 @@
 
 namespace sw { namespace universal {
 
+	
+	// Generate a type tag for this decimal encoding
+	std::string type_tag(const DecimalEncoding encoding = {}) {
+		std::stringstream s;
+		switch (encoding) {
+		case DecimalEncoding::BCD:
+		    s << "BCD";  // Binary-Coded Decimal: 4 bits per digit
+			break;
+		case DecimalEncoding::BID:
+			s << "BID";  // Binary Integer Decimal: significand stored as binary integer
+			break;
+		case DecimalEncoding::DPD:
+			s << "DPD";  // Densely Packed Decimal: significand stored as 10-bit declets
+			break;
+		default:
+			s << "UnknownDecimalEncoding";
+			break;
+		}
+		return s.str();
+	}
+
 	// Generate a type tag for this dfloat
 	template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename bt>
 	std::string type_tag(const dfloat<ndigits, es, Encoding, bt>& = {}) {
@@ -18,7 +39,7 @@ namespace sw { namespace universal {
 		s << "dfloat<"
 			<< std::setw(3) << ndigits << ", "
 			<< std::setw(3) << es << ", "
-			<< (Encoding == DecimalEncoding::BID ? "BID" : "DPD") << ", "
+			<< type_tag(Encoding) << ", "
 			<< type_tag(bt{}) << '>';
 		return s.str();
 	}
@@ -40,30 +61,31 @@ namespace sw { namespace universal {
 		using Dfloat = dfloat<ndigits, es, Encoding, bt>;
 		std::stringstream s;
 
-		// sign in red
-		s << "\033[31m" << (number.sign() ? '1' : '0') << "\033[0m" << '.';
+		Color red(ColorCode::FG_RED);
+	    Color yellow(ColorCode::FG_YELLOW);
+	    Color magenta(ColorCode::FG_MAGENTA);
+	    Color cyan(ColorCode::FG_CYAN);
+	    Color def(ColorCode::FG_DEFAULT);
 
-		// combination field in blue (5 bits)
-		s << "\033[34m";
+		s << red << (number.sign() ? '1' : '0') << def;
+
 		unsigned combStart = Dfloat::nbits - 2;
 		for (unsigned i = 0; i < Dfloat::combBits; ++i) {
-			s << (number.getbit(combStart - i) ? '1' : '0');
+			s << yellow << (number.getbit(combStart - i) ? '1' : '0');
 		}
-		s << "\033[0m" << '.';
 
-		// exponent continuation in green
-		s << "\033[32m";
+		// exponent 
 		unsigned expStart = Dfloat::nbits - 1 - 1 - Dfloat::combBits;
 		for (unsigned i = 0; i < es; ++i) {
-			s << (number.getbit(expStart - i) ? '1' : '0');
+			s << cyan <<(number.getbit(expStart - i) ? '1' : '0');
 		}
-		s << "\033[0m" << '.';
 
-		// trailing significand in default color
+		// trailing significand
 		for (int i = static_cast<int>(Dfloat::t) - 1; i >= 0; --i) {
-			s << (number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
-			if (nibbleMarker && i > 0 && (i % 4 == 0)) s << '\'';
+			s << magenta <<(number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
+			if (nibbleMarker && i > 0 && (i % 4 == 0)) s << yellow << '\'';
 		}
+	    s << def;
 
 		return s.str();
 	}

--- a/include/sw/universal/number/hfloat/manipulators.hpp
+++ b/include/sw/universal/number/hfloat/manipulators.hpp
@@ -16,13 +16,13 @@ namespace sw { namespace universal {
 	std::string type_tag(const hfloat<ndigits, es, bt>& = {}) {
 		std::stringstream s;
 		if constexpr (ndigits == 6 && es == 7) {
-			s << "hfloat_short (IBM HFP 32-bit)";
+			s << "hfp32 (IBM HFP 32-bit)";
 		}
 		else if constexpr (ndigits == 14 && es == 7) {
-			s << "hfloat_long (IBM HFP 64-bit)";
+			s << "hfp64 (IBM HFP 64-bit)";
 		}
 		else if constexpr (ndigits == 28 && es == 7) {
-			s << "hfloat_extended (IBM HFP 128-bit)";
+			s << "hfp128 (IBM HFP 128-bit)";
 		}
 		else {
 			s << "hfloat<"

--- a/static/float/dfloat/api/api.cpp
+++ b/static/float/dfloat/api/api.cpp
@@ -14,7 +14,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <strstream>
+#include <sstream>
 
 /*
 Table 3.6 of the IEEE 754-2008 spec defines a set of standard decimal floats from the total bit width k using four formulas:
@@ -146,16 +146,20 @@ try {
 		std::cout << "quarter   : " << std::setw(12) << quarter << " : " << to_binary(quarter) << '\n';
 		std::cout << "pi        : " << std::setw(12) << pi      << " : " << to_binary(pi) << '\n';
 
-		// verify round-trip through double
-		double a = 1.23456789e10;
+		// verify round-trip through double for a value that fits in
+		// decimal32's 7 significant decimal digits (1234567 * 10^4 is
+		// exact in decimal32; anything wider than 7 digits would round
+		// during the double -> decimal32 leg and the round-trip would
+		// legitimately fail).
+		double a = 1.234567e10;
 		Real r(a);
-		double b = double(a);
+		double b = double(r);
 		if (a != b) {
-			std::cerr << "FAIL: round-trip 1.23456789e10 failed: " << a << " != " << b << '\n';
+			std::cerr << "FAIL: round-trip 1.234567e10 failed: " << a << " != " << b << '\n';
 			std::cerr << to_binary(a) << '\n' << to_binary(b) << '\n';
 			++nrOfFailedTestCases;
 		} else {
-			std::cout << "PASS: round-trip 1.23456789e10 succeeded\n";
+			std::cout << "PASS: round-trip 1.234567e10 succeeded\n";
 			ReportValue(a, "a", 2, 10);
 			ReportValue(b, "b", 2, 10);
 		}

--- a/static/float/dfloat/api/api.cpp
+++ b/static/float/dfloat/api/api.cpp
@@ -10,6 +10,11 @@
 #define DFLOAT_THROW_ARITHMETIC_EXCEPTION 0
 #include <universal/number/dfloat/dfloat.hpp>
 #include <universal/verification/test_suite.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <strstream>
 
 /*
 Table 3.6 of the IEEE 754-2008 spec defines a set of standard decimal floats from the total bit width k using four formulas:
@@ -48,6 +53,30 @@ Table 3.6 of the IEEE 754-2008 spec defines a set of standard decimal floats fro
   parameters that, together with the fixed 1+5 bit sign+combination field, determine everything else.
  */
 
+namespace sw::universal {
+	template<unsigned _ndigits, unsigned _es, DecimalEncoding _Encoding, typename bt>
+	const std::string dfp_pair(const dfloat<_ndigits, _es, _Encoding, bt>& a, unsigned precision = 7) {
+		std::stringstream s;
+		s << std::setprecision(precision) << a << " : ";
+		s << to_binary(a, true);
+		return s.str();
+	}
+
+    template<typename Real>
+    void numeric_properties() {
+	    Real maxval = std::numeric_limits<Real>::max();
+	    Real minval = std::numeric_limits<Real>::min();
+	    std::cout << type_tag(Real{}) << '\n';
+	    std::cout << " radix     : " << std::numeric_limits<Real>::radix << '\n';
+	    std::cout << " digits    : " << std::numeric_limits<Real>::digits << '\n';
+	    std::cout << " digits10  : " << std::numeric_limits<Real>::digits10 << '\n';
+	    std::cout << " is_exact  : " << std::numeric_limits<Real>::is_exact << '\n';
+	    std::cout << " max       : " << dfp_pair(maxval, 7u) << '\n';
+	    std::cout << " min       : " << dfp_pair(minval, 7u) << '\n';
+    }
+    
+}
+
 int main()
 try {
 	using namespace sw::universal;
@@ -62,7 +91,6 @@ try {
 	// important behavioral traits
 	std::cout << "+---------    BID decimal floating-point behavioral traits\n";
 	{
-		//using TestType = decimal32; // == dfloat<7, 6>;
 		ReportTrivialityOfType<decimal32>();
 		ReportTrivialityOfType<decimal64>();
 		ReportTrivialityOfType<decimal128>();
@@ -71,7 +99,25 @@ try {
 	// BID encoding decimal floating-point arithmetic operators
 	std::cout << "+---------    BID encoding decimal floating-point arithmetic operators\n";
 	{
-		using Real = dfloat<7, 6>;  // decimal32 equivalent
+		using Real = dfloat<7, 6, DecimalEncoding::BID, std::uint32_t>;  // BID : Binary Integer Decimal : significand stored as binary integer
+		std::cout << "type : " << type_tag(Real{}) << '\n';
+
+		Real a(1.0f), b(0.5f);
+		ArithmeticOperators(a, b);
+	}
+	// DPD encoding decimal floating-point arithmetic operators
+	std::cout << "+---------    DPD encoding decimal floating-point arithmetic operators\n";
+	{
+		using Real = dfloat<7, 6, DecimalEncoding::DPD, std::uint32_t>;  // DPD : Densely Packed Decimal encoding : significand stored as 10-bit declets
+		std::cout << "type : " << type_tag(Real{}) << '\n';
+
+		Real a(1.0f), b(0.5f);
+		ArithmeticOperators(a, b);
+	}
+	// BCD encoding decimal floating-point arithmetic operators
+	std::cout << "+---------    BCD encoding decimal floating-point arithmetic operators\n";
+	{
+		using Real = dfloat<7, 6, DecimalEncoding::BCD, std::uint32_t>;  // BCD : Binary Coded Decimal (4 bits per digit)
 		std::cout << "type : " << type_tag(Real{}) << '\n';
 
 		Real a(1.0f), b(0.5f);
@@ -81,7 +127,7 @@ try {
 	// basic value construction and conversion
 	std::cout << "+---------    Basic value construction and conversion\n";
 	{
-		using Real = dfloat<7, 6>;
+		using Real = decimal32;
 
 		Real zero(0);
 		Real one(1);
@@ -101,13 +147,35 @@ try {
 		std::cout << "pi        : " << std::setw(12) << pi      << " : " << to_binary(pi) << '\n';
 
 		// verify round-trip through double
-		double d = 42.0;
-		Real r(d);
-		double d2 = double(r);
-		if (d != d2) {
-			std::cerr << "FAIL: round-trip 42.0 failed: " << d << " != " << d2 << '\n';
+		double a = 1.23456789e10;
+		Real r(a);
+		double b = double(a);
+		if (a != b) {
+			std::cerr << "FAIL: round-trip 1.23456789e10 failed: " << a << " != " << b << '\n';
+			std::cerr << to_binary(a) << '\n' << to_binary(b) << '\n';
 			++nrOfFailedTestCases;
+		} else {
+			std::cout << "PASS: round-trip 1.23456789e10 succeeded\n";
+			ReportValue(a, "a", 2, 10);
+			ReportValue(b, "b", 2, 10);
 		}
+	}
+
+	// Decimal Floating-Point properties: NaN, infinity
+	std::cout << "+---------    Decimal FP properties: NaN, infinity\n";
+	{
+		using Real = decimal32;
+
+		Real a(1.0f), b(0.0f), c{};
+		c = a / b;  // should produce infinity
+		ReportValue(c, "1.0 / 0.0");
+		std::cout << "  isinf(1.0 / 0.0)  : " << (c.isinf() ? "true" : "false") << '\n'; // should be true
+		c = b / b;  // should produce NaN
+		ReportValue(c, "0.0 / 0.0");
+		std::cout << "  isnan(0.0 / 0.0)  : " << (c.isnan() ? "true" : "false") << '\n'; // should be true;
+
+		Real qnan(SpecificValue::qnan);
+		ReportValue(qnan, "quiet NaN");
 	}
 
 	// special values
@@ -200,23 +268,61 @@ try {
 
 	// numeric_limits
 	std::cout << "+---------    numeric_limits\n";
-	{
-		using Real = decimal32;
-		std::cout << "decimal32 radix     : " << std::numeric_limits<Real>::radix << '\n';
-		std::cout << "decimal32 digits    : " << std::numeric_limits<Real>::digits << '\n';
-		std::cout << "decimal32 digits10  : " << std::numeric_limits<Real>::digits10 << '\n';
-		std::cout << "decimal32 is_exact  : " << std::numeric_limits<Real>::is_exact << '\n';
-		std::cout << "decimal32 max       : " << std::numeric_limits<Real>::max() << '\n';
-		std::cout << "decimal32 min       : " << std::numeric_limits<Real>::min() << '\n';
+	{ 
+		numeric_properties<decimal32>();
+		numeric_properties<decimal64>();
+		numeric_properties<decimal128>();
 	}
 
 	// parsing input strings
 	std::cout << "+---------    parsing input strings\n";
 	{
 		decimal32 d32("999.9999");
-		std::cout << "d32 : " << d32 << " : " << to_binary(d32) << '\n';
+		ReportValue(d32, "d32 initial");
 		d32.assign("-123.456e-78");
-		std::cout << "d32 : " << d32 << " : " << to_binary(d32) << '\n';
+		ReportValue(d32, "d32 assigned");
+	}
+	{
+		decimal64 d64("999.9999999999999");
+		ReportValue(d64, "d64 initial");
+		d64.assign("-123.456e-78");
+		ReportValue(d64, "d64 assigned");
+	}
+	{
+		decimal128 d128("999.999999999999999999999");
+		ReportValue(d128, "d128 initial");
+		d128.assign("-123.456e-78");
+		ReportValue(d128, "d128 assigned");
+	}
+
+		// printing
+	std::cout << "+---------    I/O and printing\n";
+	{
+		std::cout << "\ncfloat<32, 8> reference\n";
+		using Real = single;
+		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
+		std::cout << "values print : " << a << ", " << b << '\n';
+		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
+		std::cout << "color print  : " << color_print(a) << "\n             : " << color_print(b, true) << '\n';
+		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
+	}
+	{
+		std::cout << "\ndecimal32 reference\n";
+		using Real = decimal32;
+		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
+		std::cout << "values print : " << a << ", " << b << '\n';
+		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
+		std::cout << "color print  : " << color_print(a) << "\n             : " << color_print(b, true) << '\n';
+		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
+	}
+	{
+		std::cout << "\ndecimal64 reference\n";
+		using Real = decimal64;
+		Real a(SpecificValue::maxneg), b(SpecificValue::minpos);
+		std::cout << "values print : " << a << ", " << b << '\n';
+		std::cout << "binary print : " << to_binary(a, true) << "\n             : " << to_binary(b, true) << '\n';
+		std::cout << "color print  : " << color_print(a) << "\n             : " << color_print(b, true) << '\n';
+		std::cout << "components   : " << components(a) << "\n             : " << components(b) << '\n';
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -24,7 +24,21 @@ namespace sw::universal {
 		s << to_binary(a, true);
 		return s.str();
 	}
-}
+
+	template<typename Real>
+	void numeric_properties() {
+		Real maxval = std::numeric_limits<Real>::max();
+		Real minval = std::numeric_limits<Real>::min();
+		std::cout << type_tag(Real{}) << '\n';
+		std::cout << " radix            : " << std::numeric_limits<Real>::radix << '\n';
+		std::cout << " digits (binary)  : " << std::numeric_limits<Real>::digits << '\n';
+		std::cout << " has_infinity     : " << (std::numeric_limits<Real>::has_infinity ? "yes" : "no") << '\n';
+		std::cout << " has_quiet_NaN    : " << (std::numeric_limits<Real>::has_quiet_NaN ? "yes" : "no") << '\n';
+		std::cout << " round_style      : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
+		std::cout << " max              : " << hfp_pair(maxval, 7u) << '\n';
+		std::cout << " min              : " << hfp_pair(minval, 7u) << '\n';
+	}
+}  // namespace sw::universal
 
 int main()
 try {
@@ -40,6 +54,8 @@ try {
 	// important behavioral traits
 	{
 		ReportTrivialityOfType<hfp32>();
+		ReportTrivialityOfType<hfp64>();
+		ReportTrivialityOfType<hfp128>();
 	}
 
 	// IBM HFP short precision
@@ -158,44 +174,10 @@ try {
 
 	// numeric_limits
 	std::cout << "+---------    numeric_limits\n";
-	{
-		using Real = hfp32;
-		Real maxval = std::numeric_limits<Real>::max();
-		Real minval = std::numeric_limits<Real>::min();
-		std::cout << "hfp32 radix            : " << std::numeric_limits<Real>::radix << '\n';
-		std::cout << "hfp32 digits (binary)  : " << std::numeric_limits<Real>::digits << '\n';
-		std::cout << "hfp32 has_infinity     : " << (std::numeric_limits<Real>::has_infinity ? "yes" : "no") << '\n';
-		std::cout << "hfp32 has_quiet_NaN    : " << (std::numeric_limits<Real>::has_quiet_NaN ? "yes" : "no") << '\n';
-		std::cout << "hfp32 round_style      : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
-		std::cout << "hfp32 max              : " << hfp_pair(maxval, 7u) << '\n';
-		std::cout << "hfp32 min              : " << hfp_pair(minval, 7u) << '\n';
-		std::cout << '\n';
-	}
-	{
-		using Real = hfp64;
-		Real maxval = std::numeric_limits<Real>::max();
-		Real minval = std::numeric_limits<Real>::min();
-		std::cout << "hfp64 radix            : " << std::numeric_limits<Real>::radix << '\n';
-		std::cout << "hfp64 digits (binary)  : " << std::numeric_limits<Real>::digits << '\n';
-		std::cout << "hfp64 has_infinity     : " << (std::numeric_limits<Real>::has_infinity ? "yes" : "no") << '\n';
-		std::cout << "hfp64 has_quiet_NaN    : " << (std::numeric_limits<Real>::has_quiet_NaN ? "yes" : "no") << '\n';
-		std::cout << "hfp64 round_style      : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
-		std::cout << "hfp64 max              : " << hfp_pair(maxval, 14u) << '\n';
-		std::cout << "hfp64 min              : " << hfp_pair(minval, 14u) << '\n';
-		std::cout << '\n';
-	}
-	{
-		using Real = hfp128;
-		Real maxval = std::numeric_limits<Real>::max();
-		Real minval = std::numeric_limits<Real>::min();
-		std::cout << "hfp128 radix           : " << std::numeric_limits<Real>::radix << '\n';
-		std::cout << "hfp128 digits (binary) : " << std::numeric_limits<Real>::digits << '\n';
-		std::cout << "hfp128 has_infinity    : " << (std::numeric_limits<Real>::has_infinity ? "yes" : "no") << '\n';
-		std::cout << "hfp128 has_quiet_NaN   : " << (std::numeric_limits<Real>::has_quiet_NaN ? "yes" : "no") << '\n';
-		std::cout << "hfp128 round_style     : " << std::numeric_limits<Real>::round_style << " (toward_zero=0)\n";
-		std::cout << "hfp128 max             : " << hfp_pair(maxval, 24u) << '\n';
-		std::cout << "hfp128 min             : " << hfp_pair(minval, 24u) << '\n';
-		std::cout << '\n';
+	{ 
+		numeric_properties<hfp32>();
+		numeric_properties<hfp64>();
+		numeric_properties<hfp128>();
 	}
 
 	// truncation rounding verification


### PR DESCRIPTION
embellishing the parse and print patterns for the api demo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encoding-specific type labels for decimal floats; clearer human-readable hfloat identifiers
  * New diagnostic utility to print numeric properties/limits for multiple float types

* **Refactor**
  * Improved colored and formatted diagnostic output for floating-point bit/field displays

* **Tests**
  * Expanded API tests: multiple decimal encodings, parsing checks, and extended I/O/reference examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->