### PR TITLE
perf(elreal): Phase K.2 -- tagged-union generator (variant) replaces std::function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,11 +93,11 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 ####
 # Set the path to the data directory
-set(TEST_MATRIX_DATA_DIR "${CMAKE_SOURCE_DIR}/data/matrices")
+set(TEST_MATRIX_DATA_DIR "${PROJECT_SOURCE_DIR}/data/matrices")
 # Configure a header file that will contain the data directory path
 
 configure_file(
-    "${CMAKE_SOURCE_DIR}/config/TestMatrixDataDirConfig.hpp.in"
+    "${PROJECT_SOURCE_DIR}/config/TestMatrixDataDirConfig.hpp.in"
     "${CMAKE_BINARY_DIR}/generated/TestMatrixDataDirConfig.hpp"
 )
 

--- a/docs/algorithmic-details/elreal-performance-baseline.md
+++ b/docs/algorithmic-details/elreal-performance-baseline.md
@@ -100,124 +100,93 @@ roughly 2 small allocs (one make_shared per operand) -- but each
 allocation is now small and fixed-size, friendly to the allocator's
 fast path.
 
-The two compilers no longer differ materially on most operators -- both
-land in the same 12-22 Mops/s range for arithmetic. The clang gap on
-`elreal *` that the Phase I baseline flagged (4 vs 8 Mops/s) is closed.
-
-The `elreal /` Gops/s result is genuine in the workload but worth
-flagging: with the inline-buffer change, the result `elreal` is fully
-stack-allocatable, and `elreal::operator/` happens to be the simplest
-operator (single double divide, no captured generator -- depth-2+
-Newton refinement is deferred to Phase L #906). gcc inlines the whole
-operator and the only remaining work is the double divide itself. In a
-workload where the result needs to be propagated into a more complex
-expression, the throughput drops back to the same range as the other
-operators.
-
-Below, we use the gcc 13.3 post-K.1 numbers as the reference unless
+Below, we use the gcc 13.3 post-K.2 numbers as the reference unless
 otherwise noted.
 
-## Reading the table
+## Reading the table (current, post-K.2)
 
 ### elreal arithmetic at depth 1
 
-`+`, `-`, `*` all land in the 4-9 Mops/s range. The cost shape is
-dominated by:
+`+`, `-`, `*` now land in the 16-17 Mops/s range -- a roughly 2x
+improvement on the original Phase I baseline (8-9 Mops/s). The
+remaining cost is:
 
-1. **One `std::vector<double>` allocation** for `_components` per result.
-2. **One `std::function` capture** for the generator (heap-allocated by
-   libstdc++ / libc++ since the capture exceeds the small-buffer
-   optimisation threshold -- two `elreal` copies plus a `sum_err` double).
-3. **Two `elreal` copy constructions** to bind into the lambda capture.
-   Each copy walks the source's `_components` vector and increments any
-   reference counts on its `std::function`.
+1. **Two `std::make_shared<const elreal>(...)` allocations** per binary
+   op for the operand handles. Each is a small fixed-size alloc
+   (sizeof control block + sizeof elreal) that hits the allocator's
+   fast path.
+2. **The variant emplace** (no allocation; the variant alternatives are
+   stored inline in the result `elreal`).
+3. **The leading-component EFT computation** (`two_sum`/`two_diff`/`two_prod`).
 
-The two_sum / two_prod EFTs themselves are inexpensive -- they are a few
-double FLOPs each. The per-op cost is overwhelmingly memory traffic
-(allocation, vector population, function-object packing).
+The K.1 vector alloc and K.2 std::function alloc are both gone. The
+two_sum / two_prod EFTs are a small number of double FLOPs each. The
+per-op cost is now roughly balanced between the small allocations and
+the leading-component math.
 
 ### elreal `/` at depth 0
 
-Division clocks 23-36 Mops/s -- three to six times faster than the other
-arithmetic operators. The reason: as of Phase G, `elreal::operator/`
-materialises `c0 = a.at(0) / b.at(0)` (a single double division) and
-returns a degenerate generator (Newton refinement is deferred to
-future work). So there is no captured-ancestor lambda and no second
-component to compute. Once Newton iteration is in place, division will
-look much more like `*`.
+Division clocks ~ 1 Gops/s in the synthetic benchmark. The reason:
+`elreal::operator/` materialises `c0 = a.at(0) / b.at(0)` (a single
+double division) and installs a `std::monostate` generator. With both
+K.1 and K.2 in place, the entire operator is stack-allocatable, the
+compiler inlines through it, and the only remaining work is the
+double divide. In a workload where the result feeds into a complex
+expression, throughput drops to the same range as the other operators.
+Once Phase L (#906) lands Newton refinement, division will look more
+like multiplication.
 
 ### elreal math (sqrt / exp / log)
 
-13-14 Mops/s -- *faster* than `+`/`-`/`*` despite computing an `std::sqrt`
-or `std::exp` inside. The reason is structural: the math operators
-capture one operand into the lambda instead of two. Allocation is the
-bottleneck, and saving one `elreal` copy in the capture is worth more
-than the cost of a `std::sqrt` call on a modern x86 core.
-
-The clang-vs-gcc gap on `elreal *` (4 vs 8 Mops/s) is worth flagging:
-multiplication is the operator with the heaviest captured payload
-(both inputs, plus the `two_prod` error term), and libc++'s default
-allocator hits the small-object pool harder than libstdc++'s glibc
-malloc here. Both compilers land in the same shape; the absolute gap
-is the kind of thing the Phase II small-buffer optimisation on
-`_components` would close.
+36-43 Mops/s on gcc -- *faster* than `+`/`-`/`*` despite computing a
+`std::sqrt` or `std::exp` internally. The reason is structural: the
+unary math operators capture one operand into a `gen_unary_linear`
+(1 shared_ptr + 1 double = 24 bytes inline), so the per-op envelope
+is the smallest among the operators. Allocation is the bottleneck,
+and saving one shared_ptr alloc in the capture is worth more than
+the cost of a `std::sqrt` call on a modern x86 core.
 
 ### elreal `refine_to(106)` vs `refine_to(212)`
 
-These are both ~ 8-9 Mops/s, only slightly slower than depth 1. This is
-the *current* shape of the implementation: each operator's generator
-clamps at depth 1 (returns 0 for k >= 2). So requesting 212 bits via
-`refine_to` walks the generator once for k=1 and then writes zeros for
-k=2 through ceil(212/53). Once depth-2+ refinement lands (Newton for `/`
-and `sqrt`, higher-precision internal algorithms for the rest), this
-sweep will become informative.
+Both ~ 14-20 Mops/s, only slightly slower than depth 1. Each
+operator's generator clamps at depth 1 (returns 0 for k >= 2), so
+requesting 212 bits via `refine_to` walks the generator once for
+k=1 and then writes zeros for k=2 through ceil(212/53). Once
+depth-2+ refinement lands (Phase L for Newton on `/` and `sqrt`,
+Phase M for higher-precision algorithms on the transcendentals),
+this sweep will become informative.
 
 ### ereal<N> at matched precision
 
-`ereal<2>` (~ 106 bits, dd-equivalent) clocks 10-26 Mops/s for `+ - *`
-when its operands are also freshly allocated each iteration (matched
-to the elreal workload pattern) -- roughly **1.2-3x faster than elreal**
-at the same precision target. The gap holds across `ereal<4>` and
-`ereal<8>`: ereal's component vector is a `std::vector<double>` like
-elreal's, but ereal carries no captured-generator lambda alongside it,
-so the allocation cost per op is roughly half. The narrower gap on
-multiplication (1.2x rather than 3x) reflects that ereal's
-`expansion_product` does O(N) work per op, eroding its allocator
-advantage as N grows.
+`ereal<2>` (~ 106 bits, dd-equivalent) clocks 19-27 Mops/s for
+`+ - *` when its operands are also freshly allocated each iteration
+(matched to the elreal workload pattern). With K.2 in place, the
+arithmetic gap with `elreal` has narrowed substantially:
 
-The exception is `ereal<N> /`, which is **~50x slower than elreal /**
-at depth 0 (650 Kops/s vs 36 Mops/s for ereal<2> vs elreal). ereal's
-division runs iteratively until it has enough components; elreal's
-current division just does a single double divide and returns. The
-right reading: elreal's division is currently more *throughput-friendly*
-but at lower precision -- a fair comparison requires Newton refinement
-in elreal first.
+| Op | `elreal` post-K.2 (gcc) | `ereal<2>` (gcc) | Winner |
+|---|---:|---:|---|
+| `+` | 17 Mops/s | 19 Mops/s | `ereal<2>` (~ 1.1x; gap nearly closed) |
+| `-` | 17 Mops/s | 20 Mops/s | `ereal<2>` (~ 1.2x) |
+| `*` | 16 Mops/s | 11 Mops/s | **`elreal` (~ 1.5x)** |
+| `/` | (apples-to-oranges) | 680 Kops/s | -- |
+| `sqrt`, `exp`, `log` | 36-43 Mops/s | n/a | `elreal` only |
+
+Multiplication continues to favour `elreal`: `ereal<N>` multiplication
+is O(N) in the eager expansion product while `elreal *` is essentially
+a single `two_prod` plus the (now inline) result envelope.
+
+The `ereal<N> /` outlier (~ 680 Kops/s, ~ 50x slower than `elreal /`)
+is the iterative-division cost; not apples-to-apples since `elreal /`
+is depth-0 only today.
 
 ## When is `elreal` faster than `ereal`?
 
-The picture changed materially with K.1:
+After K.2, `elreal` is competitive with `ereal<2>` on every elementary
+arithmetic operator at matched precision, and *wins* on multiplication
+and on every math function (the entire math suite is `elreal`-only
+since `ereal<N>` does not expose math functions today).
 
-| Op | `elreal` post-K.1 (gcc) | `ereal<2>` (gcc) | Winner |
-|---|---:|---:|---|
-| `+` | 12 Mops/s | 24 Mops/s | `ereal<2>` (~ 2x) |
-| `-` | 14 Mops/s | 19 Mops/s | `ereal<2>` (~ 1.4x) |
-| `*` | 19 Mops/s | 10 Mops/s | **`elreal` (~ 1.9x)** |
-| `/` | (apples-to-oranges) | 650 Kops/s | -- |
-| `sqrt`, `exp`, `log` | 24-31 Mops/s | n/a | `elreal` only |
-
-Multiplication has flipped: `elreal *` now beats `ereal<2> *` at matched
-precision because `ereal<N>` multiplication is O(N) in the eager
-expansion product while `elreal *` is essentially a single `two_prod`
-plus the (now inline) result envelope.
-
-Addition and subtraction still favour `ereal<2>` -- those operators
-are O(1) in `ereal<N>` for small N and the per-iteration cost is
-dominated by the result construction, which `ereal<N>` already amortises
-better than the lazy-stream envelope. The remaining gap is what
-Phase K.2 (`std::function` -> tagged-union generator) and Phase K.3
-(reference-counted operand sharing) target.
-
-What `elreal` gives you instead, and what `ereal` cannot:
+What `elreal` provides that `ereal<N>` cannot, independent of throughput:
 
 1. **Decidable sign.** Comparison walks the stream until a non-zero
    difference is found, with a bounded budget. `ereal` has no equivalent;
@@ -228,14 +197,40 @@ What `elreal` gives you instead, and what `ereal` cannot:
    committed budget on the type. `ereal<N>` is precision-fixed at the
    instantiation site.
 3. **General-position skip.** For workloads where the *common case*
-   needs depth 0 (most geometric predicates on shuffled inputs), elreal's
-   depth-0 cost is the single double op plus the lazy-result envelope
-   -- the envelope is what we are paying for above, and shrinking it is
-   the natural Phase II work.
+   needs depth 0 (most geometric predicates on shuffled inputs),
+   elreal's depth-0 cost is the single double op plus the lazy-result
+   envelope.
 
-**Conclusion**: `elreal` wins on *correctness* in cases where `ereal`
-cannot answer, not on throughput at matched precision today. The picker
-decision tree in `multi-component-arithmetic.md` reflects this.
+**Conclusion**: `elreal` is now both *throughput-competitive* at matched
+precision *and* offers correctness features `ereal<N>` lacks. The
+picker decision tree in `multi-component-arithmetic.md` reflects this.
+
+## Historical: Phase I baseline analysis (pre-K.1)
+
+Retained for archival reference. The numbers and the cost-shape
+discussion below describe the pre-optimisation state.
+
+The Phase I baseline (#902) measured the elreal arithmetic at
+4-9 Mops/s for `+`/`-`/`*` on gcc 13.3, and identified the dominant
+cost as:
+
+1. **One `std::vector<double>` allocation** for `_components` per
+   result. (Closed by K.1.)
+2. **One `std::function` capture** for the generator (heap-allocated
+   by libstdc++/libc++ since the capture exceeded the SBO threshold
+   -- two `elreal` copies plus a residual double). (Closed by K.2.)
+3. **Two `elreal` copy constructions** into the lambda capture.
+   (Closed by K.2; operands now shared via `shared_ptr<const elreal>`.)
+
+The math functions (sqrt, exp, log) at the Phase I baseline clocked
+13-14 Mops/s -- already faster than arithmetic because the unary
+captures fit in a smaller `std::function` payload. K.2 widened that
+advantage.
+
+The pre-K.2 picker rule said `ereal<2>` won on `+/-/*` by 1.2-3x at
+matched precision; only multiplication favoured `elreal` after K.1
+(1.9x). After K.2, the gap on `+/-` is within ~ 20% and multiplication
+still favours `elreal` by 1.5x.
 
 ## Allocation hot path -- candidates for tuning
 

--- a/docs/algorithmic-details/elreal-performance-baseline.md
+++ b/docs/algorithmic-details/elreal-performance-baseline.md
@@ -1,18 +1,24 @@
 # elreal Performance Baseline
 
-Phase I of epic #873 (baseline) and Phase K.1 of follow-up epic #903
-(small-buffer optimisation on `_components`). This document is a
-baseline measurement -- not a performance target. The numbers below
-come from a single workstation and are intended to identify the cost
-shape of the shipped implementation, so that future optimisation work
-has a starting point and a way to measure progress.
+Phase I of epic #873 (baseline), Phase K.1 (#912), and Phase K.2 (#905)
+of follow-up epic #903. This document is a baseline measurement -- not
+a performance target. The numbers below come from a single workstation
+and are intended to identify the cost shape of the shipped
+implementation, so that future optimisation work has a starting point
+and a way to measure progress.
 
-> **Phase K.1 update (#905)**: The `_components` storage migrated from
+> **Phase K.1 update**: The `_components` storage migrated from
 > `std::vector<double>` to a small-buffer-optimised
-> `lazy_component_buffer` (inline 4 doubles + spill, see
-> `include/sw/universal/number/elreal/lazy_component_buffer.hpp`).
-> The headline numbers tables below carry both the original Phase I
-> baseline and the post-K.1 measurements.
+> `lazy_component_buffer` (inline 4 doubles + spill).
+>
+> **Phase K.2 update**: `_generator` migrated from
+> `std::function<double(std::size_t)>` to a `std::variant` of small POD
+> shapes (`gen_unary_linear`, `gen_binary_linear`, `gen_sqrt`,
+> `gen_unary_neg`, `gen_rational_residual`). Operand captures are now
+> `std::shared_ptr<const elreal>` (16 bytes) rather than `elreal` by
+> value (~104 bytes), eliminating the per-op std::function heap
+> allocation that the original Phase I baseline identified as the
+> dominant per-op cost.
 
 ## Measurement setup
 
@@ -52,24 +58,47 @@ These were the numbers before the K.1 small-buffer optimisation:
 | `ereal<4> /` | --- | 639 Kops/s | 721 Kops/s |
 | `ereal<8> /` | --- | 636 Kops/s | 725 Kops/s |
 
-## Headline numbers (post-K.1, current)
+## Headline numbers (post-K.1)
 
-After the K.1 small-buffer optimisation. Same workload, same hardware,
-same compilers. ereal numbers are unchanged from above (K.1 only touched
-elreal):
+After the K.1 small-buffer optimisation. Numbers retained for the
+before/after comparison; current numbers are the post-K.2 table further
+down.
+
+| Operation | Budget | gcc 13.3 | clang 18.1 |
+|---|---|---:|---:|
+| `elreal +` | depth 0 | 16 Mops/s | 17 Mops/s |
+| `elreal +` | depth 1 | 12 Mops/s | 21 Mops/s |
+| `elreal -` | depth 1 | 14 Mops/s | 17 Mops/s |
+| `elreal *` | depth 1 | 19 Mops/s | 22 Mops/s |
+| `elreal sqrt` | depth 1 | 30 Mops/s | 30 Mops/s |
+| `elreal exp` | depth 1 | 31 Mops/s | 34 Mops/s |
+| `elreal log` | depth 1 | 24 Mops/s | 28 Mops/s |
+
+## Headline numbers (post-K.2, current)
+
+After the K.2 variant-generator + shared-operand changes. The math
+functions show the largest gains because the unary derivative captures
+(1 shared_ptr + 1 double) fit naturally into the new shape:
 
 | Operation | Budget | gcc 13.3 | clang 18.1 | vs Phase I (gcc) |
 |---|---|---:|---:|---:|
-| `elreal +` | depth 0 | 16 Mops/s | 17 Mops/s | **1.8x faster** |
-| `elreal +` | depth 1 | 12 Mops/s | 21 Mops/s | **1.3x faster** |
-| `elreal -` | depth 1 | 14 Mops/s | 17 Mops/s | **1.6x faster** |
-| `elreal *` | depth 1 | 19 Mops/s | 22 Mops/s | **2.4x faster** |
-| `elreal /` | depth 0 | 1 Gops/s | 138 Mops/s | dominated by compiler inlining once heap alloc is gone (see note) |
-| `elreal sqrt` | depth 1 | 30 Mops/s | 30 Mops/s | **2.1x faster** |
-| `elreal exp` | depth 1 | 31 Mops/s | 34 Mops/s | **2.2x faster** |
-| `elreal log` | depth 1 | 24 Mops/s | 28 Mops/s | **1.7x faster** |
-| `elreal + refine_to(106)` | --- | 13 Mops/s | 15 Mops/s | 1.4x |
-| `elreal + refine_to(212)` | --- | 11 Mops/s | 17 Mops/s | 1.4x |
+| `elreal +` | depth 0 | 20 Mops/s | 16 Mops/s | **2.2x faster** |
+| `elreal +` | depth 1 | 17 Mops/s | 11 Mops/s | **1.9x faster** |
+| `elreal -` | depth 1 | 17 Mops/s | 14 Mops/s | **1.9x faster** |
+| `elreal *` | depth 1 | 16 Mops/s | 15 Mops/s | **2.0x faster** |
+| `elreal /` | depth 0 | 1 Gops/s | 64 Mops/s | dominated by inlining once heap alloc is gone |
+| `elreal sqrt` | depth 1 | 36 Mops/s | 18 Mops/s | **2.6x faster** |
+| `elreal exp` | depth 1 | 43 Mops/s | 26 Mops/s | **3.1x faster** |
+| `elreal log` | depth 1 | 38 Mops/s | 31 Mops/s | **2.7x faster** |
+| `elreal + refine_to(106)` | --- | 20 Mops/s | 19 Mops/s | 2.2x |
+| `elreal + refine_to(212)` | --- | 14 Mops/s | 19 Mops/s | 1.8x |
+
+The K.1 baseline already eliminated the `_components` vector alloc;
+K.2 eliminates the `_generator` std::function alloc. Together they
+take per-binary-op heap allocations from 2 (vector + function) to
+roughly 2 small allocs (one make_shared per operand) -- but each
+allocation is now small and fixed-size, friendly to the allocator's
+fast path.
 
 The two compilers no longer differ materially on most operators -- both
 land in the same 12-22 Mops/s range for arithmetic. The clang gap on

--- a/docs/algorithmic-details/multi-component-arithmetic.md
+++ b/docs/algorithmic-details/multi-component-arithmetic.md
@@ -635,28 +635,29 @@ clang 18.1, `-O3`). The full numbers and reproduction recipe live in
 `docs/algorithmic-details/elreal-performance-baseline.md`. The summary
 shape for picker purposes:
 
-| Op | `elreal` post-K.1 | `ereal<2>` (~106 bits) | Winner |
+| Op | `elreal` post-K.2 | `ereal<2>` (~106 bits) | Winner |
 |---|---:|---:|---|
-| `+` | ~12 Mops/s | ~24 Mops/s | `ereal<2>` (~ 2x) |
-| `-` | ~14 Mops/s | ~19 Mops/s | `ereal<2>` (~ 1.4x) |
-| `*` | ~19 Mops/s | ~10 Mops/s | **`elreal` (~ 1.9x)** |
-| `/` (elreal depth 0 only) | (dominated by inlining) | ~650 Kops/s | `elreal` (apples-to-oranges; ereal does full precision, elreal does double only) |
-| `sqrt`, `exp`, `log` | ~24-31 Mops/s | n/a | `elreal` (ereal has no math functions) |
+| `+` | ~17 Mops/s | ~19 Mops/s | `ereal<2>` (~ 1.1x; gap nearly closed) |
+| `-` | ~17 Mops/s | ~20 Mops/s | `ereal<2>` (~ 1.2x) |
+| `*` | ~16 Mops/s | ~11 Mops/s | **`elreal` (~ 1.5x)** |
+| `/` (elreal depth 0 only) | (dominated by inlining) | ~680 Kops/s | `elreal` (apples-to-oranges) |
+| `sqrt`, `exp`, `log` | ~36-43 Mops/s | n/a | `elreal` (ereal has no math functions) |
 
-(All numbers gcc 13.3 on a 12th Gen i7-12700K post-Phase-K.1 of #903;
+(All numbers gcc 13.3 on a 12th Gen i7-12700K post-Phase-K.2 of #903;
 both sides constructing fresh operands inside the loop body.
 Reproduction: `make benchmark_elreal_performance`. Phase I baseline
-numbers before K.1 are in `docs/algorithmic-details/elreal-performance-baseline.md`.)
+numbers before K.1/K.2 are in
+`docs/algorithmic-details/elreal-performance-baseline.md`.)
 
 Two reads from the table:
 
-1. **Multiplication has flipped: `elreal` now wins on `*` at matched
-   precision.** `ereal<N>` multiplication is O(N) in the eager expansion
-   product, while `elreal *` is essentially a single `two_prod` plus
-   the (post-K.1 inline) result envelope. Addition and subtraction
-   still favour `ereal<2>` because those operators are O(1) on the
-   eager side and the lazy-stream envelope's `std::function` capture
-   is still the dominant per-op cost (Phase K.2 target).
+1. **The matched-precision arithmetic gap has nearly closed.** K.1
+   eliminated the `_components` vector alloc; K.2 eliminated the
+   `std::function` heap alloc by replacing it with a `std::variant`
+   of small POD shapes. `elreal` arithmetic is now within ~ 20% of
+   `ereal<2>` on `+`/`-` and wins by 1.5x on `*` (because
+   `ereal<N>` multiplication is still O(N) in the eager expansion
+   product).
 2. **What `elreal` actually wins on is *correctness*, not throughput.**
    Decidable sign (Section 4 of `lazy-real-arithmetic.md`),
    precision-on-demand without committed-upfront budget, and access to

--- a/docs/algorithmic-details/multi-component-arithmetic.md
+++ b/docs/algorithmic-details/multi-component-arithmetic.md
@@ -627,11 +627,14 @@ For undecidable comparison (e.g. symbolic-system reals constructed via
 different algebraic paths), `elreal`'s budgeted comparison is the
 right tool.
 
-### 7.1 The elreal-vs-ereal throughput crossover (Phase I baseline)
+### 7.1 The elreal-vs-ereal throughput crossover (post-Phase-K.2)
 
-Phase I of epic #873 measured per-operation throughput for `elreal` and
-`ereal<N>` at matched precision on a 12th Gen Intel i7-12700K (gcc 13.3,
-clang 18.1, `-O3`). The full numbers and reproduction recipe live in
+Per-operation throughput for `elreal` and `ereal<N>` at matched
+precision on a 12th Gen Intel i7-12700K (gcc 13.3, clang 18.1, `-O3`),
+after the Phase K.1 (inline `_components` buffer, #912) and Phase K.2
+(tagged-union generator, #916) optimisations. The Phase I baseline
+(#902) measured the pre-optimisation numbers; both the baseline and
+the current numbers, plus the reproduction recipe, live in
 `docs/algorithmic-details/elreal-performance-baseline.md`. The summary
 shape for picker purposes:
 
@@ -664,13 +667,13 @@ Two reads from the table:
    `sqrt`/`exp`/`log`/`pow` and the geometric predicates -- none of
    which `ereal<N>` provides.
 
-So the picker rule, refined: choose `elreal` when the workload needs
-something `ereal<N>` cannot do (math functions, decidable sign,
-geometric predicates, oracle validation). Choose `ereal<N>` when raw
-arithmetic throughput at matched precision matters more than those
-capabilities. Phase II of epic #873 targets the allocation hot path
-listed in the baseline doc, which is where the throughput gap will
-shrink.
+So the picker rule, refined: after K.2, `elreal` is both
+throughput-competitive at matched precision *and* exposes correctness
+features `ereal<N>` lacks (math functions, decidable sign, geometric
+predicates, oracle validation). Choose `elreal` when any of those
+capabilities matters. Choose `ereal<N>` when raw arithmetic at a
+committed-upfront precision is the workload's hot path and the math
+suite isn't needed.
 
 Note: Universal does not currently provide implicit conversion between
 `dd`, the cascade types, `ereal`, and `elreal`. Users that need to

--- a/docs/bugs/fetch-content-architecture.md
+++ b/docs/bugs/fetch-content-architecture.md
@@ -6,7 +6,7 @@ Here's what the bug in the design of the Universal CMakeLists.txt is about
 
 What ${CMAKE_SOURCE_DIR} means
 
-In CMake, ${CMAKE_SOURCE_DIR} is a built-in variable that always points to the top-level source directory — the directory where the outermost
+In CMake, ${CMAKE_SOURCE_DIR} is a built-in variable that always points to the top-level source directory -- the directory where the outermost
 CMakeLists.txt lives (the one CMake was originally pointed at). It does not change when CMake descends into nested directories.
 
 There's a sibling variable, ${CMAKE_CURRENT_SOURCE_DIR}, which points to the directory of the CMakeLists.txt that is currently being processed. 
@@ -23,16 +23,16 @@ When you write:
 FetchContent_MakeAvailable(universal)
 ```
 
-CMake clones Universal into <build>/_deps/universal-src/ and then effectively does add_subdirectory(<build>/_deps/universal-src ...) — it runs
+CMake clones Universal into <build>/_deps/universal-src/ and then effectively does add_subdirectory(<build>/_deps/universal-src ...) -- it runs
 Universal's CMakeLists.txt as a sub-project of your build.
 
 Inside Universal's CMakeLists, when its code refers to ${CMAKE_SOURCE_DIR}, that variable still points to the 
-outermost source — your cortex repo root, not Universal's source dir. This is by design: CMAKE_SOURCE_DIR is 
+outermost source -- your cortex repo root, not Universal's source dir. This is by design: CMAKE_SOURCE_DIR is 
 a "where did the user invoke CMake" variable, not a "where am I right now" variable.
 
 ## The specific bug in Universal
 
-Universal's CMakeLists.txt (around line 95–100) has:
+Universal's CMakeLists.txt (around line 95-100) has:
 
 ```cmake
 set(TEST_MATRIX_DATA_DIR "${CMAKE_SOURCE_DIR}/data/matrices")
@@ -46,14 +46,14 @@ When Universal is the standalone top-level project (someone cloning Universal di
 CMAKE_SOURCE_DIR is Universal's root, so ${CMAKE_SOURCE_DIR}/config/TestMatrixDataDirConfig.hpp.in resolves correctly.
 
 When Universal is pulled in via FetchContent from cortex, CMAKE_SOURCE_DIR is /home/stillwater/dev/branes/clones/cortex/, 
-so the configure_file call looks for /.../cortex/config/TestMatrixDataDirConfig.hpp.in — which doesn't exist in cortex. 
+so the configure_file call looks for /.../cortex/config/TestMatrixDataDirConfig.hpp.in -- which doesn't exist in cortex. 
 The configure step fails:
 
 ```bash
 CMake Error: File /home/stillwater/.../cortex/config/TestMatrixDataDirConfig.hpp.in does not exist.
 ```
 
-The bug is that Universal should use ${CMAKE_CURRENT_SOURCE_DIR} or ${PROJECT_SOURCE_DIR} in those calls — those would 
+The bug is that Universal should use ${CMAKE_CURRENT_SOURCE_DIR} or ${PROJECT_SOURCE_DIR} in those calls -- those would 
 correctly point at Universal's own source dir regardless of how it was included.
 
 ## Why MTL5 doesn't have the same problem
@@ -66,12 +66,12 @@ target_include_directories(mtl5 INTERFACE
     ...
 ```
 
-So MTL5 works correctly whether built standalone or via FetchContent — CMAKE_CURRENT_SOURCE_DIR always points to MTL5's 
+So MTL5 works correctly whether built standalone or via FetchContent -- CMAKE_CURRENT_SOURCE_DIR always points to MTL5's 
 own source dir while MTL5's CMakeLists is being processed.
 
 ## The workaround in cortex
 
-Since Universal is header-only, cortex doesn't actually need Universal's CMakeLists machinery — only its 
+Since Universal is header-only, cortex doesn't actually need Universal's CMakeLists machinery -- only its 
 include directory (<src>/include/sw/). The workaround:
 
 1. FetchContent_Declare Universal but don't put it in FetchContent_MakeAvailable(...).
@@ -80,7 +80,7 @@ include directory (<src>/include/sw/). The workaround:
 
 That bypasses Universal's broken configure_file entirely while still getting the headers.
 
-The proper fix is upstream — file a PR on stillwater-sc/universal changing ${CMAKE_SOURCE_DIR} to ${PROJECT_SOURCE_DIR} 
+The proper fix is upstream -- file a PR on stillwater-sc/universal changing ${CMAKE_SOURCE_DIR} to ${PROJECT_SOURCE_DIR} 
 in those calls. Once that lands and we bump the pinned tag, the manual-populate workaround in cmake/deps.cmake can be 
 retired and Universal can go back into the normal FetchContent_MakeAvailable call.
 

--- a/docs/bugs/fetch-content-architecture.md
+++ b/docs/bugs/fetch-content-architecture.md
@@ -1,0 +1,86 @@
+# FetchContent Design
+
+## CMAKE_SOURCE_DIR
+
+Here's what the bug in the design of the Universal CMakeLists.txt is about
+
+What ${CMAKE_SOURCE_DIR} means
+
+In CMake, ${CMAKE_SOURCE_DIR} is a built-in variable that always points to the top-level source directory — the directory where the outermost
+CMakeLists.txt lives (the one CMake was originally pointed at). It does not change when CMake descends into nested directories.
+
+There's a sibling variable, ${CMAKE_CURRENT_SOURCE_DIR}, which points to the directory of the CMakeLists.txt that is currently being processed. 
+That one DOES change as CMake descends.
+
+A third one, ${PROJECT_SOURCE_DIR}, points to the source directory of the nearest enclosing project() call. 
+It also changes as you descend, but only at project() boundaries.
+
+## How FetchContent enters the picture
+
+When you write:
+
+```cmake
+FetchContent_MakeAvailable(universal)
+```
+
+CMake clones Universal into <build>/_deps/universal-src/ and then effectively does add_subdirectory(<build>/_deps/universal-src ...) — it runs
+Universal's CMakeLists.txt as a sub-project of your build.
+
+Inside Universal's CMakeLists, when its code refers to ${CMAKE_SOURCE_DIR}, that variable still points to the 
+outermost source — your cortex repo root, not Universal's source dir. This is by design: CMAKE_SOURCE_DIR is 
+a "where did the user invoke CMake" variable, not a "where am I right now" variable.
+
+## The specific bug in Universal
+
+Universal's CMakeLists.txt (around line 95–100) has:
+
+```cmake
+set(TEST_MATRIX_DATA_DIR "${CMAKE_SOURCE_DIR}/data/matrices")
+configure_file(
+    "${CMAKE_SOURCE_DIR}/config/TestMatrixDataDirConfig.hpp.in"
+    "${CMAKE_BINARY_DIR}/generated/TestMatrixDataDirConfig.hpp"
+)
+```
+
+When Universal is the standalone top-level project (someone cloning Universal directly and building it), 
+CMAKE_SOURCE_DIR is Universal's root, so ${CMAKE_SOURCE_DIR}/config/TestMatrixDataDirConfig.hpp.in resolves correctly.
+
+When Universal is pulled in via FetchContent from cortex, CMAKE_SOURCE_DIR is /home/stillwater/dev/branes/clones/cortex/, 
+so the configure_file call looks for /.../cortex/config/TestMatrixDataDirConfig.hpp.in — which doesn't exist in cortex. 
+The configure step fails:
+
+```bash
+CMake Error: File /home/stillwater/.../cortex/config/TestMatrixDataDirConfig.hpp.in does not exist.
+```
+
+The bug is that Universal should use ${CMAKE_CURRENT_SOURCE_DIR} or ${PROJECT_SOURCE_DIR} in those calls — those would 
+correctly point at Universal's own source dir regardless of how it was included.
+
+## Why MTL5 doesn't have the same problem
+
+MTL5's CMakeLists uses ${CMAKE_CURRENT_SOURCE_DIR} for its include directories:
+
+```cmake
+target_include_directories(mtl5 INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    ...
+```
+
+So MTL5 works correctly whether built standalone or via FetchContent — CMAKE_CURRENT_SOURCE_DIR always points to MTL5's 
+own source dir while MTL5's CMakeLists is being processed.
+
+## The workaround in cortex
+
+Since Universal is header-only, cortex doesn't actually need Universal's CMakeLists machinery — only its 
+include directory (<src>/include/sw/). The workaround:
+
+1. FetchContent_Declare Universal but don't put it in FetchContent_MakeAvailable(...).
+2. Manually populate via FetchContent_GetProperties + FetchContent_Populate (which downloads but skips the add_subdirectory).
+3. Create a cortex-owned INTERFACE library and add Universal's include dir to it.
+
+That bypasses Universal's broken configure_file entirely while still getting the headers.
+
+The proper fix is upstream — file a PR on stillwater-sc/universal changing ${CMAKE_SOURCE_DIR} to ${PROJECT_SOURCE_DIR} 
+in those calls. Once that lands and we bump the pinned tag, the manual-populate workaround in cmake/deps.cmake can be 
+retired and Universal can go back into the normal FetchContent_MakeAvailable call.
+

--- a/include/sw/universal/number/elreal/elreal_data.hpp
+++ b/include/sw/universal/number/elreal/elreal_data.hpp
@@ -1,0 +1,118 @@
+#pragma once
+// elreal_data.hpp: tagged-union generator (lazy_generator variant)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Phase K.2 of follow-up epic #903 (#905).
+//
+// Background
+// ==========
+// Phase I (#902) identified the per-operator `std::function` heap
+// allocation as a major cost source for elreal arithmetic. Each binary
+// operator captures two elreals by value (~216 bytes of capture), which
+// blows past libstdc++'s 16-byte std::function SBO and forces a heap
+// allocation per call.
+//
+// This phase replaces `std::function<double(std::size_t)>` with a small
+// `std::variant` of known generator shapes. Operand captures are by
+// `std::shared_ptr<const elreal>` (16 bytes per operand) rather than by
+// value (~104 bytes per operand), so each generator's capture fits
+// comfortably inline.
+//
+// Cost shape per binary op
+// ------------------------
+//   Today: 1 std::function alloc (~216 bytes capture, memcpy 216 bytes)
+//   After: 2 std::make_shared<const elreal> allocs (~120 bytes each,
+//          memcpy 104 bytes each) + variant emplace (no alloc)
+//
+// The new approach trades 1 big alloc for 2 small allocs. On modern
+// allocators with small-object pools this is typically a net win. The
+// throughput numbers in the Phase K.2 PR document the actual measured
+// effect under gcc 13 and clang 18.
+//
+// Canonical generator shapes (cover all ~25 elreal operators / functions)
+// ----------------------------------------------------------------------
+//   gen_unary_linear        depth-1 = coeff * a.at(1)
+//                           (exp, exp2, expm1, log family, sinh/cosh/tanh,
+//                            asinh/acosh/atanh, asin/acos/atan, sin/cos/tan)
+//
+//   gen_binary_linear       depth-1 = c0 + ca * a.at(1) + cb * b.at(1)
+//                           (+, -, *, pow, atan2)
+//
+//   gen_sqrt                depth-1 = sqrt-specific EFT residual
+//
+//   gen_unary_neg           depth-k = -wrapped.at(k)  (trampoline)
+//
+//   gen_rational_residual   depth-1 = exact p - q * c0 residual via EFTs
+//                           (elreal(long long p, long long q) constructor)
+//
+//   std::monostate          no generator (depth-0-only result)
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <variant>
+
+#include <universal/numerics/error_free_ops.hpp>
+
+namespace sw { namespace universal {
+
+class elreal;  // forward decl -- full definition in elreal_impl.hpp
+
+// Handle to an operand. Reference-counted; copying is cheap (one atomic
+// increment). The const-ness reflects the contract that a generator
+// only READS from its operands via at(k). Mutation through the
+// `mutable` interior of elreal is permitted by the elreal class's
+// lazy-materialization design, but the generator doesn't itself
+// initiate any mutation beyond demand-driven materialization.
+using elreal_handle = std::shared_ptr<const elreal>;
+
+// ---------- generator variant alternatives -----------------------------------
+
+struct gen_unary_linear {
+	elreal_handle a;
+	double coeff;
+};
+
+struct gen_binary_linear {
+	elreal_handle a;
+	elreal_handle b;
+	double c0;
+	double ca;
+	double cb;
+};
+
+struct gen_sqrt {
+	elreal_handle a;
+	double c0;
+	std::size_t lead_idx;
+};
+
+struct gen_unary_neg {
+	elreal_handle wrapped;
+};
+
+struct gen_rational_residual {
+	double p;
+	double q;
+	double c0;
+};
+
+using lazy_generator = std::variant<
+	std::monostate,
+	gen_unary_linear,
+	gen_binary_linear,
+	gen_sqrt,
+	gen_unary_neg,
+	gen_rational_residual
+>;
+
+// Forward declaration; the body is in elreal_impl.hpp where elreal is
+// fully defined (since the variant alternatives invoke elreal::at()).
+double evaluate_generator(const lazy_generator& g, std::size_t k);
+
+}}  // namespace sw::universal

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -31,10 +31,11 @@
 //    The value is stored as a memoized stream of double-precision components
 //    plus a generator that produces successive components on demand:
 //
-//        mutable lazy_component_buffer             _components;
+//        mutable lazy_component_buffer  _components;
 //             (4-double inline + spill via std::vector; Phase K.1 of #905)
-//        mutable std::function<double(std::size_t)> _generator;   // (Phase C)
-//        mutable std::size_t                        _computed_depth = 0;
+//        mutable lazy_generator         _generator;
+//             (std::variant of small POD shapes; Phase K.2 of #905)
+//        mutable std::size_t            _computed_depth = 0;
 //
 //    The members are `mutable` because refinement happens in const contexts
 //    (notably during comparison and sign determination): the *logical* value
@@ -53,11 +54,13 @@
 //        choice, so a migration is local to the implementation.
 //
 //    Trade-offs accepted:
-//      - `std::function` type-erasure overhead (~one indirect call per
-//        refinement step).
-//      - Closures capture operands by value, which can be deep for nested
-//        expressions; Phase C will introduce a `std::shared_ptr` for operand
-//        sharing if measurements warrant it.
+//      - Phase K.2 (#905) replaced std::function with a `std::variant` of
+//        small POD shapes. `std::visit` dispatch lets the compiler inline
+//        per-shape evaluators. Operand captures are `std::shared_ptr<const
+//        elreal>` (16 bytes), so per-op state stays small.
+//      - Atomic refcount bumps when sharing operands. Cheap on modern
+//        x86 (a few cycles per make_shared / copy) but still a cost on
+//        the common path.
 //      - The type is not constexpr-friendly. Phase A is not aiming for
 //        compile-time elreal.
 //
@@ -105,7 +108,8 @@
 //   - `operator double()` returns the sum of materialised components
 //
 // Phase B (#875, merged):
-//   - The closure-based generator slot is real (mutable std::function).
+//   - The generator slot is functional (Phase K.2 #905 replaced the
+//     original std::function with a std::variant of small POD shapes).
 //   - Construction from `p/q` rationals (`elreal(p, q)`).
 //   - Construction from decimal/scientific/rational strings.
 //
@@ -130,8 +134,9 @@
 //     (`elreal_default_budget = 8` components, ~424 bits cumulative).
 //
 // Triviality is *not* claimed: the type contains `lazy_component_buffer`
-// (which itself holds a `std::vector` for spill) and `std::function`,
-// neither of which is trivially constructible. Universal's library-wide
+// (with a `std::vector` for spill) and a `std::variant` whose
+// alternatives hold `std::shared_ptr<const elreal>`, neither of which
+// is trivially constructible. Universal's library-wide
 // `ReportTrivialityOfType` is reported, not asserted, for elastic types
 // -- consistent with `ereal`.
 //
@@ -160,6 +165,7 @@
 #include <universal/number/elreal/exceptions.hpp>
 #include <universal/number/elreal/elreal_fwd.hpp>
 #include <universal/number/elreal/lazy_component_buffer.hpp>
+#include <universal/number/elreal/elreal_data.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/numerics/error_free_ops.hpp>
 
@@ -273,28 +279,13 @@ public:
 		_computed_depth = 1;
 
 		// Generator: produces the k-th correction component on demand.
-		// k == 1 -> exact residual via EFTs.
+		// k == 1 -> exact residual via EFTs (see gen_rational_residual
+		//          evaluator in elreal_data.hpp).
 		// k >= 2 -> 0.0 (Phase B limitation; documented above).
-		long long p_cap = p;
-		long long q_cap = q;
-		double    c0_cap = c0;
-		_generator = [p_cap, q_cap, c0_cap](std::size_t k) -> double {
-			if (k != 1) return 0.0;
-			// Compute the residual p - c0 * q exactly using EFTs:
-			//   two_prod(c0, q)        -> (prod_hi, prod_err) with c0*q = prod_hi + prod_err
-			//   two_sum(p, -prod_hi)   -> (s1,   s1_err)
-			//   two_sum(s1, -prod_err) -> (s2,   s2_err)
-			//   residual = s2 + s1_err + s2_err  (sum of error terms collapsed to a
-			//                                     double; further bits are below
-			//                                     double precision in this scope)
-			double prod_err;
-			double prod_hi  = two_prod(c0_cap, static_cast<double>(q_cap), prod_err);
-			double s1_err;
-			double s1       = two_sum(static_cast<double>(p_cap), -prod_hi, s1_err);
-			double s2_err;
-			double s2       = two_sum(s1, -prod_err, s2_err);
-			double residual = s2 + s1_err + s2_err;
-			return residual / static_cast<double>(q_cap);
+		_generator = gen_rational_residual{
+			static_cast<double>(p),
+			static_cast<double>(q),
+			c0
 		};
 	}
 
@@ -337,17 +328,19 @@ public:
 	//                  in Phase A.
 
 	double at(std::size_t k) const {
-		// Materialise components up to and including index k by calling the
-		// generator on cache misses. When no generator is installed (e.g. for
-		// values constructed from a single double), the stream is treated as
-		// terminating at _computed_depth and at(k>=depth) returns 0.0.
-		while (_computed_depth <= k && _generator) {
-			double next = _generator(_computed_depth);
+		// Materialise components up to and including index k by walking
+		// the generator on cache misses. When no generator is installed
+		// (std::monostate -- the case for single-double constructed values),
+		// the stream is treated as terminating at _computed_depth and
+		// at(k >= depth) returns 0.0.
+		if (k < _computed_depth) return _components[k];
+		if (std::holds_alternative<std::monostate>(_generator)) return 0.0;
+		while (_computed_depth <= k) {
+			double next = evaluate_generator(_generator, _computed_depth);
 			_components.push_back(next);
 			++_computed_depth;
 		}
-		if (k < _computed_depth) return _components[k];
-		return 0.0;
+		return _components[k];
 	}
 
 	void refine_to(std::size_t precision_bits) const {
@@ -440,7 +433,7 @@ public:
 	// binary free functions.
 
 	// Unary minus: negate every materialised component and wrap the
-	// generator in a sign-flipping shim.
+	// generator in a sign-flipping trampoline (gen_unary_neg).
 	elreal operator-() const {
 		elreal result;
 		result._components.reserve(_components.size());
@@ -448,11 +441,8 @@ public:
 			result._components.push_back(-_components[i]);
 		}
 		result._computed_depth = _computed_depth;
-		if (_generator) {
-			auto gen_cap = _generator;
-			result._generator = [gen_cap](std::size_t k) -> double {
-				return -gen_cap(k);
-			};
+		if (!std::holds_alternative<std::monostate>(_generator)) {
+			result._generator = gen_unary_neg{ std::make_shared<const elreal>(*this) };
 		}
 		return result;
 	}
@@ -461,6 +451,10 @@ public:
 	elreal& operator-=(const elreal& rhs);
 	elreal& operator*=(const elreal& rhs);
 	elreal& operator/=(const elreal& rhs);
+
+	// Friend so the variant evaluator (defined after the class) can
+	// invoke at(k) on the operand handles.
+	friend double evaluate_generator(const lazy_generator& g, std::size_t k);
 
 private:
 	// The lazy stream of components. Mutable because refinement is invoked
@@ -472,12 +466,16 @@ private:
 	// _components and grow _computed_depth as the generator fires.
 	mutable std::size_t _computed_depth;
 
-	// Generator slot. Empty by default; the rational constructor (and, in
-	// Phase C, the arithmetic operators) install a closure here. When the
-	// generator is empty, at(k) for k >= _computed_depth returns 0.0
-	// (the implicit-zero extension that matches the leading-component-only
-	// representation of a constructed-from-double value).
-	mutable std::function<double(std::size_t)> _generator;
+	// Generator slot. Empty by default (std::monostate); operators
+	// install a tagged-union alternative here (see elreal_data.hpp).
+	// When the generator is monostate, at(k) for k >= _computed_depth
+	// returns 0.0 (the implicit-zero extension).
+	//
+	// Phase K.2 (#905): replaced std::function with std::variant. Operand
+	// captures are now shared_ptr<const elreal> (16 bytes each) rather
+	// than elreal-by-value (~104 bytes each), eliminating the
+	// std::function heap allocation for per-op generator state.
+	mutable lazy_generator _generator;
 
 	// String parser. Lives as a friend free function so it can populate
 	// the private state. Public-facing wrappers are the std::string
@@ -526,6 +524,62 @@ private:
 	friend elreal cos(const elreal& a);
 	friend elreal tan(const elreal& a);
 };
+
+// =============================================================================
+// Generator evaluator (Phase K.2, #905)
+// =============================================================================
+//
+// Dispatches to the per-shape formula for the requested component index k.
+// Most generators return 0.0 for k != 1 (depth-1 cap); the unary_neg
+// trampoline forwards to its wrapped operand for arbitrary k.
+//
+// Defined after the elreal class because each variant alternative
+// invokes elreal::at() via its operand handle.
+
+inline double evaluate_generator(const lazy_generator& g, std::size_t k) {
+	return std::visit([k](const auto& alt) -> double {
+		using T = std::decay_t<decltype(alt)>;
+		if constexpr (std::is_same_v<T, std::monostate>) {
+			return 0.0;
+		}
+		else if constexpr (std::is_same_v<T, gen_unary_linear>) {
+			if (k != 1) return 0.0;
+			return alt.coeff * alt.a->at(1);
+		}
+		else if constexpr (std::is_same_v<T, gen_binary_linear>) {
+			if (k != 1) return 0.0;
+			return alt.c0 + alt.ca * alt.a->at(1) + alt.cb * alt.b->at(1);
+		}
+		else if constexpr (std::is_same_v<T, gen_sqrt>) {
+			if (k != 1) return 0.0;
+			double prod_err = 0.0;
+			double prod_hi = two_prod(alt.c0, alt.c0, prod_err);
+			double num = (alt.a->at(alt.lead_idx) - prod_hi) - prod_err
+			           + alt.a->at(alt.lead_idx + 1);
+			return num / (2.0 * alt.c0);
+		}
+		else if constexpr (std::is_same_v<T, gen_unary_neg>) {
+			return -alt.wrapped->at(k);
+		}
+		else if constexpr (std::is_same_v<T, gen_rational_residual>) {
+			if (k != 1) return 0.0;
+			// Matches the original rational ctor's EFT walk:
+			//   two_prod(c0, q) -> (prod_hi, prod_err)
+			//   two_sum(p, -prod_hi) -> (s1, s1_err)
+			//   two_sum(s1, -prod_err) -> (s2, s2_err)
+			//   residual = s2 + s1_err + s2_err
+			//   return residual / q
+			double prod_err = 0.0;
+			double prod_hi = two_prod(alt.c0, alt.q, prod_err);
+			double s1_err = 0.0;
+			double s1 = two_sum(alt.p, -prod_hi, s1_err);
+			double s2_err = 0.0;
+			double s2 = two_sum(s1, -prod_err, s2_err);
+			double residual = s2 + s1_err + s2_err;
+			return residual / alt.q;
+		}
+	}, g);
+}
 
 // =============================================================================
 // String parser
@@ -819,11 +873,10 @@ inline elreal operator+(const elreal& a, const elreal& b) {
 	if (!std::isfinite(c0)) return result;
 
 	// Generator: depth 1 = sum_err + a.at(1) + b.at(1). Depth >= 2 returns 0.
-	elreal a_cap = a;
-	elreal b_cap = b;
-	result._generator = [a_cap, b_cap, sum_err](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return sum_err + a_cap.at(1) + b_cap.at(1);
+	result._generator = gen_binary_linear{
+		std::make_shared<const elreal>(a),
+		std::make_shared<const elreal>(b),
+		sum_err, 1.0, 1.0
 	};
 	return result;
 }
@@ -841,11 +894,10 @@ inline elreal operator-(const elreal& a, const elreal& b) {
 	if (!std::isfinite(c0)) return result;
 
 	// Depth 1 = diff_err + a.at(1) - b.at(1).
-	elreal a_cap = a;
-	elreal b_cap = b;
-	result._generator = [a_cap, b_cap, diff_err](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return diff_err + a_cap.at(1) - b_cap.at(1);
+	result._generator = gen_binary_linear{
+		std::make_shared<const elreal>(a),
+		std::make_shared<const elreal>(b),
+		diff_err, 1.0, -1.0
 	};
 	return result;
 }
@@ -864,14 +916,13 @@ inline elreal operator*(const elreal& a, const elreal& b) {
 
 	// Depth 1: (a0*b0 - c0) is captured exactly by prod_err.
 	// The leading correction to a*b is:
-	//   prod_err + a0 * b.at(1) + a.at(1) * b0
+	//   prod_err + b0 * a.at(1) + a0 * b.at(1)
 	// (the a.at(1)*b.at(1) cross-term is O(eps^2) and below the depth-1
 	//  precision target; deferred to deeper refinement in Phase E/F).
-	elreal a_cap = a;
-	elreal b_cap = b;
-	result._generator = [a_cap, b_cap, a0, b0, prod_err](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return prod_err + a0 * b_cap.at(1) + a_cap.at(1) * b0;
+	result._generator = gen_binary_linear{
+		std::make_shared<const elreal>(a),
+		std::make_shared<const elreal>(b),
+		prod_err, b0, a0
 	};
 	return result;
 }
@@ -991,21 +1042,9 @@ inline elreal sqrt(const elreal& a) {
 	// No depth-1 refinement makes sense for non-finite or zero leading.
 	if (!std::isfinite(c0) || c0 == 0.0) return result;
 
-	elreal a_cap = a;
-	double c0_cap = c0;
-	std::size_t lead_idx_cap = lead_idx;
-	result._generator = [a_cap, c0_cap, lead_idx_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		// EFT residual: c0^2 captured exactly via two_prod.
-		double prod_err;
-		double prod_hi = two_prod(c0_cap, c0_cap, prod_err);
-		// Numerator: (leading - c0^2) + next material correction.
-		// "leading" is a.at(lead_idx); the next correction is at
-		// lead_idx + 1. (For the common case lead_idx == 0 this collapses
-		// to the original formula.)
-		double num = (a_cap.at(lead_idx_cap) - prod_hi) - prod_err
-		           + a_cap.at(lead_idx_cap + 1);
-		return num / (2.0 * c0_cap);
+	result._generator = gen_sqrt{
+		std::make_shared<const elreal>(a),
+		c0, lead_idx
 	};
 	return result;
 }
@@ -1059,12 +1098,7 @@ inline elreal exp(const elreal& a) {
 	if (!std::isfinite(c0) || c0 == 0.0) return result;
 
 	// d/dx exp(x) = exp(x), so depth-1 = c0 * a.at(1).
-	elreal a_cap = a;
-	double c0_cap = c0;
-	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return c0_cap * a_cap.at(1);
-	};
+	result._generator = gen_unary_linear{ std::make_shared<const elreal>(a), c0 };
 	return result;
 }
 
@@ -1079,11 +1113,9 @@ inline elreal exp2(const elreal& a) {
 	if (!std::isfinite(c0) || c0 == 0.0) return result;
 
 	// d/dx 2^x = 2^x * ln(2), so depth-1 = c0 * ln2 * a.at(1).
-	elreal a_cap = a;
-	double c0_cap = c0;
-	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return c0_cap * std::numbers::ln2_v<double> * a_cap.at(1);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		c0 * std::numbers::ln2_v<double>
 	};
 	return result;
 }
@@ -1099,12 +1131,7 @@ inline elreal expm1(const elreal& a) {
 	if (!std::isfinite(c0)) return result;
 
 	// d/dx (exp(x) - 1) = exp(x) = expm1(x) + 1, so depth-1 = (c0+1) * a.at(1).
-	elreal a_cap = a;
-	double c0_cap = c0;
-	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return (c0_cap + 1.0) * a_cap.at(1);
-	};
+	result._generator = gen_unary_linear{ std::make_shared<const elreal>(a), c0 + 1.0 };
 	return result;
 }
 
@@ -1126,12 +1153,7 @@ inline elreal log(const elreal& a) {
 	if (!std::isfinite(c0) || a0 == 0.0) return result;
 
 	// d/dx log(x) = 1/x, so depth-1 = a.at(1) / a0.
-	elreal a_cap = a;
-	double a0_cap = a0;
-	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / a0_cap;
-	};
+	result._generator = gen_unary_linear{ std::make_shared<const elreal>(a), 1.0 / a0 };
 	return result;
 }
 
@@ -1146,11 +1168,9 @@ inline elreal log2(const elreal& a) {
 	if (!std::isfinite(c0) || a0 == 0.0) return result;
 
 	// d/dx log2(x) = 1 / (x * ln(2)).
-	elreal a_cap = a;
-	double a0_cap = a0;
-	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / (a0_cap * std::numbers::ln2_v<double>);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / (a0 * std::numbers::ln2_v<double>)
 	};
 	return result;
 }
@@ -1166,11 +1186,9 @@ inline elreal log10(const elreal& a) {
 	if (!std::isfinite(c0) || a0 == 0.0) return result;
 
 	// d/dx log10(x) = 1 / (x * ln(10)).
-	elreal a_cap = a;
-	double a0_cap = a0;
-	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / (a0_cap * std::numbers::ln10_v<double>);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / (a0 * std::numbers::ln10_v<double>)
 	};
 	return result;
 }
@@ -1186,11 +1204,9 @@ inline elreal log1p(const elreal& a) {
 	if (!std::isfinite(c0) || (1.0 + a0) == 0.0) return result;
 
 	// d/dx log(1 + x) = 1 / (1 + x).
-	elreal a_cap = a;
-	double a0_cap = a0;
-	result._generator = [a_cap, a0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / (1.0 + a0_cap);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / (1.0 + a0)
 	};
 	return result;
 }
@@ -1216,16 +1232,12 @@ inline elreal pow(const elreal& a, const elreal& b) {
 	//
 	// Both are evaluated at the leading doubles to avoid extra std lib
 	// calls inside the lazy machinery.
-	elreal a_cap = a;
-	elreal b_cap = b;
-	double a0_cap = a0;
-	double b0_cap = b0;
-	double c0_cap = c0;
-	result._generator = [a_cap, b_cap, a0_cap, b0_cap, c0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		double dpow_da = b0_cap * c0_cap / a0_cap;
-		double dpow_db = c0_cap * std::log(a0_cap);
-		return dpow_da * a_cap.at(1) + dpow_db * b_cap.at(1);
+	result._generator = gen_binary_linear{
+		std::make_shared<const elreal>(a),
+		std::make_shared<const elreal>(b),
+		0.0,
+		b0 * c0 / a0,
+		c0 * std::log(a0)
 	};
 	return result;
 }
@@ -1261,11 +1273,10 @@ inline elreal sinh(const elreal& a) {
 
 	if (!std::isfinite(c0)) return result;
 
-	elreal a_cap = a;
-	double cosh_a0 = std::cosh(a0);   // derivative of sinh
-	result._generator = [a_cap, cosh_a0](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return cosh_a0 * a_cap.at(1);
+	// d/dx sinh(x) = cosh(x).
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		std::cosh(a0)
 	};
 	return result;
 }
@@ -1280,11 +1291,10 @@ inline elreal cosh(const elreal& a) {
 
 	if (!std::isfinite(c0)) return result;
 
-	elreal a_cap = a;
-	double sinh_a0 = std::sinh(a0);   // derivative of cosh
-	result._generator = [a_cap, sinh_a0](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return sinh_a0 * a_cap.at(1);
+	// d/dx cosh(x) = sinh(x).
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		std::sinh(a0)
 	};
 	return result;
 }
@@ -1300,11 +1310,9 @@ inline elreal tanh(const elreal& a) {
 	if (!std::isfinite(c0)) return result;
 
 	// d/dx tanh = 1 - tanh^2 (= sech^2). Using c0 avoids a second std::tanh.
-	elreal a_cap = a;
-	double c0_cap = c0;
-	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return (1.0 - c0_cap * c0_cap) * a_cap.at(1);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 - c0 * c0
 	};
 	return result;
 }
@@ -1320,11 +1328,9 @@ inline elreal asinh(const elreal& a) {
 	if (!std::isfinite(c0)) return result;
 
 	// d/dx asinh(x) = 1 / sqrt(1 + x^2). Always finite and nonzero.
-	elreal a_cap = a;
-	double deriv_inv = std::sqrt(1.0 + a0 * a0);   // 1 / derivative
-	result._generator = [a_cap, deriv_inv](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / deriv_inv;
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / std::sqrt(1.0 + a0 * a0)
 	};
 	return result;
 }
@@ -1342,11 +1348,9 @@ inline elreal acosh(const elreal& a) {
 	if (!std::isfinite(c0) || a0 <= 1.0) return result;
 
 	// d/dx acosh(x) = 1 / sqrt(x^2 - 1).
-	elreal a_cap = a;
-	double deriv_inv = std::sqrt(a0 * a0 - 1.0);
-	result._generator = [a_cap, deriv_inv](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / deriv_inv;
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / std::sqrt(a0 * a0 - 1.0)
 	};
 	return result;
 }
@@ -1364,11 +1368,9 @@ inline elreal atanh(const elreal& a) {
 	if (!std::isfinite(c0) || std::abs(a0) >= 1.0) return result;
 
 	// d/dx atanh(x) = 1 / (1 - x^2).
-	elreal a_cap = a;
-	double one_minus_sq = 1.0 - a0 * a0;
-	result._generator = [a_cap, one_minus_sq](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / one_minus_sq;
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / (1.0 - a0 * a0)
 	};
 	return result;
 }
@@ -1414,11 +1416,9 @@ inline elreal asin(const elreal& a) {
 	if (!std::isfinite(c0) || std::abs(a0) >= 1.0) return result;
 
 	// d/dx asin(x) = 1 / sqrt(1 - x^2).
-	elreal a_cap = a;
-	double deriv_inv = std::sqrt(1.0 - a0 * a0);   // 1 / derivative
-	result._generator = [a_cap, deriv_inv](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / deriv_inv;
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / std::sqrt(1.0 - a0 * a0)
 	};
 	return result;
 }
@@ -1434,11 +1434,9 @@ inline elreal acos(const elreal& a) {
 	if (!std::isfinite(c0) || std::abs(a0) >= 1.0) return result;
 
 	// d/dx acos(x) = -1 / sqrt(1 - x^2).
-	elreal a_cap = a;
-	double deriv_inv = std::sqrt(1.0 - a0 * a0);   // 1 / |derivative|
-	result._generator = [a_cap, deriv_inv](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return -a_cap.at(1) / deriv_inv;
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		-1.0 / std::sqrt(1.0 - a0 * a0)
 	};
 	return result;
 }
@@ -1462,11 +1460,10 @@ inline elreal atan(const elreal& a) {
 	double denom = 1.0 + a0 * a0;
 	if (!std::isfinite(denom)) return result;
 
-	elreal a_cap = a;
-	double denom_cap = denom;
-	result._generator = [a_cap, denom_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return a_cap.at(1) / denom_cap;
+	// d/dx atan(x) = 1 / (1 + x^2).
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 / denom
 	};
 	return result;
 }
@@ -1489,16 +1486,13 @@ inline elreal atan2(const elreal& y, const elreal& x) {
 
 	// d/dy atan2(y,x) =  x / (x^2 + y^2)
 	// d/dx atan2(y,x) = -y / (x^2 + y^2)
-	elreal y_cap = y;
-	elreal x_cap = x;
-	double x0_cap = x0;
-	double y0_cap = y0;
-	double r2_cap = r2;
-	result._generator = [y_cap, x_cap, x0_cap, y0_cap, r2_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		double dy = x0_cap / r2_cap;
-		double dx = -y0_cap / r2_cap;
-		return dy * y_cap.at(1) + dx * x_cap.at(1);
+	// gen_binary_linear: a=y, b=x, ca=x/r2, cb=-y/r2.
+	result._generator = gen_binary_linear{
+		std::make_shared<const elreal>(y),
+		std::make_shared<const elreal>(x),
+		0.0,
+		x0 / r2,
+		-y0 / r2
 	};
 	return result;
 }
@@ -1579,11 +1573,9 @@ inline elreal sin(const elreal& a) {
 	if (!std::isfinite(c0)) return result;
 
 	// d/dx sin(x) = cos(x).
-	elreal a_cap = a;
-	double cos_a0 = std::cos(a0);
-	result._generator = [a_cap, cos_a0](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return cos_a0 * a_cap.at(1);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		std::cos(a0)
 	};
 	return result;
 }
@@ -1599,11 +1591,9 @@ inline elreal cos(const elreal& a) {
 	if (!std::isfinite(c0)) return result;
 
 	// d/dx cos(x) = -sin(x).
-	elreal a_cap = a;
-	double sin_a0 = std::sin(a0);
-	result._generator = [a_cap, sin_a0](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return -sin_a0 * a_cap.at(1);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		-std::sin(a0)
 	};
 	return result;
 }
@@ -1619,11 +1609,9 @@ inline elreal tan(const elreal& a) {
 	if (!std::isfinite(c0)) return result;
 
 	// d/dx tan(x) = 1 + tan^2(x). Using c0 avoids a second std::tan.
-	elreal a_cap = a;
-	double c0_cap = c0;
-	result._generator = [a_cap, c0_cap](std::size_t k) -> double {
-		if (k != 1) return 0.0;
-		return (1.0 + c0_cap * c0_cap) * a_cap.at(1);
+	result._generator = gen_unary_linear{
+		std::make_shared<const elreal>(a),
+		1.0 + c0 * c0
 	};
 	return result;
 }


### PR DESCRIPTION
## Summary

Phase K.2 of follow-up epic #903. The Phase I baseline identified the per-op \`std::function\` heap allocation (~216-byte capture per binary op) as a major cost. K.1 (#912) closed the \`_components\` vector alloc; this PR closes the \`_generator\` function-object alloc.

## Design

\`elreal\`'s \`_generator\` field migrates from \`std::function<double(std::size_t)>\` to a \`std::variant\` of small POD shapes:

| Shape | Size | Covers |
|---|---:|---|
| \`gen_unary_linear\` | 24 bytes | exp / log / pow family, trig (19 math functions) |
| \`gen_binary_linear\` | 56 bytes | +, -, *, pow, atan2 |
| \`gen_sqrt\` | 32 bytes | sqrt |
| \`gen_unary_neg\` | 16 bytes | unary minus trampoline |
| \`gen_rational_residual\` | 24 bytes | elreal(p, q) constructor |
| \`std::monostate\` | 0 bytes | default; depth-0-only |

Operand captures are \`std::shared_ptr<const elreal>\` (16 bytes each) so the variant fits comfortably inline. No \`std::function\`, no heap allocation per generator state.

## What landed

- **\`include/sw/universal/number/elreal/elreal_data.hpp\`** -- NEW. Variant alternative types + \`lazy_generator\` alias + \`evaluate_generator\` forward declaration. Comprehensive design rationale in the file header.
- **\`include/sw/universal/number/elreal/elreal_impl.hpp\`** -- \`_generator\` migrated. All ~25 operator/math function generators rewritten as variant emplacements. \`at()\` walks via \`evaluate_generator\`. The evaluator is defined after the class so each alternative can call \`elreal::at()\` on its operand handle.
- **\`docs/algorithmic-details/elreal-performance-baseline.md\`** -- K.2 numbers added. K.1 numbers retained for the before/after comparison.
- **\`docs/algorithmic-details/multi-component-arithmetic.md\`** -- section 7.1 picker rule updated: arithmetic gap with \`ereal<2>\` has nearly closed.

## Results (gcc 13.3 on 12th Gen Intel i7-12700K, \`-O3\`)

| Op | Phase I | K.1 | K.2 | vs Phase I |
|---|---:|---:|---:|---:|
| elreal + d1 | 9 Mops/s  | 12 Mops/s | 17 Mops/s | **1.9x** |
| elreal - d1 | 9 Mops/s  | 14 Mops/s | 17 Mops/s | **1.9x** |
| elreal * d1 | 8 Mops/s  | 19 Mops/s | 16 Mops/s | **2.0x** |
| elreal sqrt | 14 Mops/s | 30 Mops/s | 36 Mops/s | **2.6x** |
| elreal exp  | 14 Mops/s | 31 Mops/s | 43 Mops/s | **3.1x** |
| elreal log  | 14 Mops/s | 24 Mops/s | 38 Mops/s | **2.7x** |

Math functions show the largest gains because the unary-derivative captures (1 shared_ptr + 1 double = 24 bytes) fit naturally into the new shape.

### Versus \`ereal<2>\` at matched precision (gcc)

| Op | \`elreal\` post-K.2 | \`ereal<2>\` | Winner |
|---|---:|---:|---|
| `+` | 17 Mops/s | 19 Mops/s | \`ereal<2>\` (~ 1.1x; gap nearly closed) |
| `-` | 17 Mops/s | 20 Mops/s | \`ereal<2>\` (~ 1.2x) |
| `*` | 16 Mops/s | 11 Mops/s | **\`elreal\` (~ 1.5x)** |

The arithmetic gap with \`ereal<2>\` on +/- has shrunk from 2x at K.1 to within ~20% at K.2.

## Test plan

- [x] Builds clean under gcc 13.3 and clang 18.1 (\`-O3\`)
- [x] All 30 elreal regression tests PASS under both compilers
- [x] Phase J oracle sweep across dd / qd / dd_cascade / td_cascade / qd_cascade / ereal<N> PASS under both compilers
- [x] \`benchmark_elreal_performance\` shows the documented K.2 gains
- [x] No public API changes (elreal looks the same to existing callers)
- [ ] CI fast tier green
- [ ] CodeRabbit review

## What this PR does NOT do

- Convert \`elreal\` itself to a shared-ptr handle (would shrink \`sizeof(elreal)\` from 104 to 16 bytes at the cost of an additional indirection on every access). Trade-off not clearly worth it given the current numbers; deferred.
- Address per-op \`make_shared<const elreal>(a)\` operand wrapping. Each binary op still pays 2 small heap allocs (one per operand). On modern allocators with small-object pools this is typically cheap; measured throughput is excellent.
- Phase K.4 (SIMD batching on EFT primitives).

Part of #905 (Phase K of follow-up epic #903).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated performance baseline and arithmetic docs to reflect recent optimization phases and revised throughput comparisons.
  * Added a new document describing a CMake configure-file/build-content issue and the interim workaround.

* **Refactor**
  * Internal elreal implementation reworked to a more efficient generator representation, improving throughput and memory behavior for many operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->