### PR TITLE
perf(elreal): Phase L.1 -- depth-1 refinement for division

### DIFF
--- a/docs/algorithmic-details/elreal-performance-baseline.md
+++ b/docs/algorithmic-details/elreal-performance-baseline.md
@@ -124,17 +124,22 @@ two_sum / two_prod EFTs are a small number of double FLOPs each. The
 per-op cost is now roughly balanced between the small allocations and
 the leading-component math.
 
-### elreal `/` at depth 0
+### elreal `/` at depth 1 (Phase L.1, #916-or-later)
 
-Division clocks ~ 1 Gops/s in the synthetic benchmark. The reason:
-`elreal::operator/` materialises `c0 = a.at(0) / b.at(0)` (a single
-double division) and installs a `std::monostate` generator. With both
-K.1 and K.2 in place, the entire operator is stack-allocatable, the
-compiler inlines through it, and the only remaining work is the
-double divide. In a workload where the result feeds into a complex
-expression, throughput drops to the same range as the other operators.
-Once Phase L (#906) lands Newton refinement, division will look more
-like multiplication.
+After Phase L.1, division has depth-1 refinement matching the other
+arithmetic operators: a `gen_binary_linear` generator with the
+constant term carrying the IEEE-residual (`a - b*c0`, computed
+exactly via `two_prod` + `two_diff`) divided by `b0`, and operand
+corrections via the Taylor partials `1/b0` and `-c0/b0`. Throughput
+lands in the 13-16 Mops/s range -- the same as `+`/`-`/`*`.
+
+The pre-L.1 baseline had division clocking ~ 1 Gops/s on gcc, which
+was an artifact of the compiler inlining through the entire depth-0
+operator (single double divide, no captured generator). That benchmark
+shape no longer holds; the post-L.1 number reflects real depth-1
+arithmetic work.
+
+Depth 2+ via Newton iteration is Phase L.2 follow-up work.
 
 ### elreal math (sqrt / exp / log)
 
@@ -168,16 +173,19 @@ arithmetic gap with `elreal` has narrowed substantially:
 | `+` | 17 Mops/s | 19 Mops/s | `ereal<2>` (~ 1.1x; gap nearly closed) |
 | `-` | 17 Mops/s | 20 Mops/s | `ereal<2>` (~ 1.2x) |
 | `*` | 16 Mops/s | 11 Mops/s | **`elreal` (~ 1.5x)** |
-| `/` | (apples-to-oranges) | 680 Kops/s | -- |
+| `/` (depth 1 post-L.1) | 13 Mops/s | 680 Kops/s | **`elreal` (~ 19x)** |
 | `sqrt`, `exp`, `log` | 36-43 Mops/s | n/a | `elreal` only |
 
 Multiplication continues to favour `elreal`: `ereal<N>` multiplication
 is O(N) in the eager expansion product while `elreal *` is essentially
 a single `two_prod` plus the (now inline) result envelope.
 
-The `ereal<N> /` outlier (~ 680 Kops/s, ~ 50x slower than `elreal /`)
-is the iterative-division cost; not apples-to-apples since `elreal /`
-is depth-0 only today.
+Division also favours `elreal` after Phase L.1 (#906). `ereal<N> /`
+runs the iterative `expansion_quotient` algorithm (~ 680 Kops/s);
+`elreal /` produces a depth-1 result via a single `gen_binary_linear`
+generator with the IEEE residual + Taylor partials baked into the
+coefficients. Both deliver the same ~ 106-bit precision target at
+depth 1.
 
 ## When is `elreal` faster than `ereal`?
 

--- a/docs/algorithmic-details/lazy-real-arithmetic.md
+++ b/docs/algorithmic-details/lazy-real-arithmetic.md
@@ -175,16 +175,22 @@ existing EFT primitives in `include/sw/universal/numerics/error_free_ops.hpp`:
 | `a + b` | `two_sum(a0, b0)` leading | `sum_err + a.at(1) + b.at(1)` |
 | `a - b` | `two_diff(a0, b0)` leading | `diff_err + a.at(1) - b.at(1)` |
 | `a * b` | `two_prod(a0, b0)` leading | `prod_err + a0*b.at(1) + a.at(1)*b0` |
-| `a / b` | `a0 / b0` | 0.0 (Newton refinement deferred) |
+| `a / b` | `a0 / b0` | `(ieee_residual + a.at(1) - c0 * b.at(1)) / b0` |
+
+The `a / b` depth-1 generator (Phase L.1, #906) reconstructs the IEEE
+division residual `a - b * c0` exactly via `two_prod` + `two_diff`, then
+combines it with the Taylor partials. Depth 2+ via Newton iteration on
+the reciprocal is Phase L.2 follow-up.
 
 The non-overlapping property is preserved by construction -- the EFT
 residual is bounded by `ulp(leading) / 2`, and the operand depth-1 terms
 are themselves bounded by `ulp(operand_0)`.
 
-Depth 2+ for arithmetic is deferred to a follow-up; the issue is that the
-operator generators capture only the operand depth-0/1 components and don't
-propagate to depth 2 without lazy division. Newton iteration would provide
-this for `/` and `sqrt`; lazy-pi pull would provide it for `sin/cos/tan`.
+Depth 2+ for arithmetic is deferred to Phase L.2 (#906) of the follow-up
+epic. The issue is that the operator generators capture only the operand
+depth-0/1 components and don't propagate to depth 2 without lazy division
+walking deeper. Newton iteration provides this for `/` and `sqrt`;
+lazy-pi pull would provide it for `sin/cos/tan` (Phase N #908).
 
 ## 7. Math functions: derivative-based depth-1 correction (Phase E)
 

--- a/docs/algorithmic-details/multi-component-arithmetic.md
+++ b/docs/algorithmic-details/multi-component-arithmetic.md
@@ -643,7 +643,7 @@ shape for picker purposes:
 | `+` | ~17 Mops/s | ~19 Mops/s | `ereal<2>` (~ 1.1x; gap nearly closed) |
 | `-` | ~17 Mops/s | ~20 Mops/s | `ereal<2>` (~ 1.2x) |
 | `*` | ~16 Mops/s | ~11 Mops/s | **`elreal` (~ 1.5x)** |
-| `/` (elreal depth 0 only) | (dominated by inlining) | ~680 Kops/s | `elreal` (apples-to-oranges) |
+| `/` (depth 1 post-L.1) | ~13 Mops/s | ~680 Kops/s | **`elreal` (~ 19x)** |
 | `sqrt`, `exp`, `log` | ~36-43 Mops/s | n/a | `elreal` (ereal has no math functions) |
 
 (All numbers gcc 13.3 on a 12th Gen i7-12700K post-Phase-K.2 of #903;

--- a/docs/multi-component/exact-lazy-arithmetic.md
+++ b/docs/multi-component/exact-lazy-arithmetic.md
@@ -124,8 +124,9 @@ McCleeary-paradigm tier:
 - **Sign determination**: per-call refinement budget (default 8 components,
   ~424 bits cumulative); `sign(v, budget)` walks the stream to the first
   non-zero component.
-- **Arithmetic**: depth-1 EFT refinement for `+ - *`; depth-0-only for `/`
-  (Newton refinement is a follow-up).
+- **Arithmetic**: depth-1 EFT/Taylor refinement for `+ - * /` (the `/`
+  depth-1 generator landed in Phase L.1, follow-up epic #903). Depth-2+
+  Newton refinement for division and sqrt is Phase L.2 follow-up.
 - **Math**: depth-1 derivative-based refinement for the full
   exp/log/pow/hyperbolic/trig family.
 - **Geometric predicates**: `orient2d`, `orient3d`, `incircle`, `insphere`.

--- a/docs/number-systems/elreal.md
+++ b/docs/number-systems/elreal.md
@@ -235,12 +235,13 @@ depth" path. Refinement is an explicit caller choice.
 
 ## Known limitations
 
-- **Depth-1 ceiling.** Arithmetic operators and math functions currently
-  refine to depth 1. Deeper refinement (depth 2+) requires Newton-style
-  lazy iteration or a higher-precision internal algorithm. The infrastructure
-  is in place (the generator can produce arbitrarily many components); the
-  per-function generators just need to be extended. Tracked as a follow-up to
-  Phase F of the elreal epic (#873).
+- **Depth-1 ceiling.** Arithmetic operators (including `/` after Phase
+  L.1, #906) and math functions refine to depth 1 today. Deeper
+  refinement (depth 2+) requires Newton-style lazy iteration or a
+  higher-precision internal algorithm. The infrastructure is in place
+  (the generator can produce arbitrarily many components); the
+  per-function generators just need to be extended. Tracked as Phase
+  L.2 / Phase M of the elreal follow-up epic (#903).
 - **Constants stop at 4 components (~212 bits).** `elreal_pi`, `elreal_e`,
   and friends use static 4-component expansions reused from `qd_constants.hpp`.
   Extending past this requires either BBP-style on-demand bit extraction (for

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -968,12 +968,24 @@ inline elreal operator/(const elreal& a, const elreal& b) {
 	double diff_hi = two_diff(a0, prod_hi, diff_err);
 	double ieee_residual = (diff_hi + diff_err) - prod_err;
 
+	double inv_b0  = 1.0 / b0;
+	double ca      = inv_b0;
+	double cb      = -c0 * inv_b0;
+	double cconst  = ieee_residual * inv_b0;
+
+	// If b0 is a denormal whose reciprocal overflows to inf, any of
+	// ca / cb / cconst can be non-finite even though c0 = a0/b0 was
+	// finite. Installing such a generator would propagate inf/NaN
+	// into the depth-1 component (and from there into every refined
+	// result that touches at(1)). Bail out to depth-0-only.
+	if (!std::isfinite(ca) || !std::isfinite(cb) || !std::isfinite(cconst)) {
+		return result;
+	}
+
 	result._generator = gen_binary_linear{
 		std::make_shared<const elreal>(a),
 		std::make_shared<const elreal>(b),
-		ieee_residual / b0,
-		1.0 / b0,
-		-c0 / b0
+		cconst, ca, cb
 	};
 	return result;
 }

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -946,11 +946,35 @@ inline elreal operator/(const elreal& a, const elreal& b) {
 	result._components.push_back(c0);
 	result._computed_depth = 1;
 
-	// Phase C limitation: depth-1 refinement of division requires
-	// Newton-Raphson on the reciprocal stream, which lands in Phase E/F.
-	// We deliver only the leading double for now; depth >= 1 returns 0.
-	// This is a faithful answer at double precision but does not extend
-	// the lazy-real promise to deeper bits for the / operator.
+	// No depth-1 refinement when the leading is non-finite. Also skip when
+	// b0 was zero (handled above) -- the depth-1 formula divides by b0.
+	if (!std::isfinite(c0) || b0 == 0.0) return result;
+
+	// Phase L.1: depth-1 refinement via Taylor expansion + IEEE residual.
+	// Let r = a/b be the true value. At the leading doubles:
+	//   r = c0 + Δa/b0 - (a0/b0^2) Δb + (a - b*c0)/b0 + O(eps^2)
+	// where the IEEE residual `a - b*c0` is computable exactly from the
+	// leading doubles via EFTs:
+	//   two_prod(b0, c0) -> (prod_hi, prod_err) with b0*c0 = prod_hi + prod_err
+	//   two_diff(a0, prod_hi) -> (diff_hi, diff_err)
+	//   ieee_residual ~= (diff_hi + diff_err) - prod_err
+	// The depth-1 component is then
+	//   c1 = (ieee_residual + a.at(1) - c0 * b.at(1)) / b0
+	// which fits gen_binary_linear with constant = ieee_residual/b0,
+	// ca = 1/b0, cb = -c0/b0.
+	double prod_err;
+	double prod_hi = two_prod(b0, c0, prod_err);
+	double diff_err;
+	double diff_hi = two_diff(a0, prod_hi, diff_err);
+	double ieee_residual = (diff_hi + diff_err) - prod_err;
+
+	result._generator = gen_binary_linear{
+		std::make_shared<const elreal>(a),
+		std::make_shared<const elreal>(b),
+		ieee_residual / b0,
+		1.0 / b0,
+		-c0 / b0
+	};
 	return result;
 }
 


### PR DESCRIPTION
## Summary

Phase L.1 of follow-up epic #903. Lifts the "elreal / is depth-0 only" caveat that has held since Phase G.

## Algorithm

Let \`r = a/b\` be the true value. At the leading doubles:

\`\`\`
r = c0 + Δa/b0 - (a0/b0^2) Δb + (a - b*c0)/b0 + O(eps^2)
\`\`\`

where the IEEE residual \`a - b*c0\` is recoverable exactly from the leading doubles via EFTs:

\`\`\`
two_prod(b0, c0)      -> (prod_hi, prod_err) with b0*c0 = prod_hi + prod_err
two_diff(a0, prod_hi) -> (diff_hi, diff_err)
ieee_residual         = (diff_hi + diff_err) - prod_err
\`\`\`

The depth-1 component is then \`c1 = (ieee_residual + a.at(1) - c0 * b.at(1)) / b0\`, which fits the existing \`gen_binary_linear\` variant alternative with \`constant = ieee_residual / b0\`, \`ca = 1/b0\`, \`cb = -c0/b0\`. **No new generator shape needed**; just populate \`gen_binary_linear\` in \`operator/\`.

## Files

- **\`include/sw/universal/number/elreal/elreal_impl.hpp\`** -- depth-1 generator added to \`operator/\` (~40 lines changed).
- **\`docs/number-systems/elreal.md\`** -- known-limitations entry on "depth-1 ceiling" updated.
- **\`docs/algorithmic-details/lazy-real-arithmetic.md\`** -- Section 6 depth-1 generator table updated with the \`/\` row's actual formula.
- **\`docs/algorithmic-details/elreal-performance-baseline.md\`** -- division cost-shape section rewritten for post-L.1.
- **\`docs/algorithmic-details/multi-component-arithmetic.md\`** -- section 7.1 picker table updated: \`elreal /\` now beats \`ereal<N> /\` by ~ 19x at matched precision.
- **\`docs/multi-component/exact-lazy-arithmetic.md\`** -- "depth-0-only for /" caveat removed.

## Validation

- **1/3 sanity**: c0 = 0.333...331 (IEEE rounded), c1 = 1.85e-17 (the exact positive residual). Sum c0+c1 ≈ 1/3 to ~ 32 digits.
- All 30 elreal regression tests PASS under gcc 13.3 and clang 18.1.
- Phase J oracle sweep PASS under both compilers.
- \`benchmark_elreal_performance\`: division now ~ 13 Mops/s, the same range as +/-/* (was an artifact ~ 1 Gops/s pre-L.1 from gcc inlining the entire depth-0-only operator away).

## Picker shift

| Op | `elreal` post-L.1 | `ereal<2>` | Winner |
|---|---:|---:|---|
| `/` | 13 Mops/s | 680 Kops/s | **\`elreal\` (~ 19x)** |

With L.1 in place, \`elreal\` matches \`ereal<2>\` at depth 1 across the four elementary arithmetic operators, AND beats it on division by ~ 19x. \`ereal<N> /\` runs the iterative \`expansion_quotient\` algorithm; \`elreal /\` produces depth-1 in a single generator-emplace.

## What this PR does NOT do

- **Newton iteration for depth 2+**. That's Phase L.2.
- **Depth-2+ for sqrt**. Also Phase L.2 (sqrt already has depth 1 via gen_sqrt).

Part of #906 (Phase L of follow-up epic #903).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * elreal division now uses depth‑1 refinement, improving division precision and yielding ~13–16 Mops/s; elreal remains the only provider for sqrt/exp/log at ~36–43 Mops/s. Comparison clarifies other implementations’ iterative division behavior (~680 Kops/s).

* **Documentation**
  * Updated algorithmic and performance docs to reflect Phase L.1 depth‑1 behavior and defer deeper (depth‑2+) refinement to Phase L.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->