### PR TITLE
feat(elreal): Phase E.6 -- forward trig with derivative refinement (Payne-Hanek deferred)

### DIFF
--- a/elastic/elreal/math/trig.cpp
+++ b/elastic/elreal/math/trig.cpp
@@ -1,0 +1,169 @@
+// trig.cpp: tests for elreal sin/cos/tan (Phase E.6)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Phase E.6 scope reminder: forward trig ships with std-lib-based depth-0 +
+// derivative-based depth-1 refinement. Range reduction modulo pi for
+// large-magnitude arguments (Payne-Hanek) is documented in the
+// elreal_impl.hpp header as future work. Tests therefore exercise
+// "reasonable magnitude" inputs only, per the acceptance criteria of #892.
+
+#include <universal/utility/directives.hpp>
+
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+static int check_close(const char* label, double got, double expected, double tol = 1e-14) {
+	double diff = std::abs(got - expected);
+	double mag  = std::max(std::abs(expected), 1.0);
+	if (diff / mag > tol) {
+		std::cerr << "FAIL: " << label << ": got " << got
+			<< " expected " << expected << " (rel err " << diff / mag << ")\n";
+		return 1;
+	}
+	return 0;
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase E.6 forward trig";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	const double pi   = std::numbers::pi_v<double>;
+	const double pi_2 = pi / 2.0;
+	const double pi_4 = pi / 4.0;
+
+	// --- Anchor values --------------------------------------------------
+	{
+		if (double(sin(elreal(0.0))) != 0.0) { std::cerr << "FAIL: sin(0) != 0\n"; ++nrOfFailedTestCases; }
+		if (double(cos(elreal(0.0))) != 1.0) { std::cerr << "FAIL: cos(0) != 1\n"; ++nrOfFailedTestCases; }
+		if (double(tan(elreal(0.0))) != 0.0) { std::cerr << "FAIL: tan(0) != 0\n"; ++nrOfFailedTestCases; }
+
+		nrOfFailedTestCases += check_close("sin(pi/2) ~= 1",   double(sin(elreal(pi_2))),  1.0, 1e-15);
+		nrOfFailedTestCases += check_close("cos(pi/2) ~= 0",   double(cos(elreal(pi_2))),  0.0, 1e-15);
+		nrOfFailedTestCases += check_close("sin(pi) ~= 0",     double(sin(elreal(pi))),    0.0, 1e-14);
+		nrOfFailedTestCases += check_close("cos(pi) ~= -1",    double(cos(elreal(pi))),   -1.0, 1e-15);
+		nrOfFailedTestCases += check_close("tan(pi/4) ~= 1",   double(tan(elreal(pi_4))),  1.0, 1e-15);
+	}
+
+	// --- Pythagorean identity sin^2(x) + cos^2(x) == 1 -----------------
+	{
+		for (double v : {-2.0, -0.5, 0.1, 0.5, 1.0, 1.5, 3.0}) {
+			elreal x(v);
+			elreal s = sin(x);
+			elreal c = cos(x);
+			elreal sum_sq = s*s + c*c;
+			nrOfFailedTestCases += check_close(
+				(std::string("sin^2 + cos^2 (x=") + std::to_string(v) + ")").c_str(),
+				double(sum_sq), 1.0, 1e-13);
+		}
+	}
+
+	// --- tan(x) ~= sin(x) / cos(x) -------------------------------------
+	{
+		for (double v : {-1.0, -0.5, 0.5, 1.0, 1.2}) {
+			elreal x(v);
+			elreal lhs = tan(x);
+			elreal rhs = sin(x) / cos(x);
+			nrOfFailedTestCases += check_close(
+				(std::string("tan == sin/cos (x=") + std::to_string(v) + ")").c_str(),
+				double(lhs), double(rhs), 1e-13);
+		}
+	}
+
+	// --- Cross-validation vs std lib for modest magnitude --------------
+	// Reasonable magnitude: |x| < pi or thereabouts, where the std lib
+	// internal range reduction is comfortably within double precision.
+	{
+		for (double v : {-pi, -1.5, -1.0, -0.5, 0.1, 0.5, 1.0, 1.5, pi}) {
+			elreal x(v);
+			if (double(sin(x)) != std::sin(v)) { std::cerr << "FAIL: sin(" << v << ") vs std::sin\n"; ++nrOfFailedTestCases; }
+			if (double(cos(x)) != std::cos(v)) { std::cerr << "FAIL: cos(" << v << ") vs std::cos\n"; ++nrOfFailedTestCases; }
+		}
+		// tan: skip near singularities pi/2 + n*pi
+		for (double v : {-1.0, -0.5, 0.0, 0.5, 1.0}) {
+			elreal x(v);
+			if (double(tan(x)) != std::tan(v)) { std::cerr << "FAIL: tan(" << v << ") vs std::tan\n"; ++nrOfFailedTestCases; }
+		}
+	}
+
+	// --- Lazy-pi distinctness: sin(elreal_pi()) at full lazy precision is
+	// observably closer to zero than std::sin(M_PI). std::sin(M_PI) is
+	// ~1.22e-16 (because M_PI is slightly less than true pi); the depth-1
+	// correction adds cos(M_PI) * (true_pi - M_PI) = -1 * 1.22e-16,
+	// cancelling the std::sin error.
+	//
+	// NOTE: operator double() only sums *materialised* components. To make
+	// the depth-1 contribution visible we have to walk the generator
+	// explicitly via .at(1) first; otherwise double(s) returns depth-0
+	// only and the comparison below is a no-op. (This is by design --
+	// operator double() is the cheap "best estimate at current depth"
+	// path; the caller decides when to spend a refinement step.)
+	{
+		elreal lazy_pi = elreal_pi();
+		elreal s = sin(lazy_pi);
+		(void)s.at(1);                     // force depth-1 materialisation
+		double full  = double(s);          // now sums depth-0 + depth-1
+		double naive = std::sin(pi);       // ~1.22e-16
+		if (std::abs(full) >= std::abs(naive)) {
+			std::cerr << "FAIL: sin(elreal_pi()) full = " << full
+				<< " not closer to 0 than std::sin(M_PI) = " << naive
+				<< " (lazy-pi correction did not improve the result)\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// --- NaN / inf propagation ------------------------------------------
+	{
+		elreal nan_v(SpecificValue::qnan);
+		if (!sin(nan_v).isnan()) { std::cerr << "FAIL: sin(NaN) != NaN\n"; ++nrOfFailedTestCases; }
+		if (!cos(nan_v).isnan()) { std::cerr << "FAIL: cos(NaN) != NaN\n"; ++nrOfFailedTestCases; }
+		if (!tan(nan_v).isnan()) { std::cerr << "FAIL: tan(NaN) != NaN\n"; ++nrOfFailedTestCases; }
+		// sin/cos/tan of inf is NaN per IEEE-754 (no finite cycle)
+		if (!sin(elreal(SpecificValue::infpos)).isnan()) {
+			std::cerr << "FAIL: sin(+inf) != NaN\n"; ++nrOfFailedTestCases;
+		}
+	}
+
+	// --- Round-trip with inverse trig: asin(sin(x)) ~= x for |x| < pi/2
+	{
+		for (double v : {-1.0, -0.5, 0.0, 0.5, 1.0}) {
+			elreal x(v);
+			elreal back = asin(sin(x));
+			nrOfFailedTestCases += check_close(
+				(std::string("asin(sin(") + std::to_string(v) + ")) ~= x").c_str(),
+				double(back), v, 1e-14);
+		}
+	}
+
+	// --- Depth-1 propagation on rational input ------------------------
+	{
+		elreal third(1LL, 3LL);
+		if (sin(third).at(1) == 0.0) { std::cerr << "FAIL: sin(1/3).at(1) == 0\n"; ++nrOfFailedTestCases; }
+		if (cos(third).at(1) == 0.0) { std::cerr << "FAIL: cos(1/3).at(1) == 0\n"; ++nrOfFailedTestCases; }
+		if (tan(third).at(1) == 0.0) { std::cerr << "FAIL: tan(1/3).at(1) == 0\n"; ++nrOfFailedTestCases; }
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -512,6 +512,11 @@ private:
 	friend elreal acos(const elreal& a);
 	friend elreal atan(const elreal& a);
 	friend elreal atan2(const elreal& y, const elreal& x);
+
+	// Phase E.6 (#892): forward trigonometric functions.
+	friend elreal sin(const elreal& a);
+	friend elreal cos(const elreal& a);
+	friend elreal tan(const elreal& a);
 };
 
 // =============================================================================
@@ -1486,6 +1491,131 @@ inline elreal atan2(const elreal& y, const elreal& x) {
 		double dy = x0_cap / r2_cap;
 		double dx = -y0_cap / r2_cap;
 		return dy * y_cap.at(1) + dx * x_cap.at(1);
+	};
+	return result;
+}
+
+// =============================================================================
+// Phase E.6 math: forward trigonometric functions (#892)
+// =============================================================================
+//
+// sin, cos, tan via the depth-0-std-lib + depth-1-derivative pattern.
+//
+// Per-function derivatives:
+//   d/dx sin(x) =  cos(x)              -> cos(a0) * a.at(1)
+//   d/dx cos(x) = -sin(x)              -> -sin(a0) * a.at(1)
+//   d/dx tan(x) = 1 + tan^2(x)         -> (1 + c0*c0) * a.at(1)
+//
+// -----------------------------------------------------------------------------
+// Range-reduction limitation -- the canonical hard case for lazy reals
+// -----------------------------------------------------------------------------
+//
+// For large-magnitude arguments, std::sin / std::cos / std::tan internally
+// reduce the argument modulo 2*pi (or pi/2) before evaluating a polynomial
+// approximation. That reduction is done with the IEEE-754 double M_PI, which
+// carries only 53 bits of precision. When |x| approaches 2^53, the reduced
+// argument has *no precision left* -- std::sin(1e20) is essentially noise.
+//
+// McCleeary 2019 / Payne-Hanek 1983 solves this by performing the range
+// reduction with arbitrarily many bits of pi pulled lazily from the
+// constant's stream. Specifically:
+//
+//   1. Compute k = round(x / (pi/2))                  // integer multiple
+//   2. Reduce r = x - k * (pi/2) using EXACT lazy arithmetic
+//      (pi/2 carried at enough precision that |r| < ulp(x) is achievable)
+//   3. Dispatch by k mod 4:
+//        k mod 4 == 0:  sin(r),  cos(r)
+//        k mod 4 == 1:  cos(r), -sin(r)
+//        k mod 4 == 2: -sin(r), -cos(r)
+//        k mod 4 == 3: -cos(r),  sin(r)
+//   4. Evaluate sin(r) / cos(r) on the reduced argument via Taylor series.
+//
+// Phase E.6 ships ONLY the std-lib-based depth-0 + derivative-based depth-1
+// computation. This is correct for arguments of "reasonable magnitude" --
+// roughly |x| < 2^25 or so, where std::sin/cos retain their full
+// double-precision contract. For |x| beyond that, the result is faithful at
+// depth 0 only in the IEEE-754 sense (matches std::sin) but loses precision
+// as |x| grows; the depth-1 correction adds the operand's contribution but
+// cannot recover bits lost in std's internal range reduction.
+//
+// Implementing the lazy Payne-Hanek path is its own substantial PR that
+// would need:
+//   - elreal_pi extended past the current 4-component (212-bit) static
+//     expansion (a generator-based variant of from_expansion, or a BBP
+//     bit-extraction algorithm)
+//   - An integer-mod-pi reduction loop that pulls more bits of pi from
+//     elreal_pi until |r| < ulp(x) is achievable
+//   - Taylor / Chebyshev evaluation of sin/cos on the reduced argument
+//     with lazy refinement
+//
+// This is filed as a Phase-F-or-later follow-up. The acceptance criteria
+// of #892 explicitly note that direct cross-validation against std::sin
+// for huge-magnitude inputs is not meaningful (lazy real arithmetic is
+// where huge-magnitude trig *wins* over double); so the limitation is
+// documented rather than enforced as a test gate.
+//
+// References:
+//   - McCleeary, R. (2019). "Lazy Exact Real Arithmetic Using Floating
+//     Point Operations." Ph.D. dissertation, University of Iowa.
+//   - Payne, M. and Hanek, R. (1983). "Radian Reduction for Trigonometric
+//     Functions." SIGNUM Newsletter, 18(1), 19-24.
+
+inline elreal sin(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::sin(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0)) return result;
+
+	// d/dx sin(x) = cos(x).
+	elreal a_cap = a;
+	double cos_a0 = std::cos(a0);
+	result._generator = [a_cap, cos_a0](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return cos_a0 * a_cap.at(1);
+	};
+	return result;
+}
+
+inline elreal cos(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::cos(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0)) return result;
+
+	// d/dx cos(x) = -sin(x).
+	elreal a_cap = a;
+	double sin_a0 = std::sin(a0);
+	result._generator = [a_cap, sin_a0](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return -sin_a0 * a_cap.at(1);
+	};
+	return result;
+}
+
+inline elreal tan(const elreal& a) {
+	double a0 = a.at(0);
+	double c0 = std::tan(a0);
+
+	elreal result;
+	result._components.push_back(c0);
+	result._computed_depth = 1;
+
+	if (!std::isfinite(c0)) return result;
+
+	// d/dx tan(x) = 1 + tan^2(x). Using c0 avoids a second std::tan.
+	elreal a_cap = a;
+	double c0_cap = c0;
+	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
+		if (k != 1) return 0.0;
+		return (1.0 + c0_cap * c0_cap) * a_cap.at(1);
 	};
 	return result;
 }


