### PR TITLE
feat(elreal): Phase G -- elreal as a cross-implementation validation oracle

### DIFF
--- a/docs/algorithmic-details/multi-component-arithmetic.md
+++ b/docs/algorithmic-details/multi-component-arithmetic.md
@@ -741,6 +741,50 @@ by constructing configurations with geometrically obvious sign (left turn,
 right turn, collinear) and asserting the predicate returns the expected
 sign. The test cases *are* the oracle; no numeric reference is needed.
 
+### 8.6 elreal as a cross-implementation oracle (Phase G)
+
+The validation tier added by Phase G of the `elreal` epic (#880). The
+helper at `include/sw/universal/verification/test_suite_elreal_oracle.hpp`
+takes a value computed in any Universal multi-component type and an
+`elreal` reference computed via an *independent* code path, and asserts
+agreement within the target type's `numeric_limits::digits10` precision:
+
+```cpp
+template<typename TargetType>
+bool check_against_elreal_oracle(const TargetType& target,
+                                 const elreal& oracle,
+                                 int safety_margin = 2);
+```
+
+The validation it provides today is at double precision -- the same
+ceiling as `check_relative_error` -- because elreal's lazy refinement
+currently caps at depth 1 (per the Phase C / Phase E docblocks). The
+distinguishing property is *cross-implementation*: the reference is
+computed by elreal's lazy-arithmetic backend, not by the std library
+directly, so an agreement at the helper's tolerance is genuine
+two-paths confirmation, not a self-check.
+
+What this catches today:
+
+- Target-type implementations that produce a wrong sign or wrong
+  magnitude (catastrophic bugs); both paths diverge at double precision.
+- Target-type implementations that match `std::cmath` but disagree with
+  elreal's algebraic path -- a subtle-algorithmic-issue signal.
+- Regressions where the target type's precision drops below double's
+  ~16 decimal digits.
+
+What it doesn't yet catch (deferred until elreal gains depth-2+
+refinement):
+
+- Sub-double-ULP precision drift in the target type. Catching this
+  requires elreal to deliver >53 bits, which is the depth-2+ follow-up
+  filed against the `elreal` epic.
+
+The demo test at `elastic/elreal/oracle/dd_cascade_exp.cpp` exercises
+the pipeline end-to-end on `dd_cascade::exp(x)` versus `elreal::exp(x)`
+across a representative input set, including a sanity-check assertion
+that the helper rejects a deliberately-wrong oracle.
+
 ### 8.6 Where the regression tests live
 
 | Type            | Arithmetic                                            | Math                                            |
@@ -760,21 +804,30 @@ The cascade types share the corner-case infrastructure pattern; each
 
 In the interest of an honest picture:
 
