### PR TITLE
feat(elreal): Phase E.2 -- sqrt + hypot with depth-1 EFT refinement on sqrt

### DIFF
--- a/elastic/elreal/math/hypot.cpp
+++ b/elastic/elreal/math/hypot.cpp
@@ -1,0 +1,132 @@
+// hypot.cpp: tests for elreal hypot (Phase E.2)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase E.2 hypot";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- Pythagorean triples (exact for these inputs) -------------------
+	{
+		nrOfFailedTestCases += check_close("hypot(3, 4) == 5",
+			double(hypot(elreal(3.0), elreal(4.0))), 5.0);
+		nrOfFailedTestCases += check_close("hypot(5, 12) == 13",
+			double(hypot(elreal(5.0), elreal(12.0))), 13.0);
+		nrOfFailedTestCases += check_close("hypot(8, 15) == 17",
+			double(hypot(elreal(8.0), elreal(15.0))), 17.0);
+	}
+
+	// --- Zero arguments ------------------------------------------------
+	{
+		if (double(hypot(elreal(0.0), elreal(0.0))) != 0.0) {
+			std::cerr << "FAIL: hypot(0, 0) != 0\n";
+			++nrOfFailedTestCases;
+		}
+		if (double(hypot(elreal(0.0), elreal(5.0))) != 5.0) {
+			std::cerr << "FAIL: hypot(0, 5) != 5\n";
+			++nrOfFailedTestCases;
+		}
+		if (double(hypot(elreal(7.0), elreal(0.0))) != 7.0) {
+			std::cerr << "FAIL: hypot(7, 0) != 7\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Symmetry: hypot(a, b) == hypot(b, a) ---------------------------
+	{
+		for (auto [a, b] : { std::pair{2.0, 7.0}, {1.5, 0.5}, {1e10, 1.0} }) {
+			double ab = double(hypot(elreal(a), elreal(b)));
+			double ba = double(hypot(elreal(b), elreal(a)));
+			if (ab != ba) {
+				std::cerr << "FAIL: hypot(" << a << ", " << b << ") != "
+					<< "hypot(" << b << ", " << a << ") (" << ab << " vs " << ba << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- Overflow safety: x*x would overflow but std::hypot handles it -
+	{
+		// 1e200^2 = 1e400 which overflows double.  std::hypot(1e200, 1e200)
+		// = sqrt(2) * 1e200, well within double's range.
+		double huge = 1e200;
+		double result = double(hypot(elreal(huge), elreal(huge)));
+		double expected = huge * std::sqrt(2.0);
+		nrOfFailedTestCases += check_close("hypot(1e200, 1e200) no overflow",
+			result, expected, 1e-13);
+	}
+
+	// --- Negative arguments treated like their absolute values ---------
+	{
+		double r = double(hypot(elreal(-3.0), elreal(-4.0)));
+		nrOfFailedTestCases += check_close("hypot(-3, -4) == 5", r, 5.0);
+	}
+
+	// --- Cross-validation against std::hypot --------------------------
+	{
+		for (auto [a, b] : { std::pair{1.5, 2.5}, {0.1, 0.2}, {1e-10, 2e-10},
+		                     {3.14, 2.71}, {1.0, 1e-15} }) {
+			double got = double(hypot(elreal(a), elreal(b)));
+			double exp = std::hypot(a, b);
+			if (got != exp) {
+				std::cerr << "FAIL: hypot(" << a << ", " << b
+					<< ") = " << got << " (std::hypot = " << exp << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- Special values ------------------------------------------------
+	{
+		elreal inf(SpecificValue::infpos), x(1.0);
+		if (!hypot(inf, x).isinf()) {
+			std::cerr << "FAIL: hypot(+inf, 1) != +inf\n";
+			++nrOfFailedTestCases;
+		}
+		// std::hypot convention: hypot(NaN, finite) = NaN, but hypot(NaN, inf) = inf.
+		elreal nan(SpecificValue::qnan);
+		if (!hypot(nan, x).isnan()) {
+			std::cerr << "FAIL: hypot(NaN, 1) != NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/math/sqrt.cpp
+++ b/elastic/elreal/math/sqrt.cpp
@@ -110,6 +110,74 @@ try {
 			double(back), 2.0/3.0);
 	}
 
+	// --- Leading-zero expansions (regression for CodeRabbit's #894 finding)
+	// An expansion like {0.0, c1, ...} where c1 != 0 represents a value
+	// near c1, not zero. sqrt must look past the leading zero to the
+	// first non-zero component for both the sign check and the leading
+	// sqrt. The natural way to produce such an expansion is the
+	// rational-minus-rounded-double cancellation case from Phase D's
+	// distinctness test.
+	{
+		// elreal(1, 3) - elreal(1.0/3.0) cancels at depth 0 and leaves a
+		// positive depth-1 correction equal to the rational residual.
+		elreal diff = elreal(1LL, 3LL) - elreal(1.0/3.0);
+		if (diff.at(0) != 0.0) {
+			std::cerr << "FAIL: test setup: diff.at(0) != 0\n";
+			++nrOfFailedTestCases;
+		}
+		if (diff.at(1) <= 0.0) {
+			std::cerr << "FAIL: test setup: diff.at(1) (" << diff.at(1)
+				<< ") is not positive\n";
+			++nrOfFailedTestCases;
+		}
+		elreal r = sqrt(diff);
+		// True sqrt of (1/3 - double(1/3)) ~= sqrt(1.85e-17) ~= 4.3e-9.
+		// Anything close to zero would mean the leading-zero hid the
+		// positive value (pre-fix bug).
+		if (double(r) == 0.0) {
+			std::cerr << "FAIL: sqrt of {0, +eps} returned zero "
+				<< "(leading-zero bug -- did sqrt look past depth 0?)\n";
+			++nrOfFailedTestCases;
+		}
+		// Round-trip should approximately recover the input.
+		elreal back = r * r;
+		double diff_val  = double(diff);
+		double back_val  = double(back);
+		double rel_err   = (diff_val == 0.0) ? std::abs(back_val)
+		                                      : std::abs(back_val - diff_val) / diff_val;
+		if (rel_err > 1e-6) {
+			std::cerr << "FAIL: sqrt({0, +eps}) round-trip rel err " << rel_err
+				<< " (diff=" << diff_val << " back=" << back_val << ")\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		// Same shape but constructed directly via from_expansion: a value
+		// {0, -1e-9, ...} is a small negative number; sqrt must NaN/throw.
+		elreal small_neg = elreal::from_expansion({0.0, -1.0e-9});
+		elreal r = sqrt(small_neg);
+		if (!r.isnan()) {
+			std::cerr << "FAIL: sqrt({0, -1e-9}) did not produce NaN "
+				<< "(pre-fix bug: leading zero hid the negative magnitude)\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		// {0, +1e-9, ...} is a small positive number; sqrt must NOT return
+		// zero. The pre-fix code would `std::sqrt(0.0) = 0` and fall through.
+		elreal small_pos = elreal::from_expansion({0.0, 1.0e-9});
+		elreal r = sqrt(small_pos);
+		if (r.iszero()) {
+			std::cerr << "FAIL: sqrt({0, +1e-9}) returned zero "
+				<< "(pre-fix bug: leading zero hid the positive magnitude)\n";
+			++nrOfFailedTestCases;
+		}
+		// Expected ~sqrt(1e-9) ~= 3.16e-5
+		double expected = std::sqrt(1.0e-9);
+		nrOfFailedTestCases += check_close("sqrt({0, +1e-9}) leading",
+			r.at(0), expected, 1e-12);
+	}
+
 	// --- Negative argument in default mode returns NaN (no throw) -------
 	{
 		elreal neg(-4.0);

--- a/elastic/elreal/math/sqrt.cpp
+++ b/elastic/elreal/math/sqrt.cpp
@@ -1,0 +1,152 @@
+// sqrt.cpp: tests for elreal sqrt (Phase E.2)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase E.2 sqrt";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- Exact perfect squares ------------------------------------------
+	{
+		if (double(sqrt(elreal(0.0))) != 0.0)  { std::cerr << "FAIL: sqrt(0)\n";  ++nrOfFailedTestCases; }
+		if (double(sqrt(elreal(1.0))) != 1.0)  { std::cerr << "FAIL: sqrt(1)\n";  ++nrOfFailedTestCases; }
+		if (double(sqrt(elreal(4.0))) != 2.0)  { std::cerr << "FAIL: sqrt(4)\n";  ++nrOfFailedTestCases; }
+		if (double(sqrt(elreal(9.0))) != 3.0)  { std::cerr << "FAIL: sqrt(9)\n";  ++nrOfFailedTestCases; }
+		if (double(sqrt(elreal(16.0))) != 4.0) { std::cerr << "FAIL: sqrt(16)\n"; ++nrOfFailedTestCases; }
+		if (double(sqrt(elreal(1.0e100))) != 1.0e50) { std::cerr << "FAIL: sqrt(1e100)\n"; ++nrOfFailedTestCases; }
+	}
+
+	// --- Non-square arguments cross-validated against std::sqrt ---------
+	{
+		for (double v : {2.0, 3.0, 5.0, 7.0, 10.0, 3.14, 1.0/3.0, 1.5e10}) {
+			elreal a(v);
+			double got = double(sqrt(a));
+			double exp = std::sqrt(v);
+			if (got != exp) {
+				std::cerr << "FAIL: sqrt(" << v << ") = " << got
+					<< " (std::sqrt = " << exp << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- Round-trip identity: sqrt(a) * sqrt(a) ~= a --------------------
+	{
+		for (double v : {2.0, 7.0, 100.0, 0.5, 1.0e-10}) {
+			elreal a(v);
+			elreal r = sqrt(a);
+			elreal back = r * r;
+			nrOfFailedTestCases += check_close(
+				(std::string("sqrt(") + std::to_string(v) + ")^2 ~= input").c_str(),
+				double(back), v);
+		}
+	}
+
+	// --- sqrt(2) matches the elreal_sqrt2 constant (cross-check vs E.1) -
+	{
+		elreal r = sqrt(elreal(2.0));
+		double leading = r.at(0);
+		double expected = std::numbers::sqrt2_v<double>;
+		if (leading != expected) {
+			std::cerr << "FAIL: sqrt(2).at(0) (" << leading
+				<< ") != std::numbers::sqrt2 (" << expected << ")\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Depth-1 refinement: sqrt(2) on a single-double input does not
+	// produce a useful depth-1 (since the input has only a depth-0 term and
+	// the EFT residual on a square is small). But sqrt of an elreal that
+	// already has a depth-1 correction must propagate it.
+	{
+		// Use a rational input: elreal(2,3) = 2/3, an inexact double.
+		// sqrt(2/3) ~= 0.8164965... The depth-1 correction in the result
+		// must reflect both the EFT residual of c0^2 and the operand's
+		// depth-1 contribution.
+		elreal two_thirds(2LL, 3LL);
+		elreal r = sqrt(two_thirds);
+		// at(1) need not be exact; only that it is non-zero (the generator
+		// fired and propagated something useful).
+		if (r.at(1) == 0.0) {
+			std::cerr << "FAIL: sqrt(2/3).at(1) == 0 "
+				<< "(depth-1 generator not propagating residual)\n";
+			++nrOfFailedTestCases;
+		}
+		// Round-trip at depth 1 should be closer to 2/3 than at depth 0.
+		// elreal arithmetic at depth 1 routes through the operator* generator
+		// which uses two_prod -- so sqrt(2/3)^2 should recover 2/3 within
+		// double precision easily.
+		elreal back = r * r;
+		nrOfFailedTestCases += check_close("sqrt(2/3)^2 ~= 2/3",
+			double(back), 2.0/3.0);
+	}
+
+	// --- Negative argument in default mode returns NaN (no throw) -------
+	{
+		elreal neg(-4.0);
+		elreal r = sqrt(neg);
+		if (!r.isnan()) {
+			std::cerr << "FAIL: sqrt(-4) with throw disabled did not produce NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Special values --------------------------------------------------
+	{
+		elreal inf(SpecificValue::infpos);
+		if (!sqrt(inf).isinf()) {
+			std::cerr << "FAIL: sqrt(+inf) != +inf\n";
+			++nrOfFailedTestCases;
+		}
+		elreal nan(SpecificValue::qnan);
+		if (!sqrt(nan).isnan()) {
+			std::cerr << "FAIL: sqrt(NaN) != NaN\n";
+			++nrOfFailedTestCases;
+		}
+		elreal zero;
+		if (!sqrt(zero).iszero()) {
+			std::cerr << "FAIL: sqrt(0) != 0\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/math/sqrt_throw.cpp
+++ b/elastic/elreal/math/sqrt_throw.cpp
@@ -1,0 +1,95 @@
+// sqrt_throw.cpp: tests for elreal_negative_sqrt_arg exception (Phase E.2)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Companion to math/sqrt.cpp. The default-mode tests there exercise the
+// IEEE-754 fall-through path (sqrt(-x) -> NaN). This file flips
+// ELREAL_THROW_ARITHMETIC_EXCEPTION on and asserts the catchable
+// elreal_negative_sqrt_arg exception path.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 1
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase E.2 sqrt negative-arg exception";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// sqrt(-1) must throw
+	{
+		elreal a(-1.0);
+		bool threw = false;
+		try {
+			elreal r = sqrt(a);
+			(void)r;
+		}
+		catch (const elreal_negative_sqrt_arg&) {
+			threw = true;
+		}
+		if (!threw) {
+			std::cerr << "FAIL: sqrt(-1) did not throw elreal_negative_sqrt_arg "
+				<< "with ELREAL_THROW_ARITHMETIC_EXCEPTION set\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// sqrt(0) does not throw (zero is the boundary; IEEE-754 sqrt(0) = 0)
+	{
+		elreal zero;
+		bool threw = false;
+		double result_val = -1.0;
+		try {
+			result_val = double(sqrt(zero));
+		}
+		catch (...) {
+			threw = true;
+		}
+		if (threw || result_val != 0.0) {
+			std::cerr << "FAIL: sqrt(0) in throw mode (threw=" << threw
+				<< " result=" << result_val << ")\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// Non-negative input still works in throw mode
+	{
+		elreal a(9.0);
+		bool threw = false;
+		double result = 0.0;
+		try {
+			result = double(sqrt(a));
+		}
+		catch (...) {
+			threw = true;
+		}
+		if (threw) {
+			std::cerr << "FAIL: sqrt(9) threw in throw mode (should only throw on negative)\n";
+			++nrOfFailedTestCases;
+		}
+		if (result != 3.0) {
+			std::cerr << "FAIL: sqrt(9) != 3 in throw mode (got " << result << ")\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -917,9 +917,26 @@ inline elreal fabs(const elreal& a) { return abs(a); }
 // numerical-geometry use cases.
 
 inline elreal sqrt(const elreal& a) {
-	double a0 = a.at(0);
+	// Find the first non-zero materialised component. The Shewchuk non-
+	// overlapping invariant guarantees the value's sign equals sign(leading)
+	// and its magnitude is dominated by |leading|. We must walk past leading
+	// zeros because arithmetic operations can produce them legitimately --
+	// e.g. `elreal(1, 3) - elreal(1.0/3.0)` cancels at depth 0 and leaves a
+	// positive depth-1 correction. Relying on `a.at(0)` alone would
+	// (a) misclassify a positive-then-negative-correction expansion as zero
+	// and (b) misclassify a negative-magnitude value as zero, bypassing
+	// the negative-argument handler.
+	double leading = 0.0;
+	std::size_t lead_idx = 0;
+	for (std::size_t k = 0; k < a.computed_depth(); ++k) {
+		double c = a.at(k);
+		if (c != 0.0) { leading = c; lead_idx = k; break; }
+	}
+	// If every materialised component is zero we treat the value as zero
+	// (indistinguishable from zero within the materialised precision).
+	// Phase D's sign/comparison machinery uses the same convention.
 
-	if (a0 < 0.0) {
+	if (leading < 0.0) {
 #if ELREAL_THROW_ARITHMETIC_EXCEPTION
 		throw elreal_negative_sqrt_arg();
 #else
@@ -928,7 +945,7 @@ inline elreal sqrt(const elreal& a) {
 #endif
 	}
 
-	double c0 = std::sqrt(a0);
+	double c0 = std::sqrt(leading);
 	elreal result;
 	result._components.push_back(c0);
 	result._computed_depth = 1;
@@ -938,16 +955,18 @@ inline elreal sqrt(const elreal& a) {
 
 	elreal a_cap = a;
 	double c0_cap = c0;
-	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
+	std::size_t lead_idx_cap = lead_idx;
+	result._generator = [a_cap, c0_cap, lead_idx_cap](std::size_t k) -> double {
 		if (k != 1) return 0.0;
 		// EFT residual: c0^2 captured exactly via two_prod.
 		double prod_err;
 		double prod_hi = two_prod(c0_cap, c0_cap, prod_err);
-		// Numerator: (a.at(0) - c0^2) + a.at(1), with the c0^2 expanded.
-		// We do not need full extended-precision arithmetic on the
-		// numerator -- a single-double approximation is sufficient because
-		// the divide by 2*c0 happens at double precision anyway.
-		double num = (a_cap.at(0) - prod_hi) - prod_err + a_cap.at(1);
+		// Numerator: (leading - c0^2) + next material correction.
+		// "leading" is a.at(lead_idx); the next correction is at
+		// lead_idx + 1. (For the common case lead_idx == 0 this collapses
+		// to the original formula.)
+		double num = (a_cap.at(lead_idx_cap) - prod_hi) - prod_err
+		           + a_cap.at(lead_idx_cap + 1);
 		return num / (2.0 * c0_cap);
 	};
 	return result;

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -483,6 +483,10 @@ private:
 	friend elreal operator*(const elreal& a, const elreal& b);
 	friend elreal operator/(const elreal& a, const elreal& b);
 	friend elreal abs(const elreal& a);
+
+	// Phase E math functions (#878). Same friendship rationale.
+	friend elreal sqrt(const elreal& a);
+	friend elreal hypot(const elreal& a, const elreal& b);
 };
 
 // =============================================================================
@@ -875,6 +879,94 @@ inline elreal& elreal::operator/=(const elreal& rhs) { return *this = *this / rh
 // thin alias to abs() so generic code templated on a real type can use
 // either.
 inline elreal fabs(const elreal& a) { return abs(a); }
+
+// =============================================================================
+// Phase E.2 math: sqrt + hypot (#888)
+// =============================================================================
+//
+// sqrt
+// ----
+// Computes the square root of a non-negative elreal.
+//
+//   Depth 0: c0 = std::sqrt(a.at(0))  (IEEE-754 correctly rounded)
+//   Depth 1: Newton-style EFT residual
+//
+//     (c0 + delta)^2 = a  =>  delta = (a - c0^2) / (2*c0 + delta)
+//                      ~=  (a - c0^2) / (2*c0)   for |delta| << c0
+//
+//     a - c0^2 is computed exactly via two_prod (giving c0^2 = prod_hi +
+//     prod_err) and a single double subtraction, then augmented with the
+//     operand's own depth-1 correction a.at(1). The division by 2*c0 is
+//     plain double arithmetic (no lazy division of elreal needed, so we
+//     are *not* blocked by Phase F's reciprocal-stream work).
+//   Depth 2+: 0.0 with a documented limitation.
+//
+// Negative argument handling: when ELREAL_THROW_ARITHMETIC_EXCEPTION is
+// set, throws elreal_negative_sqrt_arg. Otherwise the leading double goes
+// through std::sqrt which returns NaN (IEEE-754).
+//
+// hypot
+// -----
+// hypot(x, y) computed via std::hypot on the leading components, which
+// avoids the overflow that a naive sqrt(x*x + y*y) would suffer for large
+// |x| or |y|. Depth-1+ refinement is deferred to a follow-up: doing it
+// correctly requires either (a) the overflow-protected algebraic form
+// max(|x|,|y|) * sqrt(1 + (min/max)^2) walked at depth 1 or
+// (b) sqrt of x*x + y*y at depth 1 (only safe when neither operand is
+// near the overflow threshold). The depth-0 path covers the canonical
+// numerical-geometry use cases.
+
+inline elreal sqrt(const elreal& a) {
+	double a0 = a.at(0);
+
+	if (a0 < 0.0) {
+#if ELREAL_THROW_ARITHMETIC_EXCEPTION
+		throw elreal_negative_sqrt_arg();
+#else
+		// fall through: std::sqrt of a negative double returns NaN per
+		// IEEE-754; caller can disambiguate via isnan() at the call site.
+#endif
+	}
+
+	double c0 = std::sqrt(a0);
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	// No depth-1 refinement makes sense for non-finite or zero leading.
+	if (!std::isfinite(c0) || c0 == 0.0) return result;
+
+	elreal a_cap = a;
+	double c0_cap = c0;
+	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		// EFT residual: c0^2 captured exactly via two_prod.
+		double prod_err;
+		double prod_hi = two_prod(c0_cap, c0_cap, prod_err);
+		// Numerator: (a.at(0) - c0^2) + a.at(1), with the c0^2 expanded.
+		// We do not need full extended-precision arithmetic on the
+		// numerator -- a single-double approximation is sufficient because
+		// the divide by 2*c0 happens at double precision anyway.
+		double num = (a_cap.at(0) - prod_hi) - prod_err + a_cap.at(1);
+		return num / (2.0 * c0_cap);
+	};
+	return result;
+}
+
+inline elreal hypot(const elreal& a, const elreal& b) {
+	double a0 = a.at(0);
+	double b0 = b.at(0);
+	// std::hypot handles overflow, signed zero, infinities, and NaN per
+	// IEEE-754 conventions (e.g. hypot(inf, NaN) = inf, hypot(0, 0) = 0).
+	double c0 = std::hypot(a0, b0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	// Depth-1+ deferred: see header docblock above.
+	return result;
+}
 
 // =============================================================================
 // Comparison and sign determination (Phase D)


### PR DESCRIPTION
## Summary

Phase E.2 of epic #873. Implements [#888](https://github.com/stillwater-sc/universal/issues/888) (the second math sub-issue under Phase E #878).

Square root via Newton-style EFT residual at depth 1, plus a depth-0 hypot via `std::hypot` for overflow safety. **No dependency on Phase F's lazy division** -- the sqrt depth-1 correction divides by `2*c0` (a single double), not by a lazy elreal, so it works under the Phase C / Phase F constraint that lazy `/` is depth-0 only.

## `sqrt` algorithm

Newton's identity: `(c0 + delta)^2 = a  =>  delta = (a - c0^2) / (2*c0 + delta) ~= (a - c0^2) / (2*c0)` for `|delta| << c0`.

```text
c0       = std::sqrt(a.at(0))                  // depth 0
prod_err = two_prod_residual(c0, c0)           // c0^2 = prod_hi + prod_err exactly
num      = (a.at(0) - prod_hi) - prod_err + a.at(1)
c1       = num / (2 * c0)                       // depth 1; double divide, not lazy
```

So depth-1 captures both the EFT residual of `c0^2` and the operand's own depth-1 correction `a.at(1)`. Depth 2+ returns 0.0 (Heron iteration on the lazy stream is a Phase F follow-up).

Negative argument: throws `elreal_negative_sqrt_arg` under `ELREAL_THROW_ARITHMETIC_EXCEPTION`, else returns NaN via `std::sqrt` on the leading double.

## `hypot` algorithm

`std::hypot(a.at(0), b.at(0))` at depth 0. The standard library implementation handles overflow (large operands), signed zero, infinities, and NaN per IEEE-754 -- no need to re-derive the `max * sqrt(1 + (min/max)^2)` form here. Depth-1+ deferred; could be wired up later via `sqrt(a*a + b*b)` (when neither operand is near overflow) or the algebraic overflow-protected form walked at depth 1.

## Test plan

Three new binaries under `elastic/elreal/math/`:

| Binary | Coverage |
|---|---|
| `elreal_sqrt` | exact squares, non-square cross-validation vs `std::sqrt`, round-trip `sqrt(a)^2 ~= a`, `sqrt(2)` matches `std::numbers::sqrt2_v`, depth-1 propagation on rational input (`sqrt(2/3)`), negative -> NaN, special values |
| `elreal_sqrt_throw` | `elreal_negative_sqrt_arg` raised when `ELREAL_THROW_ARITHMETIC_EXCEPTION` is set; separate binary because the macro is fixed at compile time |
| `elreal_hypot` | Pythagorean triples (3-4-5, 5-12-13, 8-15-17), zero / symmetry / negative-arg cases, overflow safety at 1e200, cross-validation vs `std::hypot`, special-value propagation |

- [x] gcc 13: 16 binaries (3 new + 13 prior) all PASS
- [x] clang: 16 binaries all PASS

## What does *not* land in this PR

- Heron iteration / depth-2+ refinement for `sqrt` (Phase F)
- Depth-1+ refinement for `hypot` (small follow-up; the algebraic form needs care to stay overflow-safe at depth 1)

## Related

- Epic: #873
- Phase E parent: #878
- Phase E.2 issue: #888
- Phase E.1 (constants), merged via #893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sqrt() and hypot() for the elreal numeric type, including improved precision for sqrt (additional refinement) and robust handling of zeros, negatives, infinities, and NaNs; configurable behavior for arithmetic exceptions.

* **Tests**
  * New comprehensive test suites validating correctness, symmetry, overflow safety, round‑trip identities, leading‑zero/expansion edge cases, special‑value behavior, and throw vs non‑throw modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->