### PR TITLE
feat(elreal): Phase E.3 -- exp/log/pow family with depth-1 derivative refinement

### DIFF
--- a/elastic/elreal/math/exponent.cpp
+++ b/elastic/elreal/math/exponent.cpp
@@ -1,0 +1,121 @@
+// exponent.cpp: tests for elreal exp / exp2 / expm1 (Phase E.3)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase E.3 exponent";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- exp identities -------------------------------------------------
+	{
+		if (double(exp(elreal(0.0))) != 1.0) {
+			std::cerr << "FAIL: exp(0) != 1\n"; ++nrOfFailedTestCases;
+		}
+		nrOfFailedTestCases += check_close("exp(1) ~= e",
+			double(exp(elreal(1.0))), std::numbers::e_v<double>);
+	}
+
+	// --- exp cross-validation against std::exp -------------------------
+	{
+		for (double v : {-2.0, -1.0, -0.5, 0.1, 0.5, 1.5, 2.0, 5.0, 10.0}) {
+			double got = double(exp(elreal(v)));
+			double exp_v = std::exp(v);
+			if (got != exp_v) {
+				std::cerr << "FAIL: exp(" << v << ") = " << got
+					<< " (std::exp = " << exp_v << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- exp(inf) = inf, exp(-inf) = 0, exp(NaN) = NaN -----------------
+	{
+		if (!exp(elreal(SpecificValue::infpos)).isinf()) {
+			std::cerr << "FAIL: exp(+inf) != +inf\n"; ++nrOfFailedTestCases;
+		}
+		if (double(exp(elreal(SpecificValue::infneg))) != 0.0) {
+			std::cerr << "FAIL: exp(-inf) != 0\n"; ++nrOfFailedTestCases;
+		}
+		if (!exp(elreal(SpecificValue::qnan)).isnan()) {
+			std::cerr << "FAIL: exp(NaN) != NaN\n"; ++nrOfFailedTestCases;
+		}
+	}
+
+	// --- exp2 identities ------------------------------------------------
+	{
+		nrOfFailedTestCases += check_close("exp2(0) == 1",  double(exp2(elreal(0.0))),  1.0);
+		nrOfFailedTestCases += check_close("exp2(1) == 2",  double(exp2(elreal(1.0))),  2.0);
+		nrOfFailedTestCases += check_close("exp2(10) == 1024", double(exp2(elreal(10.0))), 1024.0);
+		nrOfFailedTestCases += check_close("exp2(-1) == 0.5", double(exp2(elreal(-1.0))), 0.5);
+	}
+
+	// --- expm1 identities ----------------------------------------------
+	{
+		if (double(expm1(elreal(0.0))) != 0.0) {
+			std::cerr << "FAIL: expm1(0) != 0\n"; ++nrOfFailedTestCases;
+		}
+		// For small x, expm1(x) is much more accurate than exp(x) - 1.
+		// Cross-validate against std::expm1.
+		for (double v : {1.0e-15, 1.0e-10, 0.01, 1.0, 5.0}) {
+			double got = double(expm1(elreal(v)));
+			double exp_v = std::expm1(v);
+			if (got != exp_v) {
+				std::cerr << "FAIL: expm1(" << v << ") = " << got
+					<< " (std::expm1 = " << exp_v << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- Depth-1 propagation: exp on rational input has non-zero at(1) -
+	// The derivative-based correction is c0 * a.at(1); rational at(1) is
+	// non-zero, so the result's at(1) must be non-zero too.
+	{
+		elreal third(1LL, 3LL);     // 1/3, has rational residual at depth 1
+		elreal e_third = exp(third);
+		if (e_third.at(1) == 0.0) {
+			std::cerr << "FAIL: exp(1/3) has zero depth-1 (generator not propagating)\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/math/logarithm.cpp
+++ b/elastic/elreal/math/logarithm.cpp
@@ -1,0 +1,151 @@
+// logarithm.cpp: tests for elreal log / log2 / log10 / log1p (Phase E.3)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase E.3 logarithm";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- log identities -------------------------------------------------
+	{
+		if (double(log(elreal(1.0))) != 0.0) {
+			std::cerr << "FAIL: log(1) != 0\n"; ++nrOfFailedTestCases;
+		}
+		nrOfFailedTestCases += check_close("log(e) ~= 1",
+			double(log(elreal(std::numbers::e_v<double>))), 1.0, 1e-15);
+	}
+
+	// --- log cross-validation against std::log -------------------------
+	{
+		for (double v : {0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 100.0, 1e10, 1e-10}) {
+			double got = double(log(elreal(v)));
+			double exp_v = std::log(v);
+			if (got != exp_v) {
+				std::cerr << "FAIL: log(" << v << ") = " << got
+					<< " (std::log = " << exp_v << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- Edge cases: log(0), log(negative), log(+inf), log(NaN) --------
+	{
+		if (!log(elreal(0.0)).isinf()) {
+			std::cerr << "FAIL: log(0) not infinite (expected -inf)\n";
+			++nrOfFailedTestCases;
+		}
+		if (!log(elreal(-1.0)).isnan()) {
+			std::cerr << "FAIL: log(-1) != NaN\n"; ++nrOfFailedTestCases;
+		}
+		if (!log(elreal(SpecificValue::infpos)).isinf()) {
+			std::cerr << "FAIL: log(+inf) != +inf\n"; ++nrOfFailedTestCases;
+		}
+		if (!log(elreal(SpecificValue::qnan)).isnan()) {
+			std::cerr << "FAIL: log(NaN) != NaN\n"; ++nrOfFailedTestCases;
+		}
+	}
+
+	// --- log2 identities ------------------------------------------------
+	{
+		nrOfFailedTestCases += check_close("log2(1) == 0",   double(log2(elreal(1.0))), 0.0);
+		nrOfFailedTestCases += check_close("log2(2) == 1",   double(log2(elreal(2.0))), 1.0);
+		nrOfFailedTestCases += check_close("log2(1024)==10", double(log2(elreal(1024.0))), 10.0);
+		nrOfFailedTestCases += check_close("log2(0.5)==-1",  double(log2(elreal(0.5))), -1.0);
+	}
+
+	// --- log10 identities ----------------------------------------------
+	{
+		nrOfFailedTestCases += check_close("log10(1)==0",    double(log10(elreal(1.0))), 0.0);
+		nrOfFailedTestCases += check_close("log10(10)==1",   double(log10(elreal(10.0))), 1.0);
+		nrOfFailedTestCases += check_close("log10(100)==2",  double(log10(elreal(100.0))), 2.0);
+		nrOfFailedTestCases += check_close("log10(0.01)==-2",double(log10(elreal(0.01))), -2.0);
+	}
+
+	// --- log1p identities -----------------------------------------------
+	{
+		nrOfFailedTestCases += check_close("log1p(0) == 0", double(log1p(elreal(0.0))), 0.0);
+		// log1p(x) is much more accurate than log(1+x) for small x.
+		// Cross-validate against std::log1p.
+		for (double v : {1.0e-15, 1.0e-10, 0.01, 1.0, 5.0}) {
+			double got = double(log1p(elreal(v)));
+			double exp_v = std::log1p(v);
+			if (got != exp_v) {
+				std::cerr << "FAIL: log1p(" << v << ") = " << got
+					<< " (std::log1p = " << exp_v << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- Round-trip: log(exp(x)) ~= x ---------------------------------
+	{
+		for (double v : {-3.0, -1.0, 0.5, 1.0, 3.14, 10.0}) {
+			elreal x(v);
+			elreal back = log(exp(x));
+			nrOfFailedTestCases += check_close(
+				(std::string("log(exp(") + std::to_string(v) + ")) ~= x").c_str(),
+				double(back), v, 1e-13);
+		}
+	}
+
+	// --- Round-trip: exp(log(x)) ~= x ---------------------------------
+	{
+		for (double v : {0.1, 0.5, 1.0, 2.0, 10.0, 1e10}) {
+			elreal x(v);
+			elreal back = exp(log(x));
+			nrOfFailedTestCases += check_close(
+				(std::string("exp(log(") + std::to_string(v) + ")) ~= x").c_str(),
+				double(back), v, 1e-13);
+		}
+	}
+
+	// --- Depth-1 propagation: log on a rational has a non-zero at(1) --
+	{
+		elreal third(1LL, 3LL);
+		elreal l = log(third);
+		if (l.at(1) == 0.0) {
+			std::cerr << "FAIL: log(1/3) has zero depth-1 correction\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/math/pow.cpp
+++ b/elastic/elreal/math/pow.cpp
@@ -1,0 +1,140 @@
+// pow.cpp: tests for elreal pow (Phase E.3)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include <algorithm>
+#include <cmath>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase E.3 pow";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// --- Exact integer powers ------------------------------------------
+	{
+		if (double(pow(elreal(2.0), elreal(10.0))) != 1024.0) {
+			std::cerr << "FAIL: pow(2, 10) != 1024\n"; ++nrOfFailedTestCases;
+		}
+		if (double(pow(elreal(3.0), elreal(4.0))) != 81.0) {
+			std::cerr << "FAIL: pow(3, 4) != 81\n"; ++nrOfFailedTestCases;
+		}
+		if (double(pow(elreal(5.0), elreal(0.0))) != 1.0) {
+			std::cerr << "FAIL: pow(5, 0) != 1\n"; ++nrOfFailedTestCases;
+		}
+		if (double(pow(elreal(2.0), elreal(-3.0))) != 0.125) {
+			std::cerr << "FAIL: pow(2, -3) != 0.125\n"; ++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Identity cases ------------------------------------------------
+	{
+		// pow(a, 1) == a
+		nrOfFailedTestCases += check_close("pow(7, 1) == 7",
+			double(pow(elreal(7.0), elreal(1.0))), 7.0);
+		// pow(1, b) == 1 for any b
+		nrOfFailedTestCases += check_close("pow(1, 3.14) == 1",
+			double(pow(elreal(1.0), elreal(3.14))), 1.0);
+		// pow(0, b) == 0 for b > 0
+		nrOfFailedTestCases += check_close("pow(0, 3) == 0",
+			double(pow(elreal(0.0), elreal(3.0))), 0.0);
+		// pow(0, 0) == 1 per C convention
+		nrOfFailedTestCases += check_close("pow(0, 0) == 1 (C convention)",
+			double(pow(elreal(0.0), elreal(0.0))), 1.0);
+	}
+
+	// --- Cross-validation against std::pow at depth 0 ----------------
+	{
+		using P = std::pair<double, double>;
+		for (P p : {P{2.0, 0.5}, P{3.0, 1.5}, P{0.5, 4.0}, P{10.0, -2.0},
+		            P{1.5, 2.5}, P{0.25, 0.5}}) {
+			double got = double(pow(elreal(p.first), elreal(p.second)));
+			double exp_v = std::pow(p.first, p.second);
+			if (got != exp_v) {
+				std::cerr << "FAIL: pow(" << p.first << ", " << p.second << ") = " << got
+					<< " (std::pow = " << exp_v << ")\n";
+				++nrOfFailedTestCases;
+			}
+		}
+	}
+
+	// --- pow consistency with exp(b * log(a)) for a > 0 --------------
+	{
+		for (auto p : { std::pair{3.14, 2.71}, std::pair{0.5, 7.0}, std::pair{10.0, 0.3} }) {
+			elreal a(p.first), b(p.second);
+			elreal direct = pow(a, b);
+			elreal via_explog = exp(b * log(a));
+			nrOfFailedTestCases += check_close(
+				(std::string("pow(") + std::to_string(p.first) + "," + std::to_string(p.second)
+					+ ") == exp(b*log(a))").c_str(),
+				double(direct), double(via_explog), 1e-13);
+		}
+	}
+
+	// --- Edge cases: negative base with fractional exponent gives NaN --
+	{
+		// std::pow(-1, 0.5) = NaN
+		elreal r = pow(elreal(-1.0), elreal(0.5));
+		if (!r.isnan()) {
+			std::cerr << "FAIL: pow(-1, 0.5) != NaN\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Inf/NaN propagation ------------------------------------------
+	{
+		elreal nan_v(SpecificValue::qnan), x(2.0);
+		if (!pow(nan_v, x).isnan()) {
+			std::cerr << "FAIL: pow(NaN, 2) != NaN\n"; ++nrOfFailedTestCases;
+		}
+		if (!pow(x, nan_v).isnan()) {
+			std::cerr << "FAIL: pow(2, NaN) != NaN\n"; ++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Depth-1 propagation: pow on rational base has non-zero at(1) -
+	{
+		elreal third(1LL, 3LL);
+		elreal two(2.0);
+		elreal r = pow(third, two);     // (1/3)^2 = 1/9
+		if (r.at(1) == 0.0) {
+			std::cerr << "FAIL: pow(1/3, 2).at(1) == 0 "
+				<< "(depth-1 generator not propagating operand a.at(1))\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -148,6 +148,7 @@
 #include <cerrno>    // errno, ERANGE
 #include <cmath>
 #include <cctype>
+#include <numbers>   // std::numbers::ln2_v, ln10_v (Phase E.3)
 #include <vector>
 #include <string>
 #include <functional>
@@ -487,6 +488,16 @@ private:
 	// Phase E math functions (#878). Same friendship rationale.
 	friend elreal sqrt(const elreal& a);
 	friend elreal hypot(const elreal& a, const elreal& b);
+
+	// Phase E.3 (#889): exp / log / pow family.
+	friend elreal exp(const elreal& a);
+	friend elreal exp2(const elreal& a);
+	friend elreal expm1(const elreal& a);
+	friend elreal log(const elreal& a);
+	friend elreal log2(const elreal& a);
+	friend elreal log10(const elreal& a);
+	friend elreal log1p(const elreal& a);
+	friend elreal pow(const elreal& a, const elreal& b);
 };
 
 // =============================================================================
@@ -984,6 +995,211 @@ inline elreal hypot(const elreal& a, const elreal& b) {
 	result._computed_depth = 1;
 
 	// Depth-1+ deferred: see header docblock above.
+	return result;
+}
+
+// =============================================================================
+// Phase E.3 math: exp / log / pow family (#889)
+// =============================================================================
+//
+// All eight functions ship at the same level of refinement:
+//   Depth 0: standard library (std::exp / std::log / etc.) on the leading
+//            double, which is IEEE-754 correctly rounded across all
+//            platforms we target.
+//   Depth 1: derivative-based correction. For f(x), the depth-1 correction
+//            is f'(x.at(0)) * x.at(1), capturing the first-order Taylor
+//            contribution from the operand's depth-1 limb. For pow(a, b)
+//            both operand corrections are captured: dpow/da * a.at(1) +
+//            dpow/db * b.at(1).
+//   Depth 2+: 0.0. Higher-order corrections (the std::lib rounding error
+//            of the depth-0 computation, plus second-order Taylor terms)
+//            require either (a) a higher-precision algorithm internally
+//            or (b) Newton refinement using lazy division -- both Phase F.
+//
+// Edge cases: log(0) returns -inf; log(negative) and pow(negative,
+// fractional) return NaN. We propagate IEEE behaviour without throwing;
+// the result's isnan() / isinf() can be inspected by the caller. No new
+// exception types are added in this phase.
+
+inline elreal exp(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::exp(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0) || c0 == 0.0) return result;
+
+	// d/dx exp(x) = exp(x), so depth-1 = c0 * a.at(1).
+	elreal a_cap = a;
+	double c0_cap = c0;
+	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return c0_cap * a_cap.at(1);
+	};
+	return result;
+}
+
+inline elreal exp2(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::exp2(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0) || c0 == 0.0) return result;
+
+	// d/dx 2^x = 2^x * ln(2), so depth-1 = c0 * ln2 * a.at(1).
+	elreal a_cap = a;
+	double c0_cap = c0;
+	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return c0_cap * std::numbers::ln2_v<double> * a_cap.at(1);
+	};
+	return result;
+}
+
+inline elreal expm1(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::expm1(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0)) return result;
+
+	// d/dx (exp(x) - 1) = exp(x) = expm1(x) + 1, so depth-1 = (c0+1) * a.at(1).
+	elreal a_cap = a;
+	double c0_cap = c0;
+	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return (c0_cap + 1.0) * a_cap.at(1);
+	};
+	return result;
+}
+
+inline elreal log(const elreal& a) {
+	double a0 = a.at(0);
+	// std::log handles all edge cases per IEEE-754:
+	//   log(0)        = -inf
+	//   log(negative) = NaN
+	//   log(+inf)     = +inf
+	//   log(NaN)      = NaN
+	double c0 = std::log(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	// No depth-1 refinement when the leading is non-finite or the operand
+	// is zero (the 1/a0 derivative diverges).
+	if (!std::isfinite(c0) || a0 == 0.0) return result;
+
+	// d/dx log(x) = 1/x, so depth-1 = a.at(1) / a0.
+	elreal a_cap = a;
+	double a0_cap = a0;
+	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return a_cap.at(1) / a0_cap;
+	};
+	return result;
+}
+
+inline elreal log2(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::log2(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0) || a0 == 0.0) return result;
+
+	// d/dx log2(x) = 1 / (x * ln(2)).
+	elreal a_cap = a;
+	double a0_cap = a0;
+	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return a_cap.at(1) / (a0_cap * std::numbers::ln2_v<double>);
+	};
+	return result;
+}
+
+inline elreal log10(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::log10(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0) || a0 == 0.0) return result;
+
+	// d/dx log10(x) = 1 / (x * ln(10)).
+	elreal a_cap = a;
+	double a0_cap = a0;
+	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return a_cap.at(1) / (a0_cap * std::numbers::ln10_v<double>);
+	};
+	return result;
+}
+
+inline elreal log1p(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::log1p(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0) || (1.0 + a0) == 0.0) return result;
+
+	// d/dx log(1 + x) = 1 / (1 + x).
+	elreal a_cap = a;
+	double a0_cap = a0;
+	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return a_cap.at(1) / (1.0 + a0_cap);
+	};
+	return result;
+}
+
+inline elreal pow(const elreal& a, const elreal& b) {
+	double a0 = a.at(0);
+	double b0 = b.at(0);
+	double c0 = std::pow(a0, b0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	// No depth-1 refinement when the leading is non-finite. Also skip when
+	// a0 == 0 (the partial derivative with respect to a involves 1/a0 and
+	// is undefined / singular) or when a0 < 0 with non-integer b (pow itself
+	// is NaN, which is already captured at depth 0).
+	if (!std::isfinite(c0) || a0 <= 0.0) return result;
+
+	// Depth-1 correction has TWO sources:
+	//   dpow/da = b * a^(b-1) = b * c0 / a
+	//   dpow/db = a^b * log(a) = c0 * log(a)
+	//
+	// Both are evaluated at the leading doubles to avoid extra std lib
+	// calls inside the lazy machinery.
+	elreal a_cap = a;
+	elreal b_cap = b;
+	double a0_cap = a0;
+	double b0_cap = b0;
+	double c0_cap = c0;
+	result._generator = [a_cap, b_cap, a0_cap, b0_cap, c0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		double dpow_da = b0_cap * c0_cap / a0_cap;
+		double dpow_db = c0_cap * std::log(a0_cap);
+		return dpow_da * a_cap.at(1) + dpow_db * b_cap.at(1);
+	};
 	return result;
 }
 


### PR DESCRIPTION
## Summary

Phase E.3 of epic #873. Implements [#889](https://github.com/stillwater-sc/universal/issues/889) -- the largest math sub-issue under Phase E (#878).

Eight functions ship with a uniform strategy: std library at depth 0, derivative-based correction at depth 1, deferred for depth 2+. The derivative-correction trick (`f'(a.at(0)) * a.at(1)`) is the natural extension of the EFT trick that Phase E.2 used for sqrt, applied to functions whose derivatives are closed-form.

## What landed

| Function | depth-0 | depth-1 derivative |
|---|---|---|
| `exp(x)`   | `std::exp(a0)`   | `c0 * a.at(1)` |
| `exp2(x)`  | `std::exp2(a0)`  | `c0 * ln2 * a.at(1)` |
| `expm1(x)` | `std::expm1(a0)` | `(c0 + 1) * a.at(1)` |
| `log(x)`   | `std::log(a0)`   | `a.at(1) / a0` |
| `log2(x)`  | `std::log2(a0)`  | `a.at(1) / (a0 * ln2)` |
| `log10(x)` | `std::log10(a0)` | `a.at(1) / (a0 * ln10)` |
| `log1p(x)` | `std::log1p(a0)` | `a.at(1) / (1 + a0)` |
| `pow(a, b)`| `std::pow(a0, b0)` | `(b*c0/a) * a.at(1) + (c0*log(a)) * b.at(1)` |

## Edge cases (no new exception types)

`std::log` and `std::pow` already handle the canonical edge cases per IEEE-754:
- `log(0) = -inf`, `log(negative) = NaN`, `log(+inf) = +inf`
- `pow(negative, fractional) = NaN`, `pow(0, 0) = 1` (C convention)

The depth-1 generators skip refinement when the leading is non-finite or when the derivative diverges (e.g., `log` at `a0 == 0`, `pow` at `a0 <= 0`).

## What does *not* land in this PR

- **Depth 2+** for any function. Higher-order corrections require either a higher-precision algorithm (e.g. AGM for log) or Newton refinement using lazy division, both of which need Phase F infrastructure.
- **Integer-exponent specialization for `pow`** (repeated squaring). `pow(2, 10) == 1024` is already exact at depth 0 via `std::pow`; a `pow(elreal, long long)` overload that uses repeated squaring would give better depth-1 accuracy for integer cases. Defer as a small follow-up.
- **The depth-0 rounding error of std lib functions** (~0.5 ULP) — by construction not capturable at depth 1 without a higher-precision algorithm.

## Test plan

Three new binaries under `elastic/elreal/math/`:

| Binary | Coverage |
|---|---|
| `elreal_exponent`  | `exp(0)=1`, `exp(1)~=e`, `exp2(10)=1024`, cross-validation vs `std::exp/exp2/expm1`, NaN/inf propagation, depth-1 propagation on rational input |
| `elreal_logarithm` | `log(1)=0`, `log(e)~=1`, `log2(1024)=10`, `log(0)=-inf`, `log(neg)=NaN`, round-trip `log(exp(x))~=x` and `exp(log(x))~=x`, depth-1 propagation |
| `elreal_pow`       | exact integer cases (`2^10`, `3^4`, `0^0=1`), identities (`a^1=a`, `1^b=1`), consistency `pow(a,b) == exp(b*log(a))`, NaN propagation, depth-1 propagation on operand |

- [x] gcc 13: all 19 binaries (3 new + 16 prior) PASS
- [x] clang: same

## Related

- Epic: #873
- Phase E parent: #878
- Phase E.3 issue: #889
- Prior: #874-#877 (Phases A-D), #887-#888 (E.1, E.2) -- all merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transcendental and power functions (`exp`, `exp2`, `expm1`, `log`, `log2`, `log10`, `log1p`, and `pow`) to the elreal number type.

* **Tests**
  * Added comprehensive test coverage for exponential functions including identity verification and special-value handling.
  * Added extensive tests for logarithmic functions including round-trip validation and edge-case behavior.
  * Added test coverage for power function operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->