-- **No automated higher-precision oracle.** Anything past double precision
-  is validated by algebraic identities (which catch correctness bugs but
-  not subtle ULP-drift bugs) or by spot checks bounded by double precision
-  (which catch gross errors but not precision-claim violations).
+- **Higher-precision oracle gap: PIPELINE in place, PRECISION CEILING
+  pending.** The elreal-as-oracle tier added by Phase G (section 8.6)
+  establishes the validation pipeline -- cross-implementation agreement
+  is now part of the validation contract for `dd_cascade::exp` and is
+  extensible to other multi-component types. The actual precision of the
+  oracle is currently capped at double (elreal's depth-1 cap), so
+  sub-double-ULP precision drift in target types is still uncatchable
+  by automated tests. Lifting that cap is the depth-2+ refinement work
+  filed against the elreal epic (Phase F-or-later); when it lands, the
+  oracle's precision improves transparently and existing oracle tests
+  pick it up without API changes.
 - **Manual-testing scaffolding.** A non-trivial fraction of the math tests
   are still in `MANUAL_TESTING 1` mode -- they print results for human
   inspection rather than asserting pass/fail. Automating these is open work.
 - **Cross-cascade validation aspirational.** The `corner_cases.hpp` comment
   block lists "use qd as oracle for dd_cascade" as strategy 5, but the
-  shipped tests do not yet exercise that path.
+  shipped tests do not yet exercise that path. The Phase G helper provides
+  an alternative: use elreal (rather than qd) as the cross-implementation
+  oracle for cascade-type validation.
 
-MPFR / Boost.Multiprecision integration is the natural next step for
-closing the higher-precision-oracle gap and is mentioned in
-`ereal_numerics.md` as a future direction. It is not currently in the
-build or the validation path.
+MPFR / Boost.Multiprecision integration remains a natural complement for
+the high-precision-ceiling problem once elreal's depth-2+ refinement
+lands; it would provide a third independent precision reference. Not
+currently in the build or the validation path.
 
 ## 9. Geometric predicates: ereal vs elreal
 

--- a/elastic/elreal/CMakeLists.txt
+++ b/elastic/elreal/CMakeLists.txt
@@ -5,6 +5,7 @@ file (GLOB LOGIC_SRCS "./logic/*.cpp")
 file (GLOB MATHLIB_SRCS "./math/*.cpp")
 file (GLOB MATH_CONSTANTS_SRCS "./math/constants/*.cpp")
 file (GLOB GEOMETRY_SRCS "./geometry/*.cpp")
+file (GLOB ORACLE_SRCS "./oracle/*.cpp")
 file (GLOB PERFORMANCE_SRCS "./performance/*.cpp")
 
 compile_all("true" "elreal" "Number Systems/elastic/floating-point/binary/elreal/api" "${API_SRCS}")
@@ -14,4 +15,5 @@ compile_all("true" "elreal" "Number Systems/elastic/floating-point/binary/elreal
 compile_all("true" "elreal" "Number Systems/elastic/floating-point/binary/elreal/mathlib" "${MATHLIB_SRCS}")
 compile_all("true" "elreal" "Number Systems/elastic/floating-point/binary/elreal/math/constants" "${MATH_CONSTANTS_SRCS}")
 compile_all("true" "elreal" "Number Systems/elastic/floating-point/binary/elreal/geometry" "${GEOMETRY_SRCS}")
+compile_all("true" "elreal" "Number Systems/elastic/floating-point/binary/elreal/oracle" "${ORACLE_SRCS}")
 compile_all("true" "elreal" "Number Systems/elastic/floating-point/binary/elreal/performance" "${PERFORMANCE_SRCS}")

--- a/elastic/elreal/oracle/dd_cascade_exp.cpp
+++ b/elastic/elreal/oracle/dd_cascade_exp.cpp
@@ -1,0 +1,81 @@
+// dd_cascade_exp.cpp: cross-validate dd_cascade::exp against elreal::exp (Phase G, #880)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Demonstrates the elreal-as-oracle validation pipeline. The target type is
+// `dd_cascade` (Bailey/Hida double-double via floatcascade<2>); the oracle
+// is `elreal` (McCleeary lazy refinement). The two paths share zero code,
+// so an agreement at the helper's tolerance is genuine cross-implementation
+// confirmation.
+//
+// Current ceiling: elreal's depth-1 cap holds the actual validation at
+// double precision today. The pipeline -- and this test -- transparently
+// pick up the precision improvement when elreal gains depth-2+ refinement.
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/dd_cascade/dd_cascade.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+#include <universal/verification/test_suite_elreal_oracle.hpp>
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "elreal Phase G dd_cascade::exp oracle";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// Representative inputs span small / modest / slightly larger arguments,
+	// all within the safe operating range of both dd_cascade::exp and
+	// elreal::exp.
+	for (double x : { -2.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0 }) {
+		dd_cascade target = exp(dd_cascade(x));
+		elreal    oracle = exp(elreal(x));
+
+		std::string label = std::string("dd_cascade::exp(") + std::to_string(x)
+			+ ") vs elreal::exp";
+		nrOfFailedTestCases += report_against_elreal_oracle(label.c_str(),
+		                                                    target, oracle);
+	}
+
+	// Anchor: exp(0) is exactly 1.0 on both sides.
+	{
+		dd_cascade target = exp(dd_cascade(0.0));
+		elreal     oracle = exp(elreal(0.0));
+		if (double(target) != 1.0 || double(oracle) != 1.0) {
+			std::cerr << "FAIL: exp(0) anchor: target=" << double(target)
+				<< " oracle=" << double(oracle) << "\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// Sanity check the helper's reject path: a deliberately wrong "oracle"
+	// (factor 2 off) must be rejected. Guards against the helper
+	// accidentally passing on any input due to loose tolerance.
+	{
+		dd_cascade target = exp(dd_cascade(1.0));               // ~= e
+		elreal     wrong  = elreal(2.0) * exp(elreal(1.0));     // 2*e
+		if (check_against_elreal_oracle(target, wrong)) {
+			std::cerr << "FAIL: oracle helper accepted a 2x-off reference -- "
+				<< "tolerance is too loose to catch even gross errors\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/verification/test_suite_elreal_oracle.hpp
+++ b/include/sw/universal/verification/test_suite_elreal_oracle.hpp
@@ -1,0 +1,146 @@
+#pragma once
+// test_suite_elreal_oracle.hpp: elreal as a cross-validation oracle (Phase G of #873)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// =============================================================================
+// elreal as a cross-validation oracle
+// =============================================================================
+//
+// Issue #880 (Phase G of epic #873) wires `elreal` into Universal's
+// validation pipeline as the higher-precision reference for cross-validating
+// other multi-component types (`dd`, `qd`, `dd_cascade`, `td_cascade`,
+// `qd_cascade`, `ereal<N>`).
+//
+// The pipeline pattern
+// --------------------
+//
+//   1. Compute the value under test in the target type (e.g.
+//      `dd_cascade y = exp(dd_cascade(x))`).
+//   2. Compute the same expression via an INDEPENDENT path through `elreal`
+//      (e.g. `elreal o = exp(elreal(x))`). The two paths use different
+//      arithmetic backends -- Bailey/Hida hand-crafted cascade ops on one
+//      side, McCleeary lazy refinement on the other -- so disagreement is
+//      a strong bug signal.
+//   3. Call `check_against_elreal_oracle(y, o, safety_margin)`, which
+//      compares the two at the target type's advertised
+//      `numeric_limits::digits10` precision.
+//
+// Current precision ceiling
+// -------------------------
+//
+// elreal's lazy refinement currently caps at depth-1 for arithmetic ops
+// and math functions (~53 bits for double-input cases, ~106 bits for
+// rational-input cases). That cap is what makes the function bodies in
+// Phase C-E small and easy to validate; lifting it to depth-2+ requires
+// either (a) Newton refinement using lazy division (Phase F-or-later
+// follow-up), or (b) a per-function higher-precision algorithm internally.
+//
+// Until that work lands, this helper compares both sides at *double*
+// precision. The validation it provides today is therefore at the level
+// of the existing `check_relative_error` helper, with one key difference:
+// the reference is computed by an independent code path (elreal lazy)
+// rather than directly via the std library. Cross-implementation
+// agreement is a non-trivial bug signal even at matched precision.
+//
+// When deeper elreal refinement lands, this helper picks up the
+// precision improvement automatically -- the API surface does not change,
+// only the elreal oracle gets sharper.
+//
+// What the helper catches today
+// -----------------------------
+//
+//   - Target-type implementations that produce a *wrong sign* or
+//     *wrong magnitude* (catastrophic bugs); both sides disagree
+//     at double precision.
+//   - Target-type implementations that *match std lib* but disagree
+//     with the lazy-real algebraic path; indicates a subtle
+//     algorithmic issue.
+//   - Regressions in target-type precision that drop below double's
+//     ~16 decimal digits.
+//
+// What the helper does NOT yet catch
+// ----------------------------------
+//
+//   - Sub-double-ULP precision drift in the target type (e.g.
+//     dd_cascade losing the lower limb's precision). That requires
+//     elreal to deliver >53 bits, which is the depth-2+ follow-up.
+//
+// See docs/algorithmic-details/multi-component-arithmetic.md section 8.7
+// for the broader validation-strategy context.
+
+#include <cmath>
+#include <limits>
+
+#include <universal/number/elreal/elreal.hpp>
+
+namespace sw { namespace universal {
+
+// Compare a Universal-type value against an elreal oracle. Returns true if
+// the relative error |double(target) - double(oracle)| / |double(oracle)|
+// is within the target type's advertised tolerance (derived from
+// numeric_limits<TargetType>::digits10 minus a safety margin).
+//
+// safety_margin is the number of decimal digits of headroom; default 2
+// (matches the convention used by `get_adaptive_threshold` in
+// test_suite_mathlib_adaptive.hpp).
+template<typename TargetType>
+inline bool check_against_elreal_oracle(
+	const TargetType& target,
+	const elreal& oracle,
+	int safety_margin = 2)
+{
+	using std::numeric_limits;
+
+	// Tolerance derived from target's claimed decimal precision. For a
+	// target type whose digits10 exceeds double's 15, we cap at double
+	// precision today (see header docblock); when elreal gains depth-2+
+	// refinement this cap goes away.
+	constexpr int target_digits10 = numeric_limits<TargetType>::digits10;
+	constexpr int double_digits10 = numeric_limits<double>::digits10;
+	int effective_digits = target_digits10;
+	if (effective_digits > double_digits10) effective_digits = double_digits10;
+	int margin = safety_margin;
+	if (margin >= effective_digits) margin = effective_digits - 1;
+	if (margin < 0) margin = 0;
+	double rel_tol = std::pow(10.0, -static_cast<double>(effective_digits - margin));
+
+	double t = double(target);
+	double o = double(oracle);
+
+	// NaN handling: both NaN -> match; either NaN -> mismatch.
+	if (std::isnan(t) && std::isnan(o)) return true;
+	if (std::isnan(t) || std::isnan(o)) return false;
+
+	// Infinity handling: both inf with same sign -> match.
+	if (std::isinf(t) && std::isinf(o)) return (t > 0.0) == (o > 0.0);
+	if (std::isinf(t) || std::isinf(o)) return false;
+
+	// Near-zero oracle: switch to absolute tolerance to avoid divide-by-zero.
+	if (o == 0.0) return std::abs(t) < rel_tol;
+
+	return std::abs((t - o) / o) < rel_tol;
+}
+
+// Convenience wrapper that reports the failure to stderr and increments a
+// failure counter. Matches the patterns used elsewhere in the verification
+// suite (e.g. check_close in elastic/elreal/math/sqrt.cpp).
+template<typename TargetType>
+inline int report_against_elreal_oracle(
+	const char* label,
+	const TargetType& target,
+	const elreal& oracle,
+	int safety_margin = 2)
+{
+	if (check_against_elreal_oracle(target, oracle, safety_margin)) return 0;
+	std::cerr << "FAIL: " << label << " target=" << double(target)
+		<< " oracle=" << double(oracle)
+		<< " (out of tolerance derived from digits10="
+		<< std::numeric_limits<TargetType>::digits10 << ")\n";
+	return 1;
+}
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary

Phase G of epic #873. Implements [#880](https://github.com/stillwater-sc/universal/issues/880). Wires `elreal` into the validation pipeline as a cross-implementation oracle for the other multi-component types.

This is the integration win that originally motivated the epic — closing the validation-gap I documented in section 8.7 of `multi-component-arithmetic.md`. PR is honest about the current ceiling: the **pipeline** is in place, the **precision improvement** drops in when elreal's depth-2+ refinement lands.

## What landed

**New helper** at `include/sw/universal/verification/test_suite_elreal_oracle.hpp`:

```cpp
template<typename TargetType>
bool check_against_elreal_oracle(const TargetType& target,
                                 const elreal& oracle,
                                 int safety_margin = 2);

template<typename TargetType>
int report_against_elreal_oracle(const char* label,
                                 const TargetType& target,
                                 const elreal& oracle,
                                 int safety_margin = 2);
```

Compares against tolerance derived from `numeric_limits<TargetType>::digits10`. Handles NaN, ±inf, and near-zero oracle cases.

**Demo test** at `elastic/elreal/oracle/dd_cascade_exp.cpp`:
- Cross-validates `dd_cascade::exp(x)` against `elreal::exp(elreal(x))` across nine representative inputs
- Anchors `exp(0) == 1` exactly
- **Sanity-checks the helper itself** by passing a deliberately-wrong oracle (2× off) and asserting the helper rejects it — guards against accidentally-too-loose tolerance

**Documentation** updates in `docs/algorithmic-details/multi-component-arithmetic.md`:
- New section 8.6: "elreal as a cross-implementation oracle" — describes the tier, what it catches, what it doesn't, and the precision-ceiling story
- Section 8.7 updated: the "Higher-precision oracle gap" is now reframed as "PIPELINE in place, PRECISION CEILING pending"

## What this catches today

- Target-type implementations that produce a **wrong sign or wrong magnitude** (gross bugs)
- Target-type implementations that match `std::cmath` but disagree with elreal's algebraic path — subtle algorithmic issues
- Precision regressions below double's ~16 decimal digits

## What this does *not* yet catch

Sub-double-ULP precision drift in the target type. Catching that requires elreal to deliver >53 bits, which is the depth-2+ follow-up filed against the elreal epic. When that work lands, the helper's precision improves transparently — **the API surface doesn't change**.

## The cross-implementation value

The reference is computed by elreal's lazy-arithmetic backend (an entirely independent code path from dd_cascade's hand-crafted Bailey/Hida algorithm). Even at matched precision, agreement between two independent implementations of the same function is a non-trivial bug signal. Before this PR, `dd_cascade::exp` could only be cross-validated against `std::cmath` — a self-check, in effect.

## Test plan

- [x] gcc 13: 24 elreal binaries (1 new + 23 prior) PASS
- [x] clang: same
- [x] docs-site rebuild clean (83 pages)
- [x] The demo test's deliberate-wrong-oracle assertion catches the 2× error correctly

## Related

- Epic: #873
- Phase G issue: #880
- Prior: Phases A-F all merged
- Filing follow-up: depth-2+ refinement for `elreal` arithmetic + math functions (to lift the precision ceiling above double)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Phase G validation tier leveraging a high-precision reference oracle to cross-verify multi-component arithmetic implementations.

* **Documentation**
  * Updated documentation describing the new validation pipeline, its precision capabilities, and known limitations.

* **Tests**
  * Added validation test infrastructure enabling systematic verification of numeric implementations against a reference oracle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->