### PR TITLE
feat(elreal): Phase 2 -- ZBCL<FpType> lazy co-list

### DIFF
--- a/elastic/elreal/CMakeLists.txt
+++ b/elastic/elreal/CMakeLists.txt
@@ -1,8 +1,11 @@
 # elastic/elreal/CMakeLists.txt
 #
-# Phase 1 (#925): block<FpType> representation only. Co-list, arithmetic,
-# math suite and conversion are added in subsequent phases (#926-#933).
+# Phase 1 (#925): block<FpType> representation.
+# Phase 2 (#926): ZBCL<FpType> co-list of blocks.
+# Phase 3+ (#927-#933): arithmetic, math suite, real-FP conversion.
 
 file (GLOB BLOCK_SRCS "./block/*.cpp")
+file (GLOB ZBCL_SRCS  "./zbcl/*.cpp")
 
 compile_all("true" "el_block" "Number Systems/elastic/floating-point/binary/elreal/block" "${BLOCK_SRCS}")
+compile_all("true" "el_zbcl"  "Number Systems/elastic/floating-point/binary/elreal/zbcl"  "${ZBCL_SRCS}")

--- a/elastic/elreal/zbcl/cons_take.cpp
+++ b/elastic/elreal/zbcl/cons_take.cpp
@@ -1,0 +1,106 @@
+// cons_take.cpp: cons/head/tail/take/is_empty contract tests for ZBCL<FpType>.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <vector>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_cons_take(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    using S = ZBCL<FpType>;
+    int nrFailures = 0;
+
+    // Empty
+    S e = empty<FpType>();
+    if (!e.is_empty()) { std::cout << tag << " empty() not is_empty\n"; ++nrFailures; }
+    if (static_cast<bool>(e)) { std::cout << tag << " empty() truthy\n"; ++nrFailures; }
+    if (!e.take(3).empty()) { std::cout << tag << " empty().take(3) non-empty\n"; ++nrFailures; }
+
+    // Singleton
+    B b0{ FpType{1}, 0 };
+    S s1 = S::singleton(b0);
+    if (s1.is_empty()) { std::cout << tag << " singleton is_empty\n"; ++nrFailures; }
+    if (s1.head().v != b0.v) { std::cout << tag << " singleton head wrong\n"; ++nrFailures; }
+    if (!s1.tail().is_empty()) {
+        std::cout << tag << " singleton.tail() not empty\n"; ++nrFailures;
+    }
+
+    // take(n) on a single-element stream returns at most one block
+    auto taken = s1.take(5);
+    if (taken.size() != 1u) {
+        std::cout << tag << " singleton take(5) size=" << taken.size() << "\n";
+        ++nrFailures;
+    }
+
+    // Two-block finite stream: build a stream containing b0 (scale 0) and
+    // b1 (scale -k) where k = B::k. zero_overlap(b0, b1) holds at the boundary
+    // by construction (E(b0) = 0, E(b1) = -k, gap = k).
+    constexpr int k = B::k;
+    FpType b1_val = static_cast<FpType>(std::ldexp(1.0, -k));
+    B b1{ b1_val, 0 };
+    S s2 = S::cons(b0, S::singleton(b1));
+    if (s2.head().v != b0.v) { std::cout << tag << " cons head wrong\n"; ++nrFailures; }
+    if (s2.tail().is_empty()) {
+        std::cout << tag << " cons.tail() empty when shouldn't be\n"; ++nrFailures;
+    }
+    if (s2.tail().head().v != b1.v) {
+        std::cout << tag << " cons.tail().head() wrong\n"; ++nrFailures;
+    }
+    if (!s2.tail().tail().is_empty()) {
+        std::cout << tag << " cons.tail().tail() not empty\n"; ++nrFailures;
+    }
+
+    // take(2) on the two-block stream returns exactly 2 blocks in order.
+    auto taken2 = s2.take(2);
+    if (taken2.size() != 2u
+        || taken2[0].v != b0.v
+        || taken2[1].v != b1.v) {
+        std::cout << tag << " take(2) wrong size or order\n"; ++nrFailures;
+    }
+
+    // take(10) on the two-block stream still returns 2 (no over-read).
+    auto taken10 = s2.take(10);
+    if (taken10.size() != 2u) {
+        std::cout << tag << " take(10) on 2-block stream size="
+                  << taken10.size() << "\n";
+        ++nrFailures;
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal ZBCL<FpType> cons/take";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_cons_take<float>("ZBCL<float>");
+    nrOfFailedTestCases += verify_cons_take<double>("ZBCL<double>");
+    nrOfFailedTestCases += verify_cons_take<half>("ZBCL<half>");
+    nrOfFailedTestCases += verify_cons_take<bfloat16>("ZBCL<bfloat16>");
+    nrOfFailedTestCases += verify_cons_take<cfloat<24, 5, std::uint16_t, true, false, false>>("ZBCL<cfloat<24,5>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/zbcl/from_native.cpp
+++ b/elastic/elreal/zbcl/from_native.cpp
@@ -1,0 +1,84 @@
+// from_native.cpp: tests for empty<FpType>(), from_native, to_double_approx.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_from_native(const std::string& tag) {
+    using namespace sw::universal;
+    using S = ZBCL<FpType>;
+    int nrFailures = 0;
+
+    // empty() yields the canonical 0 stream.
+    S e = empty<FpType>();
+    if (!e.is_empty()) {
+        std::cout << tag << " empty() not is_empty\n"; ++nrFailures;
+    }
+    if (to_double_approx(e, 4) != 0.0) {
+        std::cout << tag << " to_double_approx(empty) != 0\n"; ++nrFailures;
+    }
+
+    // from_native(0.0) yields an empty stream.
+    S z = from_native<FpType>(0.0);
+    if (!z.is_empty()) {
+        std::cout << tag << " from_native(0.0) not empty\n"; ++nrFailures;
+    }
+
+    // from_native(1.0) round-trips exactly through the host FpType.
+    S one = from_native<FpType>(1.0);
+    if (one.is_empty()) { std::cout << tag << " from_native(1.0) empty\n"; ++nrFailures; }
+    double recovered = to_double_approx(one, 4);
+    double host_one  = static_cast<double>(FpType{1});
+    if (recovered != host_one) {
+        std::cout << tag << " from_native(1.0) round-trip: got " << recovered
+                  << " expected " << host_one << '\n';
+        ++nrFailures;
+    }
+
+    // from_native(-2.5) round-trips through the host FpType.
+    S neg = from_native<FpType>(-2.5);
+    double neg_recovered = to_double_approx(neg, 4);
+    double neg_expected  = static_cast<double>(FpType{-2.5});
+    if (neg_recovered != neg_expected) {
+        std::cout << tag << " from_native(-2.5) round-trip: got " << neg_recovered
+                  << " expected " << neg_expected << '\n';
+        ++nrFailures;
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal ZBCL<FpType> from_native";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_from_native<float>("ZBCL<float>");
+    nrOfFailedTestCases += verify_from_native<double>("ZBCL<double>");
+    nrOfFailedTestCases += verify_from_native<half>("ZBCL<half>");
+    nrOfFailedTestCases += verify_from_native<bfloat16>("ZBCL<bfloat16>");
+    nrOfFailedTestCases += verify_from_native<cfloat<24, 5, std::uint16_t, true, false, false>>("ZBCL<cfloat<24,5>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/zbcl/laziness.cpp
+++ b/elastic/elreal/zbcl/laziness.cpp
@@ -1,0 +1,118 @@
+// laziness.cpp: verify that ZBCL thunks are NOT invoked until the corresponding
+// position in the stream is forced via tail() or take(n).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <atomic>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// Build a 3-block stream where each tail thunk increments a counter so we can
+// observe exactly how many thunks have been forced.
+template <typename FpType>
+int verify_laziness(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    using S = ZBCL<FpType>;
+    int nrFailures = 0;
+
+    constexpr int k = B::k;
+    B b0{ FpType{1},                                    0 };
+    B b1{ static_cast<FpType>(std::ldexp(1.0, -k)),     0 };
+    B b2{ static_cast<FpType>(std::ldexp(1.0, -2 * k)), 0 };
+
+    // Shared mutable counters captured by the thunks. Using shared_ptr keeps
+    // the value alive across copies of the stream.
+    auto tail1_calls = std::make_shared<std::atomic<int>>(0);
+    auto tail2_calls = std::make_shared<std::atomic<int>>(0);
+
+    // Build inside-out: tail-most singleton first, then layer thunks above.
+    S s_inner = S::singleton(b2);
+    auto tail_of_b1_thunk = [tail2_calls, s_inner]() -> S {
+        tail2_calls->fetch_add(1);
+        return s_inner;
+    };
+    S s_middle = S::cons(b1, std::move(tail_of_b1_thunk));
+
+    auto tail_of_b0_thunk = [tail1_calls, s_middle]() -> S {
+        tail1_calls->fetch_add(1);
+        return s_middle;
+    };
+    S s = S::cons(b0, std::move(tail_of_b0_thunk));
+
+    // Step 0: just constructing the stream forces nothing.
+    if (tail1_calls->load() != 0) {
+        std::cout << tag << " tail1 forced at construction\n"; ++nrFailures;
+    }
+    if (tail2_calls->load() != 0) {
+        std::cout << tag << " tail2 forced at construction\n"; ++nrFailures;
+    }
+
+    // Step 1: accessing head() forces nothing past head.
+    (void) s.head();
+    if (tail1_calls->load() != 0) {
+        std::cout << tag << " tail1 forced by head()\n"; ++nrFailures;
+    }
+
+    // Step 2: take(1) forces nothing past block 0.
+    auto t1 = s.take(1);
+    if (t1.size() != 1u) { std::cout << tag << " take(1) size wrong\n"; ++nrFailures; }
+    if (tail1_calls->load() != 0) {
+        std::cout << tag << " tail1 forced by take(1)\n"; ++nrFailures;
+    }
+
+    // Step 3: take(2) forces tail1 exactly once.
+    auto t2 = s.take(2);
+    if (t2.size() != 2u) { std::cout << tag << " take(2) size wrong\n"; ++nrFailures; }
+    if (tail1_calls->load() != 1) {
+        std::cout << tag << " take(2) forced tail1 " << tail1_calls->load()
+                  << " times (expected 1)\n"; ++nrFailures;
+    }
+    if (tail2_calls->load() != 0) {
+        std::cout << tag << " take(2) forced tail2\n"; ++nrFailures;
+    }
+
+    // Step 4: take(3) forces tail2 (memoised tail1 not re-invoked).
+    auto t3 = s.take(3);
+    if (t3.size() != 3u) { std::cout << tag << " take(3) size wrong\n"; ++nrFailures; }
+    if (tail1_calls->load() != 1) {
+        std::cout << tag << " tail1 re-invoked (no memoisation): "
+                  << tail1_calls->load() << "\n"; ++nrFailures;
+    }
+    if (tail2_calls->load() != 1) {
+        std::cout << tag << " take(3) forced tail2 " << tail2_calls->load()
+                  << " times (expected 1)\n"; ++nrFailures;
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal ZBCL<FpType> laziness";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_laziness<double>("ZBCL<double>");
+    nrOfFailedTestCases += verify_laziness<float>("ZBCL<float>");
+    nrOfFailedTestCases += verify_laziness<half>("ZBCL<half>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/zbcl/zero_overlap_prefix.cpp
+++ b/elastic/elreal/zbcl/zero_overlap_prefix.cpp
@@ -1,0 +1,95 @@
+// zero_overlap_prefix.cpp: verify that every adjacent pair of blocks in a
+// constructed ZBCL satisfies the 0-overlap predicate.
+//
+// In Phase 2 the ZBCL builder is the test code itself (no arithmetic operations
+// yet), so this test exists to lock in the invariant before Phase 3+ starts
+// producing streams algorithmically. The debug-assertion check in
+// `ZBCL::tail()` will catch violations at runtime; this test exercises the
+// happy path and a few sentinel cases.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_prefix_zero_overlap(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    using S = ZBCL<FpType>;
+    int nrFailures = 0;
+
+    constexpr int k = B::k;
+
+    // Build a five-block stream with each block at scale -i*k. By construction
+    // every adjacent pair satisfies zero_overlap: E(b_n) - E(b_{n+1}) = k.
+    B b0{ FpType{1},                                    0 };
+    B b1{ static_cast<FpType>(std::ldexp(1.0, -1 * k)), 0 };
+    B b2{ static_cast<FpType>(std::ldexp(1.0, -2 * k)), 0 };
+    B b3{ static_cast<FpType>(std::ldexp(1.0, -3 * k)), 0 };
+
+    // Skip blocks where ldexp underflows in FpType (happens for narrow
+    // bfloat16/half at depth where -3*k pushes past representable normals).
+    auto is_usable = [](const B& b) { return !b.is_zero_block(); };
+    if (!is_usable(b3)) {
+        std::cout << tag << " skipping depth-3 (FpType underflow)\n";
+    }
+
+    S tail = is_usable(b3) ? S::singleton(b3) : S{};
+    if (is_usable(b2)) tail = S::cons(b2, tail);
+    if (is_usable(b1)) tail = S::cons(b1, tail);
+    S stream = S::cons(b0, tail);
+
+    // Walk the stream and confirm zero_overlap on every adjacent pair.
+    auto blocks = stream.take(10);
+    if (blocks.size() < 2u) {
+        std::cout << tag << " stream collapsed to <2 blocks\n"; ++nrFailures;
+        return nrFailures;
+    }
+    for (std::size_t i = 0; i + 1 < blocks.size(); ++i) {
+        if (!zero_overlap(blocks[i], blocks[i + 1])) {
+            std::cout << tag << " 0-overlap FAILED between block " << i
+                      << " and block " << (i + 1) << '\n';
+            ++nrFailures;
+        }
+    }
+
+    // Empty co-list: trivially 0-overlap-preserving (no adjacent pairs to check).
+    S e;
+    if (!e.take(5).empty()) { std::cout << tag << " empty leaked blocks\n"; ++nrFailures; }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal ZBCL<FpType> 0-overlap on prefixes";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_prefix_zero_overlap<float>("ZBCL<float>");
+    nrOfFailedTestCases += verify_prefix_zero_overlap<double>("ZBCL<double>");
+    nrOfFailedTestCases += verify_prefix_zero_overlap<half>("ZBCL<half>");
+    nrOfFailedTestCases += verify_prefix_zero_overlap<bfloat16>("ZBCL<bfloat16>");
+    nrOfFailedTestCases += verify_prefix_zero_overlap<cfloat<24, 5, std::uint16_t, true, false, false>>("ZBCL<cfloat<24,5>>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -14,3 +14,5 @@
 #include <universal/number/elreal/exp_field_width.hpp>
 #include <universal/number/elreal/block.hpp>
 #include <universal/number/elreal/block_manipulators.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+#include <universal/number/elreal/zbcl_helpers.hpp>

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -1,8 +1,12 @@
 // elreal.hpp: umbrella header for the McCleeary LFPERA elreal number system.
 //
-// Phase 1 ships only the `block<FpType>` primitive (issue #925). Higher-level
-// pieces (ZBCL co-list, arithmetic, math suite, real-FP conversion) arrive in
-// later phases (#926-#933 under epic #923).
+// Currently exports:
+//   Phase 1 (#925): block<FpType>, exp_field_width trait, block manipulators.
+//   Phase 2 (#926): ZBCL<FpType> lazy co-list and its empty / from_native /
+//                   to_double_approx helpers.
+//
+// Higher-level pieces (arithmetic, math suite, real-FP conversion) arrive in
+// later phases (#927-#933 under epic #923).
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/include/sw/universal/number/elreal/elreal_fwd.hpp
+++ b/include/sw/universal/number/elreal/elreal_fwd.hpp
@@ -8,10 +8,13 @@
 
 namespace sw { namespace universal {
 
-// Phase 1: the block<FpType> primitive.
-// Phase 2 (issue #926) will add ZBCL<FpType>, the lazy stream of blocks.
-// Phase 3+ adds arithmetic, math suite, real floating-point conversion.
+// Phase 1: the block<FpType> primitive (#925).
+// Phase 2: ZBCL<FpType>, the lazy stream of blocks (#926).
+// Phase 3+: arithmetic, math suite, real floating-point conversion (#927-#933).
 template <typename FpType>
 struct block;
+
+template <typename FpType>
+class ZBCL;
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/elreal/zbcl.hpp
+++ b/include/sw/universal/number/elreal/zbcl.hpp
@@ -1,0 +1,147 @@
+// zbcl.hpp: McCleeary LFPERA ZBCL<FpType> -- Zero-overlap Block Co-List.
+//
+// A ZBCL is a (possibly empty, possibly infinite) lazy stream of block<FpType>
+// satisfying the 0-overlap invariant: for any two adjacent blocks (b_n, b_{n+1})
+// in the stream, `zero_overlap(b_n, b_{n+1})` holds, i.e.
+//
+//     E(b_n) >= E(b_{n+1}) + k
+//
+// where E(.) is the combined exponent including `exp_offset`.
+//
+// Representation
+//   - Empty co-list represents the real number 0.
+//   - Non-empty co-list = (head block, tail thunk). The tail thunk is a
+//     std::function<ZBCL()>; it is evaluated on demand by `tail()` / `take(n)`
+//     and the result is memoised on the node so a thunk is invoked at most
+//     once. Nodes are shared via std::shared_ptr so ZBCL values are cheap to
+//     copy.
+//   - Sentinel for end-of-stream is an empty thunk (default-constructed
+//     std::function). The terminal block is the last one materialised; its
+//     `tail()` returns an empty ZBCL.
+//
+// Cauchy-sequence proof obligation (paraphrasing dissertation 4.1.4)
+// ------------------------------------------------------------------
+// A ZBCL <b_0, b_1, b_2, ...> represents the real number sum_{i>=0} value(b_i)
+// where value(b) = sign(b) * 2^E(b) * (significand bits of b). The 0-overlap
+// property ensures the partial-sum sequence S_n = sum_{i<=n} value(b_i) is
+// Cauchy: |S_m - S_n| <= 2^(E(b_n) + 1 - k) for m > n. Convergence to a
+// well-defined real value follows. Operations on ZBCLs must preserve both the
+// value and the 0-overlap property; the proofs live with each operation as it
+// is introduced (Phase 3+).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <universal/number/elreal/block.hpp>
+
+namespace sw { namespace universal {
+
+template <typename FpType>
+class ZBCL {
+public:
+    using value_type = block<FpType>;
+    using thunk_type = std::function<ZBCL<FpType>()>;
+
+private:
+    struct Node {
+        value_type            head;
+        thunk_type            tail_thunk;
+        mutable bool          tail_evaluated;
+        mutable ZBCL<FpType>  tail_value;
+
+        Node(const value_type& h, thunk_type t) noexcept
+            : head(h),
+              tail_thunk(std::move(t)),
+              tail_evaluated(false),
+              tail_value() {}
+    };
+
+    std::shared_ptr<const Node> _node;
+
+    explicit ZBCL(std::shared_ptr<const Node> n) noexcept : _node(std::move(n)) {}
+
+public:
+    // Default constructor: empty co-list (represents 0).
+    ZBCL() noexcept : _node() {}
+
+    // cons(head, tail): non-empty co-list. If `tail` is an empty function, the
+    // resulting stream terminates at `head`. The 0-overlap invariant is
+    // asserted in debug builds.
+    static ZBCL<FpType> cons(const value_type& head_block, thunk_type tail) {
+        auto node = std::make_shared<Node>(head_block, std::move(tail));
+        return ZBCL<FpType>(std::move(node));
+    }
+
+    // Convenience: cons with a finite (already-materialised) tail.
+    static ZBCL<FpType> cons(const value_type& head_block, ZBCL<FpType> tail) {
+        // Wrap the materialised tail in a thunk that just returns it.
+        return cons(head_block, [tail]() noexcept { return tail; });
+    }
+
+    // Convenience: single-block co-list (tail is empty).
+    static ZBCL<FpType> singleton(const value_type& head_block) {
+        return cons(head_block, thunk_type{});
+    }
+
+    bool is_empty() const noexcept { return !_node; }
+    explicit operator bool() const noexcept { return !is_empty(); }
+
+    // head(): undefined on empty co-lists (assertion-checked).
+    const value_type& head() const noexcept {
+        assert(_node && "head() called on empty ZBCL");
+        return _node->head;
+    }
+
+    // tail(): forces the thunk on first call, memoises the result.
+    // Returns an empty ZBCL when called on a node with an empty thunk.
+    ZBCL<FpType> tail() const {
+        assert(_node && "tail() called on empty ZBCL");
+        if (!_node->tail_evaluated) {
+            if (_node->tail_thunk) {
+                _node->tail_value = _node->tail_thunk();
+                // 0-overlap invariant: if the tail is non-empty, head and
+                // tail.head() must satisfy zero_overlap. Asserted only in
+                // debug builds because forcing the thunk to check would
+                // defeat laziness in release builds.
+                assert((_node->tail_value.is_empty() ||
+                        zero_overlap(_node->head, _node->tail_value.head()))
+                       && "ZBCL 0-overlap invariant violated");
+            } else {
+                _node->tail_value = ZBCL<FpType>{};
+            }
+            _node->tail_evaluated = true;
+        }
+        return _node->tail_value;
+    }
+
+    // take(n): force the first n blocks; returns fewer if the stream terminates
+    // earlier. Memoises forced tails on the way.
+    //
+    // Note on laziness: we deliberately do NOT call cur.tail() after consuming
+    // the n-th block, because doing so would force the (n+1)-th thunk for no
+    // benefit. take(1) on a multi-block stream therefore touches the first
+    // block only and leaves the rest of the stream unforced.
+    std::vector<value_type> take(std::size_t n) const {
+        std::vector<value_type> result;
+        result.reserve(n);
+        ZBCL<FpType> cur = *this;
+        while (result.size() < n) {
+            if (cur.is_empty()) break;
+            result.push_back(cur.head());
+            if (result.size() == n) break;
+            cur = cur.tail();
+        }
+        return result;
+    }
+};
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/zbcl_helpers.hpp
+++ b/include/sw/universal/number/elreal/zbcl_helpers.hpp
@@ -28,9 +28,13 @@ inline ZBCL<FpType> empty() noexcept { return ZBCL<FpType>{}; }
 // representable in FpType. Lossy conversion is acceptable for Phase 2 -- this
 // helper exists for tests, not as a production conversion path.
 //
-// Subnormals and zero produce an empty co-list (zero is represented by the
-// empty stream by convention). NaN / inf are not supported; the caller must
-// not pass them.
+// Canonicalisation:
+//   - v == 0.0 -> empty stream (zero is represented by the empty co-list).
+//   - v that underflows to FpType{0} during the cast -> also empty stream.
+//   - Subnormal results that do NOT underflow are preserved verbatim as the
+//     block's stored value (note that such a block fails block::is_normalised
+//     -- callers requiring normalised blocks must reject these inputs).
+//   - NaN / inf are not supported; the caller must not pass them.
 template <typename FpType>
 inline ZBCL<FpType> from_native(double v) {
     if (v == 0.0) return ZBCL<FpType>{};

--- a/include/sw/universal/number/elreal/zbcl_helpers.hpp
+++ b/include/sw/universal/number/elreal/zbcl_helpers.hpp
@@ -1,0 +1,56 @@
+// zbcl_helpers.hpp: convenience constructors / destructors for ZBCL<FpType>
+// used by Phase 2 tests and (later) by higher-level arithmetic.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+
+namespace sw { namespace universal {
+
+// empty<FpType>(): canonical empty ZBCL (represents the real number 0).
+template <typename FpType>
+inline ZBCL<FpType> empty() noexcept { return ZBCL<FpType>{}; }
+
+// from_native<FpType>(double v): construct a finite ZBCL containing the value v.
+//
+// For Phase 2 the simplest construction is used: a single block whose value
+// is `static_cast<FpType>(v)`, with `exp_offset = 0`. This is exact when v is
+// representable in FpType. Lossy conversion is acceptable for Phase 2 -- this
+// helper exists for tests, not as a production conversion path.
+//
+// Subnormals and zero produce an empty co-list (zero is represented by the
+// empty stream by convention). NaN / inf are not supported; the caller must
+// not pass them.
+template <typename FpType>
+inline ZBCL<FpType> from_native(double v) {
+    if (v == 0.0) return ZBCL<FpType>{};
+    FpType host_v = static_cast<FpType>(v);
+    if (host_v == FpType{0}) return ZBCL<FpType>{}; // underflowed in cast
+    block<FpType> b{host_v, 0};
+    return ZBCL<FpType>::singleton(b);
+}
+
+// to_double_approx(stream, depth): sum the first `depth` blocks as doubles.
+// The sum loses precision because each block converts to double via
+// value_as<double>; this helper is for sanity-checking, not exact comparison.
+template <typename FpType>
+inline double to_double_approx(const ZBCL<FpType>& stream, std::size_t depth) {
+    double acc = 0.0;
+    auto blocks = stream.take(depth);
+    for (const auto& b : blocks) {
+        acc += b.template value_as<double>();
+    }
+    return acc;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/zbcl_helpers.hpp
+++ b/include/sw/universal/number/elreal/zbcl_helpers.hpp
@@ -7,6 +7,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -31,16 +32,22 @@ inline ZBCL<FpType> empty() noexcept { return ZBCL<FpType>{}; }
 // Canonicalisation:
 //   - v == 0.0 -> empty stream (zero is represented by the empty co-list).
 //   - v that underflows to FpType{0} during the cast -> also empty stream.
-//   - Subnormal results that do NOT underflow are preserved verbatim as the
-//     block's stored value (note that such a block fails block::is_normalised
-//     -- callers requiring normalised blocks must reject these inputs).
 //   - NaN / inf are not supported; the caller must not pass them.
+//
+// Block invariant (asserted in debug):
+//   - The resulting block must be `is_normalised()`. If the cast produces a
+//     non-zero subnormal, the assertion fires. Tests that need to exercise
+//     subnormal-bearing blocks must construct them directly via the block<>
+//     and ZBCL::singleton APIs, not through this helper.
 template <typename FpType>
 inline ZBCL<FpType> from_native(double v) {
     if (v == 0.0) return ZBCL<FpType>{};
     FpType host_v = static_cast<FpType>(v);
     if (host_v == FpType{0}) return ZBCL<FpType>{}; // underflowed in cast
     block<FpType> b{host_v, 0};
+    assert(b.is_normalised()
+           && "from_native: cast produced a non-normalised (subnormal) block; "
+              "construct block<>/ZBCL directly if you need to test subnormal paths");
     return ZBCL<FpType>::singleton(b);
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the McCleeary LFPERA reimplementation (epic #923). Lands the lazy stream type `ZBCL<FpType>` that holds an exact-real value as a co-list of `block<FpType>` satisfying the 0-overlap invariant.

## What ZBCL is

- Empty co-list represents the real number 0.
- Non-empty co-list = (head block, tail thunk).
- Tail thunk is `std::function<ZBCL()>`, forced on first call to `tail()` or `take(n)`, **memoised on the node** so a thunk fires at most once.
- Nodes are shared via `std::shared_ptr`, so `ZBCL` values are cheap to copy.

## API

| Function | Purpose |
|---|---|
| `cons(head, tail_thunk)` | non-empty stream with lazy tail |
| `cons(head, ZBCL tail)` | non-empty stream with materialised tail |
| `singleton(block)` | single-block stream (terminal) |
| `head()`, `tail()`, `take(n)`, `is_empty()`, `operator bool()` | accessors |
| `empty<FpType>()` | canonical zero stream |
| `from_native<FpType>(double)` | single-block stream for testing |
| `to_double_approx(s, depth)` | sum first depth blocks as doubles |

## 0-overlap invariant

Enforced by an assertion in `tail()`: when the thunk fires, if the resulting stream is non-empty, `this->head()` and `tail.head()` must satisfy `zero_overlap`. Debug-build only — evaluating the thunk eagerly would defeat laziness in release.

The Cauchy-sequence-of-partial-sums proof obligation is documented inline at the top of `zbcl.hpp`; concrete proofs accompany each operation in later phases.

## Bug caught + fixed during testing

The initial `take(n)` unconditionally called `cur.tail()` after pushing the last block, forcing the `(n+1)`-th thunk for no benefit. Atomic-counter laziness test caught this; restructured to break before the final `tail()` call.

## Test results

| Target | gcc 13.3 | clang 18.1 |
|---|---|---|
| `el_zbcl_cons_take` | PASS | PASS |
| `el_zbcl_laziness` | PASS | PASS |
| `el_zbcl_from_native` | PASS | PASS |
| `el_zbcl_zero_overlap_prefix` | PASS | PASS |
| `el_block_*` (Phase 1 regression) | PASS x6 | PASS x6 |

Sweep over `{float, double, half, bfloat16, cfloat<24,5>}`.

## Out of scope

- `twoSum` / `twoMult` / `twoDiv` on blocks — Phase 3 (#927)
- `threeAdd` + ZBCL addition — Phase 4 (#928)
- Stream-level math — Phase 5+

Resolves #926

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lazy stream type for block sequences plus helper operations and numeric conversion utilities.

* **Tests**
  * Added a suite of runtime tests covering stream construction, laziness/memoization, block predicates, and numeric round-trips across multiple floating formats.

* **Chores**
  * Build system updated to support multi-phase compilation and include the new stream sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->