### PR TITLE
fix(elreal): rename _inline member to _inl_buf for MSVC compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,13 @@ if(UNIVERSAL_BUILD_CI_LITE)
 
 	# one elastic type
 	set(UNIVERSAL_BUILD_NUMBER_EINTEGERS ON)
+	# elreal: exercises std::variant, std::shared_ptr, lazy_component_buffer,
+	# and tagged-union generator -- catches MSVC-specific issues
+	# (e.g. _inline reserved-keyword collision, lambda capture quirks)
+	# that Linux gcc/clang don't surface. Included in lite to close the
+	# portability-check gap that allowed Phase K.1's _inline member-name
+	# bug to escape into PR #912.
+	set(UNIVERSAL_BUILD_NUMBER_ELREALS ON)
 
 	# conversions
 	set(UNIVERSAL_BUILD_NUMBER_CONVERSIONS ON)

--- a/include/sw/universal/number/elreal/lazy_component_buffer.hpp
+++ b/include/sw/universal/number/elreal/lazy_component_buffer.hpp
@@ -71,17 +71,17 @@ class lazy_component_buffer {
 public:
 	static constexpr std::size_t inline_capacity = 4;
 
-	lazy_component_buffer() noexcept : _inline{}, _spill{}, _size{0} {}
+	lazy_component_buffer() noexcept : _inl_buf{}, _spill{}, _size{0} {}
 
 	// Convenience: construct with a single leading component. Used by
 	// elreal's double-valued constructor to avoid going through push_back.
-	explicit lazy_component_buffer(double v) noexcept : _inline{}, _spill{}, _size{1} {
-		_inline[0] = v;
+	explicit lazy_component_buffer(double v) noexcept : _inl_buf{}, _spill{}, _size{1} {
+		_inl_buf[0] = v;
 	}
 
 	void push_back(double v) {
 		if (_size < inline_capacity) {
-			_inline[_size] = v;
+			_inl_buf[_size] = v;
 		}
 		else {
 			_spill.push_back(v);
@@ -96,7 +96,7 @@ public:
 
 	double operator[](std::size_t i) const noexcept {
 		assert(i < _size && "lazy_component_buffer index out of range");
-		return (i < inline_capacity) ? _inline[i] : _spill[i - inline_capacity];
+		return (i < inline_capacity) ? _inl_buf[i] : _spill[i - inline_capacity];
 	}
 
 	std::size_t size() const noexcept { return _size; }
@@ -111,7 +111,7 @@ public:
 	}
 
 private:
-	std::array<double, inline_capacity> _inline;
+	std::array<double, inline_capacity> _inl_buf;
 	std::vector<double>                 _spill;
 	std::size_t                         _size;
 };


### PR DESCRIPTION
## Summary

MSVC build break at HEAD of main, plus the CI gap that allowed it to slip through.

## The bug

\`lazy_component_buffer\` (shipped in Phase K.1 of #903 via PR #912) has a member named \`_inline\`. MSVC treats \`_inline\` (single underscore) as a legacy reserved keyword -- an alias for \`inline\` from old MSVC versions that's still special-cased in some parses. Symptom:

\`\`\`
error C2059: syntax error: ','
error C2334: unexpected token(s) preceding '{'; skipping apparent function body
\`\`\`

at the constructor's member-initializer list, where MSVC sees \`_inline{}\` and parses it as \`inline {}\`.

gcc and clang accept the name fine, which is why the bug shipped.

## Fixes

1. **Rename** \`_inline\` to \`_inl_buf\` in \`include/sw/universal/number/elreal/lazy_component_buffer.hpp\`. Mechanical search/replace; behavior identical.
2. **Close the CI gap** by adding \`UNIVERSAL_BUILD_NUMBER_ELREALS=ON\` to the \`UNIVERSAL_BUILD_CI_LITE\` cascade. The lite tier is the one used by the Windows MSVC runner in \`.github/workflows/cmake.yml\`; before this change it built integer / fixpnt / cfloat / posit / lns / dd / one elastic (einteger) / the MX block formats -- but not elreal. The MinGW cross-compile in the matrix uses gcc (just targeting Windows), so MinGW doesn't catch MSVC-specific issues like this either. Only the actual MSVC build does.

## Why this slipped through

- K.1 (#912) introduced \`_inline\` as a member name.
- All local builds were gcc + clang on Linux. Both accepted it.
- CI ran on the lite tier for MSVC. The lite tier didn't include elreal.
- The bug shipped via #912 and stayed quiet on main through #915, #916, #917 (which all touched elreal but compiled locally on Linux).
- Caught only when the user attempted a Windows MSVC build manually.

## Test plan

- [x] Builds clean under gcc 13.3 (\`build_elreal/\`)
- [x] Builds clean under clang 18.1 (\`build_clang_elreal/\`)
- [x] Sampled elreal tests PASS under both (api, division, division_depth2, constants, dd_math_sweep)
- [x] CI fast tier green -- specifically, the Windows MSVC job in CI_LITE will now build elreal and verify the rename works
- [x] CodeRabbit review

This PR is intentionally narrow. The MSVC issue exists on main today; this should ship before the in-flight Phase L.2.a PR (#918) which also touches elreal but doesn't introduce or fix MSVC concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled the elreals number component in CI build configurations.

* **Refactor**
  * Improved internal code organization for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->