### PR DESCRIPTION
## Summary

Phase E.6 of epic #873. Implements [#892](https://github.com/stillwater-sc/universal/issues/892) -- the last math sub-issue of Phase E and the one billed as "the hardest." This PR ships the pragmatic part (std lib + derivative-based depth-1, matching E.3/E.4/E.5) and documents the Payne-Hanek lazy-pi-pull path as the natural follow-up.

## What landed

| Function | depth-0 | depth-1 derivative |
|---|---|---|
| `sin(x)` | `std::sin(a0)` | `cos(a0) * a.at(1)` |
| `cos(x)` | `std::cos(a0)` | `-sin(a0) * a.at(1)` |
| `tan(x)` | `std::tan(a0)` | `(1 + c0*c0) * a.at(1)` |

## Range reduction: what's NOT in this PR

The header docblock (~50 lines) lays out the Payne-Hanek strategy explicitly. The summary:

For large-magnitude arguments (`|x| > 2^25` ish), `std::sin` reduces the argument modulo `2π` using IEEE-754 `M_PI` (53 bits). The reduced argument loses precision as `|x|` grows, and by `|x| = 2^53` the reduced argument is essentially noise. McCleeary 2019 / Payne-Hanek 1983 solves this by performing the reduction with **arbitrarily many bits of π pulled lazily from the constant's stream**.

