### PR TITLE
feat(elreal): Phase 1 -- block<FpType> representation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ option(UNIVERSAL_BUILD_NUMBER_EDECIMALS            "Set to ON to build elastic e
 option(UNIVERSAL_BUILD_NUMBER_ERATIONALS           "Set to ON to build elastic erational tests"          OFF)
 option(UNIVERSAL_BUILD_NUMBER_EFLOATS              "Set to ON to build elastic efloat tests"             OFF)
 option(UNIVERSAL_BUILD_NUMBER_EREALS               "Set to ON to build elastic ereals tests"             OFF)
-option(UNIVERSAL_BUILD_NUMBER_ELREALS              "Set to ON to build elastic elreal (McCleeary) tests" OFF)
+option(UNIVERSAL_BUILD_NUMBER_ELREALS              "Set to ON to build elastic elreal tests"             OFF)
 
 option(UNIVERSAL_BUILD_NUMBER_STATICS              "Set to ON to build static arithmetic type tests"     OFF)
 option(UNIVERSAL_BUILD_NUMBER_INTEGERS             "Set to ON to build static integer tests"             OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ option(UNIVERSAL_BUILD_NUMBER_EDECIMALS            "Set to ON to build elastic e
 option(UNIVERSAL_BUILD_NUMBER_ERATIONALS           "Set to ON to build elastic erational tests"          OFF)
 option(UNIVERSAL_BUILD_NUMBER_EFLOATS              "Set to ON to build elastic efloat tests"             OFF)
 option(UNIVERSAL_BUILD_NUMBER_EREALS               "Set to ON to build elastic ereals tests"             OFF)
+option(UNIVERSAL_BUILD_NUMBER_ELREALS              "Set to ON to build elastic elreal (McCleeary) tests" OFF)
 
 option(UNIVERSAL_BUILD_NUMBER_STATICS              "Set to ON to build static arithmetic type tests"     OFF)
 option(UNIVERSAL_BUILD_NUMBER_INTEGERS             "Set to ON to build static integer tests"             OFF)
@@ -893,6 +894,9 @@ if(UNIVERSAL_BUILD_CI_LITE)
 	# one elastic type
 	set(UNIVERSAL_BUILD_NUMBER_EINTEGERS ON)
 
+	# elreal Phase 1 (block<FpType>): portability across platforms is critical
+	set(UNIVERSAL_BUILD_NUMBER_ELREALS ON)
+
 	# conversions
 	set(UNIVERSAL_BUILD_NUMBER_CONVERSIONS ON)
 
@@ -944,6 +948,7 @@ if(UNIVERSAL_BUILD_NUMBER_ELASTICS)
 	set(UNIVERSAL_BUILD_NUMBER_ERATIONALS ON)
 	set(UNIVERSAL_BUILD_NUMBER_EFLOATS ON)
 	set(UNIVERSAL_BUILD_NUMBER_EREALS ON)
+	set(UNIVERSAL_BUILD_NUMBER_ELREALS ON)
 endif(UNIVERSAL_BUILD_NUMBER_ELASTICS)
 
 if(UNIVERSAL_BUILD_NUMBER_STATICS)
@@ -1076,6 +1081,10 @@ endif(UNIVERSAL_BUILD_NUMBER_EFLOATS)
 if(UNIVERSAL_BUILD_NUMBER_EREALS)
 add_subdirectory("elastic/ereal")
 endif(UNIVERSAL_BUILD_NUMBER_EREALS)
+
+if(UNIVERSAL_BUILD_NUMBER_ELREALS)
+add_subdirectory("elastic/elreal")
+endif(UNIVERSAL_BUILD_NUMBER_ELREALS)
 
 
 ###################################################################

--- a/docs/bugs/elreal-implementation.md
+++ b/docs/bugs/elreal-implementation.md
@@ -1,0 +1,206 @@
+# elreal implementation failing
+
+and it's directly connected to why L.2.c hit the non-overlap wall. Let me check what our docs say about the choice we actually made:
+
+● Honest answer: we built a hybrid, and the L.2.c failure is exactly the price of that hybrid.
+
+What McCleeary's algorithm actually is
+
+I want to flag upfront that I don't have the dissertation text in front of me — I'm reasoning from the lazy-real-arithmetic literature it builds on (Boehm,
+Geuvers, Niqui) and the citations in our own docs. Treat this as a directional answer, not a verbatim summary.
+
+McCleeary 2019 builds on the computable-real tradition where a real value x is represented as a function
+
+f: Z → Z      such that   |x - f(n)/2^n| < 1
+
+(call f an "approximation function"). For any precision request n, the function returns an integer m such that m/2^n is within 1 of the true value. Each
+arithmetic operation op(x, y) produces a new approximation function:
+
+(x + y)(n)  =  x(n+2) + y(n+2)             // refine inputs to enough precision, then add
+(x * y)(n)  =  round(x(k) * y(k), n) for k = appropriate function of n
+
+McCleeary's contribution: replace the arbitrary-precision integers with IEEE-754 doubles by tracking which exponent range each approximation lives in. The
+"approximation" at precision n is now a double whose mantissa carries the next 53 bits past what previous approximations gave. Arithmetic operations are
+still computed exactly — but exactness is preserved by tracking the residual through a sequence of EFTs and re-computing at higher precision when the
+request comes in.
+
+The key property: x(n) for any n is correct to one ulp. If you ask for n=1000 bits, the algorithm walks the EFT chain however many doubles it needs.
+
+What we built instead
+
+A Shewchuk-style non-overlapping multi-component expansion with a McCleeary-style lazy materialisation wrapper:
+
+┌───────────────┬────────────────────────────────────────────┬────────────────────────────────────────────────┬───────────────────────────────────────┐
+│    Aspect     │                  Shewchuk                  │                   McCleeary                    │              What we did              │
+├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
+│ Storage       │ array of doubles, non-overlap invariant    │ function f(n) → double with precision tracking │ array of doubles (Shewchuk)           │
+├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
+│ Refinement    │ eager: full expansion built upfront        │ lazy: compute next bits on demand              │ lazy materialisation (McCleeary)      │
+├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
+│ Arithmetic op │ exact via expansion_sum etc. (Bailey/Hida) │ exact via EFT chain with precision propagation │ closed-form depth-1 formulas (ad-hoc) │
+├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
+│ Per-op cost   │ O(N²) for N components, eager              │ O(1) for current depth, lazy                   │ O(1) lazy + 53-bit-per-depth          │
+└───────────────┴────────────────────────────────────────────┴────────────────────────────────────────────────┴───────────────────────────────────────┘
+
+So the type is Shewchuk storage + McCleeary laziness + closed-form depth-1 arithmetic. The third piece is the one that's neither.
+
+Why we didn't implement the full McCleeary algorithm
+
+Three real reasons, plus one I'm less proud of:
+
+1. Reuse. Universal had Shewchuk-style EFT primitives (error_free_ops.hpp) and the ereal<N> type already. Building elreal on the same substrate let Phase A
+ship the type skeleton in a few hundred lines instead of a full big-integer/precision-tracking infrastructure.
+2. No big integers. McCleeary's algorithm in its pure form needs to track arbitrary-precision exponent-shifted residuals, which is morally a big-integer
+computation. Universal commits to header-only, no-external-deps, double-only foundations. Building the precision-tracking infrastructure McCleeary's
+algorithm wants is a major project of its own.
+3. The depth-1 case fit cleanly. For arithmetic at depth-1 (~ 106 bits), simple closed-form formulas using EFTs give the exact answer — there's nothing for
+McCleeary's precision tracking to add. So Phase C–E shipped depth-1 with closed-form formulas and worked correctly.
+4. (less proud) We assumed depth-2+ would extend the same way. Phase L.2.a/b confirmed that for depth-2. We hit the wall at L.2.c.
+
+How this connects to L.2.c
+
+The L.2.c non-overlap violation is exactly the bug McCleeary's algorithm would have prevented.
+
+At depth-2 the dropped EFT residuals are O(eps³), well below the depth-2 magnitude (~ eps²) — they don't affect the result. At depth-3 the dropped
+residuals are O(eps⁴), comparable in magnitude to the c_3 we're computing (~ eps³). Now they dominate the discrepancy that pushes c_3 over the ulp(c_2) / 2
+bound.
+
+McCleeary's algorithm would track these residuals through the chain. Concretely, for division at depth 3:
+
+- My closed form: c_3 = (a.at(3) - sum_terms) / b0
+- McCleeary's would be: at each two_prod inside that sum, propagate prod_err into a residual-stream that becomes part of the depth-3 computation. The
+leading double of the result is correct because the discarded bits live somewhere countable.
+
+The fix #921 lists are essentially two paths back toward McCleeary:
+
+- Option A (exact EFT tracking): track residuals through two_sum/two_prod chains. This is a small piece of McCleeary's machinery — the
+precision-propagation chain for arithmetic ops.
+- Option B (renormalisation): after computing tentative c_k, redistribute bits between c_{k-1} and c_k via two_sum so the non-overlap holds. This is
+Priest/Bailey-style normalisation; not McCleeary specifically, but related.
+
+A full McCleeary implementation would be Option A taken to its logical end: every operation produces a residual-stream that propagates to wherever it's
+needed, regardless of depth.
+
+Should we switch?
+
+Honest assessment: probably not in one PR, but the direction is right.
+
+Implementing McCleeary's algorithm properly is a multi-month effort. It would require:
+
+- A new representation: elreal_mccleeary parallel to today's elreal, with proper precision-tracking
+- All ~25 operators reimplemented (math suite included)
+- New validation against MPFR / external high-precision reference (the existing oracle helper validates against the Shewchuk-style implementation, which
+has the same bias)
+
+What's pragmatic for the existing elreal:
+
+1. Ship Option A or B from #921 as the L.2.c follow-up (smaller scope; reuses the current type)
+2. Accept the depth-2 cap as a documented contract for the Shewchuk-style implementation
+3. File a separate epic if someone wants the proper McCleeary algorithm — it would be a sibling type, not a replacement
+
+The L.2.b state we shipped is honest: depth-0 and depth-1 are McCleeary-correct (~ 106 bits exact); depth-2 is approximately correct with the EFT residuals
+dropped (good enough for most uses); depth-3+ would require the residual tracking to be principled.
+
+I'd love to actually read the dissertation to verify my characterization of McCleeary's algorithm — if you have a copy of the relevant chapters, I can
+sharpen this. The big-picture answer ("we built Shewchuk-style with lazy materialisation, not McCleeary-style precision tracking") is robust either way.
+
+## McCleeary algorithm
+
+This is a fundamentally illuminating read. Our type isn't McCleeary's algorithm at all — we mislabeled. 
+Let me synthesize what McCleeary actually does, and why the L.2.c failure was inevitable given the path we took.
+
+### McCleeary's actual algorithm
+
+The representation is a ZBCL_k — Zero-overlap Block Co-list with k-bit blocks. Three layers:
+
+1. Block (s, e, bv): sign in {-1, +1}, integer exponent e, and a k-bit bit-vector bv. The block's value is s * 2^e * Σ_{i=0..k-1} bv[i] * 2^-i. So a block
+is a k-bit floating-point number with an explicit exponent and sign. Not a double — a parameterized-precision number where k is a free design parameter (he
+uses k >= 3 in proofs; in practice he picks values like the IEEE double mantissa).
+2. Co-list of blocks (BCL_k): a possibly-infinite lazy stream of blocks. The blocks at later positions in the stream contribute smaller magnitudes; the sum
+of the stream is the represented real.
+3. Zero-overlap property (ZBCL_k) — this is the crucial bit. For consecutive blocks at exponents e_n and e_{n+1}, McCleeary requires:
+
+e_n >= e_{n+1} + k
+
+3. That is, the bit-position immediately below block n and immediately above block n+1 is guaranteed to be zero. Figure 4.1 in the dissertation labels this
+position with the literal name imp (impossible-to-be-1).
+
+That imp bit (or "gap") is the entire reason the algorithm is correct. McCleeary says it explicitly (p. 45):
+
+▎ The result is guaranteed to generate either a single bit in the lower part of the output... or there is guaranteed to be a bit space in which a 0 exists
+▎ between the two blocks being outputted. ... The reason why this property is important is this is what allows us to do lazy arithmetic from left to right.
+▎  This bit ... is what allows us to consume possible carry ups from below, without going into the space of the higher block.
+
+What we built
+
+Our lazy_component_buffer stores raw IEEE-754 doubles (k=53), and our invariant is Shewchuk's:
+
+|c_{i+1}| <= ulp(c_i) / 2
+
+This is a tighter bound than McCleeary's. McCleeary's e_n >= e_{n+1} + k (block-exponent gap) allows the next block to have any bit pattern below its
+leading bit — including bits all the way down to the gap. Shewchuk's <= ulp/2 requires the next double's leading set bit to be at least one position below
+the previous double's least significant bit.
+
+Critically: Shewchuk has no imp bit. There's no buffer space between c_i and c_{i+1} to absorb carry-ups. That's why Shewchuk expansions need
+renormalization (the Renormalize algorithm in §3.1.1 of the dissertation, the same one Bailey/Hida use for QD): they eagerly compute the full result, then
+sweep back through to redistribute carries.
+
+McCleeary's imp gap eliminates the need for the renormalization sweep — the gap is built into the representation as it's produced. That's what makes the
+algorithm genuinely lazy left-to-right.
+
+How McCleeary actually computes
+
+Take addition (§4.2.1). His helper is threeAdd: take one block from each input co-list plus one block from a workspace (carry register), produce three
+output blocks out_1, out_2, out_3 satisfying:
+
+- Value preservation: a + b + c = out_1 + out_2 + out_3
+- Gap preservation: dominate out_1 out_2 ∧ dominate out_2 out_3
+- Exponent bound: (getExp a) - k <= (getExp out_1) <= (getExp a) + 2
+- A "no-shrink" guarantee: if the input exponents are far enough apart, getExp out_1 = getExp a (no catastrophic shrinkage from this step)
+
+The algorithm walks left-to-right through the input co-lists. At each step it commits exactly one output block (the leftmost one of (out_1, out_2, out_3)
+that's "safe to output" — meaning the gap to whatever comes next is preserved). The other two blocks become the workspace for the next step.
+
+And a hard-won lesson from §4.2 (p. 53): McCleeary describes his own struggle:
+
+▎ My first attempt at the addition algorithm took and performed exact floating point additions ... and tried to output a block that was safe to output. ...
+▎  Ultimately all of these attempts failed to produce a ZBCL_k. ... I was viewing the problem as a question of "How much of the input ZBCL_k do we need to
+▎ see before producing an output?". I switched the problem to a simple one, "When do we know a block_k is safe to output?"
+
+That reframing is the whole game. McCleeary's algorithm is "compute eagerly into a workspace, and only commit a block when you have proof the gap will
+hold." We don't do that. We commit each c_k immediately and assume the formulas will keep the bound.
+
+Why our L.2.c fails
+
+The L.2.c symptom (c_3 exceeds ulp(c_2)/2 by 1.5x) is the direct, predictable consequence of three mismatches:
+
+1. We use Shewchuk's tight bound instead of McCleeary's gap-leaving bound. Shewchuk forces every limb to honour <= ulp/2, but his algorithms enforce that
+via a renormalization sweep. Ours don't.
+2. We dropped EFT residuals from the depth-2+ formulas. In McCleeary, residuals would propagate into the workspace and influence whether the next block can
+be safely committed. In our system, they just disappear.
+3. We commit c_k greedily. The lazy framework's at(k) materialises c_k once and stores it. McCleeary's framework would carry the workspace forward and emit
+a block only when the gap is provable. We don't have a workspace concept; the "result so far" is exactly the materialised prefix, no slack.
+
+So the L.2.c violation is the predictable failure mode: we built a Shewchuk-style representation (which needs renormalization) on top of McCleeary-style
+laziness (which avoids renormalization but only because of the gap). Neither half is wrong by itself; the combination is.
+
+Three honest paths forward
+
+The L.2.c issue (#921) said "exact EFT tracking or post-computation renormalisation". Given the dissertation, I'd reframe those:
+
+1. Add the renormalization sweep (Shewchuk path): After computing tentative c_k, walk (c_{k-1}, c_k) through Fast2Sum (the same Renormalize algorithm
+Bailey/Hida use for QD) to redistribute bits so the Shewchuk bound holds. Lossy with respect to the existing materialised c_{k-1} — we have to mutate it.
+Conflicts with our "materialised components are immutable" contract; would need a small refactor.
+2. Add EFT residual propagation (still Shewchuk-style): Track residuals through the formula via two_sum/two_prod chains. Each depth-k evaluation becomes
+O(k) EFTs. Doesn't change the representation; just makes the formulas exact. The tightest fix that doesn't redesign the storage.
+3. Switch to McCleeary's actual algorithm (proper path): Reimplement as ZBCL_53 — blocks of size 53 (matching double mantissa), with the e_n >= e_{n+1} + k
+gap, with threeAdd-style primitives that maintain a workspace and commit blocks only when proven safe. This is a multi-month rewrite — essentially a
+different number system. Worth filing as a separate epic if the user wants a true McCleeary implementation.
+
+Honest assessment of what we shipped: Phases A-G built a very good Shewchuk-style multi-component type with McCleeary-style lazy materialisation grafted on
+top. Depth-0 and depth-1 are correct because the EFTs preserve Shewchuk's bound exactly for one-step operations. Depth-2 (L.2.a/b) is correct because the
+dropped EFT residuals are still small enough. Depth-3+ is where the architectural mismatch surfaces.
+
+I'd recommend updating issue #921 to reference the dissertation's actual algorithm and choose path (1) or (2) as the pragmatic fix, with path (3) filed as
+a longer-term aspiration if the user wants a faithful McCleeary implementation. Want me to update #921 with this finding?
+

--- a/docs/bugs/elreal-implementation.md
+++ b/docs/bugs/elreal-implementation.md
@@ -2,26 +2,28 @@
 
 and it's directly connected to why L.2.c hit the non-overlap wall. Let me check what our docs say about the choice we actually made:
 
-● Honest answer: we built a hybrid, and the L.2.c failure is exactly the price of that hybrid.
+* Honest answer: we built a hybrid, and the L.2.c failure is exactly the price of that hybrid.
 
 What McCleeary's algorithm actually is
 
-I want to flag upfront that I don't have the dissertation text in front of me — I'm reasoning from the lazy-real-arithmetic literature it builds on (Boehm,
+I want to flag upfront that I don't have the dissertation text in front of me -- I'm reasoning from the lazy-real-arithmetic literature it builds on (Boehm,
 Geuvers, Niqui) and the citations in our own docs. Treat this as a directional answer, not a verbatim summary.
 
 McCleeary 2019 builds on the computable-real tradition where a real value x is represented as a function
 
-f: Z → Z      such that   |x - f(n)/2^n| < 1
+f: Z -> Z      such that   |x - f(n)/2^n| < 1
 
 (call f an "approximation function"). For any precision request n, the function returns an integer m such that m/2^n is within 1 of the true value. Each
 arithmetic operation op(x, y) produces a new approximation function:
 
+```
 (x + y)(n)  =  x(n+2) + y(n+2)             // refine inputs to enough precision, then add
 (x * y)(n)  =  round(x(k) * y(k), n) for k = appropriate function of n
+```
 
 McCleeary's contribution: replace the arbitrary-precision integers with IEEE-754 doubles by tracking which exponent range each approximation lives in. The
 "approximation" at precision n is now a double whose mantissa carries the next 53 bits past what previous approximations gave. Arithmetic operations are
-still computed exactly — but exactness is preserved by tracking the residual through a sequence of EFTs and re-computing at higher precision when the
+still computed exactly -- but exactness is preserved by tracking the residual through a sequence of EFTs and re-computing at higher precision when the
 request comes in.
 
 The key property: x(n) for any n is correct to one ulp. If you ask for n=1000 bits, the algorithm walks the EFT chain however many doubles it needs.
@@ -30,17 +32,12 @@ What we built instead
 
 A Shewchuk-style non-overlapping multi-component expansion with a McCleeary-style lazy materialisation wrapper:
 
-┌───────────────┬────────────────────────────────────────────┬────────────────────────────────────────────────┬───────────────────────────────────────┐
-│    Aspect     │                  Shewchuk                  │                   McCleeary                    │              What we did              │
-├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
-│ Storage       │ array of doubles, non-overlap invariant    │ function f(n) → double with precision tracking │ array of doubles (Shewchuk)           │
-├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
-│ Refinement    │ eager: full expansion built upfront        │ lazy: compute next bits on demand              │ lazy materialisation (McCleeary)      │
-├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
-│ Arithmetic op │ exact via expansion_sum etc. (Bailey/Hida) │ exact via EFT chain with precision propagation │ closed-form depth-1 formulas (ad-hoc) │
-├───────────────┼────────────────────────────────────────────┼────────────────────────────────────────────────┼───────────────────────────────────────┤
-│ Per-op cost   │ O(N²) for N components, eager              │ O(1) for current depth, lazy                   │ O(1) lazy + 53-bit-per-depth          │
-└───────────────┴────────────────────────────────────────────┴────────────────────────────────────────────────┴───────────────────────────────────────┘
+| Aspect | Shewchuk | McCleeary | What we did |
+|--------|----------|-----------|-------------|
+| Storage | array of doubles, non-overlap invariant | function f(n) -> double with precision tracking | array of doubles (Shewchuk) |
+| Refinement | eager: full expansion built upfront | lazy: compute next bits on demand | lazy materialisation (McCleeary) |
+| Arithmetic op | exact via expansion_sum etc. (Bailey/Hida) | exact via EFT chain with precision propagation | closed-form depth-1 formulas (ad-hoc) |
+| Per-op cost | O(N^2) for N components, eager | O(1) for current depth, lazy | O(1) lazy + 53-bit-per-depth |
 
 So the type is Shewchuk storage + McCleeary laziness + closed-form depth-1 arithmetic. The third piece is the one that's neither.
 
@@ -53,16 +50,16 @@ ship the type skeleton in a few hundred lines instead of a full big-integer/prec
 2. No big integers. McCleeary's algorithm in its pure form needs to track arbitrary-precision exponent-shifted residuals, which is morally a big-integer
 computation. Universal commits to header-only, no-external-deps, double-only foundations. Building the precision-tracking infrastructure McCleeary's
 algorithm wants is a major project of its own.
-3. The depth-1 case fit cleanly. For arithmetic at depth-1 (~ 106 bits), simple closed-form formulas using EFTs give the exact answer — there's nothing for
-McCleeary's precision tracking to add. So Phase C–E shipped depth-1 with closed-form formulas and worked correctly.
+3. The depth-1 case fit cleanly. For arithmetic at depth-1 (~ 106 bits), simple closed-form formulas using EFTs give the exact answer -- there's nothing for
+McCleeary's precision tracking to add. So Phase C--E shipped depth-1 with closed-form formulas and worked correctly.
 4. (less proud) We assumed depth-2+ would extend the same way. Phase L.2.a/b confirmed that for depth-2. We hit the wall at L.2.c.
 
 How this connects to L.2.c
 
 The L.2.c non-overlap violation is exactly the bug McCleeary's algorithm would have prevented.
 
-At depth-2 the dropped EFT residuals are O(eps³), well below the depth-2 magnitude (~ eps²) — they don't affect the result. At depth-3 the dropped
-residuals are O(eps⁴), comparable in magnitude to the c_3 we're computing (~ eps³). Now they dominate the discrepancy that pushes c_3 over the ulp(c_2) / 2
+At depth-2 the dropped EFT residuals are O(eps^3), well below the depth-2 magnitude (~ eps^2) -- they don't affect the result. At depth-3 the dropped
+residuals are O(eps^4), comparable in magnitude to the c_3 we're computing (~ eps^3). Now they dominate the discrepancy that pushes c_3 over the ulp(c_2) / 2
 bound.
 
 McCleeary's algorithm would track these residuals through the chain. Concretely, for division at depth 3:
@@ -73,7 +70,7 @@ leading double of the result is correct because the discarded bits live somewher
 
 The fix #921 lists are essentially two paths back toward McCleeary:
 
-- Option A (exact EFT tracking): track residuals through two_sum/two_prod chains. This is a small piece of McCleeary's machinery — the
+- Option A (exact EFT tracking): track residuals through two_sum/two_prod chains. This is a small piece of McCleeary's machinery -- the
 precision-propagation chain for arithmetic ops.
 - Option B (renormalisation): after computing tentative c_k, redistribute bits between c_{k-1} and c_k via two_sum so the non-overlap holds. This is
 Priest/Bailey-style normalisation; not McCleeary specifically, but related.
@@ -96,29 +93,29 @@ What's pragmatic for the existing elreal:
 
 1. Ship Option A or B from #921 as the L.2.c follow-up (smaller scope; reuses the current type)
 2. Accept the depth-2 cap as a documented contract for the Shewchuk-style implementation
-3. File a separate epic if someone wants the proper McCleeary algorithm — it would be a sibling type, not a replacement
+3. File a separate epic if someone wants the proper McCleeary algorithm -- it would be a sibling type, not a replacement
 
 The L.2.b state we shipped is honest: depth-0 and depth-1 are McCleeary-correct (~ 106 bits exact); depth-2 is approximately correct with the EFT residuals
 dropped (good enough for most uses); depth-3+ would require the residual tracking to be principled.
 
-I'd love to actually read the dissertation to verify my characterization of McCleeary's algorithm — if you have a copy of the relevant chapters, I can
+I'd love to actually read the dissertation to verify my characterization of McCleeary's algorithm -- if you have a copy of the relevant chapters, I can
 sharpen this. The big-picture answer ("we built Shewchuk-style with lazy materialisation, not McCleeary-style precision tracking") is robust either way.
 
 ## McCleeary algorithm
 
-This is a fundamentally illuminating read. Our type isn't McCleeary's algorithm at all — we mislabeled. 
+This is a fundamentally illuminating read. Our type isn't McCleeary's algorithm at all -- we mislabeled. 
 Let me synthesize what McCleeary actually does, and why the L.2.c failure was inevitable given the path we took.
 
 ### McCleeary's actual algorithm
 
-The representation is a ZBCL_k — Zero-overlap Block Co-list with k-bit blocks. Three layers:
+The representation is a ZBCL_k -- Zero-overlap Block Co-list with k-bit blocks. Three layers:
 
-1. Block (s, e, bv): sign in {-1, +1}, integer exponent e, and a k-bit bit-vector bv. The block's value is s * 2^e * Σ_{i=0..k-1} bv[i] * 2^-i. So a block
-is a k-bit floating-point number with an explicit exponent and sign. Not a double — a parameterized-precision number where k is a free design parameter (he
+1. Block (s, e, bv): sign in {-1, +1}, integer exponent e, and a k-bit bit-vector bv. The block's value is s * 2^e * sum_{i=0..k-1} bv[i] * 2^-i. So a block
+is a k-bit floating-point number with an explicit exponent and sign. Not a double -- a parameterized-precision number where k is a free design parameter (he
 uses k >= 3 in proofs; in practice he picks values like the IEEE double mantissa).
 2. Co-list of blocks (BCL_k): a possibly-infinite lazy stream of blocks. The blocks at later positions in the stream contribute smaller magnitudes; the sum
 of the stream is the represented real.
-3. Zero-overlap property (ZBCL_k) — this is the crucial bit. For consecutive blocks at exponents e_n and e_{n+1}, McCleeary requires:
+3. Zero-overlap property (ZBCL_k) -- this is the crucial bit. For consecutive blocks at exponents e_n and e_{n+1}, McCleeary requires:
 
 e_n >= e_{n+1} + k
 
@@ -127,9 +124,9 @@ position with the literal name imp (impossible-to-be-1).
 
 That imp bit (or "gap") is the entire reason the algorithm is correct. McCleeary says it explicitly (p. 45):
 
-▎ The result is guaranteed to generate either a single bit in the lower part of the output... or there is guaranteed to be a bit space in which a 0 exists
-▎ between the two blocks being outputted. ... The reason why this property is important is this is what allows us to do lazy arithmetic from left to right.
-▎  This bit ... is what allows us to consume possible carry ups from below, without going into the space of the higher block.
+> The result is guaranteed to generate either a single bit in the lower part of the output... or there is guaranteed to be a bit space in which a 0 exists
+> between the two blocks being outputted. ... The reason why this property is important is this is what allows us to do lazy arithmetic from left to right.
+>  This bit ... is what allows us to consume possible carry ups from below, without going into the space of the higher block.
 
 What we built
 
@@ -138,34 +135,34 @@ Our lazy_component_buffer stores raw IEEE-754 doubles (k=53), and our invariant 
 |c_{i+1}| <= ulp(c_i) / 2
 
 This is a tighter bound than McCleeary's. McCleeary's e_n >= e_{n+1} + k (block-exponent gap) allows the next block to have any bit pattern below its
-leading bit — including bits all the way down to the gap. Shewchuk's <= ulp/2 requires the next double's leading set bit to be at least one position below
+leading bit -- including bits all the way down to the gap. Shewchuk's <= ulp/2 requires the next double's leading set bit to be at least one position below
 the previous double's least significant bit.
 
 Critically: Shewchuk has no imp bit. There's no buffer space between c_i and c_{i+1} to absorb carry-ups. That's why Shewchuk expansions need
-renormalization (the Renormalize algorithm in §3.1.1 of the dissertation, the same one Bailey/Hida use for QD): they eagerly compute the full result, then
+renormalization (the Renormalize algorithm in Sec. 3.1.1 of the dissertation, the same one Bailey/Hida use for QD): they eagerly compute the full result, then
 sweep back through to redistribute carries.
 
-McCleeary's imp gap eliminates the need for the renormalization sweep — the gap is built into the representation as it's produced. That's what makes the
+McCleeary's imp gap eliminates the need for the renormalization sweep -- the gap is built into the representation as it's produced. That's what makes the
 algorithm genuinely lazy left-to-right.
 
 How McCleeary actually computes
 
-Take addition (§4.2.1). His helper is threeAdd: take one block from each input co-list plus one block from a workspace (carry register), produce three
+Take addition (Sec. 4.2.1). His helper is threeAdd: take one block from each input co-list plus one block from a workspace (carry register), produce three
 output blocks out_1, out_2, out_3 satisfying:
 
 - Value preservation: a + b + c = out_1 + out_2 + out_3
-- Gap preservation: dominate out_1 out_2 ∧ dominate out_2 out_3
+- Gap preservation: dominate out_1 out_2 and dominate out_2 out_3
 - Exponent bound: (getExp a) - k <= (getExp out_1) <= (getExp a) + 2
 - A "no-shrink" guarantee: if the input exponents are far enough apart, getExp out_1 = getExp a (no catastrophic shrinkage from this step)
 
 The algorithm walks left-to-right through the input co-lists. At each step it commits exactly one output block (the leftmost one of (out_1, out_2, out_3)
-that's "safe to output" — meaning the gap to whatever comes next is preserved). The other two blocks become the workspace for the next step.
+that's "safe to output" -- meaning the gap to whatever comes next is preserved). The other two blocks become the workspace for the next step.
 
-And a hard-won lesson from §4.2 (p. 53): McCleeary describes his own struggle:
+And a hard-won lesson from Sec. 4.2 (p. 53): McCleeary describes his own struggle:
 
-▎ My first attempt at the addition algorithm took and performed exact floating point additions ... and tried to output a block that was safe to output. ...
-▎  Ultimately all of these attempts failed to produce a ZBCL_k. ... I was viewing the problem as a question of "How much of the input ZBCL_k do we need to
-▎ see before producing an output?". I switched the problem to a simple one, "When do we know a block_k is safe to output?"
+> My first attempt at the addition algorithm took and performed exact floating point additions ... and tried to output a block that was safe to output. ...
+>  Ultimately all of these attempts failed to produce a ZBCL_k. ... I was viewing the problem as a question of "How much of the input ZBCL_k do we need to
+> see before producing an output?". I switched the problem to a simple one, "When do we know a block_k is safe to output?"
 
 That reframing is the whole game. McCleeary's algorithm is "compute eagerly into a workspace, and only commit a block when you have proof the gap will
 hold." We don't do that. We commit each c_k immediately and assume the formulas will keep the bound.
@@ -189,12 +186,12 @@ Three honest paths forward
 The L.2.c issue (#921) said "exact EFT tracking or post-computation renormalisation". Given the dissertation, I'd reframe those:
 
 1. Add the renormalization sweep (Shewchuk path): After computing tentative c_k, walk (c_{k-1}, c_k) through Fast2Sum (the same Renormalize algorithm
-Bailey/Hida use for QD) to redistribute bits so the Shewchuk bound holds. Lossy with respect to the existing materialised c_{k-1} — we have to mutate it.
+Bailey/Hida use for QD) to redistribute bits so the Shewchuk bound holds. Lossy with respect to the existing materialised c_{k-1} -- we have to mutate it.
 Conflicts with our "materialised components are immutable" contract; would need a small refactor.
 2. Add EFT residual propagation (still Shewchuk-style): Track residuals through the formula via two_sum/two_prod chains. Each depth-k evaluation becomes
 O(k) EFTs. Doesn't change the representation; just makes the formulas exact. The tightest fix that doesn't redesign the storage.
-3. Switch to McCleeary's actual algorithm (proper path): Reimplement as ZBCL_53 — blocks of size 53 (matching double mantissa), with the e_n >= e_{n+1} + k
-gap, with threeAdd-style primitives that maintain a workspace and commit blocks only when proven safe. This is a multi-month rewrite — essentially a
+3. Switch to McCleeary's actual algorithm (proper path): Reimplement as ZBCL_53 -- blocks of size 53 (matching double mantissa), with the e_n >= e_{n+1} + k
+gap, with threeAdd-style primitives that maintain a workspace and commit blocks only when proven safe. This is a multi-month rewrite -- essentially a
 different number system. Worth filing as a separate epic if the user wants a true McCleeary implementation.
 
 Honest assessment of what we shipped: Phases A-G built a very good Shewchuk-style multi-component type with McCleeary-style lazy materialisation grafted on

--- a/elastic/elreal/CMakeLists.txt
+++ b/elastic/elreal/CMakeLists.txt
@@ -1,0 +1,8 @@
+# elastic/elreal/CMakeLists.txt
+#
+# Phase 1 (#925): block<FpType> representation only. Co-list, arithmetic,
+# math suite and conversion are added in subsequent phases (#926-#933).
+
+file (GLOB BLOCK_SRCS "./block/*.cpp")
+
+compile_all("true" "el_block" "Number Systems/elastic/floating-point/binary/elreal/block" "${BLOCK_SRCS}")

--- a/elastic/elreal/block/accessors.cpp
+++ b/elastic/elreal/block/accessors.cpp
@@ -46,14 +46,12 @@ int verify_accessors(const std::string& tag) {
         ++nrFailures;
     }
 
-    // value_as<double> with offset=0
+    // value_as<double> with offset=0: the recovered value must bit-match the
+    // host FpType's stored value (no rounding -- value_as is just a cast).
     B v{ FpType{3.25}, 0 };
     double recovered = v.template value_as<double>();
-    // Allow per-type conversion loss: for narrow FpType, the original 3.25 may
-    // not be exactly representable. We test that the round-trip recovers what
-    // the host FpType stored.
     double host_stored = static_cast<double>(FpType{3.25});
-    if (std::abs(recovered - host_stored) > 0.0) {
+    if (recovered != host_stored) {
         std::cout << tag << " value_as<double>(off=0) mismatch: "
                   << recovered << " vs host_stored " << host_stored << '\n';
         ++nrFailures;

--- a/elastic/elreal/block/accessors.cpp
+++ b/elastic/elreal/block/accessors.cpp
@@ -1,0 +1,88 @@
+// accessors.cpp: sign(), scale_of_v(), exponent(), value_as<>() tests for
+// elreal block<FpType>.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_accessors(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    int nrFailures = 0;
+
+    // sign on positive, negative, +0, -0
+    B pos{ FpType{1.5}, 0 };
+    B neg{ FpType{-1.5}, 0 };
+    if (pos.sign() != +1) { std::cout << tag << " pos.sign() != +1\n"; ++nrFailures; }
+    if (neg.sign() != -1) { std::cout << tag << " neg.sign() != -1\n"; ++nrFailures; }
+
+    // scale_of_v: powers of two yield integer scales
+    B p2_0{ FpType{1}, 0 };       // 2^0
+    B p2_1{ FpType{2}, 0 };       // 2^1
+    B p2_n1{ FpType{0.5}, 0 };    // 2^-1
+    if (p2_0.scale_of_v() != 0)   { std::cout << tag << " scale(1.0) != 0\n"; ++nrFailures; }
+    if (p2_1.scale_of_v() != 1)   { std::cout << tag << " scale(2.0) != 1\n"; ++nrFailures; }
+    if (p2_n1.scale_of_v() != -1) { std::cout << tag << " scale(0.5) != -1\n"; ++nrFailures; }
+
+    // exponent() = scale_of_v + exp_offset * 2^E
+    B off2{ FpType{1.5}, 2 };
+    std::int64_t expected = off2.scale_of_v() + std::int64_t(2) * B::exp_step;
+    if (off2.exponent() != expected) {
+        std::cout << tag << " exponent() with offset wrong: got " << off2.exponent()
+                  << " expected " << expected << '\n';
+        ++nrFailures;
+    }
+
+    // value_as<double> with offset=0
+    B v{ FpType{3.25}, 0 };
+    double recovered = v.template value_as<double>();
+    // Allow per-type conversion loss: for narrow FpType, the original 3.25 may
+    // not be exactly representable. We test that the round-trip recovers what
+    // the host FpType stored.
+    double host_stored = static_cast<double>(FpType{3.25});
+    if (std::abs(recovered - host_stored) > 0.0) {
+        std::cout << tag << " value_as<double>(off=0) mismatch: "
+                  << recovered << " vs host_stored " << host_stored << '\n';
+        ++nrFailures;
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal block<FpType> accessors";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_accessors<float>("block<float>");
+    nrOfFailedTestCases += verify_accessors<double>("block<double>");
+    nrOfFailedTestCases += verify_accessors<half>("block<half>");
+    nrOfFailedTestCases += verify_accessors<bfloat16>("block<bfloat16>");
+    nrOfFailedTestCases += verify_accessors<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
+    nrOfFailedTestCases += verify_accessors<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/block/construction.cpp
+++ b/elastic/elreal/block/construction.cpp
@@ -1,0 +1,92 @@
+// construction.cpp: trivial-layout + value construction tests for elreal block<FpType>.
+//
+// Phase 1 (#925) acceptance: block must be a trivial type so it can sit on
+// hardware boundaries (FPGA, accelerator) without an out-of-band constructor.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <type_traits>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_construction(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+
+    int nrFailures = 0;
+
+    static_assert(std::is_trivially_copyable_v<B>,
+                  "block<FpType> must be trivially copyable");
+    static_assert(std::is_trivially_destructible_v<B>,
+                  "block<FpType> must be trivially destructible");
+    // Default constructibility relaxed: block leaves members indeterminate by
+    // design (matches the project's other trivial number types). We require
+    // copy-constructibility instead.
+    static_assert(std::is_copy_constructible_v<B>);
+    static_assert(std::is_copy_assignable_v<B>);
+
+    // value construction
+    B one{ FpType{1}, 0 };
+    if (one.v != FpType{1}) { std::cout << tag << ": one.v != 1\n"; ++nrFailures; }
+    if (one.exp_offset != 0) { std::cout << tag << ": one.exp_offset != 0\n"; ++nrFailures; }
+
+    // value + offset construction
+    B big{ FpType{1.5}, 3 };
+    if (big.v != FpType{1.5}) { std::cout << tag << ": big.v != 1.5\n"; ++nrFailures; }
+    if (big.exp_offset != 3) { std::cout << tag << ": big.exp_offset != 3\n"; ++nrFailures; }
+
+    // negative offset
+    B small{ FpType{1.5}, -5 };
+    if (small.exp_offset != -5) { std::cout << tag << ": small.exp_offset != -5\n"; ++nrFailures; }
+
+    // copy
+    B copy = big;
+    if (copy.v != big.v || copy.exp_offset != big.exp_offset) {
+        std::cout << tag << ": copy mismatch\n"; ++nrFailures;
+    }
+
+    // compile-time constants exposed on the type
+    static_assert(B::k > 0, "block::k must be positive");
+    static_assert(B::E > 0, "block::E must be positive");
+    static_assert(B::exp_step > 0, "block::exp_step must be positive");
+
+    std::cout << tag << " k=" << B::k << " E=" << B::E
+              << " exp_step=" << B::exp_step << "\n";
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal block<FpType> construction";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_construction<float>("block<float>");
+    nrOfFailedTestCases += verify_construction<double>("block<double>");
+    nrOfFailedTestCases += verify_construction<half>("block<half>");
+    nrOfFailedTestCases += verify_construction<bfloat16>("block<bfloat16>");
+    nrOfFailedTestCases += verify_construction<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
+    nrOfFailedTestCases += verify_construction<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/block/exp_offset.cpp
+++ b/elastic/elreal/block/exp_offset.cpp
@@ -1,0 +1,98 @@
+// exp_offset.cpp: int32_t exp_offset boundary tests for elreal block<FpType>.
+//
+// The block's exp_offset multiplies in units of 2^E. Its purpose is to escape
+// the host FpType's hardware exponent range, which matters for transcendentals
+// at high depth in later phases.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <iostream>
+#include <limits>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_exp_offset(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    int nrFailures = 0;
+
+    // exp_offset = 0: exponent() == scale_of_v()
+    B at_one{ FpType{1.5}, 0 };
+    if (at_one.exponent() != at_one.scale_of_v()) {
+        std::cout << tag << " offset=0 mismatch\n"; ++nrFailures;
+    }
+
+    // Positive offset levering: each +1 step adds exp_step.
+    B step_up{ FpType{1.5}, 1 };
+    std::int64_t expected = at_one.scale_of_v() + B::exp_step;
+    if (step_up.exponent() != expected) {
+        std::cout << tag << " offset=+1 wrong: got " << step_up.exponent()
+                  << " expected " << expected << '\n';
+        ++nrFailures;
+    }
+
+    // Negative offset levering: each -1 step subtracts exp_step.
+    B step_down{ FpType{1.5}, -1 };
+    std::int64_t expected_dn = at_one.scale_of_v() - B::exp_step;
+    if (step_down.exponent() != expected_dn) {
+        std::cout << tag << " offset=-1 wrong: got " << step_down.exponent()
+                  << " expected " << expected_dn << '\n';
+        ++nrFailures;
+    }
+
+    // Large positive offset: enough to push the block's exponent far beyond
+    // FpType's hardware exponent range -- this is the whole point.
+    B very_high{ FpType{1.5}, 100 };
+    std::int64_t expected_high = at_one.scale_of_v() + std::int64_t(100) * B::exp_step;
+    if (very_high.exponent() != expected_high) {
+        std::cout << tag << " offset=+100 wrong: got " << very_high.exponent()
+                  << " expected " << expected_high << '\n';
+        ++nrFailures;
+    }
+
+    // Extreme int32 boundary: exp_offset = INT32_MAX. The exponent() computation
+    // must not overflow int (it returns int64).
+    B extreme{ FpType{1.5}, std::numeric_limits<std::int32_t>::max() };
+    std::int64_t expected_ext = at_one.scale_of_v()
+        + static_cast<std::int64_t>(std::numeric_limits<std::int32_t>::max()) * B::exp_step;
+    if (extreme.exponent() != expected_ext) {
+        std::cout << tag << " offset=INT32_MAX wrong\n"; ++nrFailures;
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal block<FpType> exp_offset boundary";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_exp_offset<float>("block<float>");
+    nrOfFailedTestCases += verify_exp_offset<double>("block<double>");
+    nrOfFailedTestCases += verify_exp_offset<half>("block<half>");
+    nrOfFailedTestCases += verify_exp_offset<bfloat16>("block<bfloat16>");
+    nrOfFailedTestCases += verify_exp_offset<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
+    nrOfFailedTestCases += verify_exp_offset<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/block/predicates.cpp
+++ b/elastic/elreal/block/predicates.cpp
@@ -1,0 +1,69 @@
+// predicates.cpp: is_zero_block() and is_normalised() tests for elreal block<FpType>.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_predicates(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    int nrFailures = 0;
+
+    // is_zero_block
+    B zero{ FpType{0}, 0 };
+    B nonzero{ FpType{1.5}, 0 };
+    if (!zero.is_zero_block())    { std::cout << tag << " zero block not detected\n"; ++nrFailures; }
+    if (nonzero.is_zero_block())  { std::cout << tag << " nonzero detected as zero\n"; ++nrFailures; }
+
+    // zero with non-zero exp_offset is still a zero block (value is zero
+    // regardless of offset scaling)
+    B zero_offset{ FpType{0}, 42 };
+    if (!zero_offset.is_zero_block()) {
+        std::cout << tag << " zero with offset not detected as zero\n"; ++nrFailures;
+    }
+
+    // is_normalised on normal values
+    B norm{ FpType{1.5}, 0 };
+    if (!norm.is_normalised()) { std::cout << tag << " 1.5 not normalised\n"; ++nrFailures; }
+
+    // is_normalised on zero -> false
+    if (zero.is_normalised()) { std::cout << tag << " zero claimed normalised\n"; ++nrFailures; }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal block<FpType> predicates";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_predicates<float>("block<float>");
+    nrOfFailedTestCases += verify_predicates<double>("block<double>");
+    nrOfFailedTestCases += verify_predicates<half>("block<half>");
+    nrOfFailedTestCases += verify_predicates<bfloat16>("block<bfloat16>");
+    nrOfFailedTestCases += verify_predicates<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
+    nrOfFailedTestCases += verify_predicates<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/block/predicates.cpp
+++ b/elastic/elreal/block/predicates.cpp
@@ -33,12 +33,29 @@ int verify_predicates(const std::string& tag) {
         std::cout << tag << " zero with offset not detected as zero\n"; ++nrFailures;
     }
 
-    // is_normalised on normal values
+    // is_normalised on normal values across the IEEE-normal range. Note that
+    // McCleeary normalisation is about the hidden bit being set (i.e., the
+    // IEEE classification is FP_NORMAL), NOT about |v| in [1,2). Both 0.75 and
+    // 3.0 are normal IEEE values and should pass.
     B norm{ FpType{1.5}, 0 };
-    if (!norm.is_normalised()) { std::cout << tag << " 1.5 not normalised\n"; ++nrFailures; }
+    B below{ FpType{0.75}, 0 };
+    B above{ FpType{3.0}, 0 };
+    if (!norm.is_normalised())  { std::cout << tag << " 1.5 not normalised\n";  ++nrFailures; }
+    if (!below.is_normalised()) { std::cout << tag << " 0.75 not normalised\n"; ++nrFailures; }
+    if (!above.is_normalised()) { std::cout << tag << " 3.0 not normalised\n";  ++nrFailures; }
 
     // is_normalised on zero -> false
     if (zero.is_normalised()) { std::cout << tag << " zero claimed normalised\n"; ++nrFailures; }
+
+    // is_normalised on a subnormal value -> false. Subnormals exist whenever
+    // numeric_limits reports denorm support; otherwise skip silently.
+    if constexpr (std::numeric_limits<FpType>::has_denorm == std::denorm_present) {
+        FpType subnormal_v = std::numeric_limits<FpType>::denorm_min();
+        B sub{ subnormal_v, 0 };
+        if (sub.is_normalised()) {
+            std::cout << tag << " subnormal claimed normalised\n"; ++nrFailures;
+        }
+    }
 
     return nrFailures;
 }

--- a/elastic/elreal/block/printers.cpp
+++ b/elastic/elreal/block/printers.cpp
@@ -1,0 +1,78 @@
+// printers.cpp: smoke tests for elreal block<FpType> pretty-printers
+// (to_binary, to_hex, color_print).
+//
+// Phase 1 (#925) doesn't pin printer output to a golden format -- subsequent
+// phases will refine the rendering. This file just confirms the printers
+// produce non-empty output for every supported FpType and don't crash.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_printers(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    int nrFailures = 0;
+
+    B b1{ FpType{1.5}, 0 };
+    B b2{ FpType{-3.0}, 7 };
+    B z{ FpType{0}, 0 };
+
+    auto tb1 = to_binary(b1);
+    auto tb2 = to_binary(b2);
+    auto tbz = to_binary(z);
+    if (tb1.empty()) { std::cout << tag << " to_binary(b1) empty\n"; ++nrFailures; }
+    if (tb2.empty()) { std::cout << tag << " to_binary(b2) empty\n"; ++nrFailures; }
+    if (tbz.empty()) { std::cout << tag << " to_binary(zero) empty\n"; ++nrFailures; }
+
+    auto th1 = to_hex(b1);
+    auto th2 = to_hex(b2);
+    if (th1.empty()) { std::cout << tag << " to_hex(b1) empty\n"; ++nrFailures; }
+    if (th2.empty()) { std::cout << tag << " to_hex(b2) empty\n"; ++nrFailures; }
+
+    auto cp1 = color_print(b1);
+    if (cp1.empty()) { std::cout << tag << " color_print(b1) empty\n"; ++nrFailures; }
+
+    // Print one example per type for human inspection
+    std::cout << tag << "  to_binary: " << tb1 << '\n';
+    std::cout << tag << "  to_binary(off): " << tb2 << '\n';
+    std::cout << tag << "  to_hex:    " << th1 << '\n';
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal block<FpType> pretty-printers";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_printers<float>("block<float>");
+    nrOfFailedTestCases += verify_printers<double>("block<double>");
+    nrOfFailedTestCases += verify_printers<half>("block<half>");
+    nrOfFailedTestCases += verify_printers<bfloat16>("block<bfloat16>");
+    nrOfFailedTestCases += verify_printers<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
+    nrOfFailedTestCases += verify_printers<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/block/zero_overlap.cpp
+++ b/elastic/elreal/block/zero_overlap.cpp
@@ -1,0 +1,97 @@
+// zero_overlap.cpp: the McCleeary 0-overlap predicate, E(b1) >= E(b2) + k.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_zero_overlap(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    int nrFailures = 0;
+
+    constexpr int k = B::k;
+
+    // Boundary: b1 at 2^0, b2 at 2^(-k) -- exactly satisfies E(b1) >= E(b2) + k.
+    B b1{ FpType{1}, 0 };
+    // For b2, build a value at scale -k. ldexp(1, -k) may underflow narrow types,
+    // so we synthesise via the block constructor with appropriate exp_offset for
+    // very small k targets. For our supported types k is at least 7 (bfloat16),
+    // so ldexp(1, -k) is representable in all of them.
+    FpType b2_val = static_cast<FpType>(std::ldexp(1.0, -k));
+    B b2{ b2_val, 0 };
+    if (!zero_overlap(b1, b2)) {
+        std::cout << tag << " 0-overlap boundary E(b1)=0, E(b2)=-k FAILED\n"; ++nrFailures;
+    }
+
+    // Just inside the gap: b2 at 2^(-k+1) violates the predicate.
+    FpType b2_inside_val = static_cast<FpType>(std::ldexp(1.0, -k + 1));
+    B b2_inside{ b2_inside_val, 0 };
+    if (zero_overlap(b1, b2_inside)) {
+        std::cout << tag << " 0-overlap mis-allows E(b2)=-k+1\n"; ++nrFailures;
+    }
+
+    // Wide gap: b2 at 2^(-2k) is well outside k.
+    FpType b2_wide_val = static_cast<FpType>(std::ldexp(1.0, -2 * k));
+    B b2_wide{ b2_wide_val, 0 };
+    if (!zero_overlap(b1, b2_wide)) {
+        std::cout << tag << " 0-overlap rejects E(b2)=-2k\n"; ++nrFailures;
+    }
+
+    // Zero block on either side: trivially 0-overlaps.
+    B zero{ FpType{0}, 0 };
+    if (!zero_overlap(b1, zero))   { std::cout << tag << " zero on rhs not trivial\n"; ++nrFailures; }
+    if (!zero_overlap(zero, b1))   { std::cout << tag << " zero on lhs not trivial\n"; ++nrFailures; }
+    if (!zero_overlap(zero, zero)) { std::cout << tag << " zero/zero not trivial\n"; ++nrFailures; }
+
+    // Cross-exp_offset gap: b1 at scale 0 with offset +1, b2 at scale 0 with offset 0.
+    // E(b1) = 0 + 1*exp_step, E(b2) = 0. Gap = exp_step, which is >> k for all
+    // supported FpType, so this MUST 0-overlap.
+    B b1_off{ FpType{1}, 1 };
+    B b2_off{ FpType{1}, 0 };
+    if (!zero_overlap(b1_off, b2_off)) {
+        std::cout << tag << " 0-overlap rejects cross-offset gap\n"; ++nrFailures;
+    }
+
+    // Reverse direction must FAIL the predicate (b1 has smaller exponent).
+    if (zero_overlap(b2_off, b1_off)) {
+        std::cout << tag << " 0-overlap mis-allows reversed pair\n"; ++nrFailures;
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal block<FpType> zero_overlap";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_zero_overlap<float>("block<float>");
+    nrOfFailedTestCases += verify_zero_overlap<double>("block<double>");
+    nrOfFailedTestCases += verify_zero_overlap<half>("block<half>");
+    nrOfFailedTestCases += verify_zero_overlap<bfloat16>("block<bfloat16>");
+    nrOfFailedTestCases += verify_zero_overlap<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
+    nrOfFailedTestCases += verify_zero_overlap<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/block.hpp
+++ b/include/sw/universal/number/elreal/block.hpp
@@ -68,9 +68,12 @@ struct block {
     // reports digits=7 -- the McCleeary k for that format would be 8).
     static constexpr int k = std::numeric_limits<FpType>::digits;
 
-    // E = exponent-field width of FpType; exp_step = 2^E.
+    // E = exponent-field width of FpType; exp_step = 2^E (computed from E
+    // directly so Cppcheck sees the dependency).
     static constexpr int          E         = exp_field_width_v<FpType>;
-    static constexpr std::int64_t exp_step  = exp_step_v<FpType>;
+    static constexpr std::int64_t exp_step  =
+        (E < 63) ? (static_cast<std::int64_t>(1) << E)
+                 : std::numeric_limits<std::int64_t>::max();
 
     FpType        v;
     std::int32_t  exp_offset;
@@ -107,22 +110,27 @@ struct block {
         return v == FpType{0};
     }
 
-    // is_normalised(): for IEEE-style FpTypes the leading significand bit must be
-    // set; equivalently, |v| in [1, 2). McCleeary blocks must be normalised so
-    // 0-overlap accounting holds.
+    // is_normalised(): true iff `v` is a finite, non-zero, non-subnormal value.
+    // For IEEE-style FpTypes this is equivalent to the hidden (leading)
+    // significand bit being set, which is the McCleeary block invariant. Note
+    // that `is_normalised()` is NOT about the numeric magnitude of `v`: a value
+    // like 3.0 (= 1.5 * 2^1) IS normalised even though its magnitude is outside
+    // [1, 2), because its IEEE-754 significand-with-hidden-bit is in [1, 2).
+    // Subnormals fail this predicate; the block representation must avoid them
+    // because 0-overlap accounting assumes the leading bit is set.
     constexpr bool is_normalised() const noexcept {
         if (is_zero_block()) return false;
-        // For all supported FpType (native and Universal), ilogb / scale returns
-        // a valid integer for normalised values. Subnormals are NOT considered
-        // normalised here.
         if constexpr (has_universal_fp_api_v<FpType>) {
-            // Universal cfloat / bfloat16: scale() works for both normal and
-            // subnormal values; check the value range explicitly.
-            FpType abs_v = v.sign() ? -v : v;
-            return abs_v >= FpType{1} || (v.scale() >= std::numeric_limits<FpType>::min_exponent - 1);
+            if constexpr (requires(const FpType& x) { x.isnormal(); }) {
+                return v.isnormal();
+            } else {
+                // Fallback for Universal types lacking isnormal() (e.g.,
+                // bfloat16): test against the smallest positive normal value.
+                FpType abs_v = v.sign() ? -v : v;
+                return abs_v >= std::numeric_limits<FpType>::min();
+            }
         } else {
-            int cls = std::fpclassify(v);
-            return cls == FP_NORMAL;
+            return std::fpclassify(v) == FP_NORMAL;
         }
     }
 

--- a/include/sw/universal/number/elreal/block.hpp
+++ b/include/sw/universal/number/elreal/block.hpp
@@ -1,0 +1,155 @@
+// block.hpp: McCleeary LFPERA block<FpType> -- the unit of co-list storage.
+//
+// A block holds (sign, exponent, k-bit significand) packed into a host
+// floating-point type T, plus an explicit int32_t `exp_offset` that lets a
+// single block escape T's hardware exponent range. The effective value is
+//
+//     v * 2^(exp_offset * 2^E_T)
+//
+// where E_T = exp_field_width_v<T>. The combined exponent
+//
+//     E(b) = scale_of(v) + exp_offset * 2^E_T
+//
+// is what the ZBCL 0-overlap predicate compares.
+//
+// References:
+//   McCleeary, R. (2019). Lazy Floating Point Exact Real Arithmetic.
+//   Ph.D. dissertation, University of Iowa. Chapter 4.1.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include <universal/number/cfloat/cfloat_fwd.hpp>
+#include <universal/number/bfloat16/bfloat16_fwd.hpp>
+#include <universal/number/elreal/exp_field_width.hpp>
+
+namespace sw { namespace universal {
+
+// Detect a Universal type that provides .sign() and .scale() member accessors.
+// All Universal floating-point wrappers (cfloat, bfloat16, half, posit, ...)
+// expose these; native float/double/long double do not.
+template <typename T, typename = void>
+struct has_universal_fp_api : std::false_type {};
+
+template <typename T>
+struct has_universal_fp_api<
+    T,
+    std::void_t<
+        decltype(std::declval<const T&>().sign()),
+        decltype(std::declval<const T&>().scale())
+    >
+> : std::true_type {};
+
+template <typename T>
+inline constexpr bool has_universal_fp_api_v = has_universal_fp_api<T>::value;
+
+// block<FpType>: McCleeary's (sign, exp, k-bit significand) packed into FpType,
+// plus an int32_t escape multiplier `exp_offset`.
+//
+// Trivial layout: no in-class member initialisers. Use {value, offset} literal
+// construction to initialise. Default construction leaves members indeterminate
+// (consistent with Universal's other trivial number types).
+template <typename FpType>
+struct block {
+    using fp_type = FpType;
+
+    // k = total significand-vector width, matching the dissertation's k.
+    // For IEEE-style formats this includes the hidden bit. The relationship
+    // numeric_limits<T>::digits == k holds when T's numeric_limits is correctly
+    // configured (a minor inconsistency exists for Universal's bfloat16 which
+    // reports digits=7 -- the McCleeary k for that format would be 8).
+    static constexpr int k = std::numeric_limits<FpType>::digits;
+
+    // E = exponent-field width of FpType; exp_step = 2^E.
+    static constexpr int          E         = exp_field_width_v<FpType>;
+    static constexpr std::int64_t exp_step  = exp_step_v<FpType>;
+
+    FpType        v;
+    std::int32_t  exp_offset;
+
+    // sign: -1 for negative, +1 for non-negative. Sign of +0.0 and -0.0 follow
+    // signbit / Universal's .sign() respectively.
+    constexpr int sign() const noexcept {
+        if constexpr (has_universal_fp_api_v<FpType>) {
+            return v.sign() ? -1 : 1;
+        } else {
+            return std::signbit(v) ? -1 : 1;
+        }
+    }
+
+    // scale_of(v): unbiased binary exponent of v (such that |v| in [2^e, 2^(e+1))).
+    // For Universal types this is .scale(); for native types it is ilogb.
+    constexpr int scale_of_v() const noexcept {
+        if constexpr (has_universal_fp_api_v<FpType>) {
+            return v.scale();
+        } else {
+            if (v == FpType{0}) return 0;
+            return std::ilogb(v);
+        }
+    }
+
+    // Combined exponent E(b) = scale(v) + exp_offset * 2^E.
+    // Returned as int64 so exp_offset levering does not overflow int.
+    constexpr std::int64_t exponent() const noexcept {
+        return static_cast<std::int64_t>(scale_of_v())
+             + static_cast<std::int64_t>(exp_offset) * exp_step;
+    }
+
+    constexpr bool is_zero_block() const noexcept {
+        return v == FpType{0};
+    }
+
+    // is_normalised(): for IEEE-style FpTypes the leading significand bit must be
+    // set; equivalently, |v| in [1, 2). McCleeary blocks must be normalised so
+    // 0-overlap accounting holds.
+    constexpr bool is_normalised() const noexcept {
+        if (is_zero_block()) return false;
+        // For all supported FpType (native and Universal), ilogb / scale returns
+        // a valid integer for normalised values. Subnormals are NOT considered
+        // normalised here.
+        if constexpr (has_universal_fp_api_v<FpType>) {
+            // Universal cfloat / bfloat16: scale() works for both normal and
+            // subnormal values; check the value range explicitly.
+            FpType abs_v = v.sign() ? -v : v;
+            return abs_v >= FpType{1} || (v.scale() >= std::numeric_limits<FpType>::min_exponent - 1);
+        } else {
+            int cls = std::fpclassify(v);
+            return cls == FP_NORMAL;
+        }
+    }
+
+    // value_as<T>(): for testing only. Combines v and exp_offset into a T value.
+    // Requires the combined exponent to fit in T's range; otherwise the result
+    // is +/-inf or zero depending on rounding.
+    template <typename T = double>
+    constexpr T value_as() const noexcept {
+        static_assert(std::is_floating_point_v<T>,
+                      "value_as<T>() requires a native floating-point T");
+        T base = static_cast<T>(v);
+        if (exp_offset == 0) return base;
+        return std::ldexp(base, static_cast<int>(static_cast<std::int64_t>(exp_offset) * exp_step));
+    }
+};
+
+// zero_overlap(b1, b2): the McCleeary 0-overlap predicate. True iff
+// E(b1) >= E(b2) + k, i.e. b2's most significant bit sits at least k+1 bit
+// positions below b1's. The intervening `imp` bit is the gap that absorbs
+// carry-ups from later refinement.
+//
+// Zero blocks impose no constraint: any block trivially 0-overlaps a zero
+// block, and a zero block trivially 0-overlaps any block.
+template <typename FpType>
+constexpr bool zero_overlap(const block<FpType>& b1, const block<FpType>& b2) noexcept {
+    if (b1.is_zero_block() || b2.is_zero_block()) return true;
+    return b1.exponent() >= b2.exponent() + static_cast<std::int64_t>(block<FpType>::k);
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/block_manipulators.hpp
+++ b/include/sw/universal/number/elreal/block_manipulators.hpp
@@ -66,6 +66,9 @@ inline std::string to_hex(const block<FpType>& b,
         s << std::hex << std::setw(16) << std::setfill('0') << bits;
     } else {
         // Universal wrapper types: defer to the human-readable form for now.
+        // Early return is intentional -- to_binary already appends the
+        // " ^ <exp_offset>" suffix when b.exp_offset != 0, so we do NOT fall
+        // through to the suffix code below.
         return to_binary(b);
     }
     if (b.exp_offset != 0) {

--- a/include/sw/universal/number/elreal/block_manipulators.hpp
+++ b/include/sw/universal/number/elreal/block_manipulators.hpp
@@ -1,0 +1,85 @@
+// block_manipulators.hpp: pretty-printers for elreal block<FpType>.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+
+#include <universal/number/elreal/block.hpp>
+
+namespace sw { namespace universal {
+
+template <typename FpType>
+inline std::string type_tag(const block<FpType>& = {}) {
+    std::stringstream s;
+    s << "block<" << typeid(FpType).name() << '>';
+    return s.str();
+}
+
+// to_binary: human-readable rendering as
+//   <sign> 2^<scale> * <fraction>  [ ^ <exp_offset> ]
+template <typename FpType>
+inline std::string to_binary(const block<FpType>& b, bool /*nibbleMarker*/ = false) {
+    std::stringstream s;
+    if (b.is_zero_block()) {
+        s << "block<>{0}";
+        if (b.exp_offset != 0) s << " ^ " << b.exp_offset;
+        return s.str();
+    }
+    s << (b.sign() < 0 ? '-' : '+');
+    s << " 2^" << b.scale_of_v();
+    double abs_frac = static_cast<double>(b.v) / std::ldexp(1.0, b.scale_of_v());
+    if (abs_frac < 0) abs_frac = -abs_frac;
+    s << " * " << std::scientific << std::setprecision(6) << abs_frac;
+    if (b.exp_offset != 0) {
+        s << " ^ " << b.exp_offset;
+    }
+    return s.str();
+}
+
+// to_hex: render the native host FpType bit pattern in hex, else fall back to
+// the human-readable form. Bit-level hex for Universal wrapper types is the
+// responsibility of the wrapper's own to_hex (we do not delegate to avoid
+// cross-header dependency churn).
+template <typename FpType>
+inline std::string to_hex(const block<FpType>& b,
+                          bool /*nibbleMarker*/ = false,
+                          bool hexPrefix        = true) {
+    std::stringstream s;
+    if constexpr (std::is_same_v<FpType, float>) {
+        std::uint32_t bits = 0;
+        std::memcpy(&bits, &b.v, sizeof(bits));
+        if (hexPrefix) s << "0x";
+        s << std::hex << std::setw(8) << std::setfill('0') << bits;
+    } else if constexpr (std::is_same_v<FpType, double>) {
+        std::uint64_t bits = 0;
+        std::memcpy(&bits, &b.v, sizeof(bits));
+        if (hexPrefix) s << "0x";
+        s << std::hex << std::setw(16) << std::setfill('0') << bits;
+    } else {
+        // Universal wrapper types: defer to the human-readable form for now.
+        return to_binary(b);
+    }
+    if (b.exp_offset != 0) {
+        s << std::dec << " ^ " << b.exp_offset;
+    }
+    return s.str();
+}
+
+// color_print: ASCII-only render. Phase 1 reuses to_binary; richer colouring
+// (per-bit highlighting of sign/exponent/significand fields) can come later.
+template <typename FpType>
+inline std::string color_print(const block<FpType>& b, bool nibbleMarker = false) {
+    return to_binary(b, nibbleMarker);
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/block_manipulators.hpp
+++ b/include/sw/universal/number/elreal/block_manipulators.hpp
@@ -37,8 +37,7 @@ inline std::string to_binary(const block<FpType>& b, bool /*nibbleMarker*/ = fal
     }
     s << (b.sign() < 0 ? '-' : '+');
     s << " 2^" << b.scale_of_v();
-    double abs_frac = static_cast<double>(b.v) / std::ldexp(1.0, b.scale_of_v());
-    if (abs_frac < 0) abs_frac = -abs_frac;
+    double abs_frac = std::fabs(static_cast<double>(b.v) / std::ldexp(1.0, b.scale_of_v()));
     s << " * " << std::scientific << std::setprecision(6) << abs_frac;
     if (b.exp_offset != 0) {
         s << " ^ " << b.exp_offset;

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -1,0 +1,16 @@
+// elreal.hpp: umbrella header for the McCleeary LFPERA elreal number system.
+//
+// Phase 1 ships only the `block<FpType>` primitive (issue #925). Higher-level
+// pieces (ZBCL co-list, arithmetic, math suite, real-FP conversion) arrive in
+// later phases (#926-#933 under epic #923).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/exp_field_width.hpp>
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/block_manipulators.hpp>

--- a/include/sw/universal/number/elreal/elreal_fwd.hpp
+++ b/include/sw/universal/number/elreal/elreal_fwd.hpp
@@ -1,0 +1,17 @@
+// elreal_fwd.hpp: forward declarations for the elreal (McCleeary LFPERA) types.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+namespace sw { namespace universal {
+
+// Phase 1: the block<FpType> primitive.
+// Phase 2 (issue #926) will add ZBCL<FpType>, the lazy stream of blocks.
+// Phase 3+ adds arithmetic, math suite, real floating-point conversion.
+template <typename FpType>
+struct block;
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/exp_field_width.hpp
+++ b/include/sw/universal/number/elreal/exp_field_width.hpp
@@ -1,0 +1,46 @@
+// exp_field_width.hpp: trait that yields the exponent-field width E (in bits)
+//                       of a host floating-point type. Used by elreal block<>.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include <universal/number/cfloat/cfloat_fwd.hpp>
+#include <universal/number/bfloat16/bfloat16_fwd.hpp>
+
+namespace sw { namespace universal {
+
+// exp_field_width<T>::value -- bit width of T's biased exponent field.
+// Primary template intentionally left undefined so unsupported types fail at compile time.
+template <typename T>
+struct exp_field_width;
+
+template <> struct exp_field_width<float>       { static constexpr int value = 8;  };
+template <> struct exp_field_width<double>      { static constexpr int value = 11; };
+#if LONG_DOUBLE_SUPPORT
+template <> struct exp_field_width<long double> { static constexpr int value = 15; };
+#endif
+
+template <unsigned nbits, unsigned es, typename bt,
+          bool hasSubnormals, bool hasSupernormals, bool isSaturating>
+struct exp_field_width<cfloat<nbits, es, bt, hasSubnormals, hasSupernormals, isSaturating>> {
+    static constexpr int value = static_cast<int>(es);
+};
+
+template <> struct exp_field_width<bfloat16> { static constexpr int value = 8; };
+
+template <typename T>
+inline constexpr int exp_field_width_v = exp_field_width<T>::value;
+
+// exp_step<T>: 2^E_T, the multiplier in units of `exp_offset`.
+template <typename T>
+inline constexpr std::int64_t exp_step_v =
+    static_cast<std::int64_t>(1) << exp_field_width_v<T>;
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/exp_field_width.hpp
+++ b/include/sw/universal/number/elreal/exp_field_width.hpp
@@ -39,8 +39,14 @@ template <typename T>
 inline constexpr int exp_field_width_v = exp_field_width<T>::value;
 
 // exp_step<T>: 2^E_T, the multiplier in units of `exp_offset`.
+// Guarded against undefined behaviour for hypothetical FpType with E >= 63.
+// Real hardware FP types have E <= 19 (FP256 with 19-bit exponent is the
+// widest IEEE 754 extended format), so the guard is defensive against
+// experimental cfloat<N, E> configurations.
 template <typename T>
 inline constexpr std::int64_t exp_step_v =
-    static_cast<std::int64_t>(1) << exp_field_width_v<T>;
+    (exp_field_width_v<T> < 63)
+        ? (static_cast<std::int64_t>(1) << exp_field_width_v<T>)
+        : (std::numeric_limits<std::int64_t>::max());
 
 }} // namespace sw::universal


### PR DESCRIPTION
## Summary

Phase 1 of the McCleeary LFPERA reimplementation (epic #923). Foundational `block<FpType>` type with the `int32_t exp_offset` escape multiplier, 0-overlap predicate, pretty-printers, and a sweep test suite over six FpType variants.

| Topic | Detail |
|---|---|
| Block layout | `(FpType v, int32_t exp_offset)`; trivial copyable, no in-class init |
| Combined exponent | `E(b) = scale_of(v) + exp_offset * 2^E_FpType` (int64, won't overflow) |
| McCleeary `k` | `numeric_limits<FpType>::digits` (matches dissertation's block-vector width) |
| FpType sweep | `float`, `double`, `half`, `bfloat16`, `cfloat<24,5>`, `cfloat<32,8>` |
| 0-overlap predicate | `E(b1) >= E(b2) + k`; zero blocks trivially 0-overlap any block |

## What's in / what's out

**In Phase 1:**
- `block<FpType>` struct + accessors (`sign()`, `scale_of_v()`, `exponent()`, `value_as<T>()`)
- Predicates (`is_zero_block()`, `is_normalised()`)
- Free function `zero_overlap(b1, b2)`
- Pretty-printers (`to_binary`, `to_hex`, `color_print`)
- 6 sweep tests parameterised over FpType
- CMake wiring: new `UNIVERSAL_BUILD_NUMBER_ELREALS` option, cascade into ELASTICS and CI_LITE

**Deferred:**
- ZBCL co-list construction -- Phase 2 (#926)
- twoSum / twoMult / twoDiv on blocks -- Phase 3 (#927)
- Stream-level arithmetic -- Phase 4+ (#928+)

## k values observed

| FpType | k | E | exp_step |
|---|---:|---:|---:|
| `float` | 24 | 8 | 256 |
| `double` | 53 | 11 | 2048 |
| `half` (cfloat<16,5>) | 11 | 5 | 32 |
| `bfloat16` | 7 | 8 | 256 |
| `cfloat<24,5>` | 19 | 5 | 32 |
| `cfloat<32,8>` | 24 | 8 | 256 |

Note on `bfloat16`: Universal's `numeric_limits<bfloat16>::digits` reports 7 (just the explicit fraction bits); the dissertation-consistent k would be 8 (including the hidden bit). Recorded here for visibility; not a Phase 1 blocker.

## Test results

| Target | gcc 13.3 | clang 18.1 |
|---|---|---|
| `el_block_construction` | PASS | PASS |
| `el_block_accessors` | PASS | PASS |
| `el_block_predicates` | PASS | PASS |
| `el_block_zero_overlap` | PASS | PASS |
| `el_block_exp_offset` | PASS | PASS |
| `el_block_printers` | PASS | PASS |

## Test plan
- [x] gcc + clang local builds clean and all tests pass
- [ ] Fast CI (gcc + clang CI_LITE)
- [ ] Promote to ready (`gh pr ready`) when satisfied
- [ ] Full CI on ready

Resolves #925

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Phase‑1 "elreal" number system with a block<> numeric primitive, human‑readable binary/hex formatting, and a zero‑overlap predicate.

* **Tests**
  * Added test suites covering block construction, accessors, exponent/offset behavior, predicates, printers, and overlap detection across multiple floating‑point types.

* **Build**
  * New build option to enable elreal; CI presets updated to enable it by default.

* **Documentation**
  * Added analysis documenting current implementation behavior and suggested remediation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->