### PR TITLE
fix: streamlining long running regression tests

### DIFF
--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -306,7 +306,7 @@ try {
 	benchmark_config<lns< 8, 4, std::uint8_t >>("lns< 8, 4, uint8_t>",  TPUT_SMALL,  ACC_SAMPLES);
 	benchmark_config<lns<16, 8, std::uint16_t>>("lns<16, 8, uint16_t>", TPUT_MEDIUM, ACC_SAMPLES);
 	benchmark_config<lns<24,16, std::uint32_t>>("lns<24,16, uint32_t>", TPUT_MEDIUM, ACC_SAMPLES);
-	benchmark_config<lns<32,16, std::uint32_t>>("lns<32,24, uint32_t>", TPUT_LARGE,  ACC_SAMPLES);
+	benchmark_config<lns<32,24, std::uint32_t>>("lns<32,24, uint32_t>", TPUT_LARGE,  ACC_SAMPLES);
 
 	std::cout << "\n## Reading the table\n\n";
 	std::cout << "- DoubleTrip is the legacy placeholder and a useful reference\n";

--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -21,6 +21,9 @@
 //
 // Results are printed as Markdown tables suitable for direct paste into
 // release notes or the design document at docs/design/lns-add-sub.md.
+#include <universal/utility/directives.hpp>
+#define LNS_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/lns/lns.hpp>
 
 #include <iostream>
 #include <iomanip>
@@ -32,9 +35,6 @@
 #include <cmath>
 #include <cstdlib>
 #include <limits>
-
-#define LNS_THROW_ARITHMETIC_EXCEPTION 0
-#include <universal/number/lns/lns.hpp>
 
 namespace sw { namespace universal {
 
@@ -296,16 +296,17 @@ try {
 
 	// Throughput iterations per config: scale down for the larger lns sizes
 	// so the benchmark completes in seconds rather than minutes.
-	constexpr std::size_t TPUT_SMALL  = 1'000'000;
-	constexpr std::size_t TPUT_MEDIUM =   500'000;
-	constexpr std::size_t TPUT_LARGE  =   200'000;
+	constexpr std::size_t TPUT_TINY   = 1'000'000;
+	constexpr std::size_t TPUT_SMALL  =    75'000;
+	constexpr std::size_t TPUT_MEDIUM =    50'000;
+	constexpr std::size_t TPUT_LARGE  =    25'000;
 	// Accuracy sample count (per axis; total = N*N pairs).
 	constexpr std::size_t ACC_SAMPLES = 64;
 
-	benchmark_config<lns< 8, 4, std::uint8_t>>("lns< 8, 4, uint8_t>",  TPUT_SMALL,  ACC_SAMPLES);
+	benchmark_config<lns< 8, 4, std::uint8_t >>("lns< 8, 4, uint8_t>",  TPUT_SMALL,  ACC_SAMPLES);
 	benchmark_config<lns<16, 8, std::uint16_t>>("lns<16, 8, uint16_t>", TPUT_MEDIUM, ACC_SAMPLES);
 	benchmark_config<lns<24,16, std::uint32_t>>("lns<24,16, uint32_t>", TPUT_MEDIUM, ACC_SAMPLES);
-	benchmark_config<lns<32,16, std::uint32_t>>("lns<32,16, uint32_t>", TPUT_LARGE,  ACC_SAMPLES);
+	benchmark_config<lns<32,16, std::uint32_t>>("lns<32,24, uint32_t>", TPUT_LARGE,  ACC_SAMPLES);
 
 	std::cout << "\n## Reading the table\n\n";
 	std::cout << "- DoubleTrip is the legacy placeholder and a useful reference\n";

--- a/playground/closure_of_8bit_systems.cpp
+++ b/playground/closure_of_8bit_systems.cpp
@@ -11,20 +11,19 @@
 // 
 // the generated closure plots can be found in the dir: build/mappings/user_generated
 
-#include <iostream>
-#include <string>
-#include <fstream>
-#include <filesystem>
-
 #include <universal/number/posit/posit.hpp>
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/number/lns/lns.hpp> 
 
 #include <universal/utility/generateClosurePlots.hpp>
 
+#include <iostream>
+#include <string>
+#include <fstream>
+#include <filesystem>
 
 ///This is the configuration the generate the three comparable number systems
-namespace sw::universal{
+namespace sw::universal {
 
 constexpr unsigned nbits{ 8 };  // size in bits of the encoding
 constexpr unsigned cfloat_exp{ 4 };
@@ -38,34 +37,41 @@ using RealL = lns<nbits, lns_exp>;  // range of ~[2^-8 , 2^8]
 template int buildClosurePlot<RealC>(std::string, std::ostream&, std::ostream&);
 template int buildClosurePlot<RealP>(std::string, std::ostream&, std::ostream&);
 template int buildClosurePlot<RealL>(std::string, std::ostream&, std::ostream&);
+
+template<typename TestType>
+void generateClosurePlots(const std::string& ns_name, unsigned param2) {
+	constexpr unsigned    nbits  = TestType::nbits;
+	std::string           ns_str = ns_name + "_" + std::to_string(nbits) + "_" + std::to_string(param2);
+	std::filesystem::path mappings{"mappings/user_generated/"};
+	std::filesystem::create_directories(mappings / ns_str);
+
+	std::ofstream txt_file(mappings / ns_str / (ns_str + ".txt"));
+	std::ofstream csv_file(mappings / ns_str / (ns_str + ".csv"));
+
+	buildClosurePlot<TestType>(ns_str, txt_file, csv_file);
 }
 
-///main driver function
+}
+
+#define MANUAL_TESTING 0
+
 int main() {
-    using namespace sw::universal;
+	using namespace sw::universal;
 
+#if MANUAL_TESTING
+	std::cout << "Manual testing mode: only generating closure plots for 8 bit systems\n";
 
-    std::string cfloat_str = "cfloat_" + std::to_string(nbits) + "_" + std::to_string(cfloat_exp); 
-    std::string posit_str = "posit_" + std::to_string(nbits) + "_" + std::to_string(posit_exp); 
-    std::string lns_str = "lns_" + std::to_string(nbits) + "_" + std::to_string(lns_exp); 
+	// TODO: the whole stack is currently hardcoded to 8-bit systems.
+    generateClosurePlots<cfloat<8, 4>>("cfloat", 4u);
+	generateClosurePlots<posit<8, 0>>("posit", 0u);
+    generateClosurePlots<lns<8, 3>>("lns", 3u);
+	
+#else
+	std::cout << "Regression testing mode: NOP\n";
 
-    std::filesystem::path mappings{"mappings/user_generated/"};
-    std::filesystem::create_directories(mappings / cfloat_str); 
-    std::filesystem::create_directories(mappings / posit_str); 
-    std::filesystem::create_directories(mappings / lns_str); 
-
-    std::ofstream cfloat_txt_file(mappings / cfloat_str / (cfloat_str + ".txt")); 
-    std::ofstream cfloat_csv_file(mappings / cfloat_str / (cfloat_str + ".csv"));
-
-    std::ofstream posit_txt_file(mappings / posit_str / (posit_str + ".txt")); 
-    std::ofstream posit_csv_file(mappings / posit_str / (posit_str + ".csv"));
-
-    std::ofstream lns_txt_file(mappings / lns_str / (lns_str + ".txt")); 
-    std::ofstream lns_csv_file(mappings / lns_str / (lns_str + ".csv"));
-
-    buildClosurePlot<RealC>(cfloat_str, cfloat_txt_file, cfloat_csv_file);
-    buildClosurePlot<RealP>(posit_str, posit_txt_file, posit_csv_file);
-    buildClosurePlot<RealL>(lns_str, lns_txt_file, lns_csv_file);
+#endif
 
     return EXIT_SUCCESS;
 }
+
+

--- a/playground/evaluate_small_number_systems.cpp
+++ b/playground/evaluate_small_number_systems.cpp
@@ -26,19 +26,18 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <universal/number/posit/posit.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/lns/lns.hpp>
+
+#include <universal/utility/evaluate_closure_of_number_systems.hpp>
+#include <universal/utility/generateClosurePlots.hpp>
+
 #include <iostream>
 #include <string>
 #include <string_view>
 #include <fstream>
 #include <filesystem>
-
-#include <universal/number/posit/posit.hpp>
-#include <universal/number/cfloat/cfloat.hpp>
-#include <universal/number/lns/lns.hpp>
-
-
-#include <universal/utility/evaluate_closure_of_number_systems.hpp>
-#include <universal/utility/generateClosurePlots.hpp>
 
 using namespace sw::universal;
 
@@ -87,78 +86,80 @@ struct lnsConfigs {
 };
 
 
-    int main(int argc, char *argv[]) {
-        using namespace std;
+int main(int argc, char *argv[]) {
+    using namespace std;
 
-        bool _4bit = false;
-        bool _6bit = false;
-        bool _8bit = false;
-        bool _10bit = false;
-        bool _12bit = false;
+    bool _4bit  = false;
+	bool _6bit  = false;
+	bool _8bit  = false;
+	bool _10bit = false;
+	bool _12bit = false;
 
-        if(argc >= 2){
-            // Loop through each argument
-            for (int i = 1; i < argc; ++i) {
-                if (string(argv[i]) == "-4")
-                    _4bit = true;
-                else if (string(argv[i]) == "-6")
-                    _6bit = true;
-                else if (string(argv[i]) == "-8")
-                    _8bit = true;
-                else if (string(argv[i]) == "-10")
-                    _10bit = true;
-                else if (string(argv[i]) == "-12")
-                    _12bit = true;
-                else{
-                    cerr << "\nInvalid flag detected.  Enter one or many flags of the form:\n'-4' for 4 bit systems\n'-6' for 6 bit systems\n'-8' for 8 bit systems\n'-10' for 10 bit systems\n'-12' for 12 bit systems"<< endl;
-                    return EXIT_FAILURE;
-                }
+    if (argc == 1) {
+        cout << "No flags detected. Defaulting to processing only 4 bit systems.\n\n" ;
+        cout << "To process other systems, enter one or many flags of the form:\n'-4' for 4 bit systems\n'-6' for 6 bit systems\n'-8' for 8 bit systems\n'-10' for 10 bit systems\n'-12' for 12 bit systems"<< endl;
+		_4bit = true;
+	} else if (argc >= 2) {
+        // Loop through each argument
+        for (int i = 1; i < argc; ++i) {
+            if (string(argv[i]) == "-4")
+                _4bit = true;
+            else if (string(argv[i]) == "-6")
+                _6bit = true;
+            else if (string(argv[i]) == "-8")
+                _8bit = true;
+            else if (string(argv[i]) == "-10")
+                _10bit = true;
+            else if (string(argv[i]) == "-12")
+                _12bit = true;
+            else{
+                cerr << "\nInvalid flag detected.  Enter one or many flags of the form:\n'-4' for 4 bit systems\n'-6' for 6 bit systems\n'-8' for 8 bit systems\n'-10' for 10 bit systems\n'-12' for 12 bit systems"<< endl;
+                return EXIT_FAILURE;
             }
         }
-        else //default to only 8 bit systems
-            _8bit = true;
+    }
+
+    //process the systems in sequential order
+    if(_4bit){
+        cout << "Processing 4 bit systems:\n\n" ;
+        processASystem<cfloatConfigs::cfg4_t>(cfloatConfigs::cfg4_str);
+        processASystem<positConfigs::cfg4_t>(positConfigs::cfg4_str);
+        processASystem<lnsConfigs::cfg4_t>(lnsConfigs::cfg4_str);
+        cout << "\n";
+    }
+
+    if(_6bit){
+        cout << "Processing 6 bit systems:\n\n" ;
+        processASystem<cfloatConfigs::cfg6_t>(cfloatConfigs::cfg6_str);
+        processASystem<positConfigs::cfg6_t>(positConfigs::cfg6_str);
+        processASystem<lnsConfigs::cfg6_t>(lnsConfigs::cfg6_str);
+        cout << "\n";
+    }
+
+    if(_8bit){
+        cout << "Processing 8 bit systems:\n\n" ;
+        processASystem<cfloatConfigs::cfg8_t>(cfloatConfigs::cfg8_str);
+        processASystem<positConfigs::cfg8_t>(positConfigs::cfg8_str);
+        processASystem<lnsConfigs::cfg8_t>(lnsConfigs::cfg8_str);
+        cout << "\n";
+    }
 
 
-        //process the systems in sequential order
-        if(_4bit){
-            cout << "Processing 4 bit systems:\n\n" ;
-            processASystem<cfloatConfigs::cfg4_t>(cfloatConfigs::cfg4_str);
-            processASystem<positConfigs::cfg4_t>(positConfigs::cfg4_str);
-            processASystem<lnsConfigs::cfg4_t>(lnsConfigs::cfg4_str);
-            cout << "\n";
-        }
+    if(_10bit){
+        cout << "Processing 10 bit systems:\n\n" ;
+        processASystem<cfloatConfigs::cfg10_t>(cfloatConfigs::cfg10_str);
+        processASystem<positConfigs::cfg10_t>(positConfigs::cfg10_str);
+        processASystem<lnsConfigs::cfg10_t>(lnsConfigs::cfg10_str);
+        cout << "\n";
+    }
 
-        if(_6bit){
-            cout << "Processing 6 bit systems:\n\n" ;
-            processASystem<cfloatConfigs::cfg6_t>(cfloatConfigs::cfg6_str);
-            processASystem<positConfigs::cfg6_t>(positConfigs::cfg6_str);
-            processASystem<lnsConfigs::cfg6_t>(lnsConfigs::cfg6_str);
-            cout << "\n";
-        }
+    if(_12bit){
+        cout << "Processing 12 bit systems:\n\n" ;
+        processASystem<cfloatConfigs::cfg12_t>(cfloatConfigs::cfg12_str);
+        processASystem<positConfigs::cfg12_t>(positConfigs::cfg12_str);
+        processASystem<lnsConfigs::cfg12_t>(lnsConfigs::cfg12_str);
+        cout << "\n";
+    }
 
-        if(_8bit){
-            cout << "Processing 8 bit systems:\n\n" ;
-            processASystem<cfloatConfigs::cfg8_t>(cfloatConfigs::cfg8_str);
-            processASystem<positConfigs::cfg8_t>(positConfigs::cfg8_str);
-            processASystem<lnsConfigs::cfg8_t>(lnsConfigs::cfg8_str);
-            cout << "\n";
-        }
-
-
-        if(_10bit){
-            cout << "Processing 10 bit systems:\n\n" ;
-            processASystem<cfloatConfigs::cfg10_t>(cfloatConfigs::cfg10_str);
-            processASystem<positConfigs::cfg10_t>(positConfigs::cfg10_str);
-            processASystem<lnsConfigs::cfg10_t>(lnsConfigs::cfg10_str);
-            cout << "\n";
-        }
-
-        if(_12bit){
-            cout << "Processing 12 bit systems:\n\n" ;
-            processASystem<cfloatConfigs::cfg12_t>(cfloatConfigs::cfg12_str);
-            processASystem<positConfigs::cfg12_t>(positConfigs::cfg12_str);
-            processASystem<lnsConfigs::cfg12_t>(lnsConfigs::cfg12_str);
-            cout << "\n";
-        }
     return EXIT_SUCCESS;
 }

--- a/static/bisection/conversion/aux_real.cpp
+++ b/static/bisection/conversion/aux_real.cpp
@@ -15,18 +15,18 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project.
-
-#define BISECTION_THROW_ARITHMETIC_EXCEPTION 0
 #define DD_THROW_ARITHMETIC_EXCEPTION 0
 #define QD_THROW_ARITHMETIC_EXCEPTION 0
+#define BISECTION_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/dd/dd.hpp>
+#include <universal/number/qd/qd.hpp>
+#include <universal/number/bisection/bisection.hpp>
+#include <universal/verification/test_status.hpp>
+#include <universal/verification/test_reporters.hpp>
 
 #include <iostream>
 #include <iomanip>
 #include <string>
-
-#include <universal/number/dd/dd.hpp>
-#include <universal/number/qd/qd.hpp>
-#include <universal/number/bisection/bisection.hpp>
 
 namespace {
 
@@ -41,7 +41,7 @@ template<typename T>
 int round_trip(const std::string& label) {
 	constexpr unsigned p = T::nbits;
 	const int64_t N = int64_t(1) << p;
-	int failures = 0;
+	int nrOfFailedTestCases = 0;
 	for (int64_t i = 0; i < N; ++i) {
 		T a;
 		a.setbits(static_cast<uint64_t>(i));
@@ -49,8 +49,8 @@ int round_trip(const std::string& label) {
 		double d = double(a);
 		T b(d);
 		if (a != b) {
-			++failures;
-			if (failures <= 5) {
+			++nrOfFailedTestCases;
+			if (nrOfFailedTestCases <= 5) {
 				std::cerr << "  FAIL " << label
 				          << " enc=" << i
 				          << " decoded=" << std::setprecision(17) << d
@@ -60,9 +60,9 @@ int round_trip(const std::string& label) {
 		}
 	}
 	std::cout << "  " << std::left << std::setw(44) << label
-	          << "round-trip " << (failures == 0 ? "PASS" : "FAIL")
-	          << " (" << failures << ")\n";
-	return failures;
+	          << "round-trip " << (nrOfFailedTestCases == 0 ? "PASS" : "FAIL")
+	          << " (" << nrOfFailedTestCases << ")\n";
+	return nrOfFailedTestCases;
 }
 
 /// Verify the decoded sequence is monotonic non-decreasing when we walk
@@ -73,7 +73,7 @@ template<typename T>
 int monotonic(const std::string& label) {
 	constexpr unsigned p = T::nbits;
 	const int64_t N = int64_t(1) << p;
-	int failures = 0;
+	int nrOfFailedTestCases = 0;
 	double prev = -std::numeric_limits<double>::infinity();
 	// Iterate in signed order: start at maxneg (+1 past NaN) and walk up.
 	for (int64_t i = 1; i < N; ++i) {
@@ -84,8 +84,8 @@ int monotonic(const std::string& label) {
 		if (a.isnan()) continue;
 		double d = double(a);
 		if (d < prev) {
-			++failures;
-			if (failures <= 5) {
+			++nrOfFailedTestCases;
+			if (nrOfFailedTestCases <= 5) {
 				std::cerr << "  FAIL " << label
 				          << " monotonic break at enc=" << signed_idx
 				          << " prev=" << prev << " cur=" << d << "\n";
@@ -94,9 +94,9 @@ int monotonic(const std::string& label) {
 		prev = d;
 	}
 	std::cout << "  " << std::left << std::setw(44) << label
-	          << "monotonic  " << (failures == 0 ? "PASS" : "FAIL")
-	          << " (" << failures << ")\n";
-	return failures;
+	          << "monotonic  " << (nrOfFailedTestCases == 0 ? "PASS" : "FAIL")
+	          << " (" << nrOfFailedTestCases << ")\n";
+	return nrOfFailedTestCases;
 }
 
 /// Demonstrate that dd-backed decoding carries visibly more precision
@@ -114,36 +114,55 @@ void report_precision_delta(const std::string& label) {
 	Tdd     a_dd(x);
 	double  d_double = double(a_double);
 	dd      d_dd     = static_cast<dd>(a_dd);
-	std::cout << "  " << label
+	std::cout << "  " << label << std::scientific
 	          << "  double path: " << std::setprecision(17) << d_double
 	          << "\n  " << std::string(label.size(), ' ')
-	          << "  dd    path: " << std::setprecision(33) << d_dd << "\n";
+	          << "  dd     path: " << std::setprecision(33) << d_dd << "\n";
 }
 
 } // anonymous namespace
 
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 1
+#	define REGRESSION_LEVEL_4 1
+#endif
+
 int main() {
 	using namespace sw::universal;
-	int failures = 0;
+	std::string test_suite          = "bisection<> AuxReal parameterization tests";
+	std::string test_tag            = "bisection<> AuxReal";
+	bool        reportTestCases     = false;
+	int         nrOfFailedTestCases = 0;
 
-	std::cout << "bisection<> AuxReal parameterization tests\n";
-	std::cout << "-------------------------------------------\n";
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+	// manual exhaustive test
+
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#else
+
+#	if REGRESSION_LEVEL_1
 	// 8-bit exhaustive (fast): same encoding, different AuxReal.
 	std::cout << "\n[8-bit exhaustive]\n";
-	failures += round_trip<bisection_posit<8, 0, uint8_t, double>>("bisection_posit<8,0,uint8_t,double>");
-	failures += round_trip<bisection_posit<8, 0, uint8_t, dd>>    ("bisection_posit<8,0,uint8_t,dd>    ");
-	failures += round_trip<bisection_posit<8, 0, uint8_t, qd>>    ("bisection_posit<8,0,uint8_t,qd>    ");
-	failures += monotonic <bisection_posit<8, 0, uint8_t, double>>("bisection_posit<8,0,uint8_t,double>");
-	failures += monotonic <bisection_posit<8, 0, uint8_t, dd>>    ("bisection_posit<8,0,uint8_t,dd>    ");
-
-	// 16-bit exhaustive -- covers the "useful precision" band where
-	// AuxReal=double is still sufficient but the dd path should agree.
-	std::cout << "\n[16-bit exhaustive]\n";
-	failures += round_trip<bisection_posit<16, 0, uint8_t, double>>("bisection_posit<16,0,uint8_t,double>");
-	failures += round_trip<bisection_posit<16, 0, uint8_t, dd>>    ("bisection_posit<16,0,uint8_t,dd>    ");
-	failures += monotonic <bisection_posit<16, 0, uint8_t, dd>>    ("bisection_posit<16,0,uint8_t,dd>    ");
-	failures += round_trip<bisection_natposit<16, 0, uint8_t, dd>> ("bisection_natposit<16,0,uint8_t,dd> ");
+	nrOfFailedTestCases += round_trip<bisection_posit<8, 2, uint8_t, double>>("bisection_posit<8,2,uint8_t,double>");
+	nrOfFailedTestCases += round_trip<bisection_posit<8, 2, uint8_t, dd>>    ("bisection_posit<8,2,uint8_t,dd>    ");
+	nrOfFailedTestCases += round_trip<bisection_posit<8, 2, uint8_t, qd>>    ("bisection_posit<8,2,uint8_t,qd>    ");
+	nrOfFailedTestCases += monotonic <bisection_posit<8, 2, uint8_t, double>>("bisection_posit<8,2,uint8_t,double>");
+	nrOfFailedTestCases += monotonic <bisection_posit<8, 2, uint8_t, dd>>    ("bisection_posit<8,2,uint8_t,dd>    ");
+	nrOfFailedTestCases += monotonic <bisection_posit<8, 2, uint8_t, qd>>    ("bisection_posit<8,2,uint8_t,qd>    ");
+	nrOfFailedTestCases += round_trip<bisection_natposit<8, 2, uint8_t, dd>> ("bisection_natposit<8,2,uint8_t,dd> ");
 
 	// Informational: show the dd path decodes to extra precision.
 	std::cout << "\n[precision reporting]\n";
@@ -151,9 +170,29 @@ int main() {
 		bisection_posit<32, 0, uint8_t, double>,
 		bisection_posit<32, 0, uint8_t, dd>>("posit32 encoding of 1/7");
 
-	std::cout << "\n-------------------------------------------\n";
-	std::cout << "bisection AuxReal tests: "
-	          << (failures == 0 ? "PASS" : "FAIL")
-	          << " (" << failures << " failures)\n";
-	return failures == 0 ? 0 : 1;
+#	endif
+
+#	if REGRESSION_LEVEL_2
+	// 16-bit exhaustive -- covers the "useful precision" band where
+	// AuxReal=double is still sufficient but the dd path should agree.
+	std::cout << "\n[16-bit exhaustive]\n";
+	nrOfFailedTestCases += round_trip<bisection_posit<16, 2, uint16_t, double>>("bisection_posit<16,2,uint16_t,double>");
+	nrOfFailedTestCases += round_trip<bisection_posit<16, 2, uint16_t, dd>>    ("bisection_posit<16,2,uint16_t,dd>    ");
+	nrOfFailedTestCases += round_trip<bisection_posit<16, 2, uint16_t, qd>>    ("bisection_posit<16,2,uint16_t,qd>    ");
+	nrOfFailedTestCases += monotonic <bisection_posit<16, 2, uint16_t, double>>("bisection_posit<16,2,uint16_t,double>");
+	nrOfFailedTestCases += monotonic <bisection_posit<16, 2, uint16_t, dd>>    ("bisection_posit<16,2,uint16_t,dd>    ");
+	nrOfFailedTestCases += monotonic <bisection_posit<16, 2, uint16_t, qd>>    ("bisection_posit<16,2,uint16_t,qd>    ");
+#	endif
+
+#	if REGRESSION_LEVEL_3
+
+#	endif
+
+#	if REGRESSION_LEVEL_4
+
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
 }

--- a/static/bisection/conversion/density.cpp
+++ b/static/bisection/conversion/density.cpp
@@ -19,16 +19,16 @@
 
 #define BISECTION_THROW_ARITHMETIC_EXCEPTION 0
 
+#include <universal/utility/directives.hpp>
+#include <universal/number/bisection/bisection.hpp>
+#include <universal/verification/test_suite.hpp>
+
 #include <iostream>
 #include <iomanip>
 #include <cmath>
 #include <vector>
 #include <string>
 #include <map>
-
-#include <universal/utility/directives.hpp>
-#include <universal/number/bisection/bisection.hpp>
-#include <universal/verification/test_suite.hpp>
 
 namespace {
 


### PR DESCRIPTION
three regression tests that took longer than 30sec streamlined to instantaneous or seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual testing mode added for closure plot generation.

* **Bug Fixes**
  * Evaluation tool now defaults to processing 4-bit systems when run without arguments.

* **Refactor**
  * Closure-plot generation reorganized for reuse.
  * Benchmark throughput scaling and iteration counts rebalanced for more accurate performance tests.
  * Test reporting and output formatting standardized for clearer pass/fail summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->