This PR does NOT implement that path. It would need:
- `elreal_pi` extended past the current 4-component (~212-bit) static expansion (BBP or a generator-based factory)
- An integer-mod-pi reduction loop that pulls more bits of π until `|r| < ulp(x)` is achievable
- Taylor / Chebyshev evaluation of `sin/cos` on the reduced argument with lazy refinement

Filed as Phase-F-or-later follow-up. The acceptance criteria of #892 explicitly note that direct cross-validation against `std::sin` for huge-magnitude inputs is not meaningful — lazy real arithmetic is *where huge-magnitude trig wins* over double, so there's no double-precision baseline to compare to. The limitation is documented rather than enforced as a test gate.

## Test plan (`elreal_trig`)

- Anchor values: `sin(0)=0`, `cos(0)=1`, `tan(0)=0`, `sin(π/2)~=1`, `cos(π)~=-1`, `tan(π/4)~=1`
- **Pythagorean identity** `sin²(x) + cos²(x) == 1` at modest x
- `tan(x) ~= sin(x) / cos(x)` consistency
- Cross-validation vs `std::sin / cos / tan` for `|x| < π`
- **Lazy-pi distinctness**: after explicit `.at(1)` materialisation, `sin(elreal_pi())` is closer to true zero than `std::sin(M_PI)`. The `cos(M_PI) * pi.at(1)` correction cancels the std rounding error. *This is the whole point of lazy real arithmetic applied to trig at modest magnitude.*
- NaN/inf propagation
- Round-trip `asin(sin(x)) ~= x` for `|x| < π/2`
- Depth-1 propagation on rational input

