### PR TITLE
test(elreal): Phase J -- oracle sweep across dd, qd, cascades, ereal<N>

### DIFF
--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -95,6 +95,7 @@ const FILE_MAP = {
   'algorithmic-details/multi-component-arithmetic.md': 'algorithmic-details/multi-component-arithmetic.md',
   'algorithmic-details/lazy-real-arithmetic.md': 'algorithmic-details/lazy-real-arithmetic.md',
   'algorithmic-details/elreal-performance-baseline.md': 'algorithmic-details/elreal-performance-baseline.md',
+  'algorithmic-details/elreal-oracle-sweep-results.md': 'algorithmic-details/elreal-oracle-sweep-results.md',
 
   // ── Design ─────────────────────────────────────────────────────
   'multi-limb-arithmetic.md': 'design/multi-limb.md',

--- a/docs/algorithmic-details/elreal-oracle-sweep-results.md
+++ b/docs/algorithmic-details/elreal-oracle-sweep-results.md
@@ -1,0 +1,149 @@
+# elreal Oracle Sweep Results
+
+Phase J of the elreal follow-up epic (#903). The Phase G validation
+oracle (`check_against_elreal_oracle` / `report_against_elreal_oracle`,
+shipped in #900) is extended across every multi-component type in
+Universal that exposes a math suite: `dd`, `qd`, `dd_cascade`,
+`td_cascade`, `qd_cascade`, and `ereal<N>`.
+
+This document is the aggregated pass/fail report. The per-type sweep
+sources live in `elastic/elreal/oracle/*_sweep.cpp`; the common
+helper headers are `elastic/elreal/oracle/math_sweep_common.hpp` and
+`include/sw/universal/verification/test_suite_elreal_oracle.hpp`.
+
+## Precision ceiling caveat
+
+elreal's lazy refinement currently caps at **depth 1** for arithmetic
+and math (see `docs/algorithmic-details/lazy-real-arithmetic.md`). The
+helper's effective comparison precision is therefore **double**
+(~ 15 decimal digits), regardless of the target type's nominal
+precision. The sweep at today's ceiling catches:
+
+- Catastrophic disagreement (wrong sign, wrong magnitude, NaN where a
+  finite result is expected, finite where a NaN is expected)
+- Algorithmic drift visible at double precision (i.e. the target type
+  diverges from std-library agreement in the leading 15 digits)
+
+The sweep at today's ceiling does **not** catch:
+
+- Sub-double-ULP precision drift in the target type (e.g. `qd` losing
+  the bottom limb's precision while keeping ~ 32 digits of correctness)
+
+That deeper check lights up automatically when Phase L (#906, depth-2+
+arithmetic) and Phase M (#907, depth-2+ math) of the follow-up epic
+land. No API changes to the helper or to these sweep tests are
+required at that point -- the oracle simply gets sharper.
+
+## Test setup
+
+- **Hardware**: 12th Gen Intel Core i7-12700K, single thread
+- **Compilers**: gcc 13.3.0 and clang 18.1.3
+- **Build**: `cmake -DUNIVERSAL_BUILD_NUMBER_ELREALS=ON
+  -DUNIVERSAL_BUILD_NUMBER_DOUBLE_DOUBLE=ON
+  -DUNIVERSAL_BUILD_NUMBER_QUAD_DOUBLE=ON
+  -DUNIVERSAL_BUILD_NUMBER_DD_CASCADE=ON
+  -DUNIVERSAL_BUILD_NUMBER_TD_CASCADE=ON
+  -DUNIVERSAL_BUILD_NUMBER_QD_CASCADE=ON
+  -DUNIVERSAL_BUILD_NUMBER_EREALS=ON ..` (Release, `-O3 -DNDEBUG`)
+
+## Coverage map
+
+Each cell shows whether the target type exposes the function (and
+whether the sweep exercises it). Empty cells mean the target type
+does not expose the function today; "x" means the function is part
+of the type's math suite and the sweep exercises it.
+
+| Function   | dd | qd | dd_cascade | td_cascade | qd_cascade | ereal<N> |
+|------------|:--:|:--:|:----------:|:----------:|:----------:|:--------:|
+| `sqrt`     | x  | x  | x          | x          | x          |          |
+| `exp`      | x  | x  | x          | x          | x          |          |
+| `exp2`     | x  | x  | x          |            | x          |          |
+| `expm1`    | x  | x  | x          |            | x          |          |
+| `log`      | x  | x  | x          | x          | x          |          |
+| `log2`     | x  | x  | x          |            | x          |          |
+| `log10`    | x  | x  | x          |            | x          |          |
+| `log1p`    | x  | x  | x          |            | x          |          |
+| `sin`      | x  | x  | x          | x          | x          |          |
+| `cos`      | x  | x  | x          | x          | x          |          |
+| `tan`      | x  | x  | x          | x          | x          |          |
+| `asin`     | x  | x  | x          | x          | x          |          |
+| `acos`     | x  | x  | x          | x          | x          |          |
+| `atan`     | x  | x  | x          | x          | x          |          |
+| `sinh`     | x  | x  | x          | x          | x          |          |
+| `cosh`     | x  | x  | x          | x          | x          |          |
+| `tanh`     | x  | x  | x          | x          | x          |          |
+| `asinh`    |    |    |            | x          |            |          |
+| `acosh`    |    |    |            | x          |            |          |
+| `atanh`    |    |    |            | x          |            |          |
+| `pow`      | x  | x  | x          | x          | x          |          |
+| `pown`     |    |    |            |            |            | x        |
+
+The td_cascade column is the narrowest -- it does not yet expose
+exp2 / expm1 / log2 / log10 / log1p. Worth flagging as a separate
+issue if td_cascade is meant to have feature parity with the other
+cascade types; out of scope for Phase J.
+
+ereal<N> exposes only `pown` from the math suite today; the rest of
+its math support is via `pown` over an integer-valued double exponent
+plus user-side arithmetic.
+
+## Results
+
+| Sweep                            | gcc 13.3 | clang 18.1 | Reject-path check |
+|----------------------------------|:--------:|:----------:|:-----------------:|
+| dd math (17 functions)           | PASS     | PASS       | OK                |
+| qd math (17 functions)           | PASS     | PASS       | OK                |
+| dd_cascade math (17 functions)   | PASS     | PASS       | OK                |
+| td_cascade math (15 functions)   | PASS     | PASS       | OK                |
+| qd_cascade math (17 functions)   | PASS     | PASS       | OK                |
+| ereal<2> / ereal<4> / ereal<8> pown | PASS  | PASS       | OK                |
+
+"Reject-path check" exercises the helper with a deliberately-wrong
+2x-off oracle and verifies the helper *rejects* it. This guards
+against the helper silently passing on any input due to loose
+tolerance.
+
+## What this means
+
+Cross-implementation agreement at double precision is a non-trivial
+bug signal even when the comparison is at double precision rather than
+at the target's nominal precision: the two paths through dd / qd / 
+cascades on one side and through elreal lazy refinement on the other
+share *zero code*. Any wrong-sign / wrong-magnitude / wrong-NaN bug
+on either side would diverge them, and the sweep would catch it.
+
+After this phase lands, the elreal oracle is the standard
+cross-implementation reference for the math suite across every
+multi-component type in Universal. When Phase L and Phase M lift the
+depth-1 ceiling, the sweep will sharpen automatically -- the helpers
+and the test sources do not need to change.
+
+## Reproducing
+
+```bash
+mkdir build && cd build
+cmake -DUNIVERSAL_BUILD_NUMBER_ELREALS=ON \
+      -DUNIVERSAL_BUILD_NUMBER_DOUBLE_DOUBLE=ON \
+      -DUNIVERSAL_BUILD_NUMBER_QUAD_DOUBLE=ON \
+      -DUNIVERSAL_BUILD_NUMBER_DD_CASCADE=ON \
+      -DUNIVERSAL_BUILD_NUMBER_TD_CASCADE=ON \
+      -DUNIVERSAL_BUILD_NUMBER_QD_CASCADE=ON \
+      -DUNIVERSAL_BUILD_NUMBER_EREALS=ON ..
+make elreal_dd_math_sweep elreal_qd_math_sweep \
+     elreal_dd_cascade_math_sweep elreal_td_cascade_math_sweep \
+     elreal_qd_cascade_math_sweep elreal_ereal_pown_sweep -j4
+for t in elreal_dd_math_sweep elreal_qd_math_sweep \
+         elreal_dd_cascade_math_sweep elreal_td_cascade_math_sweep \
+         elreal_qd_cascade_math_sweep elreal_ereal_pown_sweep; do
+  ./elastic/elreal/$t
+done
+```
+
+## References
+
+- Phase G helper: `include/sw/universal/verification/test_suite_elreal_oracle.hpp`
+- Sweep common: `elastic/elreal/oracle/math_sweep_common.hpp`
+- Per-type sweeps: `elastic/elreal/oracle/*_sweep.cpp`
+- Algorithmic context: `docs/algorithmic-details/lazy-real-arithmetic.md`
+- Follow-up epic: #903
+- Phase J issue: #904

--- a/docs/site/algorithmic-details/index.md
+++ b/docs/site/algorithmic-details/index.md
@@ -26,6 +26,11 @@ the trade-off space rather than the API-level usage.
   -- Phase I throughput measurements: per-operation cost shape,
   matched-precision comparison against `ereal<N>`, and the allocator
   hot path that bounds today's throughput.
+- [elreal oracle sweep results](../algorithmic-details/elreal-oracle-sweep-results/)
+  -- Phase J cross-implementation validation: the elreal oracle
+  exercised across every multi-component type in Universal
+  (`dd`, `qd`, `dd_cascade`, `td_cascade`, `qd_cascade`, `ereal<N>`),
+  with pass/fail per type and the precision-ceiling caveat.
 
 ## Companion sections
 

--- a/elastic/elreal/oracle/dd_cascade_math_sweep.cpp
+++ b/elastic/elreal/oracle/dd_cascade_math_sweep.cpp
@@ -1,0 +1,124 @@
+// dd_cascade_math_sweep.cpp: cross-validate dd_cascade math suite against elreal (Phase J, #904)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Companion of dd_math_sweep.cpp for the dd_cascade type (the
+// floatcascade<2>-based double-double).
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/dd_cascade/dd_cascade.hpp>
+#include <universal/verification/test_suite.hpp>
+#include "math_sweep_common.hpp"
+
+int main()
+try {
+	using namespace sw::universal;
+	using namespace sw::universal::elreal_oracle_sweep;
+
+	std::string test_suite = "elreal Phase J: dd_cascade math oracle sweep";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	const auto& g = general_inputs();
+	const auto& p = positive_inputs();
+	const auto& b = bounded_inputs();
+
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::sqrt", p,
+		[](const dd_cascade& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::exp",   g,
+		[](const dd_cascade& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::exp2",  g,
+		[](const dd_cascade& a) { return exp2(a); },
+		[](const elreal& a) { return exp2(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::expm1", g,
+		[](const dd_cascade& a) { return expm1(a); },
+		[](const elreal& a) { return expm1(a); });
+
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::log",   p,
+		[](const dd_cascade& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::log2",  p,
+		[](const dd_cascade& a) { return log2(a); },
+		[](const elreal& a) { return log2(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::log10", p,
+		[](const dd_cascade& a) { return log10(a); },
+		[](const elreal& a) { return log10(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::log1p", log1p_inputs(),
+		[](const dd_cascade& a) { return log1p(a); },
+		[](const elreal& a) { return log1p(a); });
+
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::sin", g,
+		[](const dd_cascade& a) { return sin(a); },
+		[](const elreal& a) { return sin(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::cos", g,
+		[](const dd_cascade& a) { return cos(a); },
+		[](const elreal& a) { return cos(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::tan", g,
+		[](const dd_cascade& a) { return tan(a); },
+		[](const elreal& a) { return tan(a); });
+
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::asin", b,
+		[](const dd_cascade& a) { return asin(a); },
+		[](const elreal& a) { return asin(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::acos", b,
+		[](const dd_cascade& a) { return acos(a); },
+		[](const elreal& a) { return acos(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::atan", g,
+		[](const dd_cascade& a) { return atan(a); },
+		[](const elreal& a) { return atan(a); });
+
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::sinh", g,
+		[](const dd_cascade& a) { return sinh(a); },
+		[](const elreal& a) { return sinh(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::cosh", g,
+		[](const dd_cascade& a) { return cosh(a); },
+		[](const elreal& a) { return cosh(a); });
+	nrOfFailedTestCases += sweep_unary<dd_cascade>("dd_cascade::tanh", g,
+		[](const dd_cascade& a) { return tanh(a); },
+		[](const elreal& a) { return tanh(a); });
+
+	std::vector<std::pair<double, double>> pow_inputs = {
+		{2.0, 3.0}, {2.0, 0.5}, {3.0, 2.5}, {0.5, 4.0}, {10.0, 0.25}
+	};
+	nrOfFailedTestCases += sweep_binary<dd_cascade>("dd_cascade::pow", pow_inputs,
+		[](const dd_cascade& a, const dd_cascade& bb) { return pow(a, bb); },
+		[](const elreal& a, const elreal& bb) { return pow(a, bb); });
+
+	nrOfFailedTestCases += anchor_check<dd_cascade>("exp(0)=1", 0.0, 1.0,
+		[](const dd_cascade& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += anchor_check<dd_cascade>("log(1)=0", 1.0, 0.0,
+		[](const dd_cascade& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += anchor_check<dd_cascade>("sqrt(1)=1", 1.0, 1.0,
+		[](const dd_cascade& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	{
+		dd_cascade target = exp(dd_cascade(1.0));
+		elreal     wrong  = elreal(2.0) * exp(elreal(1.0));
+		if (check_against_elreal_oracle(target, wrong)) {
+			std::cerr << "FAIL: dd_cascade oracle helper accepted a 2x-off reference\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/oracle/dd_math_sweep.cpp
+++ b/elastic/elreal/oracle/dd_math_sweep.cpp
@@ -1,0 +1,143 @@
+// dd_math_sweep.cpp: cross-validate dd math suite against elreal (Phase J, #904)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Exercises every math function the dd type exposes through the
+// elreal-as-oracle pipeline. Each call goes through:
+//
+//   target = math_fn(dd(x))
+//   oracle = math_fn(elreal(x))
+//   check_against_elreal_oracle(target, oracle)
+//
+// The two paths share no code (Bailey/Hida hand-crafted dd algorithms
+// on one side, McCleeary lazy refinement on the other) so a clean
+// sweep is genuine cross-implementation confirmation at double
+// precision. See math_sweep_common.hpp for the precision-ceiling
+// caveat.
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/dd/dd.hpp>
+#include <universal/verification/test_suite.hpp>
+#include "math_sweep_common.hpp"
+
+int main()
+try {
+	using namespace sw::universal;
+	using namespace sw::universal::elreal_oracle_sweep;
+
+	std::string test_suite = "elreal Phase J: dd math oracle sweep";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	const auto& g = general_inputs();
+	const auto& p = positive_inputs();
+	const auto& b = bounded_inputs();
+
+	// sqrt and hypot
+	nrOfFailedTestCases += sweep_unary<dd>("dd::sqrt",  p,
+		[](const dd& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	// exp family
+	nrOfFailedTestCases += sweep_unary<dd>("dd::exp",   g,
+		[](const dd& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::exp2",  g,
+		[](const dd& a) { return exp2(a); },
+		[](const elreal& a) { return exp2(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::expm1", g,
+		[](const dd& a) { return expm1(a); },
+		[](const elreal& a) { return expm1(a); });
+
+	// log family
+	nrOfFailedTestCases += sweep_unary<dd>("dd::log",   p,
+		[](const dd& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::log2",  p,
+		[](const dd& a) { return log2(a); },
+		[](const elreal& a) { return log2(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::log10", p,
+		[](const dd& a) { return log10(a); },
+		[](const elreal& a) { return log10(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::log1p", log1p_inputs(),
+		[](const dd& a) { return log1p(a); },
+		[](const elreal& a) { return log1p(a); });
+
+	// trig
+	nrOfFailedTestCases += sweep_unary<dd>("dd::sin",   g,
+		[](const dd& a) { return sin(a); },
+		[](const elreal& a) { return sin(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::cos",   g,
+		[](const dd& a) { return cos(a); },
+		[](const elreal& a) { return cos(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::tan",   g,
+		[](const dd& a) { return tan(a); },
+		[](const elreal& a) { return tan(a); });
+
+	// inverse trig
+	nrOfFailedTestCases += sweep_unary<dd>("dd::asin",  b,
+		[](const dd& a) { return asin(a); },
+		[](const elreal& a) { return asin(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::acos",  b,
+		[](const dd& a) { return acos(a); },
+		[](const elreal& a) { return acos(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::atan",  g,
+		[](const dd& a) { return atan(a); },
+		[](const elreal& a) { return atan(a); });
+
+	// hyperbolic
+	nrOfFailedTestCases += sweep_unary<dd>("dd::sinh",  g,
+		[](const dd& a) { return sinh(a); },
+		[](const elreal& a) { return sinh(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::cosh",  g,
+		[](const dd& a) { return cosh(a); },
+		[](const elreal& a) { return cosh(a); });
+	nrOfFailedTestCases += sweep_unary<dd>("dd::tanh",  g,
+		[](const dd& a) { return tanh(a); },
+		[](const elreal& a) { return tanh(a); });
+
+	// pow with double exponent
+	std::vector<std::pair<double, double>> pow_inputs = {
+		{2.0, 3.0}, {2.0, 0.5}, {3.0, 2.5}, {0.5, 4.0}, {10.0, 0.25}
+	};
+	nrOfFailedTestCases += sweep_binary<dd>("dd::pow", pow_inputs,
+		[](const dd& a, const dd& bb) { return pow(a, bb); },
+		[](const elreal& a, const elreal& bb) { return pow(a, bb); });
+
+	// Anchors: deterministic exact-result expectations
+	nrOfFailedTestCases += anchor_check<dd>("exp(0)=1", 0.0, 1.0,
+		[](const dd& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += anchor_check<dd>("log(1)=0", 1.0, 0.0,
+		[](const dd& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += anchor_check<dd>("sqrt(1)=1", 1.0, 1.0,
+		[](const dd& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	// Reject path: deliberately wrong oracle must fail the helper.
+	{
+		dd     target = exp(dd(1.0));
+		elreal wrong  = elreal(2.0) * exp(elreal(1.0));
+		if (check_against_elreal_oracle(target, wrong)) {
+			std::cerr << "FAIL: dd oracle helper accepted a 2x-off reference\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/oracle/ereal_pown_sweep.cpp
+++ b/elastic/elreal/oracle/ereal_pown_sweep.cpp
@@ -1,0 +1,93 @@
+// ereal_pown_sweep.cpp: cross-validate ereal<N>::pown against elreal (Phase J, #904)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// ereal<N> exposes only `pown` from the math suite today; the rest of
+// the Phase J sweep does not apply. The oracle for pown is
+// elreal::pow(x, elreal(static_cast<double>(n))) since elreal does not
+// currently provide a free-function pown overload (see
+// math_sweep_common.hpp::sweep_pown).
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/ereal/ereal.hpp>
+#include <universal/verification/test_suite.hpp>
+#include "math_sweep_common.hpp"
+
+int main()
+try {
+	using namespace sw::universal;
+	using namespace sw::universal::elreal_oracle_sweep;
+
+	std::string test_suite = "elreal Phase J: ereal pown oracle sweep";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// Modest exponents only: pown of large bases at large exponents
+	// overflows even double precision, and the oracle would have to
+	// agree on inf which is also not interesting. The point of the
+	// sweep is to catch algorithmic disagreement, not floating-point
+	// limits.
+	std::vector<std::pair<double, int>> pown_inputs = {
+		{ 2.0,  0}, { 2.0,  1}, { 2.0,  2}, { 2.0,  3}, { 2.0,  5},
+		{ 0.5,  0}, { 0.5,  1}, { 0.5,  2}, { 0.5,  3}, { 0.5,  5},
+		{ 1.5,  0}, { 1.5,  1}, { 1.5,  3}, { 1.5,  5},
+		{ 3.0, -1}, { 3.0, -2}, { 3.0, -3},
+		{-2.0,  0}, {-2.0,  1}, {-2.0,  2}, {-2.0,  3},
+	};
+
+	// ereal<2>: dd-equivalent precision
+	nrOfFailedTestCases += sweep_pown<ereal<2>>("ereal<2>::pown", pown_inputs,
+		[](const ereal<2>& a, int n) { return pown(a, n); });
+
+	// ereal<4>: qd-equivalent
+	nrOfFailedTestCases += sweep_pown<ereal<4>>("ereal<4>::pown", pown_inputs,
+		[](const ereal<4>& a, int n) { return pown(a, n); });
+
+	// ereal<8>: default ereal max
+	nrOfFailedTestCases += sweep_pown<ereal<8>>("ereal<8>::pown", pown_inputs,
+		[](const ereal<8>& a, int n) { return pown(a, n); });
+
+	// Anchors specific to pown:
+	{
+		ereal<2> target; target = 2.0;
+		ereal<2> z = pown(target, 0);
+		if (double(z) != 1.0) {
+			std::cerr << "FAIL: ereal<2>::pown(2,0)=" << double(z) << " expected 1\n";
+			++nrOfFailedTestCases;
+		}
+	}
+	{
+		ereal<2> one_e2; one_e2 = 1.0;
+		ereal<2> z = pown(one_e2, 100);
+		if (double(z) != 1.0) {
+			std::cerr << "FAIL: ereal<2>::pown(1,100)=" << double(z) << " expected 1\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	// Reject path: deliberately wrong elreal must not match.
+	{
+		ereal<2> target; target = 8.0;  // = pown(2, 3)
+		elreal   wrong  = elreal(16.0); // 2x off
+		if (check_against_elreal_oracle(target, wrong)) {
+			std::cerr << "FAIL: ereal<2> oracle helper accepted a 2x-off reference\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/oracle/math_sweep_common.hpp
+++ b/elastic/elreal/oracle/math_sweep_common.hpp
@@ -1,0 +1,186 @@
+#pragma once
+// math_sweep_common.hpp: shared inputs + reporting for elreal oracle sweeps
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Phase J of #903 (follow-up to #873). The Phase G oracle helper
+// `check_against_elreal_oracle` lives in
+// `include/sw/universal/verification/test_suite_elreal_oracle.hpp`. This
+// header bundles the per-type sweep machinery for the multi-component
+// types `dd`, `qd`, `dd_cascade`, `td_cascade`, `qd_cascade`, and
+// `ereal<N>` so each per-type sweep cpp can stay short.
+//
+// Precision ceiling note
+// ----------------------
+// Today's elreal caps refinement at depth 1, which holds the helper's
+// effective comparison at double precision (~ 15 decimal digits). The
+// dd / qd / cascade types target 31 / 64 / 32 / 48 / 64 digits
+// respectively, so the helper currently *cannot* detect drift below
+// the 15th decimal. Phase L (#906) and Phase M (#907) of the follow-up
+// epic lift this ceiling; the sweep API does not change when they
+// land. Until then, a passing sweep means "no cross-implementation
+// disagreement at double precision", not "all bits of the target
+// type are correct".
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite_elreal_oracle.hpp>
+
+namespace sw { namespace universal { namespace elreal_oracle_sweep {
+
+// Representative inputs for unary functions over the real line. The
+// span is chosen to exercise typical, small-magnitude, and modestly
+// large arguments. None push into the std-library's accuracy-loss
+// regions (Payne-Hanek for trig is a Phase N concern).
+inline const std::vector<double>& general_inputs() {
+	static const std::vector<double> inputs = {
+		-2.5, -1.0, -0.5, -0.125, 0.0, 0.125, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0
+	};
+	return inputs;
+}
+
+// Positive-only inputs for functions whose natural domain is x > 0
+// (sqrt, log, log2, log10, log1p uses x > -1).
+inline const std::vector<double>& positive_inputs() {
+	static const std::vector<double> inputs = {
+		0.125, 0.5, 1.0, 1.5, 2.0, 3.0, 5.0, 10.0, 100.0
+	};
+	return inputs;
+}
+
+// [-1, 1] domain for asin / acos / atanh.
+inline const std::vector<double>& bounded_inputs() {
+	static const std::vector<double> inputs = {
+		-0.875, -0.5, -0.125, 0.0, 0.125, 0.5, 0.875
+	};
+	return inputs;
+}
+
+// (-1, inf) domain for log1p. Stays strictly above -1.
+inline const std::vector<double>& log1p_inputs() {
+	static const std::vector<double> inputs = {
+		-0.875, -0.5, -0.125, 0.0, 0.125, 0.5, 1.0, 2.0, 5.0
+	};
+	return inputs;
+}
+
+// [1, inf) domain for acosh.
+inline const std::vector<double>& acosh_inputs() {
+	static const std::vector<double> inputs = {
+		1.0, 1.125, 1.5, 2.0, 3.0, 5.0, 10.0
+	};
+	return inputs;
+}
+
+// Run a unary function on both sides of the oracle pipeline and report
+// a single FAIL line per disagreement.
+//
+//   - target_fn:  takes a TargetType, returns a TargetType
+//   - oracle_fn:  takes an elreal, returns an elreal
+//   - label_fn:   produces the human-readable label for the input
+template<typename TargetType, typename TargetFn, typename OracleFn>
+int sweep_unary(
+	const char* function_name,
+	const std::vector<double>& inputs,
+	TargetFn target_fn,
+	OracleFn oracle_fn,
+	int safety_margin = 2)
+{
+	int failures = 0;
+	for (double x : inputs) {
+		TargetType target = target_fn(TargetType(x));
+		elreal     oracle = oracle_fn(elreal(x));
+
+		std::string label = std::string(function_name) + "(" + std::to_string(x) + ")";
+		failures += report_against_elreal_oracle(label.c_str(),
+		                                        target, oracle,
+		                                        safety_margin);
+	}
+	return failures;
+}
+
+// Binary function sweep. Inputs come in (x, y) pairs.
+template<typename TargetType, typename TargetFn, typename OracleFn>
+int sweep_binary(
+	const char* function_name,
+	const std::vector<std::pair<double, double>>& inputs,
+	TargetFn target_fn,
+	OracleFn oracle_fn,
+	int safety_margin = 2)
+{
+	int failures = 0;
+	for (auto& xy : inputs) {
+		double x = xy.first, y = xy.second;
+		TargetType target = target_fn(TargetType(x), TargetType(y));
+		elreal     oracle = oracle_fn(elreal(x), elreal(y));
+
+		std::string label = std::string(function_name) + "(" + std::to_string(x)
+			+ ", " + std::to_string(y) + ")";
+		failures += report_against_elreal_oracle(label.c_str(),
+		                                        target, oracle,
+		                                        safety_margin);
+	}
+	return failures;
+}
+
+// Integer-exponent pown sweep: TargetType pown(target, int n) compared
+// against elreal pow(oracle, elreal(n)). elreal does not currently
+// expose a free-function pown overload; pow with an integer-valued
+// elreal exponent walks the same depth-1 derivative correction path
+// and is the right oracle for testing pown.
+template<typename TargetType, typename TargetFn>
+int sweep_pown(
+	const char* function_name,
+	const std::vector<std::pair<double, int>>& inputs,
+	TargetFn target_fn,
+	int safety_margin = 2)
+{
+	using sw::universal::pow;
+	int failures = 0;
+	for (auto& xn : inputs) {
+		double x = xn.first;
+		int    n = xn.second;
+		TargetType target = target_fn(TargetType(x), n);
+		elreal     oracle = pow(elreal(x), elreal(static_cast<double>(n)));
+
+		std::string label = std::string(function_name) + "(" + std::to_string(x)
+			+ ", " + std::to_string(n) + ")";
+		failures += report_against_elreal_oracle(label.c_str(),
+		                                        target, oracle,
+		                                        safety_margin);
+	}
+	return failures;
+}
+
+// Anchor checks: deterministic exact-result expectations that catch
+// gross bugs that any random-input pass would miss (e.g. exp(0) == 1
+// regardless of sign convention).
+template<typename TargetType, typename TargetFn, typename OracleFn>
+int anchor_check(
+	const char* anchor_label,
+	double x,
+	double expected,
+	TargetFn target_fn,
+	OracleFn oracle_fn)
+{
+	TargetType target = target_fn(TargetType(x));
+	elreal     oracle = oracle_fn(elreal(x));
+	if (double(target) != expected || double(oracle) != expected) {
+		std::cerr << "FAIL: " << anchor_label
+			<< " target=" << double(target)
+			<< " oracle=" << double(oracle)
+			<< " expected=" << expected << "\n";
+		return 1;
+	}
+	return 0;
+}
+
+} } } // namespace sw::universal::elreal_oracle_sweep

--- a/elastic/elreal/oracle/qd_cascade_math_sweep.cpp
+++ b/elastic/elreal/oracle/qd_cascade_math_sweep.cpp
@@ -1,0 +1,121 @@
+// qd_cascade_math_sweep.cpp: cross-validate qd_cascade math suite against elreal (Phase J, #904)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/qd_cascade/qd_cascade.hpp>
+#include <universal/verification/test_suite.hpp>
+#include "math_sweep_common.hpp"
+
+int main()
+try {
+	using namespace sw::universal;
+	using namespace sw::universal::elreal_oracle_sweep;
+
+	std::string test_suite = "elreal Phase J: qd_cascade math oracle sweep";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	const auto& g = general_inputs();
+	const auto& p = positive_inputs();
+	const auto& b = bounded_inputs();
+
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::sqrt", p,
+		[](const qd_cascade& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::exp",   g,
+		[](const qd_cascade& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::exp2",  g,
+		[](const qd_cascade& a) { return exp2(a); },
+		[](const elreal& a) { return exp2(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::expm1", g,
+		[](const qd_cascade& a) { return expm1(a); },
+		[](const elreal& a) { return expm1(a); });
+
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::log",   p,
+		[](const qd_cascade& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::log2",  p,
+		[](const qd_cascade& a) { return log2(a); },
+		[](const elreal& a) { return log2(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::log10", p,
+		[](const qd_cascade& a) { return log10(a); },
+		[](const elreal& a) { return log10(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::log1p", log1p_inputs(),
+		[](const qd_cascade& a) { return log1p(a); },
+		[](const elreal& a) { return log1p(a); });
+
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::sin", g,
+		[](const qd_cascade& a) { return sin(a); },
+		[](const elreal& a) { return sin(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::cos", g,
+		[](const qd_cascade& a) { return cos(a); },
+		[](const elreal& a) { return cos(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::tan", g,
+		[](const qd_cascade& a) { return tan(a); },
+		[](const elreal& a) { return tan(a); });
+
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::asin", b,
+		[](const qd_cascade& a) { return asin(a); },
+		[](const elreal& a) { return asin(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::acos", b,
+		[](const qd_cascade& a) { return acos(a); },
+		[](const elreal& a) { return acos(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::atan", g,
+		[](const qd_cascade& a) { return atan(a); },
+		[](const elreal& a) { return atan(a); });
+
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::sinh", g,
+		[](const qd_cascade& a) { return sinh(a); },
+		[](const elreal& a) { return sinh(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::cosh", g,
+		[](const qd_cascade& a) { return cosh(a); },
+		[](const elreal& a) { return cosh(a); });
+	nrOfFailedTestCases += sweep_unary<qd_cascade>("qd_cascade::tanh", g,
+		[](const qd_cascade& a) { return tanh(a); },
+		[](const elreal& a) { return tanh(a); });
+
+	std::vector<std::pair<double, double>> pow_inputs = {
+		{2.0, 3.0}, {2.0, 0.5}, {3.0, 2.5}, {0.5, 4.0}, {10.0, 0.25}
+	};
+	nrOfFailedTestCases += sweep_binary<qd_cascade>("qd_cascade::pow", pow_inputs,
+		[](const qd_cascade& a, const qd_cascade& bb) { return pow(a, bb); },
+		[](const elreal& a, const elreal& bb) { return pow(a, bb); });
+
+	nrOfFailedTestCases += anchor_check<qd_cascade>("exp(0)=1", 0.0, 1.0,
+		[](const qd_cascade& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += anchor_check<qd_cascade>("log(1)=0", 1.0, 0.0,
+		[](const qd_cascade& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += anchor_check<qd_cascade>("sqrt(1)=1", 1.0, 1.0,
+		[](const qd_cascade& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	{
+		qd_cascade target = exp(qd_cascade(1.0));
+		elreal     wrong  = elreal(2.0) * exp(elreal(1.0));
+		if (check_against_elreal_oracle(target, wrong)) {
+			std::cerr << "FAIL: qd_cascade oracle helper accepted a 2x-off reference\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/oracle/qd_math_sweep.cpp
+++ b/elastic/elreal/oracle/qd_math_sweep.cpp
@@ -1,0 +1,134 @@
+// qd_math_sweep.cpp: cross-validate qd math suite against elreal (Phase J, #904)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Companion of dd_math_sweep.cpp for the qd (quad-double) type. See
+// dd_math_sweep.cpp for the design rationale and the precision-ceiling
+// caveat that applies to all multi-component oracle sweeps today.
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/qd/qd.hpp>
+#include <universal/verification/test_suite.hpp>
+#include "math_sweep_common.hpp"
+
+int main()
+try {
+	using namespace sw::universal;
+	using namespace sw::universal::elreal_oracle_sweep;
+
+	std::string test_suite = "elreal Phase J: qd math oracle sweep";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	const auto& g = general_inputs();
+	const auto& p = positive_inputs();
+	const auto& b = bounded_inputs();
+
+	// sqrt
+	nrOfFailedTestCases += sweep_unary<qd>("qd::sqrt", p,
+		[](const qd& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	// exp family
+	nrOfFailedTestCases += sweep_unary<qd>("qd::exp",   g,
+		[](const qd& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::exp2",  g,
+		[](const qd& a) { return exp2(a); },
+		[](const elreal& a) { return exp2(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::expm1", g,
+		[](const qd& a) { return expm1(a); },
+		[](const elreal& a) { return expm1(a); });
+
+	// log family
+	nrOfFailedTestCases += sweep_unary<qd>("qd::log",   p,
+		[](const qd& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::log2",  p,
+		[](const qd& a) { return log2(a); },
+		[](const elreal& a) { return log2(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::log10", p,
+		[](const qd& a) { return log10(a); },
+		[](const elreal& a) { return log10(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::log1p", log1p_inputs(),
+		[](const qd& a) { return log1p(a); },
+		[](const elreal& a) { return log1p(a); });
+
+	// trig
+	nrOfFailedTestCases += sweep_unary<qd>("qd::sin", g,
+		[](const qd& a) { return sin(a); },
+		[](const elreal& a) { return sin(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::cos", g,
+		[](const qd& a) { return cos(a); },
+		[](const elreal& a) { return cos(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::tan", g,
+		[](const qd& a) { return tan(a); },
+		[](const elreal& a) { return tan(a); });
+
+	// inverse trig
+	nrOfFailedTestCases += sweep_unary<qd>("qd::asin", b,
+		[](const qd& a) { return asin(a); },
+		[](const elreal& a) { return asin(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::acos", b,
+		[](const qd& a) { return acos(a); },
+		[](const elreal& a) { return acos(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::atan", g,
+		[](const qd& a) { return atan(a); },
+		[](const elreal& a) { return atan(a); });
+
+	// hyperbolic
+	nrOfFailedTestCases += sweep_unary<qd>("qd::sinh", g,
+		[](const qd& a) { return sinh(a); },
+		[](const elreal& a) { return sinh(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::cosh", g,
+		[](const qd& a) { return cosh(a); },
+		[](const elreal& a) { return cosh(a); });
+	nrOfFailedTestCases += sweep_unary<qd>("qd::tanh", g,
+		[](const qd& a) { return tanh(a); },
+		[](const elreal& a) { return tanh(a); });
+
+	// pow
+	std::vector<std::pair<double, double>> pow_inputs = {
+		{2.0, 3.0}, {2.0, 0.5}, {3.0, 2.5}, {0.5, 4.0}, {10.0, 0.25}
+	};
+	nrOfFailedTestCases += sweep_binary<qd>("qd::pow", pow_inputs,
+		[](const qd& a, const qd& bb) { return pow(a, bb); },
+		[](const elreal& a, const elreal& bb) { return pow(a, bb); });
+
+	// Anchors
+	nrOfFailedTestCases += anchor_check<qd>("exp(0)=1", 0.0, 1.0,
+		[](const qd& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += anchor_check<qd>("log(1)=0", 1.0, 0.0,
+		[](const qd& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+	nrOfFailedTestCases += anchor_check<qd>("sqrt(1)=1", 1.0, 1.0,
+		[](const qd& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	// Reject path
+	{
+		qd     target = exp(qd(1.0));
+		elreal wrong  = elreal(2.0) * exp(elreal(1.0));
+		if (check_against_elreal_oracle(target, wrong)) {
+			std::cerr << "FAIL: qd oracle helper accepted a 2x-off reference\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}

--- a/elastic/elreal/oracle/td_cascade_math_sweep.cpp
+++ b/elastic/elreal/oracle/td_cascade_math_sweep.cpp
@@ -1,0 +1,115 @@
+// td_cascade_math_sweep.cpp: cross-validate td_cascade math suite against elreal (Phase J, #904)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+#include <universal/utility/directives.hpp>
+
+#include <universal/number/td_cascade/td_cascade.hpp>
+#include <universal/verification/test_suite.hpp>
+#include "math_sweep_common.hpp"
+
+int main()
+try {
+	using namespace sw::universal;
+	using namespace sw::universal::elreal_oracle_sweep;
+
+	std::string test_suite = "elreal Phase J: td_cascade math oracle sweep";
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, false);
+
+	// td_cascade exposes a smaller math suite than dd / qd / dd_cascade /
+	// qd_cascade today (no exp2 / exp10 / expm1 / log2 / log10 / log1p),
+	// so this sweep is correspondingly narrower.
+	const auto& g = general_inputs();
+	const auto& p = positive_inputs();
+	const auto& b = bounded_inputs();
+
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::sqrt", p,
+		[](const td_cascade& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::exp", g,
+		[](const td_cascade& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::log", p,
+		[](const td_cascade& a) { return log(a); },
+		[](const elreal& a) { return log(a); });
+
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::sin", g,
+		[](const td_cascade& a) { return sin(a); },
+		[](const elreal& a) { return sin(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::cos", g,
+		[](const td_cascade& a) { return cos(a); },
+		[](const elreal& a) { return cos(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::tan", g,
+		[](const td_cascade& a) { return tan(a); },
+		[](const elreal& a) { return tan(a); });
+
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::asin", b,
+		[](const td_cascade& a) { return asin(a); },
+		[](const elreal& a) { return asin(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::acos", b,
+		[](const td_cascade& a) { return acos(a); },
+		[](const elreal& a) { return acos(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::atan", g,
+		[](const td_cascade& a) { return atan(a); },
+		[](const elreal& a) { return atan(a); });
+
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::sinh", g,
+		[](const td_cascade& a) { return sinh(a); },
+		[](const elreal& a) { return sinh(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::cosh", g,
+		[](const td_cascade& a) { return cosh(a); },
+		[](const elreal& a) { return cosh(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::tanh", g,
+		[](const td_cascade& a) { return tanh(a); },
+		[](const elreal& a) { return tanh(a); });
+
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::asinh", g,
+		[](const td_cascade& a) { return asinh(a); },
+		[](const elreal& a) { return asinh(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::acosh", acosh_inputs(),
+		[](const td_cascade& a) { return acosh(a); },
+		[](const elreal& a) { return acosh(a); });
+	nrOfFailedTestCases += sweep_unary<td_cascade>("td_cascade::atanh", b,
+		[](const td_cascade& a) { return atanh(a); },
+		[](const elreal& a) { return atanh(a); });
+
+	std::vector<std::pair<double, double>> pow_inputs = {
+		{2.0, 3.0}, {2.0, 0.5}, {3.0, 2.5}, {0.5, 4.0}, {10.0, 0.25}
+	};
+	nrOfFailedTestCases += sweep_binary<td_cascade>("td_cascade::pow", pow_inputs,
+		[](const td_cascade& a, const td_cascade& bb) { return pow(a, bb); },
+		[](const elreal& a, const elreal& bb) { return pow(a, bb); });
+
+	nrOfFailedTestCases += anchor_check<td_cascade>("exp(0)=1", 0.0, 1.0,
+		[](const td_cascade& a) { return exp(a); },
+		[](const elreal& a) { return exp(a); });
+	nrOfFailedTestCases += anchor_check<td_cascade>("sqrt(1)=1", 1.0, 1.0,
+		[](const td_cascade& a) { return sqrt(a); },
+		[](const elreal& a) { return sqrt(a); });
+
+	{
+		td_cascade target = exp(td_cascade(1.0));
+		elreal     wrong  = elreal(2.0) * exp(elreal(1.0));
+		if (check_against_elreal_oracle(target, wrong)) {
+			std::cerr << "FAIL: td_cascade oracle helper accepted a 2x-off reference\n";
+			++nrOfFailedTestCases;
+		}
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Phase J of #903 (follow-up to #873). Extends the Phase G validation oracle (\`check_against_elreal_oracle\`, shipped in PR #900) into a comprehensive sweep so the elreal oracle becomes the standard cross-implementation reference for every multi-component type in Universal.

## What landed

- **\`elastic/elreal/oracle/math_sweep_common.hpp\`** -- shared input tables (general / positive / bounded / log1p / acosh domains) and three sweep templates (\`sweep_unary\`, \`sweep_binary\`, \`sweep_pown\`) plus an \`anchor_check\` helper for deterministic-result expectations.
- **Six per-type sweep cpp files** in \`elastic/elreal/oracle/\`:
  - \`dd_math_sweep.cpp\` -- 17 functions
  - \`qd_math_sweep.cpp\` -- 17 functions
  - \`dd_cascade_math_sweep.cpp\` -- 17 functions
  - \`td_cascade_math_sweep.cpp\` -- 15 functions (td_cascade lacks exp2/expm1/log2/log10/log1p but has asinh/acosh/atanh)
  - \`qd_cascade_math_sweep.cpp\` -- 17 functions
  - \`ereal_pown_sweep.cpp\` -- \`ereal<2>\`, \`ereal<4>\`, \`ereal<8>\` pown (the only math function ereal exposes today)

  Each file also exercises:
  - **Reject-path check**: the helper must *reject* a deliberately-wrong 2x-off oracle, guarding against silent passes from loose tolerance
  - **Anchors**: deterministic exact-result expectations (\`exp(0)=1\`, \`log(1)=0\`, \`sqrt(1)=1\`) that catch gross bugs random-input passes miss

- **\`docs/algorithmic-details/elreal-oracle-sweep-results.md\`** -- the aggregated pass/fail report. Documents the precision-ceiling caveat prominently: today's helper compares at double precision because elreal caps at depth-1 refinement. When Phase L (#906) and Phase M (#907) lift the depth-1 cap, the sweep sharpens automatically -- the helpers and sweep sources do not change.
- **\`docs/site/algorithmic-details/index.md\`** -- new doc listed.
- **\`docs-site/sync-content.mjs\`** -- wired into the content map.

## Results

| Sweep                                | gcc 13.3 | clang 18.1 | Reject-path |
|--------------------------------------|:--------:|:----------:|:-----------:|
| dd math (17 functions)               | PASS     | PASS       | OK          |
| qd math (17 functions)               | PASS     | PASS       | OK          |
| dd_cascade math (17 functions)       | PASS     | PASS       | OK          |
| td_cascade math (15 functions)       | PASS     | PASS       | OK          |
| qd_cascade math (17 functions)       | PASS     | PASS       | OK          |
| ereal<2> / ereal<4> / ereal<8> pown  | PASS     | PASS       | OK          |

Cross-implementation agreement at double precision is the contract today; deeper validation is gated on the elreal depth-2+ work in Phases L and M of the follow-up epic.

## Test plan

- [x] Builds clean under gcc 13.3 (\`build_elreal/\`)
- [x] Builds clean under clang 18.1 (\`build_clang_elreal/\`)
- [x] All six sweeps PASS under both compilers
- [x] Reject-path check confirms helper rejects 2x-off oracle on every type
- [x] docs-site builds (87 pages, sweep-results page rendered)
- [x] CI fast tier green (gcc + clang lite)
- [x] CodeRabbit review

## Out of scope

- Newton refinement for \`/\` and \`sqrt\` (that's Phase L #906)
- Depth-2+ math (Phase M #907)
- Payne-Hanek for forward trig (Phase N #908)
- Deeper constants (Phase O #909)
- Allocator hot-path optimisation (Phase K #905)
- td_cascade math suite gaps (out of Phase J scope; flagged in the doc)

Closes #904.
Part of epic #903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation of Phase J oracle sweep results, detailing cross-implementation validation across multiple precision types with pass/fail outcomes and precision specifications.
  * Updated documentation index to include the new oracle sweep results page.

* **Tests**
  * Added comprehensive test suite for validating mathematical function implementations against oracle baseline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->