### PR TITLE
docs(elreal): Phase H -- user reference, algorithmic deep-dive, ELREALO retirement

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -112,6 +112,7 @@ export default defineConfig({
                 { label: 'dd_cascade', link: '/number-systems/dd-cascade/' },
                 { label: 'td_cascade', link: '/number-systems/td-cascade/' },
                 { label: 'qd_cascade', link: '/number-systems/qd-cascade/' },
+                { label: 'elreal', link: '/number-systems/elreal/' },
               ],
             },
             { label: 'Complex', link: '/number-systems/complex/' },

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -63,6 +63,7 @@ const FILE_MAP = {
   'number-systems/dd_cascade.md': 'number-systems/dd-cascade.md',
   'number-systems/td_cascade.md': 'number-systems/td-cascade.md',
   'number-systems/qd_cascade.md': 'number-systems/qd-cascade.md',
+  'number-systems/elreal.md': 'number-systems/elreal.md',
   'number-systems/complex.md': 'number-systems/complex.md',
 
   // ── ucalc ──────────────────────────────────────────────────────
@@ -92,6 +93,7 @@ const FILE_MAP = {
   // GitHub directory view only.)
   'algorithmic-details/lns-log-add-sub.md': 'algorithmic-details/lns-log-add-sub.md',
   'algorithmic-details/multi-component-arithmetic.md': 'algorithmic-details/multi-component-arithmetic.md',
+  'algorithmic-details/lazy-real-arithmetic.md': 'algorithmic-details/lazy-real-arithmetic.md',
 
   // ── Design ─────────────────────────────────────────────────────
   'multi-limb-arithmetic.md': 'design/multi-limb.md',

--- a/docs/algorithmic-details/lazy-real-arithmetic.md
+++ b/docs/algorithmic-details/lazy-real-arithmetic.md
@@ -1,0 +1,365 @@
+# Lazy real arithmetic: the `elreal` algorithm
+
+A deep dive into the algorithmic design of Universal's `elreal` type. This
+document is the companion to `docs/number-systems/elreal.md` (the API
+reference) and `docs/algorithmic-details/multi-component-arithmetic.md`
+(the broader multi-component context).
+
+For the original treatment of the algorithm, see Ryan McCleeary's
+dissertation:
+
+> McCleeary, R. (2019). *Lazy Exact Real Arithmetic Using Floating Point
+> Operations*. PhD dissertation, University of Iowa.
+
+## 1. The problem: undecidable equality in finite precision
+
+Every fixed-precision real-number type -- IEEE `double`, `dd`, `qd`,
+`ereal<N>` -- commits to a working precision at type-instantiation time.
+That commitment is the source of three persistent pain points:
+
+- **Geometric predicates** in mesh generation need a definite sign for any
+  configuration of points, including near-degenerate ones. Fixed precision
+  cannot resolve `orient2d(a, b, c)` when the three points are barely
+  collinear; the determinant evaluates to a value smaller than the working
+  precision's smallest representable difference.
+- **Comparison in symbolic systems.** If `a` and `b` are computed by
+  different algebraic paths but represent the same mathematical real, a
+  fixed-precision comparison may report either equality or inequality
+  depending on accumulated roundoff. A correct answer requires arbitrary
+  precision *on demand*.
+- **Iterative refinement.** In numerical linear algebra, the residual of a
+  computed solution is needed at higher precision than the solution itself.
+  Fixed-precision residuals saturate at the working precision and stop
+  improving the answer.
+
+`elreal` addresses all three by *not committing* to a precision upfront.
+A real value is represented as a stream that the caller can pull from
+arbitrarily deep -- or, in practice, until a per-call refinement budget is
+exhausted.
+
+## 2. The representation
+
+Each `elreal` value carries:
+
+- A vector of materialised components `c_0, c_1, ..., c_{N-1}`, each an
+  IEEE-754 `double`, satisfying the Shewchuk **non-overlapping property**
+  `|c_{i+1}| <= ulp(c_i) / 2`.
+- A *generator* function that, given an index `k >= N`, produces the next
+  component `c_k`. The generator embodies the operation that produced this
+  `elreal` (e.g., the rational `p/q` to be expanded, or the `exp` of an
+  operand).
+
+The mathematical value of the `elreal` is the sum
+`c_0 + c_1 + c_2 + ...`, taken over as many components as the caller
+chooses to materialise.
+
+```text
+                  generator (closure capturing operands)
+                       |
+                       v
+   _components: [c_0, c_1, c_2, ...]
+   _computed_depth: N                   <- water mark for materialised limbs
+```
+
+The non-overlapping property guarantees that `|sum(c_i for i >= N)|` is
+bounded by the magnitude of the *next* unmaterialised component, which is
+in turn bounded by `ulp(c_{N-1})`. This is what makes sign determination
+tractable: once a non-zero component is found, the tail cannot flip the
+sign.
+
+## 3. The refinement protocol
+
+Two entry points:
+
+```cpp
+double at(std::size_t k) const;             // primitive
+void   refine_to(std::size_t bits) const;   // wrapper
+```
+
+`at(k)` walks the generator: if `k >= computed_depth`, the generator is
+called for each successive index until the depth reaches `k`, with each
+produced component appended to `_components`. Once materialised, components
+are cached. `at(k)` for `k < computed_depth` is an O(1) lookup.
+
+`refine_to(bits)` is the user-facing variant: it computes the number of
+~53-bit components needed for the requested precision and calls `at` for
+the deepest required index, materialising the entire prefix.
+
+Both methods are `const` and use `mutable` storage for the materialised
+components -- the *logical* value of the `elreal` does not change with
+refinement; only the *representation precision* deepens.
+
+### `operator double()` is intentionally not a refinement step
+
+`operator double()` returns the sum of *currently-materialised* components.
+It does **not** invoke the generator. The user must explicitly call `at(k)`
+or `refine_to` to spend a refinement step.
+
+This split matters: in tight code (e.g., a comparison sweep over an array)
+the caller wants the cheap "best estimate at current depth" path. Refinement
+is a deliberate cost the caller opts into.
+
+## 4. Sign determination (Phase D)
+
+Comparison is the signature operation of any exact-real type. McCleeary's
+dissertation section 4.2 gives the correctness theorem in the
+non-overlapping-expansion setting:
+
+> For a normalized `elreal` with components `c_0, c_1, ..., c_{N-1}`
+> satisfying `|c_{i+1}| <= ulp(c_i)/2` and decreasing in magnitude, the
+> sign of the true value equals the sign of the first non-zero component.
+
+The proof is straightforward: each subsequent component is at most half a
+ULP of the previous, so their *sum* is bounded by `|c_k|` for any `k`
+where `c_k != 0`. The tail therefore cannot flip the sign of the prefix.
+
+The algorithm:
+
+```cpp
+int sign(const elreal& v, std::size_t budget = elreal_default_budget) {
+    if (v.isnan()) return 0;
+    if (v.isinf()) return v.isneg() ? -1 : +1;
+    for (std::size_t k = 0; k < budget; ++k) {
+        double c = v.at(k);
+        if (c > 0.0) return +1;
+        if (c < 0.0) return -1;
+    }
+    return 0;   // exhausted budget; treat as zero within precision
+}
+```
+
+Two cases drive the budget choice:
+
+- **General position.** The first non-zero component is `c_0`; the sign
+  resolves in one step. Cheap.
+- **Cancellation.** A subtraction like `a - b` for `a ~= b` produces an
+  elreal whose `c_0` is exactly zero (the EFT residual of `a.at(0) - b.at(0)`
+  vanishes by construction). Sign determination proceeds to `c_1`, which
+  carries the operand depth-1 contributions. If those also cancel, the
+  algorithm continues until the first non-zero component is found or the
+  budget is exhausted.
+
+The budget defaults to 8 components (~424 bits cumulative). Callers that
+need more pass a larger value: `sign(v, 32)`. The budget is per-call --
+no global state.
+
+## 5. The refinement-budget contract for `==`
+
+Equality is the algorithmically *undecidable* case. Given two `elreal`
+values that are mathematically equal (by some path that built them
+differently), the comparison must walk arbitrarily deep before declaring
+agreement -- and in finite precision, "arbitrarily deep" must be a number.
+
+`elreal`'s contract:
+
+- `a == b` iff `compare(a, b, default_budget) == 0`. That is,
+  *indistinguishable within the budget*.
+- The user can tighten the budget per call.
+- Mathematically-distinct values whose first divergent component lies *past*
+  the budget will be reported as equal. That is a known limitation, not a
+  bug, and is the inevitable consequence of requiring finite-cost
+  comparison.
+
+This matches the standard contract for IEEE-754 floating-point: equality
+is approximate. `elreal` simply makes the precision *explicit* and
+*per-call* rather than implicit and global.
+
+## 6. Refinement depth in arithmetic operators (Phase C)
+
+Each ring operation `(+, -, *, /)` produces a new `elreal` whose generator
+captures the operand streams by value. The depth-1 corrections use the
+existing EFT primitives in `include/sw/universal/numerics/error_free_ops.hpp`:
+
+| Op | depth-0 | depth-1 generator |
+|---|---|---|
+| `a + b` | `two_sum(a0, b0)` leading | `sum_err + a.at(1) + b.at(1)` |
+| `a - b` | `two_diff(a0, b0)` leading | `diff_err + a.at(1) - b.at(1)` |
+| `a * b` | `two_prod(a0, b0)` leading | `prod_err + a0*b.at(1) + a.at(1)*b0` |
+| `a / b` | `a0 / b0` | 0.0 (Newton refinement deferred) |
+
+The non-overlapping property is preserved by construction -- the EFT
+residual is bounded by `ulp(leading) / 2`, and the operand depth-1 terms
+are themselves bounded by `ulp(operand_0)`.
+
+Depth 2+ for arithmetic is deferred to a follow-up; the issue is that the
+operator generators capture only the operand depth-0/1 components and don't
+propagate to depth 2 without lazy division. Newton iteration would provide
+this for `/` and `sqrt`; lazy-pi pull would provide it for `sin/cos/tan`.
+
+## 7. Math functions: derivative-based depth-1 correction (Phase E)
+
+Math functions follow a uniform pattern:
+
+```text
+result.at(0) = std::f(a.at(0))        // depth-0 = std lib correctly rounded
+result.at(1) = f'(a.at(0)) * a.at(1)  // depth-1 = derivative * operand correction
+result.at(k>=2) = 0                   // deferred
+```
+
+The first-order Taylor expansion: `f(x_0 + x_1 + ...) ~= f(x_0) + f'(x_0) * (x_1 + ...)`,
+truncated to depth 1.
+
+This works for any function whose derivative is closed-form:
+
+| Family | Function | Derivative |
+|---|---|---|
+| Roots | `sqrt(x)` | `1 / (2 sqrt(x))` -- EFT residual trick avoids lazy `/` |
+| Exp | `exp(x)` | `exp(x)` |
+| Exp | `exp2(x)` | `exp2(x) * ln(2)` |
+| Exp | `expm1(x)` | `exp(x)` = `expm1(x) + 1` |
+| Log | `log(x)` | `1 / x` |
+| Log | `log2(x)` | `1 / (x * ln(2))` |
+| Log | `log10(x)` | `1 / (x * ln(10))` |
+| Log | `log1p(x)` | `1 / (1 + x)` |
+| Pow | `pow(a, b)` | partials `b * a^(b-1)` and `a^b * log(a)` |
+| Hyperbolic | `sinh / cosh / tanh` | `cosh / sinh / sech^2` |
+| Inv hyperbolic | `asinh / acosh / atanh` | `1/sqrt(1+x^2)`, `1/sqrt(x^2-1)`, `1/(1-x^2)` |
+| Inv trig | `asin / acos / atan / atan2` | `±1/sqrt(1-x^2)`, `1/(1+x^2)`, ... |
+| Trig | `sin / cos / tan` | `cos / -sin / sec^2` |
+
+For inputs that are themselves rationals (e.g., `exp(elreal(1, 3))`), the
+operand carries a non-zero depth-1 component and the derivative correction
+delivers meaningful refinement past the std library's depth-0 result. For
+inputs constructed from a single `double`, the operand depth-1 is zero and
+the derivative correction collapses -- the result is just `std::f(double)`.
+
+This is why `sin(elreal_pi())` is observably closer to true zero than
+`std::sin(M_PI)`: the multi-component `elreal_pi` has a non-zero depth-1
+component carrying the bits past M_PI's 53-bit representation, and the
+derivative `cos(M_PI) * pi.at(1)` cancels the std::sin rounding error.
+
+## 8. The forward-trig limitation (Payne-Hanek)
+
+`sin / cos / tan` for large-magnitude arguments require *exact range
+reduction* modulo `2*pi`. The standard library reduces using
+IEEE-754 `M_PI` (53 bits); for `|x|` near `2^53`, the reduced argument has
+no precision left.
+
+McCleeary 2019 / Payne-Hanek 1983 solve this by performing the reduction
+with arbitrarily many bits of pi pulled from `elreal_pi`'s stream:
+
+```text
+1. Compute k = round(x / (pi/2))                 // integer multiple
+2. Reduce r = x - k * (pi/2) using exact lazy arithmetic
+3. Dispatch on k mod 4 -> sin(r) or cos(r) on the reduced argument
+4. Evaluate sin(r) / cos(r) via Taylor on the reduced argument
+```
+
+The Phase E.6 implementation does **not** ship this path -- it uses
+`std::sin/cos/tan` for depth 0 and a derivative correction for depth 1.
+Faithful results require `|x|` within "reasonable magnitude" (roughly
+`|x| < 2^25`); past that, the result is faithful in the IEEE-754 sense (it
+matches `std::sin`) but loses precision as `|x|` grows.
+
+Full Payne-Hanek with lazy pi-pull is a follow-up to Phase E.6 of the
+elreal epic (#873). When it lands:
+
+- `elreal_pi` extends past the current 4-component static expansion (BBP
+  bit-extraction or a generator-based variant of `from_expansion`).
+- An integer-mod-pi reduction loop pulls more bits of pi until
+  `|r| < ulp(x)`.
+- Taylor or Chebyshev evaluation of sin/cos on the reduced argument provides
+  the lazy refinement.
+
+## 9. Geometric predicates as the killer app
+
+The orient2d / orient3d / incircle / insphere predicates are determinants
+of small matrices, evaluated with the operand coordinates. Each predicate
+reduces to a sign query, which goes through Phase D's `sign(...)`.
+
+```cpp
+elreal orient2d(Point2D<elreal> a, Point2D<elreal> b, Point2D<elreal> c) {
+    elreal acx = a.x - c.x;
+    elreal acy = a.y - c.y;
+    elreal bcx = b.x - c.x;
+    elreal bcy = b.y - c.y;
+    return acx * bcy - acy * bcx;
+}
+```
+
+The caller asks `sign(orient2d(a, b, c), budget)` to get +1 / 0 / -1.
+
+For **general-position inputs**, the determinant's depth-0 is decisive and
+the predicate resolves in O(1) double-precision work. For
+**near-degenerate inputs**, the depth-0 is small (relative to its expected
+magnitude given non-degenerate inputs) and the sign-determination walk
+proceeds to depth 1, 2, ... until either a non-zero component is found or
+the budget is exhausted. **Exactly-degenerate** inputs (collinear,
+coplanar, cocircular, cospherical) with integer-valued coordinates produce
+a stream where every materialised component is exactly zero; the predicate
+correctly returns 0.
+
+This is the canonical Shewchuk vs McCleeary distinction. Shewchuk's
+expansion arithmetic eagerly builds the full expansion needed to resolve
+the sign exactly; McCleeary's lazy refinement does only as much work as
+the current input demands.
+
+`docs/algorithmic-details/multi-component-arithmetic.md` section 9 has the
+full ereal-vs-elreal comparison.
+
+## 10. The validation-oracle role (Phase G)
+
+`elreal` doubles as a *cross-implementation oracle* for validating other
+multi-component types: `dd`, `qd`, `dd_cascade`, `td_cascade`, `qd_cascade`,
+`ereal<N>`.
+
+The helper at
+`include/sw/universal/verification/test_suite_elreal_oracle.hpp` takes a
+target-type value and an `elreal` reference computed via an entirely
+independent code path, and asserts agreement within the target's
+`numeric_limits::digits10` precision. Cross-implementation agreement is a
+non-trivial bug signal even at matched precision -- before this pipeline,
+the only references available for multi-component math-function tests
+were `std::cmath`, which is a self-check (the multi-component
+implementations themselves typically use std lib as the depth-0 building
+block).
+
+Today's ceiling is double precision (capped by elreal's depth-1 in
+arithmetic and math). When deeper refinement lands, the oracle's
+precision improves transparently -- the helper's API surface does not
+change.
+
+See `multi-component-arithmetic.md` section 8.6 for the broader
+validation-strategy context.
+
+## 11. Implementation in Universal: a phase-by-phase summary
+
+The `elreal` type was built up across nine PRs (epic #873):
+
+| Phase | Issue | Delivered |
+|---|---|---|
+| A | #874 | type skeleton, `at(k)` / `refine_to` protocol, exceptions, traits |
+| B | #875 | construction from `double`, integers, rationals, decimal/scientific strings |
+| C | #876 | arithmetic operators with depth-1 EFT refinement |
+| D | #877 | sign / compare / ordering with per-call refinement budget |
+| E.1-E.6 | #887-#892 | math constants, sqrt/hypot, exp/log/pow, hyperbolic, inverse trig, forward trig |
+| F | #879 | geometric predicates (orient2d/3d, incircle, insphere) |
+| G | #880 | validation-oracle helper for other multi-component types |
+
+Each phase added a focused capability layer on top of the previous. The
+foundation (Phase A) -- the storage representation and the refinement
+protocol -- is what makes every subsequent phase work without ad-hoc
+restructuring.
+
+## References
+
+- McCleeary, R. (2019). *Lazy Exact Real Arithmetic Using Floating Point
+  Operations*. PhD dissertation, University of Iowa.
+  <https://iro.uiowa.edu/esploro/outputs/doctoral/Lazy-exact-real-arithmetic-using-floating/9983776998202771>
+- Shewchuk, J. R. (1997). "Adaptive Precision Floating-Point Arithmetic and
+  Fast Robust Geometric Predicates." *Discrete & Computational Geometry*
+  18(3), 305-363.
+- Payne, M. and Hanek, R. (1983). "Radian Reduction for Trigonometric
+  Functions." *SIGNUM Newsletter*, 18(1), 19-24.
+- Priest, D. M. (1991). *On Properties of Floating Point Arithmetics:
+  Numerical Stability and the Cost of Accurate Computations*. PhD
+  dissertation, UC Berkeley.
+
+## See also
+
+- `docs/number-systems/elreal.md` -- user-facing API reference
+- `docs/algorithmic-details/multi-component-arithmetic.md` -- the broader
+  Priest / Bailey-Hida / Shewchuk / McCleeary landscape and validation
+  strategies
+- `include/sw/universal/number/elreal/elreal_impl.hpp` -- the implementation,
+  with substantial inline documentation

--- a/docs/algorithmic-details/multi-component-arithmetic.md
+++ b/docs/algorithmic-details/multi-component-arithmetic.md
@@ -1,8 +1,8 @@
 # Multi-component floating-point arithmetic
 
-Three foundational threads of multi-component arithmetic underpin Universal's
-extended-precision types (`dd`, `td`, `qd`, the `*_cascade` family, and the
-adaptive `priest` / `ereal` types):
+Four foundational threads of multi-component arithmetic underpin Universal's
+extended-precision types (`dd`, `td`, `qd`, the `*_cascade` family, the
+adaptive `ereal`, and the lazy `elreal`):
 
 1. **Douglas Priest (1991)** -- theoretical foundations and the error-free
    transformations (EFTs) that make exact floating-point arithmetic possible.
@@ -10,11 +10,13 @@ adaptive `priest` / `ereal` types):
    implementations: the QD library, double-double and quad-double.
 3. **Jonathan Shewchuk (1996-1997)** -- adaptive-precision expansions for
    robust geometric predicates.
+4. **Ryan McCleeary (2019)** -- lazy exact real arithmetic with
+   precision-on-demand refinement.
 
 This document is the educational companion to the implementation files. It
 explains *what each thread contributes*, *what mathematics they share*, and
-*how Universal's FloatCascade<N> building block unifies them*. Strict ASCII;
-algorithms in standard imperative form.
+*how Universal's floatcascade<N> building block + lazy-stream elreal cover
+the precision-engineering space*.
 
 Related implementation reading:
 
@@ -22,6 +24,9 @@ Related implementation reading:
 - `include/sw/universal/number/dd/dd_impl.hpp` -- double-double (Bailey/Hida)
 - `include/sw/universal/number/qd/qd_impl.hpp` -- quad-double (Hida/Li/Bailey)
 - `include/sw/universal/number/ereal/` -- adaptive multi-component real
+- `include/sw/universal/number/elreal/` -- lazy exact real (McCleeary)
+- `docs/algorithmic-details/lazy-real-arithmetic.md` -- elreal algorithm
+  deep-dive
 - `docs/multi-component/comparison-priest-bailey-shewchuk.md` -- earlier
   reference document this one supersedes
 
@@ -571,30 +576,31 @@ unification):
 
 ## 6. Comparison summary
 
-| Aspect                    | Priest (theory)       | Bailey/Hida (`dd`, `qd`)            | Shewchuk (adaptive `ereal`)   |
-|---------------------------|------------------------|-------------------------------------|-------------------------------|
-| Precision                 | Variable (conceptual) | Fixed (2 or 4 components)            | Dynamic (grows as needed)     |
-| Primitives                | Defined the EFTs       | Uses EFTs in fixed hand-crafted patterns | Uses EFTs with expansion growth |
-| Storage                   | Theoretical            | `std::array<double, N>`              | `std::vector<double>`         |
-| Per-op cost               | N/A                    | Constant time, small constant         | Variable, common case fast    |
-| Per-op storage            | N/A                    | Constant                              | Grows with input separation   |
-| Determinism               | N/A                    | Constant time and space               | Variable time and space       |
-| Vectorization             | N/A                    | SIMD-friendly                         | Hard to vectorize            |
-| Cache locality            | N/A                    | 16-32 bytes per value                 | Variable, may exceed L1       |
-| Use case                  | Academic foundation    | HPC, physics, ML mixed-precision      | Computational geometry, CAD/CAM |
-| Worst-case timing         | N/A                    | Same as common case                   | 2-3.5x common case            |
-| Error control             | Proven bounds          | Pre-set precision                     | Adaptive until bound met      |
-| Universal type            | -                      | `dd`, `qd`, `dd_cascade`, `td_cascade`, `qd_cascade`  | `ereal`                |
+| Aspect                    | Priest (theory)       | Bailey/Hida (`dd`, `qd`)            | Shewchuk (adaptive `ereal`)     | McCleeary (lazy `elreal`)            |
+|---------------------------|------------------------|-------------------------------------|---------------------------------|--------------------------------------|
+| Precision                 | Variable (conceptual) | Fixed (2 or 4 components)            | Dynamic (grows as needed)       | Lazy on demand (per-call refinement) |
+| Primitives                | Defined the EFTs       | Uses EFTs in fixed hand-crafted patterns | Uses EFTs with expansion growth | Uses EFTs in a generator-driven stream |
+| Storage                   | Theoretical            | `std::array<double, N>`              | `std::vector<double>`            | `std::vector<double>` + generator    |
+| Per-op cost               | N/A                    | Constant time, small constant         | Variable, common case fast      | Common case is depth-0 (cheap)        |
+| Per-op storage            | N/A                    | Constant                              | Grows with input separation     | Grows with refinement depth          |
+| Determinism               | N/A                    | Constant time and space               | Variable time and space         | Bounded by refinement budget         |
+| Vectorization             | N/A                    | SIMD-friendly                         | Hard to vectorize               | Hard to vectorize                    |
+| Cache locality            | N/A                    | 16-32 bytes per value                 | Variable, may exceed L1         | Variable, grows with depth           |
+| Use case                  | Academic foundation    | HPC, physics, ML mixed-precision      | Computational geometry, CAD/CAM | Geometric predicates, undecidable comparison, validation oracle |
+| Worst-case timing         | N/A                    | Same as common case                   | 2-3.5x common case              | Budget-bounded refinement walk       |
+| Error control             | Proven bounds          | Pre-set precision                     | Adaptive until bound met        | Per-call refinement budget           |
+| Universal type            | -                      | `dd`, `qd`, `dd_cascade`, `td_cascade`, `qd_cascade`  | `ereal`              | `elreal`                              |
 
-The three approaches are complementary, not competing. Priest provided the
+The four approaches are complementary, not competing. Priest provided the
 theoretical foundation. Bailey/Hida productionized it for the
 known-precision case. Shewchuk extended it to the variable-precision case.
-Universal ships both productionized variants of Bailey/Hida (the original
-hand-crafted `dd`/`qd` and the cascade-based `dd_cascade`/`td_cascade`/
-`qd_cascade` rewrite) and the Shewchuk-adaptive `ereal`. A fully adaptive
-`priest` class is sketched in
-`include/sw/universal/internal/variablecascade/priest_adaptive_design.txt`
-as a future direction but is not implemented today.
+McCleeary added the lazy paradigm for the precision-on-demand case.
+Universal ships all four:
+
+- Bailey/Hida via the original hand-crafted `dd`/`qd` and the
+  cascade-based `dd_cascade`/`td_cascade`/`qd_cascade` rewrite
+- Shewchuk via `ereal<maxlimbs>`
+- McCleeary via `elreal` (epic #873, A-G shipped)
 
 ## 7. Picking a type
 
@@ -606,17 +612,26 @@ Use the following decision tree:
 | needs ~212 bits of significand, knows it upfront                     | `qd` (Hida/Li/Bailey)|
 | same precision targets via the unified cascade framework             | `dd_cascade`, `td_cascade`, `qd_cascade` |
 | needs ~159 bits (triple-double)                                      | `td_cascade`         |
-| has computational-geometry predicates where input separation varies  | `ereal`              |
-| needs adaptive precision up to ~303 decimal digits                   | `ereal<19>`          |
+| has computational-geometry predicates where input separation varies  | `elreal` (cheap common case) or `ereal` (eager expansion) |
+| needs adaptive precision up to ~303 decimal digits, committed upfront | `ereal<19>`         |
+| needs precision-on-demand with budget-bounded comparison              | `elreal`             |
+| validating another type's math function via cross-implementation oracle | `elreal` via `check_against_elreal_oracle` |
 
 For the typical numerical-analysis workload (HPC, ML training, physics
-simulation) the answer is `dd` or `qd`. For computational-geometry and
-formal-verification work the answer is `ereal`.
+simulation) the answer is `dd` or `qd`. For computational-geometry work
+the choice between `ereal` and `elreal` depends on whether the inputs
+are typically general-position (then `elreal`'s depth-0 fast path wins)
+or adversarially near-degenerate (then `ereal`'s eager expansion wins;
+the cost is paid every call but is bounded by the type's `maxlimbs`).
+For undecidable comparison (e.g. symbolic-system reals constructed via
+different algebraic paths), `elreal`'s budgeted comparison is the
+right tool.
 
 Note: Universal does not currently provide implicit conversion between
-`dd`, the cascade types, and `ereal`. Users that need to switch tiers do
-so by going through `double` (e.g. `dd d = double(e);`) -- which is
-lossy at the conversion point but unavoidable given the current API.
+`dd`, the cascade types, `ereal`, and `elreal`. Users that need to
+switch tiers do so by going through `double` (e.g. `dd d = double(e);`)
+-- which is lossy at the conversion point but unavoidable given the
+current API.
 
 ## 8. Validation strategy
 

--- a/docs/multi-component/README.md
+++ b/docs/multi-component/README.md
@@ -79,17 +79,16 @@ The following papers are foundational to multi-component arithmetic. Download th
    - Stream-based representation with on-demand precision
    - Deferred computation until results actually needed
    - Infinite precision capability with finite resources
-   - **Universal's planned elrealo (Exact Lazy Real Oracle) implementation extends Priest/Bailey/Shewchuk**
+   - **Universal's `elreal` implementation (epic #873, shipped) extends Priest/Bailey/Shewchuk**
 
 ### Universal Library Implementation Status
 
 - ✅ **dd (double-double)**: Complete, production-ready (Bailey/Hida approach)
 - ✅ **qd (quad-double)**: Complete, production-ready (Bailey/Hida approach)
-- 🟡 **td (triple-double)**: Header structure exists, arithmetic incomplete (Bailey/Hida approach)
-- ❌ **priest (adaptive eager)**: Design complete, implementation not started (Shewchuk approach)
-- ❌ **elrealo (Exact Lazy Real Oracle)**: Design complete, implementation not started (McCleeary approach)
-  - Oracle type for mixed-precision SDK numerical assessments
-  - Provides exact real evaluations on-demand
+- ✅ **dd_cascade / td_cascade / qd_cascade**: Cascade-based rewrite of Bailey/Hida (shipped via the `floatcascade<N>` template)
+- ✅ **ereal**: Adaptive multi-component (Shewchuk approach), `ereal<maxlimbs>` up to 19 limbs
+- ✅ **elreal**: Lazy exact real arithmetic (McCleeary approach), shipped via epic #873 phases A-G; see `../number-systems/elreal.md` and `../algorithmic-details/lazy-real-arithmetic.md`
+- ❌ **priest (adaptive eager)**: Design sketch only; see `include/sw/universal/internal/variablecascade/priest_adaptive_design.txt`
 
 See `comparison-priest-bailey-shewchuk.md` for detailed comparison.
 

--- a/docs/multi-component/exact-lazy-arithmetic.md
+++ b/docs/multi-component/exact-lazy-arithmetic.md
@@ -1,1034 +1,225 @@
-# Exact Lazy Arithmetic: Theory and Implementation in Universal
+# Exact Lazy Arithmetic in Universal
 
-## Overview
+This document is the design narrative for **lazy exact real arithmetic** as
+implemented by Universal's `elreal` type. The type ships as the
+McCleeary-paradigm tier in Universal's multi-component arithmetic family,
+complementing the Priest-foundation EFTs, the Bailey/Hida fixed-precision
+`dd`/`qd`, and the Shewchuk-style adaptive `ereal<N>`.
 
-This document describes **Exact Lazy Arithmetic** as developed by Ryan McCleeary (University of Iowa, 2019) and outlines its implementation in the Universal Numbers Library as `elrealo` (Exact Lazy Real Oracle) - an extension of the Priest/Bailey/Shewchuk multi-component arithmetic framework.
+For the shipped API, see:
 
-The `elrealo` type serves as Universal's **Oracle type** for resolving numerical questions around precision in the mixed-precision SDK, providing exact real assessments on-demand.
+- `docs/number-systems/elreal.md` -- user-facing API reference
+- `docs/algorithmic-details/lazy-real-arithmetic.md` -- algorithmic deep-dive
+  (lazy-stream representation, refinement protocol, sign-determination
+  proof, per-phase delivery)
+- `docs/algorithmic-details/multi-component-arithmetic.md` -- broader
+  Priest/Bailey-Hida/Shewchuk/McCleeary landscape
+
+This document focuses on **why lazy** rather than **how lazy is
+implemented**.
 
 ---
 
-## 1. Ryan McCleeary's Exact Lazy Real Arithmetic
+## 1. The Ryan McCleeary contribution
 
-### Dissertation
-
-**Title**: "Lazy Exact Real Arithmetic Using Floating Point Operations"
+**Dissertation**: "Lazy Exact Real Arithmetic Using Floating Point Operations"
 **Author**: Ryan McCleeary
 **Institution**: University of Iowa
 **Year**: 2019
-**Available at**: https://ir.uiowa.edu/etd/6991/
+**URL**: <https://iro.uiowa.edu/esploro/outputs/doctoral/Lazy-exact-real-arithmetic-using-floating/9983776998202771>
 
-### Abstract and Key Concepts
+McCleeary's dissertation argues that lazy exact real arithmetic over
+floating-point primitives is a practical foundation for problems where
+fixed-precision arithmetic cannot give a definite answer. The three core
+ideas:
 
-McCleeary's dissertation proposes a novel exact real arithmetic system with the following characteristics:
+1. **Stream representation.** A real number is represented as a sequence
+   of progressively refined floating-point approximations -- conceptually
+   infinite, materialised only as deep as the caller asks.
+2. **Hardware-leveraged.** Each stream element is an IEEE-754 `double`.
+   The lazy machinery is pure C++; no extended-precision hardware required.
+3. **Decidable sign with bounded budget.** Comparison of two lazy reals
+   walks the streams in lockstep until a non-zero difference is found.
+   The Shewchuk non-overlapping property bounds the work per refinement
+   step; a per-call budget bounds the worst case.
 
-1. **Representation**: Real numbers are represented as **lazy lists of floating-point numbers**
-2. **Hardware Support**: Algorithms leverage modern floating-point hardware operations
-3. **Exactness**: Despite using floating-point primitives, the system provides exact arithmetic
-4. **Laziness**: Computation is deferred until results are actually needed
-5. **Correctness**: Formal proofs of algorithm correctness are provided
+The fourth idea -- correctness proofs for the core operations under finite
+precision -- is what distinguishes McCleeary's treatment from earlier
+lazy-real implementations. The dissertation provides formal arguments that
+the operations remain exact in the limit of unbounded refinement.
 
-### Motivation
+---
 
-Traditional exact real arithmetic systems face several challenges:
+## 2. Why lazy
 
-- **Symbolic systems** (e.g., computer algebra) are exact but often prohibitively slow
-- **Fixed-precision arithmetic** (e.g., Bailey's dd/qd) is fast but may lack sufficient precision
-- **Adaptive precision** (e.g., Shewchuk) is flexible but requires upfront error analysis
+Traditional exact real arithmetic systems face one of three pain points:
 
-**Lazy exact arithmetic** provides a different paradigm:
-- Computation proceeds **on-demand** - only as much precision as needed
-- Results are **guaranteed exact** - no rounding errors accumulate
-- **Stream-based** evaluation - precision can grow indefinitely
-- **Hardware-accelerated** - uses native floating-point operations as building blocks
+- **Symbolic systems** (e.g. computer algebra over rationals) are
+  mathematically exact but often prohibitively slow for analytic
+  computation.
+- **Fixed-precision arithmetic** (`double`, `dd`, `qd`) is fast but limited
+  to its committed precision. For ill-conditioned problems, the precision
+  budget is fixed at compile time.
+- **Adaptive precision** (Shewchuk's expansions, Universal's `ereal<N>`) is
+  flexible but requires upfront error analysis. The user must know how many
+  components might be needed before instantiating the type.
 
-### Applications
+Lazy exact arithmetic adds a fourth option:
+
+- **Computation proceeds on-demand** -- only as much precision as needed
+  for the *current call*.
+- **Results are exact within the refinement budget** -- no rounding errors
+  accumulate.
+- **Stream-based evaluation** -- precision can grow per-call without
+  committing to a worst-case budget at type-declaration time.
+- **Hardware-accelerated** -- uses native floating-point operations as
+  the building block.
+
+For exact-real workloads in which the *common case* is general-position
+inputs that resolve quickly, the lazy paradigm wins on cost: the common
+case is depth-0 work, with refinement spent only on the inputs that
+actually need it.
+
+---
+
+## 3. Applications
 
 Exact real arithmetic is critical for:
 
 1. **Computational Geometry**
-   - Robust geometric predicates
-   - Mesh generation
-   - CAD/CAM systems
+   - Robust geometric predicates (orient, incircle, insphere)
+   - Mesh generation and CAD/CAM systems
+   - Delaunay triangulation that does not loop on near-degenerate inputs
 
-2. **Scientific Computing**
-   - Differential equation solvers
-   - Linear equation solvers
-   - Large-scale mathematical models
+2. **Symbolic Computation**
+   - Deciding equality of reals constructed via different algebraic paths
+   - Termination guarantees in computer-algebra systems
 
-3. **Formal Verification**
-   - SMT (Satisfiability Modulo Theories) solvers
-   - Theorem provers
-   - Certified computation
+3. **Numerical Analysis with Correctness Targets**
+   - Iterative refinement with on-demand residual precision
+   - Verified numerical computation (interval arithmetic outer bound +
+     elreal refinement inner bound)
 
-4. **Numerical Analysis**
-   - Rigorous interval arithmetic
-   - Verified computing
-   - Error-free transformations
+4. **Cross-Implementation Validation**
+   - Validating that a multi-component arithmetic implementation
+     (`dd`, `qd`, `dd_cascade`, etc.) matches an independent reference
+     -- catching the class of bugs a self-comparison cannot
 
----
-
-## 2. Lazy Evaluation: Conceptual Framework
-
-### What is Lazy Evaluation?
-
-**Lazy evaluation** is a computation strategy where:
-- Expressions are **not evaluated** until their values are needed
-- Intermediate results are **memoized** (cached) for reuse
-- Computation proceeds **incrementally** - one step at a time
-- **Infinite data structures** are possible (conceptually)
-
-### Lazy Lists (Streams)
-
-A **lazy list** or **stream** is a data structure representing a potentially infinite sequence:
-
-```
-x = [x₀, x₁, x₂, x₃, ...]
-```
-
-where:
-- `x₀` is immediately available (the "head")
-- `x₁, x₂, x₃, ...` are computed only when requested (the "tail")
-- The tail itself is a lazy list (recursive structure)
-
-### Lazy Real Number Representation
-
-McCleeary's approach represents a real number `r` as a lazy list of floating-point approximations:
-
-```
-r = [r₀, r₁, r₂, r₃, ...]
-```
-
-where:
-- Each `rᵢ` is a standard IEEE-754 floating-point number
-- `r₀` provides a coarse approximation
-- `r₁, r₂, r₃, ...` provide progressively better approximations
-- The sequence converges to the exact real value
-- Additional terms are computed only when more precision is demanded
-
-### Relationship to Multi-Component Arithmetic
-
-| Approach | Representation | Evaluation | Precision |
-|----------|----------------|------------|-----------|
-| **Bailey (dd/qd)** | Fixed array `[h, l]` | Eager (immediate) | Fixed (2-4 components) |
-| **Shewchuk** | Growing array | Adaptive (demand-driven growth) | Variable (stops when bound met) |
-| **McCleeary (lazy exact)** | Lazy list/stream | Lazy (on-demand, incremental) | Unbounded (infinite stream) |
+The geometric-predicate use case is the canonical one. Shewchuk's 1996
+dissertation argued that exact arithmetic is needed for any geometric
+algorithm that branches on sign; McCleeary's lazy paradigm makes the
+cost of that exactness pay-as-you-go.
 
 ---
 
-## 3. Lazy Exact Arithmetic Algorithms
+## 4. The shipped implementation: `elreal`
 
-### Core Idea: Deferred Computation
+Universal's `elreal` (epic #873, shipped 2026 via PRs #883-#900) is the
+McCleeary-paradigm tier:
 
-Instead of computing the full result immediately, lazy exact arithmetic:
+- **Storage**: `std::vector<double>` of materialised components plus a
+  `std::function<double(std::size_t)>` generator.
+- **Refinement**: `at(k)` and `refine_to(precision_bits)` walk the generator
+  on demand.
+- **Sign determination**: per-call refinement budget (default 8 components,
+  ~424 bits cumulative); `sign(v, budget)` walks the stream to the first
+  non-zero component.
+- **Arithmetic**: depth-1 EFT refinement for `+ - *`; depth-0-only for `/`
+  (Newton refinement is a follow-up).
+- **Math**: depth-1 derivative-based refinement for the full
+  exp/log/pow/hyperbolic/trig family.
+- **Geometric predicates**: `orient2d`, `orient3d`, `incircle`, `insphere`.
+- **Validation oracle**: cross-implementation validation helper for the
+  other multi-component types.
 
-1. **Starts** with a cheap, approximate computation (native floating-point)
-2. **Tests** if the approximation is sufficient for the current need
-3. **Refines** the computation only if more precision is required
-4. **Repeats** steps 2-3 until the desired accuracy is achieved
-
-### Basic Operations
-
-#### Lazy Addition
-
-**Input**: Two lazy lists `a = [a₀, a₁, ...]` and `b = [b₀, b₁, ...]`
-**Output**: Lazy list `c = [c₀, c₁, ...]` where `c = a + b` exactly
-
-**Algorithm**:
-```
-c₀ = a₀ + b₀                    // Initial approximation (native FP)
-
-For i > 0:
-  cᵢ = aᵢ + bᵢ + error(cᵢ₋₁)   // Refine using error-free transformations
-```
-
-**Key insight**: Use Priest's `two_sum` to track errors exactly:
-```cpp
-// Compute c₀ and its error
-double c0, e0;
-c0 = two_sum(a0, b0, e0);
-
-// Stream continues with e0, a1, b1, ...
-```
-
-#### Lazy Multiplication
-
-**Algorithm**:
-```
-c₀ = a₀ × b₀                    // Initial approximation
-
-For i > 0:
-  cᵢ = Σⱼ₊ₖ₌ᵢ (aⱼ × bₖ)         // Cross-products at level i
-  + error propagation from level i-1
-```
-
-Uses Priest's `two_prod` for exact tracking of multiplication errors.
-
-#### Lazy Division
-
-**Algorithm**: Iterative refinement using Newton-Raphson
-```
-q₀ = a₀ / b₀                    // Initial approximation
-
-For i > 0:
-  rᵢ = a - qᵢ × b               // Compute residual
-  δᵢ = rᵢ / b                    // Correction term
-  qᵢ₊₁ = qᵢ + δᵢ                // Refine quotient
-```
-
-Each step uses error-free transformations to track exact errors.
-
-### Lazy Comparison
-
-**Challenge**: Determining `a < b` when both are lazy streams
-
-**Solution**: Compute `d = a - b` lazily until:
-- A term `dᵢ ≠ 0` is found → sign determines ordering
-- Precision bound reached → equality within tolerance
-
-This is why "lazy" is essential for comparisons - we may need arbitrary precision to determine ordering.
-
-### Lazy Predicates
-
-For geometric predicates (Shewchuk's application):
-
-```
-orient2d(p1, p2, p3) = sign(det([x1 y1 1]
-                                 [x2 y2 1]
-                                 [x3 y3 1]))
-```
-
-**Lazy approach**:
-1. Compute determinant with native floating-point
-2. If result is "far from zero" → return sign
-3. Otherwise, refine using exact arithmetic
-4. Continue until sign is definitively determined
+For the full API and per-phase breakdown, see
+`docs/number-systems/elreal.md`.
 
 ---
 
-## 4. Implementation in Universal: Design
+## 5. Comparison with the other multi-component approaches
 
-### Architecture Overview
+| Approach | When it wins | When it loses |
+|---|---|---|
+| **Priest EFTs** | foundation only -- not a user-facing type | n/a |
+| **Bailey/Hida `dd`/`qd`** | hot loops at known precision (106 or 212 bits); SIMD-friendly | adaptive precision; undecidable comparison |
+| **Shewchuk `ereal`** | adaptive precision with a committed upper bound; eager expansion | extreme precision-on-demand; lazy refinement of common cases |
+| **McCleeary `elreal`** | general-position dominates; undecidable comparison; validation oracle | hot loops at committed precision (Bailey/Hida wins on raw speed) |
 
-Universal's implementation extends the Priest/Bailey/Shewchuk foundation:
-
-```
-┌─────────────────────────────────────────────────┐
-│  Priest Error-Free Transformations (EFTs)       │
-│  - two_sum, two_prod, quick_two_sum             │
-└────────────┬────────────────────────────────────┘
-             │
-    ┌────────┴────────┐
-    │                 │
-┌───▼─────────┐  ┌───▼──────────────────────────────────┐
-│ Fixed Types │  │ Adaptive/Lazy Types                  │
-│             │  │                                      │
-│ dd (2)      │  │ priest (dynamic, eager)              │
-│ td (3)      │  │ elrealo (stream, lazy, oracle)       │
-│ qd (4)      │  │                                      │
-└─────────────┘  └──────────────────────────────────────┘
-```
-
-### New Type: `elrealo` (Exact Lazy Real Oracle)
-
-#### Class Structure
-
-```cpp
-namespace sw::universal {
-
-// Configuration for lazy evaluation
-struct LazyConfig {
-    size_t initial_precision = 2;      // Start with dd-equivalent
-    size_t max_precision = 100;        // Maximum components
-    double convergence_threshold = 1e-30;
-    bool auto_refine = true;           // Automatic refinement on demand
-};
-
-// Exact Lazy Real Oracle - stream-based representation
-// Oracle type for exact real numerical assessments
-class elrealo {
-private:
-    // The lazy stream of components
-    mutable std::vector<double> components;  // Memoized computed values
-
-    // Computation closure - how to generate next component
-    mutable std::function<double()> generator;
-
-    // State tracking
-    mutable size_t computed_depth;     // How many components computed
-    mutable bool converged;            // Has computation converged?
-
-    LazyConfig config;
-
-public:
-    // Constructors
-    elrealo();
-    elrealo(double val, const LazyConfig& cfg = {});
-    elrealo(const dd& d, const LazyConfig& cfg = {});
-    elrealo(const priest& p, const LazyConfig& cfg = {});
-
-    // Lazy arithmetic operators
-    elrealo operator+(const elrealo& rhs) const;
-    elrealo operator-(const elrealo& rhs) const;
-    elrealo operator*(const elrealo& rhs) const;
-    elrealo operator/(const elrealo& rhs) const;
-
-    // Lazy comparison - may trigger refinement (Oracle functionality)
-    bool operator<(const elrealo& rhs) const;
-    bool operator==(const elrealo& rhs) const;
-
-    // Force evaluation to specified precision
-    void refine(size_t target_depth);
-    void refine_until_converged();
-
-    // Query current state
-    size_t depth() const { return computed_depth; }
-    bool is_converged() const { return converged; }
-    double estimate() const;  // Sum of computed components
-
-    // Conversion
-    explicit operator double() const;
-    explicit operator dd() const;
-    explicit operator priest() const;
-
-private:
-    // Internal refinement
-    void compute_next_component() const;
-    bool check_convergence() const;
-};
-
-} // namespace sw::universal
-```
-
-#### Key Design Decisions
-
-1. **Mutable State**: The `components` vector and `computed_depth` are mutable because:
-   - Lazy evaluation requires computing values on-demand
-   - This happens even in `const` contexts (e.g., comparison)
-   - The logical value doesn't change, only its representation precision
-
-2. **Generator Function**: The `std::function<double()>` closure:
-   - Captures the operation to perform (add, multiply, etc.)
-   - Generates the next component when called
-   - Enables true lazy evaluation - computation is deferred
-
-3. **Memoization**: Computed components are cached:
-   - Avoid redundant computation
-   - Amortize cost over multiple accesses
-   - Enable efficient reuse in complex expressions
-
-### Integration with Existing Types
-
-#### Conversion from Fixed Types
-
-```cpp
-// Promote dd to elrealo
-elrealo::elrealo(const dd& d, const LazyConfig& cfg)
-    : config(cfg), computed_depth(2), converged(false)
-{
-    components.reserve(cfg.max_precision);
-    components.push_back(d.high());
-    components.push_back(d.low());
-
-    // Generator produces zero (already exact at this precision)
-    generator = []() { return 0.0; };
-}
-```
-
-#### Conversion to Fixed Types
-
-```cpp
-// Extract dd from elrealo (Oracle provides assessment at dd precision)
-elrealo::operator dd() const {
-    // Ensure at least 2 components computed
-    while (computed_depth < 2) {
-        compute_next_component();
-    }
-
-    return dd(components[0], components[1]);
-}
-```
-
-#### Interoperability with `priest`
-
-The `priest` class (adaptive, eager) and `elrealo` (adaptive, lazy, oracle) complement each other:
-
-- **`priest`**: Best when you know you'll need the full precision
-  - Computes all necessary components upfront
-  - Deterministic performance
-  - Suitable for batch computations
-
-- **`elrealo`**: Best when precision needs are uncertain (Oracle role)
-  - Computes incrementally, on-demand
-  - Variable performance (pay-as-you-go)
-  - Suitable for conditional computations, comparisons, precision queries
-  - Acts as Oracle for numerical assessments in mixed-precision algorithms
-
-```cpp
-// Convert between eager and lazy
-priest p = some_computation();
-elrealo oracle(p);  // Now lazy oracle - won't refine until needed
-
-elrealo oracle2 = another_computation();
-priest p2 = priest(oracle2);  // Force full evaluation from oracle
-```
+The four approaches are complementary, not competing. Universal ships all
+four (Bailey/Hida via `dd`, `qd`, and the cascade-based rewrites; Shewchuk
+via `ereal<N>`; McCleeary via `elreal`; with Priest as the shared
+foundation underneath all of them).
 
 ---
 
-## 5. Implementation Details
+## 6. Known limitations of the shipped `elreal`
 
-### Lazy Addition Implementation
+Phase G of the epic completed in 2026. Outstanding work as of that
+milestone:
 
-```cpp
-elrealo elrealo::operator+(const elrealo& rhs) const {
-    elrealo result;
-
-    // Capture operands by value for generator closure
-    auto lhs_copy = *this;
-    auto rhs_copy = rhs;
-
-    // Generator function
-    result.generator = [lhs_copy, rhs_copy, depth = size_t(0)]() mutable {
-        // Ensure operands have enough components
-        while (lhs_copy.computed_depth <= depth) {
-            lhs_copy.compute_next_component();
-        }
-        while (rhs_copy.computed_depth <= depth) {
-            rhs_copy.compute_next_component();
-        }
-
-        // Compute sum at this level using two_sum
-        double a = lhs_copy.components[depth];
-        double b = rhs_copy.components[depth];
-        double sum, error;
-        sum = two_sum(a, b, error);
-
-        // Store error for next level
-        // (Implementation detail: error propagation)
-
-        ++depth;
-        return sum;
-    };
-
-    // Compute initial component eagerly
-    result.compute_next_component();
-
-    return result;
-}
-```
-
-### Lazy Comparison Implementation (Oracle Functionality)
-
-```cpp
-bool elrealo::operator<(const elrealo& rhs) const {
-    // Compute difference lazily (Oracle assesses sign)
-    elrealo diff = *this - rhs;
-
-    // Refine until sign is determined
-    while (diff.computed_depth < config.max_precision) {
-        double estimate = diff.estimate();
-
-        // Check if far enough from zero to determine sign
-        double magnitude = std::abs(estimate);
-        double uncertainty = std::ldexp(1.0, -(53 * diff.computed_depth));
-
-        if (magnitude > uncertainty) {
-            // Sign is definitive
-            return estimate < 0.0;
-        }
-
-        // Need more precision
-        diff.compute_next_component();
-    }
-
-    // Reached max precision - treat as equal
-    return false;
-}
-```
-
-### Refinement Strategy
-
-```cpp
-void elrealo::compute_next_component() const {
-    if (converged || computed_depth >= config.max_precision) {
-        return;
-    }
-
-    // Generate next component
-    double next = generator();
-    components.push_back(next);
-    ++computed_depth;
-
-    // Check convergence
-    if (check_convergence()) {
-        converged = true;
-    }
-}
-
-bool elrealo::check_convergence() const {
-    if (computed_depth < 2) return false;
-
-    // Get last component magnitude
-    double last = std::abs(components.back());
-
-    // Get total magnitude
-    double total = std::abs(estimate());
-
-    if (total == 0.0) {
-        return last < config.convergence_threshold;
-    }
-
-    // Relative convergence test
-    return (last / total) < config.convergence_threshold;
-}
-```
+- **Depth-2+ refinement.** Arithmetic operators and math functions refine
+  to depth 1. Deeper refinement requires Newton iteration (for `/` and
+  `sqrt`) or a higher-precision internal algorithm. The lazy-stream
+  infrastructure supports arbitrary depth; only the per-function generators
+  need extending.
+- **Constants stop at 4 components (~212 bits).** `elreal_pi` and friends
+  reuse the precomputed expansions from `qd_constants.hpp`. BBP-style
+  on-demand bit extraction for pi, Taylor truncation for e/ln2 with lazy
+  refinement -- both follow-up work.
+- **Forward trig range reduction.** `sin/cos/tan` use the std library for
+  depth 0; large-magnitude arguments lose precision. Payne-Hanek range
+  reduction with lazy pi-pull is documented in `elreal_impl.hpp` as the
+  path forward.
+- **Oracle precision ceiling.** The validation-oracle helper caps at
+  double precision today (limited by elreal's depth-1). When deeper
+  refinement lands, the oracle's precision improves transparently --
+  the helper's API doesn't change.
 
 ---
 
-## 6. Comparison: Priest/Bailey/Shewchuk vs. Lazy Exact
-
-### Evaluation Strategy
-
-| Approach | When Computed | Precision | Cost Model |
-|----------|---------------|-----------|------------|
-| **Bailey (dd/qd)** | All components immediately | Fixed (2-4) | Constant, predictable |
-| **Shewchuk (adaptive)** | All needed components immediately | Variable (until bound) | Variable, upfront |
-| **Priest (adaptive eager)** | All components immediately | Variable (until bound) | Variable, upfront |
-| **McCleeary (lazy exact)** | One component at a time, on-demand | Variable (infinite stream) | Variable, amortized |
-
-### Use Case Comparison
-
-#### Fixed Precision (dd/qd)
-
-**Best for**:
-- Scientific computing with known precision requirements
-- Inner loops of numerical algorithms
-- Real-time systems requiring predictable performance
-
-**Example**: Iterative PDE solver
-```cpp
-dd x = initial_guess;
-for (int i = 0; i < max_iterations; ++i) {
-    dd residual = compute_residual(x);  // Fast, predictable
-    x = update(x, residual);
-}
-```
-
-#### Adaptive Eager (priest)
-
-**Best for**:
-- Computations where full precision is definitely needed
-- Batch operations on many values
-- When amortizing setup cost over multiple uses
-
-**Example**: High-precision matrix operations
-```cpp
-priest det = compute_determinant(matrix);  // Compute fully
-bool singular = (det == priest(0.0));      // Comparison is cheap
-```
-
-#### Adaptive Exact Lazy Real Oracle (elrealo)
-
-**Best for**:
-- Comparisons and predicates (may not need full precision)
-- Conditional computations (branches avoid unnecessary work)
-- Exploratory computations (unknown precision needs)
-- **Oracle queries** in mixed-precision algorithms
-- Numerical assessments requiring exact real evaluation
-
-**Example**: Geometric predicate with Oracle
-```cpp
-elrealo orient = orientation_det(p1, p2, p3);
-
-// Most cases: Oracle resolves with low precision
-if (orient < elrealo(0.0)) {          // Lazy comparison (Oracle assesses)
-    // May only compute 2-3 components
-    return LEFT;
-}
-else if (orient > elrealo(0.0)) {
-    return RIGHT;
-}
-else {
-    return COLLINEAR;  // Exact zero - Oracle needed full precision
-}
-```
-
-### Performance Characteristics
-
-#### Computational Complexity
-
-For operation on N-component values:
-
-| Operation | Bailey (dd) | Shewchuk | Priest (eager) | Lazy Real |
-|-----------|-------------|----------|----------------|-----------|
-| **Addition** | O(1) | O(N) | O(N) | O(1) initial, O(N) total |
-| **Multiplication** | O(1) | O(N²) | O(N²) | O(1) initial, O(N²) total |
-| **Division** | O(1) | O(N²) | O(N²) | O(1) initial, O(N²) total |
-| **Comparison** | O(1) | O(N) | O(N) | O(1) to O(N) adaptive |
-
-**Key insight**: Lazy evaluation amortizes cost:
-- Initial result is cheap
-- Full cost only paid if high precision is demanded
-- Comparisons often terminate early
-
-#### Memory Usage
-
-| Approach | Storage | Allocation |
-|----------|---------|------------|
-| **dd/qd** | `sizeof(double) * N` (stack) | Static |
-| **priest** | `sizeof(double) * N` (heap) | Dynamic, upfront |
-| **elrealo** | `sizeof(double) * N` (heap) | Dynamic, incremental (on-demand oracle) |
-
-Lazy evaluation has memory advantage for large precision:
-- Only allocates computed components
-- May avoid computing many components entirely
-
----
-
-## 7. Implementation Roadmap for Universal
-
-### Phase 1: Foundation (Current Status ✅)
-
-**Completed**:
-- ✅ Priest EFTs (`two_sum`, `two_prod`, `quick_two_sum`)
-- ✅ Bailey's dd (double-double)
-- ✅ Bailey's qd (quad-double)
-- ✅ Error-free transformation infrastructure
-
-**Location**: `include/sw/universal/numerics/error_free_ops.hpp`
-
-### Phase 2: Adaptive Eager (In Progress 🟡)
-
-**Goals**:
-1. Complete td (triple-double) implementation
-2. Implement priest (adaptive eager precision)
-3. Create shared expansion template framework
-
-**Files to create/modify**:
-- `include/sw/universal/number/td/td_impl.hpp` (complete arithmetic)
-- `include/sw/universal/number/priest/priest.hpp` (new)
-- `include/sw/universal/number/priest/priest_impl.hpp` (new)
-- `include/sw/universal/internal/expansion/expansion.hpp` (shared framework)
-
-**Status**: Design complete (see `docs/priest.md`), implementation pending
-
-### Phase 3: Exact Lazy Real Oracle (Planned ❌)
-
-**Goals**:
-1. Implement `elrealo` (Exact Lazy Real Oracle) class with stream-based evaluation
-2. Integrate with existing priest and dd/qd types
-3. Provide lazy geometric predicates for Oracle queries
-4. Enable Oracle functionality for mixed-precision SDK
-5. Create comprehensive test suite
-
-**New files**:
-```
-include/sw/universal/number/elrealo/
-├── elrealo_fwd.hpp
-├── elrealo_impl.hpp
-├── elrealo_stream.hpp       # Stream/generator infrastructure
-├── elrealo_ops.hpp          # Lazy arithmetic operations
-├── elrealo_predicates.hpp   # Geometric predicates (Oracle assessments)
-├── elrealo_oracle.hpp       # Oracle-specific functionality
-├── numeric_limits.hpp
-└── mathlib.hpp
-
-static/elrealo/
-├── api/
-│   └── api.cpp             # Usage examples (Oracle patterns)
-├── arithmetic/
-│   ├── addition.cpp
-│   ├── multiplication.cpp
-│   └── division.cpp
-├── comparison/
-│   └── comparison.cpp      # Lazy comparison tests (Oracle queries)
-├── predicates/
-│   ├── orientation.cpp     # Orient2D, Orient3D (Oracle assessments)
-│   └── incircle.cpp        # InCircle2D, InCircle3D
-└── oracle/
-    └── mixed_precision.cpp # Oracle use in mixed-precision SDK
-```
-
-**Timeline**: After priest implementation complete
-
-### Phase 4: Optimization and Applications (Future 📅)
-
-**Goals**:
-1. Performance profiling and optimization
-2. Vectorization of EFT operations
-3. Parallel lazy evaluation
-4. Integration with Universal's BLAS
-5. Real-world application examples
-
-**Applications to demonstrate**:
-- Robust Delaunay triangulation
-- Mesh generation with guaranteed quality
-- Verified numerical integration
-- Exact linear algebra (reproducible)
-
----
-
-## 8. API Design and Usage Examples
-
-### Basic Usage
-
-```cpp
-#include <sw/universal/number/elrealo/elrealo.hpp>
-
-using namespace sw::universal;
-
-// Create Exact Lazy Real Oracle instances
-elrealo x(1.0 / 3.0);  // Represents 1/3 exactly
-elrealo y = elrealo(1.0) / elrealo(3.0);  // Same, via lazy division
-
-// Arithmetic is lazy - Oracle defers computation
-elrealo z = x + y;     // Generator created, not computed yet
-
-// Force evaluation when needed (Oracle provides answer)
-double approx = double(z);  // Oracle computes enough for double precision
-std::cout << z << '\n';     // Oracle computes enough for display precision
-```
-
-### Lazy Predicates for Geometry (Oracle Assessments)
-
-```cpp
-// Orientation test: which side of line (p1,p2) is p3 on?
-// Oracle provides exact assessment
-enum Orientation { LEFT, RIGHT, COLLINEAR };
-
-Orientation orient2d(Point p1, Point p2, Point p3) {
-    // Lazy computation of determinant (Oracle)
-    elrealo det = elrealo(p1.x) * (elrealo(p2.y) - elrealo(p3.y))
-                + elrealo(p2.x) * (elrealo(p3.y) - elrealo(p1.y))
-                + elrealo(p3.x) * (elrealo(p1.y) - elrealo(p2.y));
-
-    // Oracle comparison - refines only as needed for exact answer
-    if (det < elrealo(0.0)) return LEFT;
-    if (det > elrealo(0.0)) return RIGHT;
-    return COLLINEAR;
-}
-
-// In practice, Oracle resolves most cases with 2-3 components
-// Only near-degenerate cases require Oracle to use full precision
-```
-
-### Conditional Computation (Oracle Query Pattern)
-
-```cpp
-elrealo expensive_computation() {
-    // Build lazy expression tree (Oracle defers work)
-    elrealo x = /* ... complex calculation ... */;
-    return x;
-}
-
-void conditional_use(bool need_high_precision) {
-    elrealo x = expensive_computation();
-
-    if (!need_high_precision) {
-        // Quick check - Oracle provides quick assessment
-        double approx = double(x);
-        if (std::abs(approx) < 1e-6) {
-            return;  // Oracle avoided full computation!
-        }
-    }
-
-    // Need full precision - ask Oracle for complete answer
-    x.refine_until_converged();
-    // ... use fully refined result from Oracle ...
-}
-```
-
-### Interoperability (Oracle in Mixed-Precision Workflow)
-
-```cpp
-// Start with fixed precision
-dd x_dd(1.0, 2.220446049250313e-16);  // 1.0 with max precision
-
-// Promote to Oracle when uncertain about needs
-elrealo x_oracle(x_dd);
-
-// Perform lazy operations (Oracle defers)
-elrealo y_oracle = some_complex_computation(x_oracle);
-
-// Convert to eager when batch processing
-priest y_priest = priest(y_oracle);  // Force full evaluation from Oracle
-
-// Or back to fixed if Oracle determines sufficient precision
-dd y_dd = dd(y_oracle);  // Extract first 2 components from Oracle
-```
-
----
-
-## 9. Testing Strategy
-
-### Unit Tests
-
-**Level 1: Component Generation (Oracle Basics)**
-```cpp
-TEST(Elrealo, OracleGeneratorBasics) {
-    elrealo x(1.0 / 3.0);
-
-    EXPECT_EQ(x.depth(), 1);  // Initial computation
-    x.refine(3);              // Oracle computes 2 more
-    EXPECT_EQ(x.depth(), 3);
-
-    // Check convergence
-    x.refine_until_converged();
-    EXPECT_TRUE(x.is_converged());
-}
-```
-
-**Level 2: Lazy Arithmetic (Oracle Operations)**
-```cpp
-TEST(Elrealo, OracleLazyAddition) {
-    elrealo a(0.5);
-    elrealo b(0.25);
-    elrealo c = a + b;  // Oracle defers computation
-
-    // Initial computation
-    EXPECT_EQ(c.depth(), 1);
-
-    // Verify result - Oracle provides answer
-    double result = double(c);
-    EXPECT_NEAR(result, 0.75, 1e-15);
-}
-```
-
-**Level 3: Lazy Comparison (Oracle Assessment)**
-```cpp
-TEST(Elrealo, OracleLazyComparison) {
-    elrealo a(1.0 / 3.0);
-    elrealo b(0.333333333);
-
-    // Oracle should refine until difference is determined
-    bool less = (a < b);
-
-    // Oracle may have computed several components
-    EXPECT_GT(a.depth(), 1);
-}
-```
-
-### Integration Tests
-
-**Geometric Predicates (Oracle Assessments)**
-```cpp
-TEST(ElrealoPredicates, OracleOrient2D) {
-    Point p1{0, 0}, p2{1, 0}, p3{0.5, 0.1};
-
-    auto orient = orient2d(p1, p2, p3);  // Oracle assesses
-    EXPECT_EQ(orient, LEFT);
-
-    // Collinear case - Oracle needs more precision for exact answer
-    Point p4{0.5, 0.0};
-    orient = orient2d(p1, p2, p4);
-    EXPECT_EQ(orient, COLLINEAR);
-}
-```
-
-### Performance Tests
-
-**Oracle vs. Eager Comparison**
-```cpp
-BENCHMARK(OracleVsEagerComparison) {
-    // Oracle approach (lazy, on-demand)
-    {
-        Timer t("Oracle (elrealo)");
-        for (int i = 0; i < N; ++i) {
-            elrealo a = test_values_a[i];
-            elrealo b = test_values_b[i];
-            bool result = (a < b);  // Oracle may terminate early
-        }
-    }
-
-    // Eager approach (always full precision)
-    {
-        Timer t("Eager (priest)");
-        for (int i = 0; i < N; ++i) {
-            priest a = priest(test_values_a[i]);
-            priest b = priest(test_values_b[i]);
-            bool result = (a < b);  // Always full precision
-        }
-    }
-}
-```
-
----
-
-## 10. Advantages and Limitations
-
-### Advantages of Lazy Exact Arithmetic
-
-1. **Pay-as-you-go Precision**
-   - Only compute as much as needed
-   - Avoid waste when low precision suffices
-   - Automatic precision determination
-
-2. **Infinite Precision Capability**
-   - Conceptually unbounded precision
-   - Stream can generate components indefinitely
-   - Suitable for formal verification
-
-3. **Efficient Comparisons**
-   - Most comparisons resolve quickly
-   - Only pathological cases need full precision
-   - Critical for geometric predicates
-
-4. **Composability**
-   - Lazy expressions compose naturally
-   - Complex expression trees optimize automatically
-   - Fusion opportunities for optimization
-
-5. **Correctness Guarantees**
-   - Exact arithmetic - no accumulated errors
-   - Formal proofs possible
-   - Suitable for certified computation
-
-### Limitations and Challenges
-
-1. **Memory Management**
-   - Memoization requires storage
-   - Generator closures capture operands
-   - May use more memory than eager approaches
-
-2. **Performance Unpredictability**
-   - Variable cost depending on precision needed
-   - Difficult to profile/optimize
-   - May have poor worst-case performance
-
-3. **Complexity**
-   - More complex implementation than fixed types
-   - Requires careful closure management
-   - Potential for memory leaks if not careful
-
-4. **Limited Hardware Support**
-   - Can't directly use SIMD/GPU acceleration
-   - Generator functions not vectorizable
-   - May miss optimization opportunities
-
-5. **Interoperability**
-   - Not a drop-in replacement for `double`
-   - Requires explicit type usage
-   - May not integrate with existing libraries
-
----
-
-## 11. Future Research Directions
-
-### Optimization Opportunities
-
-1. **Lazy Expression Templates**
-   - Delay entire expression tree evaluation
-   - Optimize away intermediate allocations
-   - Fuse operations at code generation time
-
-2. **Adaptive Precision Hints**
-   - User provides precision requirements
-   - System optimizes evaluation strategy
-   - Hybrid lazy/eager based on heuristics
-
-3. **Parallel Lazy Evaluation**
-   - Speculative computation of components
-   - Multi-threaded refinement
-   - Lock-free data structures for memoization
-
-4. **Hardware Acceleration**
-   - Use SIMD for bulk component generation
-   - GPU kernels for specific operations
-   - Custom hardware support for EFTs
-
-### Theoretical Extensions
-
-1. **Formal Verification**
-   - Machine-checkable proofs of correctness
-   - Integration with proof assistants (Coq, Lean)
-   - Certified compilation
-
-2. **Interval Lazy Arithmetic**
-   - Combine lazy evaluation with interval arithmetic
-   - Rigorous error bounds at all times
-   - Validated computing framework
-
-3. **Symbolic-Numeric Hybrid**
-   - Combine symbolic manipulation with lazy numeric evaluation
-   - Switch between representations dynamically
-   - Best of both worlds
-
----
-
-## 12. Conclusion
-
-**Exact Lazy Arithmetic** represents a paradigm shift in high-precision computation:
-
-- **Priest/Bailey** provided fast, fixed-precision multi-component arithmetic
-- **Shewchuk** added adaptive precision for geometric predicates
-- **McCleeary** introduced lazy evaluation for on-demand precision
-
-The **Universal Numbers Library** aims to provide **all approaches**:
-- **dd/qd**: Fast, predictable, fixed precision
-- **priest**: Adaptive, eager, determined upfront
-- **elrealo** (Exact Lazy Real Oracle): Adaptive, lazy, on-demand
-
-This gives users the right tool for each scenario:
-- **Performance-critical code**: Use dd/qd
-- **High-precision batch operations**: Use priest
-- **Comparisons, predicates, and precision queries**: Use **elrealo** (Oracle)
-- **Mixed-precision algorithm development**: Use **elrealo** as Oracle for numerical assessments
-- **Seamless interoperability**: Convert between types as needed
-
-The **elrealo** Oracle provides:
-- **Exact real assessments** on-demand
-- **Adaptive precision** based on query complexity
-- **Efficient resolution** of numerical questions
-- **Foundation** for Universal's mixed-precision SDK
-
-By building on the solid foundation of Priest's error-free transformations and extending the Bailey/Shewchuk implementations, Universal provides a comprehensive framework for exact and adaptive arithmetic suitable for a wide range of applications from scientific computing to computational geometry to formal verification.
+## 7. Future directions
+
+Beyond the depth-2+ work, two longer-term directions for exact-real
+arithmetic in Universal:
+
+- **Verified numerical computation.** Pair `elreal` with `interval` to
+  get a rigorous outer-bound + lazy-refined inner-bound representation.
+  This is the foundation for verified scientific computing.
+- **Mixed-precision oracle.** Extend the validation-oracle helper to be
+  the standard reference for *all* multi-component math function tests
+  across the library. Today's helper is a demonstration on `dd_cascade`;
+  the natural follow-up is a sweep across `dd`, `qd`, the cascades, and
+  `ereal<N>`.
 
 ---
 
 ## References
 
-### Primary Sources
+### Foundational papers
 
-1. **Ryan McCleeary** (2019)
-   "Lazy Exact Real Arithmetic Using Floating Point Operations"
-   Ph.D. Dissertation, University of Iowa
-   https://ir.uiowa.edu/etd/6991/
+1. **McCleeary, R.** (2019). *Lazy Exact Real Arithmetic Using Floating
+   Point Operations*. Ph.D. dissertation, University of Iowa.
+   <https://iro.uiowa.edu/esploro/outputs/doctoral/Lazy-exact-real-arithmetic-using-floating/9983776998202771>
+2. **Shewchuk, J. R.** (1997). "Adaptive Precision Floating-Point
+   Arithmetic and Fast Robust Geometric Predicates." *Discrete &
+   Computational Geometry*, 18(3), 305-363.
+   <https://people.eecs.berkeley.edu/~jrs/papers/robustr.pdf>
+3. **Priest, D. M.** (1991). *On Properties of Floating Point Arithmetics:
+   Numerical Stability and the Cost of Accurate Computations*. Ph.D.
+   dissertation, University of California, Berkeley.
+4. **Hida, Y., Li, X. S., Bailey, D. H.** (2000). "Algorithms for
+   Quad-Double Precision Floating Point Arithmetic." *Proc. 15th IEEE
+   Symposium on Computer Arithmetic*, 155-162.
+5. **Payne, M., Hanek, R.** (1983). "Radian Reduction for Trigonometric
+   Functions." *SIGNUM Newsletter*, 18(1), 19-24.
 
-### Related Work
+### Universal library documentation
 
-2. **Douglas M. Priest** (1991)
-   "On Properties of Floating Point Arithmetics: Numerical Stability and the Cost of Accurate Computations"
-   Ph.D. Dissertation, UC Berkeley
-
-3. **Jonathan Richard Shewchuk** (1997)
-   "Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates"
-   Discrete & Computational Geometry 18:305-363
-
-4. **David H. Bailey, Yozo Hida** (2008)
-   "Library for Double-Double and Quad-Double Arithmetic"
-   LBNL Technical Report
-
-5. **Jean Vuillemin** (1990)
-   "Exact Real Computer Arithmetic with Continued Fractions"
-   IEEE Transactions on Computers
-
-6. **Martín Escardó**
-   "A Calculator for Exact Real Number Computation"
-   https://www.cs.bham.ac.uk/~mhe/
-
-7. **R. W. Gosper** (1972)
-   "Continued Fraction Arithmetic"
-   HAKMEM, MIT AI Memo 239
-
-### Software Implementations
-
-- **Universal Numbers Library**: https://github.com/stillwater-sc/universal
-- **Haskell `cf` package**: https://hackage.haskell.org/package/cf
-- **Shewchuk's Predicates**: https://www.cs.cmu.edu/~quake/robust.html
-
----
-
-**Document Version**: 1.0
-**Date**: 2025-10-17
-**Author**: Generated for Universal Numbers Library
-**Status**: Design document for lazy exact arithmetic implementation
+- `docs/number-systems/elreal.md` -- user-facing API reference for `elreal`
+- `docs/algorithmic-details/lazy-real-arithmetic.md` -- algorithmic
+  deep-dive on the lazy-stream paradigm
+- `docs/algorithmic-details/multi-component-arithmetic.md` -- broader
+  Priest/Bailey-Hida/Shewchuk/McCleeary comparison
+- `docs/multi-component/comparison-priest-bailey-shewchuk.md` -- earlier
+  reference document, superseded by the algorithmic-details version

--- a/docs/number-systems/README.md
+++ b/docs/number-systems/README.md
@@ -74,6 +74,7 @@ The quire is a number-system-agnostic accumulator that provides exact dot produc
 | [dd_cascade](dd_cascade.md) | 128 | ~31 | DD via unified cascade framework | Consistent API across precision tiers |
 | [td_cascade](td_cascade.md) | 192 | ~48 | Triple-double (3 doubles) | Intermediate precision tier |
 | [qd_cascade](qd_cascade.md) | 256 | ~64 | QD via unified cascade framework | Consistent API across precision tiers |
+| [elreal](elreal.md) | streaming | refinable | Lazy exact real (McCleeary 2019) | Robust geometric predicates, cross-implementation validation oracle |
 
 ### Adaptive (Elastic) Precision
 

--- a/docs/number-systems/elreal.md
+++ b/docs/number-systems/elreal.md
@@ -1,0 +1,291 @@
+# elreal: Exact Lazy Real Arithmetic
+
+## Why
+
+Some computations cannot tolerate any precision loss. Geometric predicates in
+mesh generation need a definite sign for any input -- including configurations
+that are arbitrarily close to degenerate. Comparisons in symbolic computation
+need to terminate with a correct answer for any pair of distinct reals.
+Iterative refinement loops in numerical PDE solvers need a residual that does
+not accumulate roundoff. Fixed-precision arithmetic (`double`, `dd`, `qd`,
+even `ereal<19>`) gives up these guarantees when the working precision is set
+upfront.
+
+`elreal` implements the exact-real-arithmetic paradigm from Ryan McCleeary's
+2019 dissertation: a real value is represented as a **lazy stream of
+progressively refined floating-point components**. Operations return promises;
+precision is pulled on demand only when the caller asks for it. Comparison
+walks the stream until the sign is determined -- the canonical hard problem
+of exact-real arithmetic, made tractable by a bounded refinement budget.
+
+## What
+
+`elreal` is the third (and most precise) multi-component arithmetic tier in
+Universal, joining the fixed-precision Bailey/Hida types (`dd`, `qd`) and the
+adaptive Shewchuk-style `ereal<N>`:
+
+| Property | Value |
+|----------|-------|
+| Class form | `class elreal` (non-templated) |
+| Storage | `std::vector<double>` + `std::function<double(std::size_t)>` generator |
+| Internal element | IEEE-754 `double` per stream component |
+| Refinement on demand | Yes, via `at(k)` and `refine_to(precision_bits)` |
+| Comparison | Budgeted sign-determination (`sign`, `compare`) |
+| Special values | `+/-inf`, `NaN`, signed zero -- all preserved through arithmetic |
+| Mathematical functions | `sqrt`, `hypot`, `exp` family, `log` family, `pow`, hyperbolic, inverse trig, forward trig |
+| Geometric predicates | `orient2d`, `orient3d`, `incircle`, `insphere` |
+| Cross-validation oracle | `check_against_elreal_oracle` for other multi-component types |
+
+### Key properties
+
+- **Lazy refinement.** Each operation returns an `elreal` whose `at(k)`
+  component is computed only when called. A typical comparison resolves at
+  depth 0; near-degenerate inputs may consume the refinement budget.
+- **Non-templated.** A single class -- no `maxlimbs` parameter to set
+  upfront. Refinement depth is per-call.
+- **Bounded budget.** Sign determination has a per-call budget
+  (`elreal_default_budget = 8`) that caps worst-case work on the
+  algorithmically-undecidable equality case.
+- **No external dependencies.** Pure header-only C++20, like the rest of
+  Universal.
+
+### Internal representation
+
+```cpp
+class elreal {
+private:
+    mutable std::vector<double>                _components;       // materialised stream
+    mutable std::size_t                        _computed_depth;   // high-water mark
+    mutable std::function<double(std::size_t)> _generator;        // produces depth k on demand
+
+    // ... constructors, operators, math functions
+};
+```
+
+The mathematical value is the sum of all stream components -- materialised
+plus any the generator would produce. `at(k)` returns the k-th component,
+materialising it via the generator if necessary. `operator double()` returns
+the sum of *currently-materialised* components (it does not call the
+generator -- callers spend a refinement step explicitly via `at(k)` or
+`refine_to`).
+
+## How to use
+
+### Include
+
+```cpp
+#include <universal/number/elreal/elreal.hpp>
+using namespace sw::universal;
+```
+
+### Construction
+
+```cpp
+elreal a(3.14);                        // from double
+elreal b(42);                          // from int (and other native integer types)
+elreal one_third(1LL, 3LL);            // from rational p/q (the canonical exact case)
+elreal pi_string("3.14159265358979");  // from decimal / scientific / rational string
+elreal r(SpecificValue::infpos);       // from SpecificValue enum
+elreal raw = elreal::from_expansion({3.14, 1.0e-17});  // from a pre-computed expansion
+```
+
+The rational constructor is the distinguishing feature: `elreal(1LL, 3LL)`
+represents 1/3 *exactly*, not the IEEE-rounded double approximation. Phase D's
+comparison resolves `elreal(1LL, 3LL) > elreal(1.0/3.0)` as true, because the
+stream's depth-1 correction reveals the residual bit pattern that the rounded
+double dropped.
+
+### Arithmetic
+
+```cpp
+elreal a("1/3"), b("1/2");
+elreal sum = a + b;
+elreal diff = a - b;
+elreal prod = a * b;
+elreal quot = a / b;
+elreal neg  = -a;
+elreal r    = abs(a);
+elreal s    = sqrt(a);
+elreal h    = hypot(a, b);
+```
+
+All operators produce a new `elreal` whose generator captures the operand
+streams. Compound assignment (`+=`, `-=`, `*=`, `/=`) is also available.
+
+Division by zero throws `elreal_divide_by_zero` when
+`ELREAL_THROW_ARITHMETIC_EXCEPTION` is defined; otherwise IEEE-754 `+/-inf`
+or `NaN` propagates.
+
+### Comparison with refinement budget
+
+```cpp
+elreal a(1LL, 3LL);
+elreal b(1.0 / 3.0);
+
+if (a > b)      { /* true: the rational a has more bits than the double b */ }
+if (a == b)     { /* false: same reason */ }
+
+int s = sign(a - b);          // returns +1
+int c = compare(a, b);        // returns +1; equivalent to sign(a - b)
+int s2 = sign(a - b, 16);     // wider refinement budget (default is 8)
+```
+
+Comparison is *budgeted*. The default budget of 8 components is enough for
+any practical signed-comparison query. For algorithmically-undecidable cases
+(asking whether two distinct mathematical reals happen to be equal),
+the comparison returns 0 (treats as equal) once the budget is exhausted.
+
+### Math functions
+
+All shipped at depth-0 (matching `std::cmath`) with depth-1 derivative-based
+refinement:
+
+```cpp
+elreal y;
+
+y = exp(a);    y = exp2(a);   y = expm1(a);
+y = log(a);    y = log2(a);   y = log10(a);   y = log1p(a);
+y = pow(a, b);
+
+y = sinh(a);   y = cosh(a);   y = tanh(a);
+y = asinh(a);  y = acosh(a);  y = atanh(a);
+
+y = sin(a);    y = cos(a);    y = tan(a);
+y = asin(a);   y = acos(a);   y = atan(a);
+y = atan2(a, b);
+```
+
+Math constants are available as factory functions returning multi-component
+expansions:
+
+```cpp
+elreal pi   = elreal_pi();      // ~212-bit expansion of pi
+elreal e    = elreal_e();       // Euler's number
+elreal ln2  = elreal_ln2();
+elreal ln10 = elreal_ln10();
+elreal phi  = elreal_phi();     // golden ratio
+elreal sqrt2 = elreal_sqrt2();
+```
+
+### Geometric predicates
+
+The canonical showcase for exact-real arithmetic:
+
+```cpp
+#include <universal/number/elreal/geometry/predicates.hpp>
+
+Point2D<elreal> a(elreal(0.0), elreal(0.0));
+Point2D<elreal> b(elreal(1.0), elreal(0.0));
+Point2D<elreal> c(elreal(0.5), elreal(0.5));
+
+elreal r = orient2d(a, b, c);
+int s = sign(r);  // +1 for left turn, -1 right, 0 collinear
+```
+
+`orient3d`, `incircle`, `insphere` follow the same pattern.
+
+### Cross-validation oracle
+
+`elreal` can serve as the cross-implementation oracle for other multi-component
+types in Universal's validation pipeline:
+
+```cpp
+#include <universal/verification/test_suite_elreal_oracle.hpp>
+
+dd_cascade target = exp(dd_cascade(0.5));
+elreal     oracle = exp(elreal(0.5));
+
+bool ok = check_against_elreal_oracle(target, oracle);
+```
+
+See `docs/algorithmic-details/multi-component-arithmetic.md` section 8.6 for
+details on what this catches today (cross-implementation gross-error
+detection) and the current precision ceiling.
+
+## Refinement protocol
+
+`at(k)` is the primitive; `refine_to(bits)` is the user-facing wrapper:
+
+```cpp
+elreal v = exp(elreal(0.5));
+
+double c0 = v.at(0);           // leading double (calls generator if needed)
+double c1 = v.at(1);           // depth-1 correction
+v.refine_to(200);              // ask for ~200 bits of precision
+
+std::size_t depth = v.computed_depth();   // high-water materialised
+const std::vector<double>& comps = v.components();  // read-only access
+```
+
+`operator double()` sums only the *currently-materialised* components and
+does **not** invoke the generator. To see a generator-driven correction in
+the double-converted value, explicitly call `at(k)` (or `refine_to`) first:
+
+```cpp
+elreal s = sin(elreal_pi());
+
+double naive = double(s);      // depth-0 only: ~1.22e-16 (= std::sin(M_PI))
+(void)s.at(1);                 // forces depth-1 materialisation
+double full = double(s);       // depth-0 + depth-1 ~= 0 (the cos(pi)*pi.at(1)
+                               //   correction cancels std::sin's rounding error)
+```
+
+This is by design: `operator double()` is the cheap "best estimate at current
+depth" path. Refinement is an explicit caller choice.
+
+## Known limitations
+
+- **Depth-1 ceiling.** Arithmetic operators and math functions currently
+  refine to depth 1. Deeper refinement (depth 2+) requires Newton-style
+  lazy iteration or a higher-precision internal algorithm. The infrastructure
+  is in place (the generator can produce arbitrarily many components); the
+  per-function generators just need to be extended. Tracked as a follow-up to
+  Phase F of the elreal epic (#873).
+- **Constants stop at 4 components (~212 bits).** `elreal_pi`, `elreal_e`,
+  and friends use static 4-component expansions reused from `qd_constants.hpp`.
+  Extending past this requires either BBP-style on-demand bit extraction (for
+  pi) or Taylor truncation with lazy refinement (for e, ln2, etc.).
+- **Forward trig range reduction.** `sin/cos/tan` use the std library for
+  depth 0, which limits faithful results to "reasonable magnitude" inputs
+  (roughly `|x| < 2^25`). Payne-Hanek range reduction using lazy pi bit-pull
+  is documented in `elreal_impl.hpp` as the path forward.
+- **Comparison budget is not strictly an oracle.** Equality returns 0 within
+  the budget; mathematically-distinct values whose first non-zero component
+  lies past the budget will compare equal. Raise the budget per-call when
+  this matters.
+
+## Comparison with `dd`, `qd`, `ereal`
+
+| Aspect | `dd` (Bailey/Hida) | `qd` (Bailey/Hida) | `ereal<N>` (Shewchuk) | `elreal` (McCleeary) |
+|---|---|---|---|---|
+| Components | 2 (fixed) | 4 (fixed) | up to N (compile-time) | unbounded (per-call) |
+| Precision target | committed upfront | committed upfront | committed upfront | per-call (budget) |
+| Common-case cost | constant | constant | constant | depth-0 (cheapest) |
+| Worst-case cost | constant | constant | up to N components | up to budget components |
+| Best use case | hot loops at 106 bits | hot loops at 212 bits | adaptive ~127-303 bits | precision-on-demand, undecidable comparisons |
+
+Pick `dd` / `qd` when the precision target is known. Pick `ereal<N>` when it
+is adaptive but bounded. Pick `elreal` when the common case dominates *or*
+when undecidable comparison (geometric predicates, symbolic computation) is
+in scope.
+
+## References
+
+- McCleeary, R. (2019). *Lazy Exact Real Arithmetic Using Floating Point
+  Operations*. PhD dissertation, University of Iowa.
+  <https://iro.uiowa.edu/esploro/outputs/doctoral/Lazy-exact-real-arithmetic-using-floating/9983776998202771>
+- Shewchuk, J. R. (1997). "Adaptive Precision Floating-Point Arithmetic and
+  Fast Robust Geometric Predicates." *Discrete & Computational Geometry*
+  18(3), 305-363.
+- Priest, D. M. (1991). *On Properties of Floating Point Arithmetics:
+  Numerical Stability and the Cost of Accurate Computations*. PhD
+  dissertation, UC Berkeley.
+
+## Files
+
+- `include/sw/universal/number/elreal/elreal.hpp` -- umbrella header
+- `include/sw/universal/number/elreal/elreal_impl.hpp` -- main class + arithmetic + math
+- `include/sw/universal/number/elreal/math/constants/elreal_constants.hpp` -- pi, e, ln2, ...
+- `include/sw/universal/number/elreal/geometry/predicates.hpp` -- geometric predicates
+- `include/sw/universal/verification/test_suite_elreal_oracle.hpp` -- oracle helper
+- `docs/algorithmic-details/multi-component-arithmetic.md` -- design + comparison study

--- a/docs/site/algorithmic-details/index.md
+++ b/docs/site/algorithmic-details/index.md
@@ -17,6 +17,11 @@ the trade-off space rather than the API-level usage.
   -- Priest's error-free transformations, Bailey/Hida's hand-crafted
   fixed-precision `dd` / `qd`, Shewchuk's adaptive expansions, and how
   Universal's `floatcascade<N>` building block ties them together.
+- [Lazy exact real arithmetic](../algorithmic-details/lazy-real-arithmetic/)
+  -- McCleeary's lazy-stream paradigm as shipped in `elreal`: the
+  refinement protocol, sign-determination with bounded budget, depth-1
+  derivative-based math, geometric predicates, and the cross-implementation
+  validation oracle.
 
 ## Companion sections
 

--- a/include/sw/universal/internal/floatcascade/floatcascade_volatile_hardening.md
+++ b/include/sw/universal/internal/floatcascade/floatcascade_volatile_hardening.md
@@ -220,7 +220,7 @@ floatcascade<N> renormalize(const floatcascade<N>& e) {
 
 ---
 
-## Why This Matters for Priest and ELREALO
+## Why This Matters for Priest and elreal
 
 The `floatcascade` template is the workhorse foundation for:
 
@@ -228,7 +228,7 @@ The `floatcascade` template is the workhorse foundation for:
 - **td** (triple-double) - 159-bit precision (~48 decimal digits)
 - **qd** (quad-double) - 212-bit precision (~64 decimal digits)
 - **Priest's algorithms** - Multi-precision arithmetic operations
-- **ELREALO** (Exact Lazy Real Objects) - Upcoming exact arithmetic type
+- **elreal** (lazy exact real arithmetic, McCleeary 2019) - shipped via epic #873; see `include/sw/universal/number/elreal/` and `docs/number-systems/elreal.md`
 
 With volatile modifiers, these types are now rock-solid across:
 - All platforms (Windows, Linux, macOS)

--- a/include/sw/universal/number/dd_cascade/README.md
+++ b/include/sw/universal/number/dd_cascade/README.md
@@ -11,7 +11,7 @@ This implementation exists to:
 1. **Unify the codebase** - All multi-component types (dd, td, qd) will eventually use the same floatcascade infrastructure
 2. **Leverage fortified operations** - Benefits from volatile-hardened error-free transformations in floatcascade
 3. **Maintain compatibility** - Provides the same API as classic `dd` (high(), low() accessors)
-4. **Enable future features** - Foundation for Priest's algorithms and ELREALO (Exact Lazy Real Objects)
+4. **Enable future features** - Foundation for Priest's algorithms and `elreal` (lazy exact real arithmetic, see `include/sw/universal/number/elreal/` and `docs/number-systems/elreal.md`)
 
 ## Current Status
 


### PR DESCRIPTION
## Summary

Phase H of epic #873 (ELREAL number system implementation). Documentation-only PR landing the user-facing reference for the shipped `elreal` type, an algorithmic deep-dive on the lazy-stream paradigm, and retiring the aspirational "ELREALO" naming across pre-existing docs (the shipped type is named `elreal`).

## New documents

- **`docs/number-systems/elreal.md`** -- user-facing API reference: construction (rational, double, string, lazy generator), refinement protocol (`at(k)`, `refine_to`), comparison budget, arithmetic, math function coverage (Phase E.1-E.6), geometric predicates (Phase F), the cross-implementation validation oracle (Phase G), known limitations (depth-1 cap, forward-trig range, oracle ceiling), and a comparison with `dd` / `qd` / `ereal`.
- **`docs/algorithmic-details/lazy-real-arithmetic.md`** -- 11-section algorithmic deep-dive on McCleeary 2019 as shipped: lazy-stream representation, refinement protocol, sign determination with bounded budget, arithmetic refinement via EFTs, depth-1 derivative refinement for math, forward-trig limitation and the Payne-Hanek path forward, geometric predicates, oracle role, per-phase delivery summary.

## Updates

- `docs/algorithmic-details/multi-component-arithmetic.md` -- comparison table and picker decision tree extended to include the McCleeary/elreal thread alongside Priest, Bailey/Hida, and Shewchuk. Opening updated from "three threads" to "four threads with McCleeary".
- `docs/multi-component/exact-lazy-arithmetic.md` -- rewritten (1034 -> 226 lines) to match the shipped API; keeps the theoretical "why lazy" narrative and links to the deep-dive for algorithmic content. Removes references to an aspirational `elrealo` API that never shipped.
- `docs/multi-component/README.md` -- ELREALO references replaced with `elreal` (status now "shipped via epic #873"); status table updated.
- `docs/number-systems/README.md` -- elreal added to the Extended Precision (Multi-Component) table.
- `docs/site/algorithmic-details/index.md` -- lazy-real-arithmetic page listed alongside the multi-component-arithmetic page.
- `include/sw/universal/internal/floatcascade/floatcascade_volatile_hardening.md` -- "ELREALO (Exact Lazy Real Objects)" replaced with the shipped elreal type plus link to `docs/number-systems/elreal.md`.
- `include/sw/universal/number/dd_cascade/README.md` -- same retitling.
- `docs-site/sync-content.mjs` and `docs-site/astro.config.mjs` -- new pages wired into the synced content map and Starlight sidebar.

## Test plan

- [x] `docs-site` build succeeds with 85 pages
- [x] `dist/number-systems/elreal/index.html` rendered
- [x] `dist/algorithmic-details/lazy-real-arithmetic/index.html` rendered
- [x] CI fast tier green (gcc + clang lite)
- [x] CodeRabbit review

## Honest claims

All API surface in `docs/number-systems/elreal.md` is verified against the shipped code in `include/sw/universal/number/elreal/`. No fabricated functions, no hypothetical performance numbers. Known limitations (depth-1 cap, Payne-Hanek deferred, oracle precision ceiling at double) documented explicitly rather than hidden.

Closes #881.
Part of epic #873.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation pages describing exact lazy real arithmetic functionality, usage guidance, and implementation details.
  * Updated site navigation and documentation structure to include elreal as an extended precision number system option.
  * Expanded algorithmic reference documentation covering lazy refinement protocols, bounded sign determination, and geometric predicate support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->