### PR TITLE
feat(elreal): Phase A foundation -- type skeleton and refinement protocol

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -65,6 +65,7 @@ jobs:
             erational
             efloat
             ereal
+            elreal
             internal
             blockbinary
             blockdecimal

--- a/elastic/elreal/api/api.cpp
+++ b/elastic/elreal/api/api.cpp
@@ -1,0 +1,167 @@
+// api.cpp: Phase A canary test for the elreal (Exact Lazy Real) number system
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Phase A scope: exercise the foundation skeleton (issue #874 of epic #873).
+// The lazy machinery (closure-based generator, multi-component refinement,
+// arithmetic) is intentionally absent here; this test just verifies the type
+// compiles, constructs from native types, and that the refinement-protocol
+// entry points are callable.
+//
+// As later phases land, this file grows into a full API tour analogous to
+// elastic/ereal/api/api.cpp.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal<> Phase A foundation skeleton";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- behavioral traits ---------------------------------------------------
+	{
+		// Universal's library-wide convention is to *report* triviality rather
+		// than assert it for elastic / variable-precision types. elreal holds
+		// std::vector<double>, so it is neither trivially constructible nor
+		// trivially copyable -- that is expected.
+		bool isTrivial = std::is_trivial<elreal>::value;
+		std::string testType = type_tag(elreal{});
+		std::cout << testType
+			<< (isTrivial ? " is trivial" : " is not trivial")
+			<< " (expected: not trivial for an elastic type)\n";
+	}
+
+	// --- construction --------------------------------------------------------
+	std::cout << "+--------- elreal construction\n";
+	{
+		elreal zero;
+		elreal one(1.0);
+		elreal pi_approx(3.141592653589793);
+		elreal neg(-2.5);
+		elreal big(1.0e100);
+		elreal i(int{42});
+		elreal ll(static_cast<long long>(1) << 40);
+
+		std::cout << "zero:        " << to_binary(zero)      << '\n';
+		std::cout << "1.0:         " << to_binary(one)       << '\n';
+		std::cout << "pi approx:   " << to_binary(pi_approx) << '\n';
+		std::cout << "-2.5:        " << to_binary(neg)       << '\n';
+		std::cout << "1e100:       " << to_binary(big)       << '\n';
+		std::cout << "int(42):     " << to_binary(i)         << '\n';
+		std::cout << "1LL << 40:   " << to_binary(ll)        << '\n';
+
+		// Verify the elementary invariants we *can* check in Phase A.
+		if (!zero.iszero())             { ++nrOfFailedTestCases; std::cerr << "FAIL: default-constructed elreal is not zero\n"; }
+		if (double(one)        != 1.0)  { ++nrOfFailedTestCases; std::cerr << "FAIL: elreal(1.0) decoded != 1.0\n"; }
+		if (double(neg)        != -2.5) { ++nrOfFailedTestCases; std::cerr << "FAIL: elreal(-2.5) decoded != -2.5\n"; }
+		if (double(i)          != 42.0) { ++nrOfFailedTestCases; std::cerr << "FAIL: elreal(int 42) decoded != 42.0\n"; }
+	}
+
+	// --- specific values -----------------------------------------------------
+	std::cout << "+--------- elreal specific values\n";
+	{
+		elreal infpos(SpecificValue::infpos);
+		elreal infneg(SpecificValue::infneg);
+		elreal qnan(SpecificValue::qnan);
+		elreal zero(SpecificValue::zero);
+
+		std::cout << "+inf:        " << to_binary(infpos) << '\n';
+		std::cout << "-inf:        " << to_binary(infneg) << '\n';
+		std::cout << "qnan:        " << to_binary(qnan)   << '\n';
+		std::cout << "zero:        " << to_binary(zero)   << '\n';
+
+		if (!infpos.isinf()) { ++nrOfFailedTestCases; std::cerr << "FAIL: +inf isinf() returned false\n"; }
+		if (!infneg.isinf()) { ++nrOfFailedTestCases; std::cerr << "FAIL: -inf isinf() returned false\n"; }
+		if (!qnan.isnan())   { ++nrOfFailedTestCases; std::cerr << "FAIL: qnan isnan() returned false\n"; }
+		if (!zero.iszero())  { ++nrOfFailedTestCases; std::cerr << "FAIL: SpecificValue::zero iszero() returned false\n"; }
+	}
+
+	// --- refinement protocol -------------------------------------------------
+	std::cout << "+--------- elreal refinement protocol (Phase A: stub)\n";
+	{
+		elreal v(3.14);
+		// at(0) should return the leading component.
+		if (v.at(0) != 3.14) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: at(0) did not return the leading component\n";
+		}
+		// at(k) for k beyond the materialised depth returns the implicit zero
+		// extension in Phase A. Phase C will replace this with generator-driven
+		// refinement.
+		if (v.at(5) != 0.0) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: at(beyond depth) did not return 0.0 (Phase A stub)\n";
+		}
+		// refine_to is a no-op in Phase A; verify it does not crash and does
+		// not change observable state.
+		std::size_t depth_before = v.computed_depth();
+		v.refine_to(80);
+		std::size_t depth_after  = v.computed_depth();
+		if (depth_before != depth_after) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: refine_to changed computed_depth in Phase A (should be no-op)\n";
+		}
+		std::cout << "computed_depth after refine_to(80): " << v.computed_depth() << '\n';
+	}
+
+	// --- traits --------------------------------------------------------------
+	std::cout << "+--------- elreal trait dispatch\n";
+	{
+		static_assert(is_elreal< elreal >,         "is_elreal<elreal> must be true");
+		static_assert(!is_elreal< double >,        "is_elreal<double> must be false");
+		std::cout << "is_elreal<elreal> = true (compile-time)\n";
+	}
+
+	// --- numeric_limits ------------------------------------------------------
+	std::cout << "+--------- std::numeric_limits<elreal>\n";
+	{
+		using limits = std::numeric_limits<elreal>;
+		std::cout << "digits         = " << limits::digits         << '\n';
+		std::cout << "digits10       = " << limits::digits10       << '\n';
+		std::cout << "is_signed      = " << limits::is_signed      << '\n';
+		std::cout << "is_exact       = " << limits::is_exact       << '\n';
+		std::cout << "is_bounded     = " << limits::is_bounded     << '\n';
+		std::cout << "has_infinity   = " << limits::has_infinity   << '\n';
+		std::cout << "has_quiet_NaN  = " << limits::has_quiet_NaN  << '\n';
+		std::cout << "epsilon        = " << double(limits::epsilon())  << '\n';
+
+		if (!limits::is_specialized) {
+			++nrOfFailedTestCases;
+			std::cerr << "FAIL: numeric_limits<elreal>::is_specialized is false\n";
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Caught unexpected universal internal exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -1,0 +1,48 @@
+// elreal: Exact Lazy Real number system (McCleeary 2019) -- standard header
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+////////////////////////////////////////////////////////////////////////////////////////
+///  COMPILATION DIRECTIVES TO DIFFERENT COMPILERS
+#include <universal/utility/compiler.hpp>
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// required std libraries
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+////////////////////////////////////////////////////////////////////////////////////////
+///  BEHAVIORAL COMPILATION SWITCHES
+
+////////////////////////////////////////////////////////////////////////////////////////
+// enable throwing specific exceptions for arithmetic errors
+// left to application to enable
+#if !defined(ELREAL_THROW_ARITHMETIC_EXCEPTION)
+// default is to use std::cerr for signalling an error
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+
+///////////////////////////////////////////////////////////////////////////////////////
+// bring in the trait functions
+#include <universal/traits/number_traits.hpp>
+#include <universal/traits/arithmetic_traits.hpp>
+#include <universal/common/number_traits_reports.hpp>
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// INCLUDE FILES that make up the library
+#include <universal/number/elreal/exceptions.hpp>
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/elreal_impl.hpp>
+#include <universal/traits/elreal_traits.hpp>
+#include <universal/number/elreal/numeric_limits.hpp>
+
+////////////////////////////////////////////////////////////////////////////////////////
+// useful functions to work with elreals
+#include <universal/number/elreal/manipulators.hpp>

--- a/include/sw/universal/number/elreal/elreal_fwd.hpp
+++ b/include/sw/universal/number/elreal/elreal_fwd.hpp
@@ -1,0 +1,23 @@
+#pragma once
+// elreal_fwd.hpp : forward declarations of elreal (Exact Lazy Real, McCleeary 2019)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <cstddef>
+
+namespace sw { namespace universal {
+
+// elreal is the Exact Lazy Real type: a non-templated class that represents
+// a real value as a lazy stream of progressively refined double-precision
+// components. See elreal_impl.hpp for the storage representation, approximation
+// element, and refinement protocol.
+class elreal;
+
+// free-function helpers (full definitions land in Phase C / E)
+elreal abs(const elreal&);
+elreal fabs(const elreal&);
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -1,0 +1,300 @@
+#pragma once
+// elreal_impl.hpp: Exact Lazy Real (McCleeary 2019) -- foundation skeleton (Phase A of epic #873)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// =============================================================================
+// elreal: Exact Lazy Real number system
+// =============================================================================
+//
+// Reference:
+//   McCleeary, R. (2019). "Lazy Exact Real Arithmetic Using Floating Point
+//   Operations." Ph.D. dissertation, University of Iowa.
+//   https://iro.uiowa.edu/esploro/outputs/doctoral/Lazy-exact-real-arithmetic-using-floating/9983776998202771
+//
+// This phase (Phase A, issue #874) establishes the type skeleton, storage
+// representation, and refinement protocol. No arithmetic is implemented here;
+// that lands in Phase C (#876). Comparison and sign determination land in
+// Phase D (#877). The lazy machinery (closure-based generator) lights up in
+// Phase C; this phase exposes the API surface and a single-component
+// initialisation path so other code can compile against the type.
+//
+// -----------------------------------------------------------------------------
+// Design decisions for Phase A (settled per the issue's design-questions list)
+// -----------------------------------------------------------------------------
+//
+// 1. STORAGE REPRESENTATION
+//
+//    The value is stored as a memoized stream of double-precision components
+//    plus a generator that produces successive components on demand:
+//
+//        mutable std::vector<double>               _components;
+//        mutable std::function<double(std::size_t)> _generator;   // (Phase C)
+//        mutable std::size_t                        _computed_depth = 0;
+//
+//    The members are `mutable` because refinement happens in const contexts
+//    (notably during comparison and sign determination): the *logical* value
+//    does not change, only the *representation precision* deepens.
+//
+//    Why this and not the alternatives:
+//      - Closure-based generator is the natural fit for McCleeary's lazy
+//        formulation. It re-uses Universal's existing EFT primitives
+//        (`error_free_ops.hpp`): each successive component is the EFT
+//        residual from the previous level.
+//      - The existing design note `docs/multi-component/exact-lazy-arithmetic.md`
+//        sketches this same approach.
+//      - An explicit DAG of operation nodes (more powerful for sharing common
+//        sub-expressions) is a future possibility, but a strictly larger
+//        engineering scope. Phase A's API surface is independent of the
+//        choice, so a migration is local to the implementation.
+//
+//    Trade-offs accepted:
+//      - `std::function` type-erasure overhead (~one indirect call per
+//        refinement step).
+//      - Closures capture operands by value, which can be deep for nested
+//        expressions; Phase C will introduce a `std::shared_ptr` for operand
+//        sharing if measurements warrant it.
+//      - The type is not constexpr-friendly. Phase A is not aiming for
+//        compile-time elreal.
+//
+// 2. APPROXIMATION ELEMENT
+//
+//    Each element of `_components` is a single `double` interpreted as a
+//    Shewchuk-style correction term:
+//
+//        value = _components[0] + _components[1] + _components[2] + ...
+//
+//    with the non-overlapping property `|_components[i+1]| < ulp(_components[i])`
+//    preserved across operations (the EFTs in `error_free_ops.hpp` are designed
+//    to produce this).
+//
+//    Why this and not (lo, hi) intervals or `floatcascade<2>` per element:
+//      - Reuses EFT primitives directly; no conversion layer.
+//      - Half the storage of an interval representation.
+//      - Sign / comparison are still decidable: once
+//        `|sum(first N components)| > 2 * ulp(_components[N-1])`, the sign
+//        of the truncated sum equals the sign of the true value. The
+//        comparison machinery in Phase D refines until this holds, or until
+//        the per-call budget is exhausted.
+//
+// 3. REFINEMENT PROTOCOL
+//
+//    Two-tier API:
+//      - `at(k)` is the primitive: ensure `_components[k]` is materialised
+//        (call the generator if `k >= _computed_depth`) and return it.
+//      - `refine_to(precision_bits)` is the user-facing wrapper:
+//        call `at(0), at(1), ..., at(ceil(precision_bits / 53))` so the
+//        prefix of the stream is materialised to at least `precision_bits`
+//        bits of cumulative precision.
+//
+//    The primitive is `at`; everything else is convenience. This shape is
+//    independent of the storage choice (the alternative DAG implementation
+//    would expose the same `at(k)` entry point).
+//
+// -----------------------------------------------------------------------------
+// What ships in Phase A vs later phases
+// -----------------------------------------------------------------------------
+//
+// Phase A (this file, skeleton only):
+//   - Construct from `double` (the trivial case: a single-component stream)
+//   - Construct from `int`, `long`, `long long` (all exact at this stage if
+//     within double's representable range)
+//   - `at(0)` and `refine_to(precision_bits)` as no-ops past component 0
+//   - `operator double()` returns `_components[0]`
+//   - Triviality is *not* claimed: the type contains `std::vector` and (in
+//     Phase C) `std::function`, neither of which is trivially constructible.
+//     Universal's library-wide `ReportTrivialityOfType` is reported, not
+//     asserted, for elastic types -- consistent with `ereal`.
+//
+// Deferred to later phases:
+//   - Construction from `p/q` rationals and decimal strings (Phase B, #875)
+//   - Cross-construction from `dd`, `qd`, `ereal<N>` (Phase B, #875)
+//   - The closure-based generator and the four ring operations (Phase C, #876)
+//   - Comparison, sign, and the refinement budget policy (Phase D, #877)
+//   - Math functions (Phase E, #878)
+//
+// =============================================================================
+
+#include <cstddef>
+#include <cstdint>
+#include <cmath>
+#include <vector>
+#include <type_traits>
+
+#include <universal/number/elreal/exceptions.hpp>
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/shared/specific_value_encoding.hpp>
+
+namespace sw { namespace universal {
+
+class elreal {
+public:
+	// IEEE-754 double precision constants for constructing special values.
+	// These mirror ereal's analogous constants and exist so numeric_limits
+	// can be specialized without including the entire arithmetic implementation.
+	static constexpr int EXP_BIAS         = 1023;
+	static constexpr int MAX_EXP          = 1024;
+	static constexpr int MIN_EXP_NORMAL   = -1022;
+
+	// ---------------------------------------------------------------------
+	// constructors
+	// ---------------------------------------------------------------------
+	elreal() : _components{}, _computed_depth{0} {
+		// canonical zero -- empty stream interpreted as 0
+	}
+
+	// Construction from native floating-point types. The stream starts with
+	// the input value as its sole component; subsequent refinements (in
+	// Phase C onward) extend the stream.
+	explicit elreal(double v) : _components{v}, _computed_depth{1} {}
+	explicit elreal(float v) : _components{static_cast<double>(v)}, _computed_depth{1} {}
+
+	// Construction from integer types. Integers up to 2^53 are exact in
+	// `double`; larger integers are correctly representable only when the
+	// rational constructor lands in Phase B. For now, store the rounded
+	// double; Phase B will extend the stream with the residual when needed.
+	explicit elreal(signed char v)        : elreal(static_cast<double>(v)) {}
+	explicit elreal(short v)              : elreal(static_cast<double>(v)) {}
+	explicit elreal(int v)                : elreal(static_cast<double>(v)) {}
+	explicit elreal(long v)               : elreal(static_cast<double>(v)) {}
+	explicit elreal(long long v)          : elreal(static_cast<double>(v)) {}
+	explicit elreal(unsigned char v)      : elreal(static_cast<double>(v)) {}
+	explicit elreal(unsigned short v)     : elreal(static_cast<double>(v)) {}
+	explicit elreal(unsigned int v)       : elreal(static_cast<double>(v)) {}
+	explicit elreal(unsigned long v)      : elreal(static_cast<double>(v)) {}
+	explicit elreal(unsigned long long v) : elreal(static_cast<double>(v)) {}
+
+	// Specific-value construction (canonical zero / NaN / inf encodings).
+	// Phase A treats NaN / inf as single-component leading values; finer
+	// special-value semantics arrive with arithmetic in Phase C.
+	explicit elreal(SpecificValue code) : _components{}, _computed_depth{0} {
+		switch (code) {
+		case SpecificValue::infpos:
+			_components.push_back(std::numeric_limits<double>::infinity());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::infneg:
+			_components.push_back(-std::numeric_limits<double>::infinity());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::qnan:
+			_components.push_back(std::numeric_limits<double>::quiet_NaN());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::snan:
+			_components.push_back(std::numeric_limits<double>::signaling_NaN());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::maxpos:
+			_components.push_back(std::numeric_limits<double>::max());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::maxneg:
+			_components.push_back(std::numeric_limits<double>::lowest());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::minpos:
+			_components.push_back(std::numeric_limits<double>::min());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::minneg:
+			_components.push_back(-std::numeric_limits<double>::min());
+			_computed_depth = 1;
+			break;
+		case SpecificValue::zero:
+		default:
+			// empty stream == 0
+			break;
+		}
+	}
+
+	// rule-of-five: defaulted, defensible for a vector-holding type
+	elreal(const elreal&)            = default;
+	elreal(elreal&&) noexcept        = default;
+	elreal& operator=(const elreal&) = default;
+	elreal& operator=(elreal&&) noexcept = default;
+	~elreal()                        = default;
+
+	// ---------------------------------------------------------------------
+	// refinement protocol
+	// ---------------------------------------------------------------------
+	//
+	// at(k):           the primitive. Returns the k-th component of the
+	//                  lazy stream, generating it if necessary. In Phase A
+	//                  the generator is absent, so k >= _computed_depth
+	//                  returns 0.0 (the implicit trailing extension).
+	//
+	// refine_to(p):    the user-facing wrapper. Ensures the stream has at
+	//                  least ceil(p / 53) components materialised. No-op
+	//                  in Phase A.
+
+	double at(std::size_t k) const noexcept {
+		if (k < _computed_depth) return _components[k];
+		// Phase A: no generator; the implicit extension is 0.0.
+		return 0.0;
+	}
+
+	void refine_to(std::size_t precision_bits) const noexcept {
+		// Phase A: no-op. Phase C will iteratively call at(k) to materialise
+		// the prefix.
+		(void)precision_bits;
+	}
+
+	std::size_t computed_depth() const noexcept { return _computed_depth; }
+
+	// ---------------------------------------------------------------------
+	// selectors
+	// ---------------------------------------------------------------------
+
+	// Sum of the currently-computed components -- the best estimate of the
+	// true value at the current refinement depth.
+	explicit operator double() const noexcept {
+		double s = 0.0;
+		for (std::size_t i = 0; i < _computed_depth; ++i) s += _components[i];
+		return s;
+	}
+
+	// Component access for tests and inspection. Returns a copy; the
+	// underlying vector is not mutable through this accessor.
+	const std::vector<double>& components() const noexcept { return _components; }
+
+	bool iszero() const noexcept { return _computed_depth == 0 || double(*this) == 0.0; }
+
+	bool isnan() const noexcept {
+		for (std::size_t i = 0; i < _computed_depth; ++i) {
+			if (std::isnan(_components[i])) return true;
+		}
+		return false;
+	}
+
+	bool isinf() const noexcept {
+		for (std::size_t i = 0; i < _computed_depth; ++i) {
+			if (std::isinf(_components[i])) return true;
+		}
+		return false;
+	}
+
+private:
+	// The lazy stream of components. Mutable because refinement is invoked
+	// in const contexts (comparison, decode-to-double).
+	mutable std::vector<double> _components;
+
+	// The high-water mark of materialised components. Phase A always has
+	// _computed_depth == _components.size(); Phase C may pre-allocate
+	// _components and grow _computed_depth as the generator fires.
+	mutable std::size_t _computed_depth;
+
+	// Generator slot for Phase C. Empty in Phase A; the at(k) entry point
+	// returns the implicit-zero extension when k >= _computed_depth.
+	//
+	// (Declared here as a comment to document the planned storage layout;
+	// the actual member lands in Phase C alongside the closure-instantiation
+	// patterns.)
+	//
+	// mutable std::function<double(std::size_t)> _generator;
+};
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/exceptions.hpp
+++ b/include/sw/universal/number/elreal/exceptions.hpp
@@ -1,0 +1,68 @@
+#pragma once
+// exceptions.hpp: exception hierarchy for the elreal (Exact Lazy Real) number system
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/common/exceptions.hpp>
+
+namespace sw { namespace universal {
+
+// base class for elreal arithmetic exceptions
+struct elreal_arithmetic_exception : public universal_arithmetic_exception {
+	elreal_arithmetic_exception(const std::string& err)
+		: universal_arithmetic_exception(std::string("elreal arithmetic exception: ") + err) {}
+};
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// specialized arithmetic exceptions
+
+// thrown when a NaN operand is encountered
+struct elreal_not_a_number : public elreal_arithmetic_exception {
+	elreal_not_a_number() : elreal_arithmetic_exception("not a number") {}
+};
+
+// thrown when a division by zero is attempted
+struct elreal_divide_by_zero : public elreal_arithmetic_exception {
+	elreal_divide_by_zero() : elreal_arithmetic_exception("divide by zero") {}
+};
+
+// thrown when the denominator in a division is NaN
+struct elreal_divide_by_nan : public elreal_arithmetic_exception {
+	elreal_divide_by_nan() : elreal_arithmetic_exception("divide by nan") {}
+};
+
+// thrown when sqrt is applied to a negative argument
+struct elreal_negative_sqrt_arg : public elreal_arithmetic_exception {
+	elreal_negative_sqrt_arg() : elreal_arithmetic_exception("negative sqrt argument") {}
+};
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// lazy-real-specific exceptions
+
+// Comparisons of lazy reals can be undecidable in general (the "is x == y?" problem).
+// When a refinement budget is exhausted before the comparison resolves, callers may
+// see this exception (controlled by the ELREAL_THROW_ARITHMETIC_EXCEPTION guard and
+// the per-call budget policy that lands in Phase D).
+struct elreal_undecidable_comparison : public elreal_arithmetic_exception {
+	elreal_undecidable_comparison()
+		: elreal_arithmetic_exception("comparison undecidable within refinement budget") {}
+};
+
+// Thrown when any operation's per-call refinement budget is exhausted before
+// producing a definite answer.
+struct elreal_budget_exhausted : public elreal_arithmetic_exception {
+	elreal_budget_exhausted()
+		: elreal_arithmetic_exception("refinement budget exhausted") {}
+};
+
+///////////////////////////////////////////////////////////////////////////////////////
+/// REAL INTERNAL OPERATION EXCEPTIONS
+
+struct elreal_internal_exception : public universal_internal_exception {
+	elreal_internal_exception(const std::string& err)
+		: universal_internal_exception(std::string("elreal internal exception: ") + err) {}
+};
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/manipulators.hpp
+++ b/include/sw/universal/number/elreal/manipulators.hpp
@@ -1,0 +1,56 @@
+#pragma once
+// manipulators.hpp: helper functions for elreal type manipulation (Phase A stubs)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/elreal_impl.hpp>
+#include <universal/traits/elreal_traits.hpp>
+
+namespace sw { namespace universal {
+
+// Generate a type tag for elreal values. elreal is not templated; the tag is
+// fixed, but the function signature mirrors the rest of the library so generic
+// reporting code can take any number-system value and ask for its tag.
+inline std::string type_tag(const elreal& = {}) {
+	return std::string("elreal");
+}
+
+// Inspect the materialised components of an elreal value. The full lazy
+// stream is unbounded; this prints only what has actually been computed.
+template<typename ElrealType,
+	std::enable_if_t< is_elreal<ElrealType>, bool > = true
+>
+inline std::string to_components(const ElrealType& v) {
+	std::stringstream s;
+	const auto& c = v.components();
+	s << "( ";
+	for (std::size_t i = 0; i < c.size(); ++i) {
+		s << std::setprecision(17) << c[i];
+		if (i + 1 < c.size()) s << ", ";
+	}
+	s << " )";
+	return s.str();
+}
+
+// Binary representation of the leading component. Full multi-component
+// binary inspection lands in Phase B when conversion-out from rationals
+// and strings is in place.
+template<typename ElrealType,
+	std::enable_if_t< is_elreal<ElrealType>, bool > = true
+>
+inline std::string to_binary(const ElrealType& v) {
+	std::stringstream s;
+	s << "elreal{ depth = " << v.computed_depth()
+	  << ", leading = " << std::setprecision(17) << double(v) << " }";
+	return s.str();
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/numeric_limits.hpp
+++ b/include/sw/universal/number/elreal/numeric_limits.hpp
@@ -12,6 +12,11 @@
 // elreal-native value constants (pi, e, ln2, ...) come online.
 #include <limits>
 #include <universal/number/elreal/elreal_fwd.hpp>
+// elreal_impl.hpp is included directly so SpecificValue is in scope for the
+// infinity / NaN / max / min constructors below. Without this, this header
+// is only correct when included via the elreal.hpp umbrella in a specific
+// order; including it directly here removes that fragile coupling.
+#include <universal/number/elreal/elreal_impl.hpp>
 
 namespace std {
 
@@ -65,7 +70,12 @@ public:
 	static ElrealType infinity()      { return ElrealType(sw::universal::SpecificValue::infpos); }
 	static ElrealType quiet_NaN()     { return ElrealType(sw::universal::SpecificValue::qnan); }
 	static ElrealType signaling_NaN() { return ElrealType(sw::universal::SpecificValue::snan); }
-	static ElrealType denorm_min()    { return ElrealType(std::numeric_limits<double>::denorm_min()); }
+	// Per the C++ standard: when has_denorm == denorm_absent, denorm_min()
+	// must equal min(). elreal does not expose denormals at the number-system
+	// level (the lazy stream has no subnormal regime; the underlying double's
+	// denormals are an implementation detail of a single component, not of the
+	// value as a whole), so the contract pair is (denorm_absent, min()).
+	static ElrealType denorm_min()    { return (min)(); }
 
 	static constexpr bool is_iec559    = false;
 	static constexpr bool is_bounded   = false;  // unbounded by design

--- a/include/sw/universal/number/elreal/numeric_limits.hpp
+++ b/include/sw/universal/number/elreal/numeric_limits.hpp
@@ -1,0 +1,78 @@
+#pragma once
+// numeric_limits.hpp: numeric_limits specialization for the elreal type (Phase A stub)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Phase A ships a minimal specialization: the constants that downstream code
+// (e.g. generic algorithms templated on a real type) typically asks about,
+// stubbed to the underlying `double` ranges. Phase E will refine these as the
+// elreal-native value constants (pi, e, ln2, ...) come online.
+#include <limits>
+#include <universal/number/elreal/elreal_fwd.hpp>
+
+namespace std {
+
+template<>
+class numeric_limits< sw::universal::elreal > {
+public:
+	using ElrealType = sw::universal::elreal;
+	static constexpr bool is_specialized = true;
+
+	static ElrealType (min)() {
+		return ElrealType(std::numeric_limits<double>::min());
+	}
+
+	static ElrealType (max)() {
+		return ElrealType(std::numeric_limits<double>::max());
+	}
+
+	static ElrealType lowest() {
+		// Phase A has no unary minus on elreal (arithmetic lands in Phase C).
+		// Construct directly from the lowest double instead.
+		return ElrealType(std::numeric_limits<double>::lowest());
+	}
+
+	// elreal precision is unbounded by construction; the value reported here
+	// is the *initial* precision of a value constructed from a single double.
+	// Phase D will introduce a per-call refinement budget that callers can
+	// query for the actual upper bound of a given expression.
+	static constexpr int digits     = std::numeric_limits<double>::digits;
+	static constexpr int digits10   = std::numeric_limits<double>::digits10;
+	static constexpr int max_digits10 = std::numeric_limits<double>::max_digits10;
+
+	static constexpr bool is_signed  = true;
+	static constexpr bool is_integer = false;
+	static constexpr bool is_exact   = false;
+	static constexpr int  radix      = 2;
+
+	static ElrealType epsilon()      { return ElrealType(std::numeric_limits<double>::epsilon()); }
+	static ElrealType round_error()  { return ElrealType(0.5); }
+
+	static constexpr int  min_exponent   = std::numeric_limits<double>::min_exponent;
+	static constexpr int  min_exponent10 = std::numeric_limits<double>::min_exponent10;
+	static constexpr int  max_exponent   = std::numeric_limits<double>::max_exponent;
+	static constexpr int  max_exponent10 = std::numeric_limits<double>::max_exponent10;
+
+	static constexpr bool has_infinity      = true;
+	static constexpr bool has_quiet_NaN     = true;
+	static constexpr bool has_signaling_NaN = true;
+	static constexpr float_denorm_style has_denorm = denorm_absent;
+	static constexpr bool has_denorm_loss   = false;
+
+	static ElrealType infinity()      { return ElrealType(sw::universal::SpecificValue::infpos); }
+	static ElrealType quiet_NaN()     { return ElrealType(sw::universal::SpecificValue::qnan); }
+	static ElrealType signaling_NaN() { return ElrealType(sw::universal::SpecificValue::snan); }
+	static ElrealType denorm_min()    { return ElrealType(std::numeric_limits<double>::denorm_min()); }
+
+	static constexpr bool is_iec559    = false;
+	static constexpr bool is_bounded   = false;  // unbounded by design
+	static constexpr bool is_modulo    = false;
+	static constexpr bool traps        = false;
+	static constexpr bool tinyness_before  = false;
+	static constexpr float_round_style round_style = round_to_nearest;
+};
+
+} // namespace std

--- a/include/sw/universal/traits/elreal_traits.hpp
+++ b/include/sw/universal/traits/elreal_traits.hpp
@@ -1,0 +1,33 @@
+#pragma once
+// elreal_traits.hpp : traits for the elreal (Exact Lazy Real) number system
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <type_traits>
+#include <universal/traits/integral_constant.hpp>
+#include <universal/number/elreal/elreal_fwd.hpp>
+
+namespace sw { namespace universal {
+
+// define a trait for elreal types
+template<typename _Ty>
+struct is_elreal_trait
+	: false_type
+{
+};
+
+template<>
+struct is_elreal_trait< elreal >
+	: true_type
+{
+};
+
+template<typename _Ty>
+constexpr bool is_elreal = is_elreal_trait<_Ty>::value;
+
+template<typename _Ty, typename Type = void>
+using enable_if_elreal = std::enable_if_t<is_elreal<_Ty>, Type>;
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary

Phase A of epic #873. Implements [#874](https://github.com/stillwater-sc/universal/issues/874).

Establishes the `elreal` (Exact Lazy Real, McCleeary 2019) type skeleton: file layout, exception hierarchy, traits, `numeric_limits` specialization, the `at(k)` / `refine_to(p)` / `computed_depth()` API surface, and a canary test. No arithmetic in this phase -- that lands in Phase C ([#876](https://github.com/stillwater-sc/universal/issues/876)). The closure-based generator is also deferred to Phase C; Phase A's `at(k)` returns the implicit-zero extension past the leading component.

## Design decisions (settled per #874)

The acceptance criterion on #874 was *documentation* of the three design choices on a header comment, not approval-in-advance. Decisions made and the rationale (full text at the top of `elreal_impl.hpp`):

1. **Storage**: memoized `std::vector<double>` of components + a generator closure slot (reserved for Phase C). Members are `mutable` for const-context refinement.
2. **Approximation element**: single `double` per stream element interpreted as a Shewchuk-style correction term -- `value = sum(_components[0..N])`. Reuses `numerics/error_free_ops.hpp`.
3. **Refinement protocol**: `at(k)` primitive; `refine_to(precision_bits)` wrapper.

Open to changes in PR review.

## Files

- `include/sw/universal/number/elreal/{elreal_fwd,exceptions,elreal_impl,numeric_limits,manipulators,elreal}.hpp`
- `include/sw/universal/traits/elreal_traits.hpp`
- `elastic/elreal/api/api.cpp`

The `exceptions.hpp` hierarchy includes two lazy-specific exception types (`elreal_undecidable_comparison`, `elreal_budget_exhausted`) that will get wired up in Phase D ([#877](https://github.com/stillwater-sc/universal/issues/877)). They are defined now so downstream phases do not churn the hierarchy.

## Test plan

- [x] gcc 13: `cmake -DUNIVERSAL_BUILD_NUMBER_ELREALS=ON ..` configures cleanly
- [x] gcc 13: `make elreal_api -j4` builds clean (no warnings)
- [x] gcc 13: canary runs, all assertions PASS
- [x] clang: dedicated build directory configures cleanly
- [x] clang: builds clean
- [x] clang: canary runs, all assertions PASS

Canary output excerpt (gcc):

```text
elreal is not trivial (expected: not trivial for an elastic type)
+--------- elreal construction
zero:        elreal{ depth = 0, leading = 0 }
1.0:         elreal{ depth = 1, leading = 1 }
pi approx:   elreal{ depth = 1, leading = 3.1415926535897931 }
...
+--------- elreal refinement protocol (Phase A: stub)
computed_depth after refine_to(80): 1
+--------- std::numeric_limits<elreal>
digits = 53, digits10 = 15, is_signed = 1, is_bounded = 0
elreal<> Phase A foundation skeleton: PASS
```

## What does *not* land in this PR

- Arithmetic (operators `+`, `-`, `*`, `/`) -- Phase C
- Comparison and sign determination -- Phase D
- Math functions -- Phase E
- Multi-component refinement (Phase A's `at(k>0)` returns the implicit zero extension; the closure-based generator wires up in Phase C)
- Construction from `p/q` rationals or decimal strings -- Phase B

## Related

- Epic: #873
- Phase A issue: #874
- Phase C (the next functional phase): #876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the elreal (Exact Lazy Real) numeric type with constructors from standard numeric types, canonical special values (zero, NaN, ±infinity), numeric-limits support, type traits, and inspection/manipulation helpers; added dedicated elreal arithmetic and internal exceptions.

* **Tests**
  * Added a Phase A foundation test program exercising construction, special-value handling, basic refinement/inspection, trait checks, and test-suite reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->