### PR TITLE
feat(elreal): Phase C -- ring operations with depth-1 EFT refinement

### DIFF
--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -1,0 +1,129 @@
+// addition.cpp: tests for elreal binary + and += (Phase C)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase C addition";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- Basic correctness ----------------------------------------------
+	{
+		elreal a(1.5), b(2.25), c = a + b;
+		nrOfFailedTestCases += check_close("1.5 + 2.25", double(c), 3.75);
+	}
+	{
+		elreal a(0.0), b(7.0), c = a + b;
+		nrOfFailedTestCases += check_close("0 + 7", double(c), 7.0);
+	}
+	{
+		elreal a(-3.0), b(3.0), c = a + b;
+		nrOfFailedTestCases += check_close("-3 + 3", double(c), 0.0);
+	}
+
+	// --- Commutativity (a + b) == (b + a) on leading double -------------
+	{
+		elreal a(1.0/7.0), b(22.0/7.0);
+		elreal ab = a + b;
+		elreal ba = b + a;
+		if (double(ab) != double(ba)) {
+			std::cerr << "FAIL: commutativity (leading): " << double(ab)
+				<< " != " << double(ba) << "\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Algebraic identity: (a + b) - b ~= a ---------------------------
+	{
+		elreal a(1.0/3.0), b(22.0/7.0);
+		elreal back = (a + b) - b;
+		nrOfFailedTestCases += check_close("(a+b)-b ~= a", double(back), double(a));
+	}
+
+	// --- Compound assignment matches binary -----------------------------
+	{
+		elreal x(1.5), y(0.25), z = x + y;
+		x += y;
+		if (double(x) != double(z)) {
+			std::cerr << "FAIL: a += b not equivalent to a = a + b\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Depth-1 refinement: 1/3 + 1/3 should have a non-zero correction
+	// (each operand has its own correction; the sum's correction is the
+	// sum of theirs plus the EFT residual on the leading doubles).
+	{
+		elreal third(1LL, 3LL);
+		elreal sum = third + third;
+		// at(1) should not equal 0: the rational operand has at(1) != 0,
+		// and the operator+ generator propagates that to the result.
+		if (sum.at(1) == 0.0) {
+			std::cerr << "FAIL: (1/3) + (1/3) has zero depth-1 correction "
+				<< "(generator not propagating operand refinement)\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- NaN / inf propagation ------------------------------------------
+	{
+		elreal nan_v(SpecificValue::qnan), a(1.0);
+		elreal r = nan_v + a;
+		if (!r.isnan()) {
+			std::cerr << "FAIL: NaN + 1 != NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		elreal pinf(SpecificValue::infpos), a(1.0);
+		elreal r = pinf + a;
+		if (!r.isinf()) {
+			std::cerr << "FAIL: +inf + 1 != +inf\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		// +inf + -inf = NaN
+		elreal pinf(SpecificValue::infpos), ninf(SpecificValue::infneg);
+		elreal r = pinf + ninf;
+		if (!r.isnan()) {
+			std::cerr << "FAIL: +inf + -inf != NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -11,6 +11,9 @@
 #include <universal/number/elreal/elreal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <algorithm>   // std::max
+#include <cmath>       // std::abs
+
 static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
 	double diff = std::abs(got - expected);
 	double mag  = std::max(std::abs(expected), 1.0);

--- a/elastic/elreal/arithmetic/division.cpp
+++ b/elastic/elreal/arithmetic/division.cpp
@@ -1,0 +1,137 @@
+// division.cpp: tests for elreal binary / and /= (Phase C)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Phase C scope reminder: division ships only the depth-0 leading double
+// result. Newton-Raphson refinement on the reciprocal stream is Phase E/F.
+// Tests here exercise correctness at double precision plus the special
+// cases (divide-by-zero, signs, identities).
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase C division";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- Basic correctness ----------------------------------------------
+	{
+		elreal a(6.0), b(2.0), c = a / b;
+		nrOfFailedTestCases += check_close("6 / 2", double(c), 3.0);
+	}
+	{
+		elreal a(1.0), b(4.0), c = a / b;
+		nrOfFailedTestCases += check_close("1 / 4", double(c), 0.25);
+	}
+	{
+		elreal a(-6.0), b(2.0), c = a / b;
+		nrOfFailedTestCases += check_close("-6 / 2", double(c), -3.0);
+	}
+
+	// --- Identity: a / a == 1 --------------------------------------------
+	{
+		elreal a(3.14);
+		nrOfFailedTestCases += check_close("a / a == 1", double(a / a), 1.0);
+	}
+	{
+		elreal a(1.0/3.0);
+		// Even for "inexact" leading components, the leading-double divide
+		// at runtime is exact for a/a since a/a always rounds to 1.0.
+		nrOfFailedTestCases += check_close("(1/3) / (1/3) == 1", double(a / a), 1.0);
+	}
+
+	// --- 1 / a is the reciprocal ----------------------------------------
+	{
+		elreal a(4.0);
+		elreal recip = elreal(1.0) / a;
+		nrOfFailedTestCases += check_close("1 / 4 == 0.25", double(recip), 0.25);
+	}
+
+	// --- Double reciprocal: 1 / (1 / a) ~= a (at double precision) ------
+	{
+		elreal a(3.14);
+		elreal recip = elreal(1.0) / a;
+		elreal back  = elreal(1.0) / recip;
+		nrOfFailedTestCases += check_close("1 / (1/a) ~= a", double(back), 3.14);
+	}
+
+	// --- Compound assignment --------------------------------------------
+	{
+		elreal x(6.0), y(2.0), z = x / y;
+		x /= y;
+		if (double(x) != double(z)) {
+			std::cerr << "FAIL: a /= b not equivalent to a = a / b\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Division by zero, default mode (no exception) -------------------
+	// ELREAL_THROW_ARITHMETIC_EXCEPTION is 0 by default; div-by-zero
+	// should propagate IEEE-754 +/-inf or NaN through the leading double.
+	{
+		elreal a(1.0), zero;
+		elreal r = a / zero;
+		if (!r.isinf()) {
+			std::cerr << "FAIL: 1 / 0 with throw disabled did not produce inf\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		elreal zero1, zero2;
+		elreal r = zero1 / zero2;
+		if (!r.isnan()) {
+			std::cerr << "FAIL: 0 / 0 with throw disabled did not produce NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		elreal neg(-1.0), zero;
+		elreal r = neg / zero;
+		if (!r.isinf() || double(r) > 0.0) {
+			std::cerr << "FAIL: -1 / 0 with throw disabled did not produce -inf\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- NaN propagation ------------------------------------------------
+	{
+		elreal nan_v(SpecificValue::qnan), a(2.0);
+		elreal r = nan_v / a;
+		if (!r.isnan()) {
+			std::cerr << "FAIL: NaN / 2 != NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/division.cpp
+++ b/elastic/elreal/arithmetic/division.cpp
@@ -15,6 +15,18 @@
 #include <universal/number/elreal/elreal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <algorithm>   // std::max
+#include <cmath>       // std::abs
+
+// This test file asserts the IEEE-754 fall-through behavior of div-by-zero.
+// A separate file (division_throw.cpp) covers the throw-on-zero mode. If a
+// future build flips the macro on globally, this file's contract would be
+// invalidated -- fail fast with a clear message rather than silently passing
+// or throwing unexpectedly.
+#if defined(ELREAL_THROW_ARITHMETIC_EXCEPTION) && ELREAL_THROW_ARITHMETIC_EXCEPTION
+#error "division.cpp requires ELREAL_THROW_ARITHMETIC_EXCEPTION == 0; the throw-mode tests live in division_throw.cpp"
+#endif
+
 static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
 	double diff = std::abs(got - expected);
 	double mag  = std::max(std::abs(expected), 1.0);
@@ -92,8 +104,11 @@ try {
 	{
 		elreal a(1.0), zero;
 		elreal r = a / zero;
-		if (!r.isinf()) {
-			std::cerr << "FAIL: 1 / 0 with throw disabled did not produce inf\n";
+		// Must be inf AND positive (matching IEEE-754 1/0 == +inf;
+		// 1/(-0) would be -inf, so check both pieces).
+		if (!r.isinf() || r.isneg()) {
+			std::cerr << "FAIL: 1 / 0 with throw disabled did not produce +inf "
+				<< "(got isinf=" << r.isinf() << " isneg=" << r.isneg() << ")\n";
 			++nrOfFailedTestCases;
 		}
 	}

--- a/elastic/elreal/arithmetic/division_throw.cpp
+++ b/elastic/elreal/arithmetic/division_throw.cpp
@@ -1,0 +1,113 @@
+// division_throw.cpp: tests for elreal_divide_by_zero exception (Phase C)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Companion to arithmetic/division.cpp. The default-mode tests there exercise
+// the IEEE-754 fall-through path (div-by-zero -> +/-inf or NaN). This file
+// flips ELREAL_THROW_ARITHMETIC_EXCEPTION on and asserts the catchable
+// exception path.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 1
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase C divide-by-zero exception";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// 1 / 0 must throw
+	{
+		elreal a(1.0), zero;
+		bool threw = false;
+		try {
+			elreal r = a / zero;
+			(void)r;
+		}
+		catch (const elreal_divide_by_zero&) {
+			threw = true;
+		}
+		if (!threw) {
+			std::cerr << "FAIL: 1 / 0 did not throw elreal_divide_by_zero "
+				<< "with ELREAL_THROW_ARITHMETIC_EXCEPTION set\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// 0 / 0 must also throw (the leading-double divide would yield NaN,
+	// but the exception path takes precedence when the macro is set).
+	{
+		elreal zero1, zero2;
+		bool threw = false;
+		try {
+			elreal r = zero1 / zero2;
+			(void)r;
+		}
+		catch (const elreal_divide_by_zero&) {
+			threw = true;
+		}
+		if (!threw) {
+			std::cerr << "FAIL: 0 / 0 did not throw elreal_divide_by_zero\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// /= also throws
+	{
+		elreal x(1.0), zero;
+		bool threw = false;
+		try {
+			x /= zero;
+		}
+		catch (const elreal_divide_by_zero&) {
+			threw = true;
+		}
+		if (!threw) {
+			std::cerr << "FAIL: x /= 0 did not throw elreal_divide_by_zero\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// Non-zero division still works in throw mode
+	{
+		elreal a(6.0), b(2.0);
+		bool threw = false;
+		double result = 0.0;
+		try {
+			elreal r = a / b;
+			result = double(r);
+		}
+		catch (...) {
+			threw = true;
+		}
+		if (threw) {
+			std::cerr << "FAIL: 6 / 2 threw in throw mode (should only "
+				<< "throw on divisor == 0)\n";
+			++nrOfFailedTestCases;
+		}
+		if (result != 3.0) {
+			std::cerr << "FAIL: 6 / 2 != 3 in throw mode\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/multiplication.cpp
+++ b/elastic/elreal/arithmetic/multiplication.cpp
@@ -1,0 +1,133 @@
+// multiplication.cpp: tests for elreal binary * and *= (Phase C)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase C multiplication";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- Basic correctness ----------------------------------------------
+	{
+		elreal a(3.0), b(4.0), c = a * b;
+		nrOfFailedTestCases += check_close("3 * 4", double(c), 12.0);
+	}
+	{
+		elreal a(0.5), b(0.25), c = a * b;
+		nrOfFailedTestCases += check_close("0.5 * 0.25", double(c), 0.125);
+	}
+	{
+		elreal a(-2.0), b(3.0), c = a * b;
+		nrOfFailedTestCases += check_close("-2 * 3", double(c), -6.0);
+	}
+
+	// --- Identity: 1 * a == a, a * 1 == a -------------------------------
+	{
+		elreal one(1.0), a(7.5);
+		nrOfFailedTestCases += check_close("1 * a == a",  double(one * a), 7.5);
+		nrOfFailedTestCases += check_close("a * 1 == a",  double(a * one), 7.5);
+	}
+
+	// --- Absorbing element: 0 * a == 0 ---------------------------------
+	{
+		elreal zero, a(7.5);
+		nrOfFailedTestCases += check_close("0 * a == 0", double(zero * a), 0.0);
+		nrOfFailedTestCases += check_close("a * 0 == 0", double(a * zero), 0.0);
+	}
+
+	// --- Commutativity ---------------------------------------------------
+	{
+		elreal a(1.0/3.0), b(22.0/7.0);
+		if (double(a * b) != double(b * a)) {
+			std::cerr << "FAIL: commutativity (leading): "
+				<< double(a * b) << " != " << double(b * a) << "\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- (a * b) / b ~= a (when b != 0) --------------------------------
+	{
+		elreal a(3.14), b(2.71);
+		elreal back = (a * b) / b;
+		nrOfFailedTestCases += check_close("(a*b)/b ~= a", double(back), 3.14);
+	}
+
+	// --- Compound assignment --------------------------------------------
+	{
+		elreal x(3.0), y(4.0), z = x * y;
+		x *= y;
+		if (double(x) != double(z)) {
+			std::cerr << "FAIL: a *= b not equivalent to a = a * b\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Depth-1 refinement: 3 * (1/3) should have a residual -----------
+	{
+		elreal three(3.0);
+		elreal third(1LL, 3LL);
+		elreal r = three * third;
+		// 3 * (1/3) is the canonical "doesn't quite equal 1" case in IEEE.
+		// Depth-0 result: c0 = 3.0 * (1/3) rounded; that may equal 1.0
+		// exactly (depending on rounding), and we'd then expect the depth-1
+		// correction to be small but non-zero (the EFT residual plus the
+		// operand correction). We only assert that the leading is close to
+		// 1.0; the depth-1 contract is just "the generator fired."
+		nrOfFailedTestCases += check_close("3 * (1/3) ~= 1.0", double(r), 1.0);
+		// Touching at(1) walks the generator -- not zero on a rational operand.
+		(void)r.at(1);
+	}
+
+	// --- NaN / inf propagation ------------------------------------------
+	{
+		elreal nan_v(SpecificValue::qnan), a(2.0);
+		elreal r = nan_v * a;
+		if (!r.isnan()) {
+			std::cerr << "FAIL: NaN * 2 != NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		elreal pinf(SpecificValue::infpos), zero;
+		elreal r = pinf * zero;
+		if (!r.isnan()) {
+			std::cerr << "FAIL: inf * 0 != NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/multiplication.cpp
+++ b/elastic/elreal/arithmetic/multiplication.cpp
@@ -11,6 +11,9 @@
 #include <universal/number/elreal/elreal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <algorithm>   // std::max
+#include <cmath>       // std::abs
+
 static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
 	double diff = std::abs(got - expected);
 	double mag  = std::max(std::abs(expected), 1.0);
@@ -86,20 +89,38 @@ try {
 		}
 	}
 
-	// --- Depth-1 refinement: 3 * (1/3) should have a residual -----------
+	// --- Depth-1 refinement on a cancellation case ---------------------
 	{
+		// 3 * (1/3) has depth-1 correction *exactly* zero by mathematical
+		// identity: the true value is 1.0 (an exact double), the leading-
+		// product rounds to 1.0, and the contributions
+		//   prod_err = -3*epsilon  (since 3*D = 1 - 3*epsilon rounded to 1)
+		//   3 * third.at(1) = 3 * epsilon
+		// cancel exactly. So we only assert the depth-0 result here; the
+		// depth-1 propagation check moves to (1/7) * (1/3) below where no
+		// such cancellation applies.
 		elreal three(3.0);
 		elreal third(1LL, 3LL);
 		elreal r = three * third;
-		// 3 * (1/3) is the canonical "doesn't quite equal 1" case in IEEE.
-		// Depth-0 result: c0 = 3.0 * (1/3) rounded; that may equal 1.0
-		// exactly (depending on rounding), and we'd then expect the depth-1
-		// correction to be small but non-zero (the EFT residual plus the
-		// operand correction). We only assert that the leading is close to
-		// 1.0; the depth-1 contract is just "the generator fired."
 		nrOfFailedTestCases += check_close("3 * (1/3) ~= 1.0", double(r), 1.0);
-		// Touching at(1) walks the generator -- not zero on a rational operand.
-		(void)r.at(1);
+	}
+
+	// --- Depth-1 refinement on a non-cancellation case ------------------
+	{
+		// (1/7) * (1/3) = 1/21. Neither operand is a clean power of two
+		// relative to the other, so the depth-1 generator must produce a
+		// non-zero correction: prod_err + a0*b.at(1) + a.at(1)*b0 has no
+		// algebraic identity collapsing it to zero.
+		elreal seventh(1LL, 7LL);
+		elreal third(1LL, 3LL);
+		elreal r = seventh * third;
+		nrOfFailedTestCases += check_close("(1/7)*(1/3) ~= 1/21",
+			double(r), 1.0 / 21.0);
+		if (r.at(1) == 0.0) {
+			std::cerr << "FAIL: (1/7)*(1/3) has zero depth-1 correction "
+				<< "(operator* generator not propagating operand refinement)\n";
+			++nrOfFailedTestCases;
+		}
 	}
 
 	// --- NaN / inf propagation ------------------------------------------

--- a/elastic/elreal/arithmetic/subtraction.cpp
+++ b/elastic/elreal/arithmetic/subtraction.cpp
@@ -1,0 +1,122 @@
+// subtraction.cpp: tests for elreal binary - and -=, plus unary - and abs (Phase C)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase C subtraction";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- Basic correctness ----------------------------------------------
+	{
+		elreal a(5.0), b(3.0), c = a - b;
+		nrOfFailedTestCases += check_close("5 - 3", double(c), 2.0);
+	}
+	{
+		elreal a(0.0), b(7.0), c = a - b;
+		nrOfFailedTestCases += check_close("0 - 7", double(c), -7.0);
+	}
+
+	// --- Identity: a - a == 0 -------------------------------------------
+	{
+		elreal a(1.0/3.0);
+		elreal r = a - a;
+		nrOfFailedTestCases += check_close("a - a == 0", double(r), 0.0);
+	}
+
+	// --- (a - b) + b ~= a -----------------------------------------------
+	{
+		elreal a(22.0/7.0), b(1.0/3.0);
+		elreal back = (a - b) + b;
+		nrOfFailedTestCases += check_close("(a-b)+b ~= a", double(back), double(a));
+	}
+
+	// --- Compound assignment --------------------------------------------
+	{
+		elreal x(5.0), y(2.0), z = x - y;
+		x -= y;
+		if (double(x) != double(z)) {
+			std::cerr << "FAIL: a -= b not equivalent to a = a - b\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Unary minus: negate every component, including the correction --
+	{
+		elreal third(1LL, 3LL);
+		elreal neg_third = -third;
+		// Leading component
+		if (neg_third.at(0) != -third.at(0)) {
+			std::cerr << "FAIL: unary -(1/3) did not negate leading\n";
+			++nrOfFailedTestCases;
+		}
+		// Correction component (from the generator)
+		if (neg_third.at(1) != -third.at(1)) {
+			std::cerr << "FAIL: unary -(1/3) did not negate depth-1 correction\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Double negation is identity -------------------------------------
+	{
+		elreal a(1.0/3.0);
+		elreal back = -(-a);
+		if (back.at(0) != a.at(0) || back.at(1) != a.at(1)) {
+			std::cerr << "FAIL: -(-a) != a at depth 0 or 1\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- abs(): negative becomes positive, positive unchanged ----------
+	{
+		elreal a(-3.14);
+		elreal b = abs(a);
+		nrOfFailedTestCases += check_close("abs(-3.14) == 3.14", double(b), 3.14);
+	}
+	{
+		elreal a(7.0);
+		elreal b = abs(a);
+		nrOfFailedTestCases += check_close("abs(7) == 7", double(b), 7.0);
+	}
+	// fabs alias
+	{
+		elreal a(-2.5);
+		elreal b = fabs(a);
+		nrOfFailedTestCases += check_close("fabs(-2.5) == 2.5", double(b), 2.5);
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/subtraction.cpp
+++ b/elastic/elreal/arithmetic/subtraction.cpp
@@ -11,6 +11,9 @@
 #include <universal/number/elreal/elreal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <algorithm>   // std::max
+#include <cmath>       // std::abs
+
 static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
 	double diff = std::abs(got - expected);
 	double mag  = std::max(std::abs(expected), 1.0);

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -103,36 +103,43 @@
 //   - `at(0)` and `refine_to(precision_bits)` -- entry points in place
 //   - `operator double()` returns the sum of materialised components
 //
-// Phase B (this update, #875):
-//   - The closure-based generator slot is now real (mutable std::function).
-//     `at(k)` calls the generator on cache miss; `refine_to(p)` iterates
-//     `at(0..ceil(p/53))`.
-//   - Construction from `p/q` rationals (`elreal(p, q)`). Component 0 is
-//     `double(p)/double(q)`. Component 1 is the exact residual via EFTs
-//     (two_prod + two_sum). Components 2+ return 0.0 with a documented
-//     limitation -- full McCleeary long division for arbitrary depth is
-//     deferred to Phase E/F. The acceptance criterion of #875 is that
-//     `elreal(1,3).at(1) != 0`, i.e. observably distinct from
-//     `elreal(1.0/3.0)`.
-//   - Construction from decimal/scientific/rational strings. The parser
-//     normalises the input to a rational `(p, q)` form, then delegates to
-//     the rational constructor.
-//   - Cross-construction from `dd` / `qd` / `ereal<N>` is left as future
-//     work (the include-graph cost is non-trivial and these types' Phase B
-//     acceptance criterion is not "implicit cross-conversion exists").
+// Phase B (#875, merged):
+//   - The closure-based generator slot is real (mutable std::function).
+//   - Construction from `p/q` rationals (`elreal(p, q)`).
+//   - Construction from decimal/scientific/rational strings.
 //
-// Triviality is *not* claimed: the type contains `std::vector` and now also
+// Phase C (this update, #876):
+//   - The four ring operations: `operator+`, `operator-`, `operator*`,
+//     `operator/`. Each returns a new elreal whose generator computes the
+//     k-th component lazily from the operand streams.
+//   - Compound assignment `+=`, `-=`, `*=`, `/=`.
+//   - Unary `operator-()` and `abs()`.
+//   - Refinement depth supported:
+//        depth 0: the leading-double result of the operation (always)
+//        depth 1: the EFT residual + operand stream corrections for `+`,
+//                 `-`, `*`. Division at depth 1 is deferred to Phase E/F
+//                 (Newton-Raphson refinement). Returns 0.0 for now.
+//        depth 2+: 0.0 with a documented limitation; the McCleeary
+//                 expansion-arithmetic scheme that delivers arbitrary
+//                 depth lands in Phase E/F.
+//   - Division by zero: when `b.at(0) == 0`, throw `elreal_divide_by_zero`
+//     if `ELREAL_THROW_ARITHMETIC_EXCEPTION` is set; otherwise propagate
+//     IEEE-754 `+/-inf` / NaN through the leading-double divide.
+//   - Special values: NaN / inf propagate via the leading-double path
+//     (IEEE-754 semantics handle add/sub/mul/div naturally).
+//
+// Triviality is *not* claimed: the type contains `std::vector` and
 // `std::function`, neither of which is trivially constructible. Universal's
 // library-wide `ReportTrivialityOfType` is reported, not asserted, for
 // elastic types -- consistent with `ereal`.
 //
 // Deferred to later phases:
-//   - The four ring operations (Phase C, #876)
 //   - Comparison, sign, and the refinement budget policy (Phase D, #877)
 //   - Math functions (Phase E, #878)
-//   - Cross-construction from dd/qd/ereal (a future PR; #875 marks it optional)
-//   - Deep-depth rational refinement (k >= 2) via McCleeary long division
-//     (Phase E/F)
+//   - Cross-construction from dd/qd/ereal (future PR; #875 marks it optional)
+//   - Deep-depth refinement (k >= 2) for both rationals and arithmetic
+//     results (Phase E/F via McCleeary expansion arithmetic)
+//   - Division at depth 1 via Newton-Raphson (Phase E/F)
 //
 // =============================================================================
 
@@ -387,6 +394,44 @@ public:
 		return false;
 	}
 
+	bool isneg() const noexcept {
+		// Sign of the materialised sum. For empty streams (canonical zero)
+		// the answer is "not negative." For a single -0.0 leading component
+		// this honors the IEEE-754 sign bit and returns true.
+		if (_computed_depth == 0) return false;
+		return std::signbit(double(*this));
+	}
+
+	// ---------------------------------------------------------------------
+	// arithmetic: unary minus, abs, and compound assignment
+	// ---------------------------------------------------------------------
+	//
+	// Binary +, -, *, / live as friend free functions after the class so
+	// they have public-form access while still touching the private storage
+	// via friendship. The compound assignment forms below delegate to the
+	// binary free functions.
+
+	// Unary minus: negate every materialised component and wrap the
+	// generator in a sign-flipping shim.
+	elreal operator-() const {
+		elreal result;
+		result._components.reserve(_components.size());
+		for (double c : _components) result._components.push_back(-c);
+		result._computed_depth = _computed_depth;
+		if (_generator) {
+			auto gen_cap = _generator;
+			result._generator = [gen_cap](std::size_t k) -> double {
+				return -gen_cap(k);
+			};
+		}
+		return result;
+	}
+
+	elreal& operator+=(const elreal& rhs);
+	elreal& operator-=(const elreal& rhs);
+	elreal& operator*=(const elreal& rhs);
+	elreal& operator/=(const elreal& rhs);
+
 private:
 	// The lazy stream of components. Mutable because refinement is invoked
 	// in const contexts (comparison, decode-to-double).
@@ -409,6 +454,14 @@ private:
 	// constructor and the namespace-level parse(str, elreal&) declared
 	// in elreal_fwd.hpp.
 	friend bool parse_into(elreal& out, const std::string& str);
+
+	// Binary arithmetic ops live as friend free functions so they can
+	// construct the result while touching the private generator slot.
+	friend elreal operator+(const elreal& a, const elreal& b);
+	friend elreal operator-(const elreal& a, const elreal& b);
+	friend elreal operator*(const elreal& a, const elreal& b);
+	friend elreal operator/(const elreal& a, const elreal& b);
+	friend elreal abs(const elreal& a);
 };
 
 // =============================================================================
@@ -668,5 +721,138 @@ inline bool parse_into(elreal& out, const std::string& str) {
 inline bool parse(const std::string& str, elreal& out) {
 	return parse_into(out, str);
 }
+
+// =============================================================================
+// Arithmetic operators (Phase C)
+// =============================================================================
+//
+// Each binary operator returns a new elreal:
+//   - Component 0 is the leading-double result of the operation, which
+//     handles NaN / infinity / signed-zero propagation per IEEE-754
+//     automatically.
+//   - Component 1 (for +, -, *) is the exact residual from the operation
+//     on the leading components, captured via EFTs (two_sum / two_diff /
+//     two_prod from `numerics/error_free_ops.hpp`), plus depth-1
+//     corrections from each operand's stream.
+//   - Components 2+ return 0.0 with a documented Phase C limitation;
+//     full McCleeary expansion-arithmetic refinement lands in Phase E/F.
+//   - Division at depth 1 is deferred to Phase E/F (Newton-Raphson on
+//     the reciprocal stream); the depth-0 leading-double result is
+//     correct, but the depth-1 correction returns 0.0.
+
+inline elreal operator+(const elreal& a, const elreal& b) {
+	double a0 = a.at(0);
+	double b0 = b.at(0);
+	double sum_err = 0.0;
+	double c0 = two_sum(a0, b0, sum_err);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	// If the leading result is not finite, skip refinement: the EFT
+	// residual is already zero (two_sum's contract) and deeper bits
+	// don't make sense for inf / NaN.
+	if (!std::isfinite(c0)) return result;
+
+	// Generator: depth 1 = sum_err + a.at(1) + b.at(1). Depth >= 2 returns 0.
+	elreal a_cap = a;
+	elreal b_cap = b;
+	result._generator = [a_cap, b_cap, sum_err](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return sum_err + a_cap.at(1) + b_cap.at(1);
+	};
+	return result;
+}
+
+inline elreal operator-(const elreal& a, const elreal& b) {
+	double a0 = a.at(0);
+	double b0 = b.at(0);
+	double diff_err = 0.0;
+	double c0 = two_diff(a0, b0, diff_err);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0)) return result;
+
+	// Depth 1 = diff_err + a.at(1) - b.at(1).
+	elreal a_cap = a;
+	elreal b_cap = b;
+	result._generator = [a_cap, b_cap, diff_err](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return diff_err + a_cap.at(1) - b_cap.at(1);
+	};
+	return result;
+}
+
+inline elreal operator*(const elreal& a, const elreal& b) {
+	double a0 = a.at(0);
+	double b0 = b.at(0);
+	double prod_err = 0.0;
+	double c0 = two_prod(a0, b0, prod_err);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0)) return result;
+
+	// Depth 1: (a0*b0 - c0) is captured exactly by prod_err.
+	// The leading correction to a*b is:
+	//   prod_err + a0 * b.at(1) + a.at(1) * b0
+	// (the a.at(1)*b.at(1) cross-term is O(eps^2) and below the depth-1
+	//  precision target; deferred to deeper refinement in Phase E/F).
+	elreal a_cap = a;
+	elreal b_cap = b;
+	result._generator = [a_cap, b_cap, a0, b0, prod_err](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return prod_err + a0 * b_cap.at(1) + a_cap.at(1) * b0;
+	};
+	return result;
+}
+
+inline elreal operator/(const elreal& a, const elreal& b) {
+	double b0 = b.at(0);
+	if (b0 == 0.0) {
+#if ELREAL_THROW_ARITHMETIC_EXCEPTION
+		throw elreal_divide_by_zero();
+#else
+		// Fall through: native double divide yields +/-inf or NaN per
+		// IEEE-754. The user can disambiguate via isinf() / isnan() at the
+		// call site; or they can opt into exception throwing by defining
+		// ELREAL_THROW_ARITHMETIC_EXCEPTION before including elreal.hpp.
+#endif
+	}
+	double a0 = a.at(0);
+	double c0 = a0 / b0;
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	// Phase C limitation: depth-1 refinement of division requires
+	// Newton-Raphson on the reciprocal stream, which lands in Phase E/F.
+	// We deliver only the leading double for now; depth >= 1 returns 0.
+	// This is a faithful answer at double precision but does not extend
+	// the lazy-real promise to deeper bits for the / operator.
+	return result;
+}
+
+inline elreal abs(const elreal& a) {
+	if (a.isneg()) return -a;
+	return a;
+}
+
+inline elreal& elreal::operator+=(const elreal& rhs) { return *this = *this + rhs; }
+inline elreal& elreal::operator-=(const elreal& rhs) { return *this = *this - rhs; }
+inline elreal& elreal::operator*=(const elreal& rhs) { return *this = *this * rhs; }
+inline elreal& elreal::operator/=(const elreal& rhs) { return *this = *this / rhs; }
+
+// fabs() is the canonical floating-point absolute-value name; provide as a
+// thin alias to abs() so generic code templated on a real type can use
+// either.
+inline elreal fabs(const elreal& a) { return abs(a); }
 
 }} // namespace sw::universal


### PR DESCRIPTION
## Summary

Phase C of epic #873. Implements [#876](https://github.com/stillwater-sc/universal/issues/876).

Adds the four ring operations (`+`, `-`, `*`, `/`), compound assignment (`+=`, `-=`, `*=`, `/=`), unary `-`, and `abs` / `fabs` to `elreal`. Depth-1 refinement uses the EFTs already in `numerics/error_free_ops.hpp` -- the same primitives Phase B's rational ctor leans on.

## What changed

- **Five free operators + abs** as friends of `elreal`:
  - `operator+` -- `two_sum` on the leading components captures the EFT residual; generator returns `residual + a.at(1) + b.at(1)` at depth 1.
  - `operator-` -- `two_diff` analog.
  - `operator*` -- `two_prod` analog. Depth-1 correction is `prod_err + a0 * b.at(1) + a.at(1) * b0`; the `a.at(1) * b.at(1)` cross-term is `O(eps^2)` and deferred to deeper refinement.
  - `operator/` -- depth-0 only. Newton-Raphson refinement on the reciprocal stream is Phase E/F.
  - `abs` (and `fabs` alias).
- **Compound assignment** trivially delegates to `*this = *this OP rhs`.
- **Unary minus**: negates every materialised component and wraps the generator in a sign-flipping shim.
- **Division by zero** honors `ELREAL_THROW_ARITHMETIC_EXCEPTION`: throws `elreal_divide_by_zero` when set, falls through to IEEE-754 `+/-inf`/NaN otherwise. The exception type was already declared in Phase A's `exceptions.hpp`; this PR wires it up.
- **New `isneg()`** helper on the class -- needed by `abs`, will also be useful in Phase D.

## Refinement contract (documented in `elreal_impl.hpp` header docblock)

| Depth | + | - | * | / |
|---|---|---|---|---|
| 0 | leading double | leading double | leading double | leading double |
| 1 | EFT residual + operand corrections | EFT residual + operand corrections | EFT residual + operand-cross corrections | **0.0** (Phase E/F) |
| 2+ | 0.0 (Phase E/F) | 0.0 (Phase E/F) | 0.0 (Phase E/F) | 0.0 (Phase E/F) |

## Test plan

Five new binaries under `elastic/elreal/arithmetic/`:

| Binary | Coverage |
|---|---|
| `elreal_addition` | commutativity, `(a+b)-b ~= a`, depth-1 propagation on rationals, NaN/inf propagation, compound `+=` |
| `elreal_subtraction` | `a - a == 0`, `(a-b)+b ~= a`, unary minus at depth 0 and 1, double-negation identity, `abs` / `fabs` |
| `elreal_multiplication` | identity `1 * a`, absorption `0 * a`, commutativity, `(a*b)/b ~= a`, `3 * (1/3) ~= 1`, NaN/inf |
| `elreal_division` | `a / a == 1`, `1 / (1/a) ~= a`, signed divide-by-zero in default (no-throw) mode |
| `elreal_division_throw` | divide-by-zero with `ELREAL_THROW_ARITHMETIC_EXCEPTION` set; separate binary because the macro is fixed at compile time |

- [x] gcc 13 (`build_elreal/`): all 5 new + 4 Phase-A/B tests PASS
- [x] clang (`build_clang_elreal/`): all 5 new + 4 Phase-A/B tests PASS

## What does *not* land in this PR

- Division refinement at depth 1+ (Newton-Raphson on the reciprocal stream) -- Phase E/F
- Deep-depth refinement (k >= 2) for any operator -- Phase E/F via McCleeary expansion arithmetic
- Comparison and sign determination -- Phase D ([#877](https://github.com/stillwater-sc/universal/issues/877))
- Math functions (sqrt, exp, log, trig) -- Phase E ([#878](https://github.com/stillwater-sc/universal/issues/878))

## Related

- Epic: #873
- Phase A foundation: #874 (merged in #883)
- Phase B rational + string construction: #875 (merged in #884)
- Phase C issue: #876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Arithmetic operators (+, -, *, /) fully supported for elreal, with unary negation, isneg(), abs(), and fabs().
  * Compound assignments (+=, -=, *=, /=) added.
  * Configurable division-by-zero behavior (IEEE semantics or exception) and correct NaN/∞ propagation.

* **Tests**
  * New standalone test executables validating addition, subtraction, multiplication, division, and exception-mode division-by-zero.

* **Documentation**
  * Updated Phase-A/B/C docs describing refinement depth, division behavior, and special-value rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->