## Important behavioural note

While writing the lazy-pi-distinctness test I caught a real subtlety worth recording: **`operator double()` only sums *materialised* components**, not generator-driven lazy ones. The first version of the distinctness test failed because `double(sin(elreal_pi()))` returned only the depth-0 leading. To make the depth-1 correction visible to `double()`, the caller must walk the stream via `.at(1)` (or `refine_to(...)`) first. This is by design — `operator double()` is the cheap "best estimate at current depth" path; the caller decides when to spend a refinement step. The test calls `.at(1)` explicitly and the source comment explains why.

This semantic is consistent across all phases but only made *visible* by the trig test (where depth-0 and depth-1 must cancel to recover the lazy-pi advantage).

- [x] gcc 13: 22 binaries (1 new + 21 prior) PASS
- [x] clang: same

## Epic-level milestone

This PR completes Phase E (math functions). **All eight sub-issues of #878 are now done**: constants (#887), sqrt/hypot (#888), exp/log/pow (#889), hyperbolic (#890), inverse trig (#891), forward trig (#892).

## Related

- Epic: #873
- Phase E parent: #878
- Phase E.6 issue: #892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trigonometric functions (`sin`, `cos`, `tan`) for the elreal type with comprehensive test coverage validating numerical accuracy and mathematical identities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->