### PR TITLE
fix(cfloat): work around clang miscompile in to_native<long double>

### DIFF
--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -2056,7 +2056,14 @@ public:
 				// regular: (-1)^s * 2^(e+1-2^(es-1)) * (1 + f/2^fbits))
 				int exponent = static_cast<int>(unsigned(ebits) - EXP_BIAS);
 				if (-64 < exponent && exponent < 64) {
-					TargetFloat exponentiation = (exponent >= 0 ? TargetFloat(1ull << exponent) : (1.0f / TargetFloat(1ull << -exponent)));
+					// NB: the negative branch uses std::ldexp instead of
+					// 1.0f / TargetFloat(1ull << -exponent) because clang -O2
+					// miscompiles the latter for TargetFloat == long double via
+					// a buggy direct-bit-pattern optimisation (see issue #937).
+					// gcc handles either form correctly; ldexp is portable.
+					TargetFloat exponentiation = (exponent >= 0
+						? TargetFloat(1ull << exponent)
+						: std::ldexp(TargetFloat(1), exponent));
 					v = exponentiation * (TargetFloat(1.0) + f);
 				}
 				else {
@@ -2074,7 +2081,10 @@ public:
 					// regular: (-1)^s * 2^(e+1-2^(es-1)) * (1 + f/2^fbits))
 					int exponent = static_cast<int>(unsigned(ebits) - EXP_BIAS);
 					if (-64 < exponent && exponent < 64) {
-						TargetFloat exponentiation = (exponent >= 0 ? TargetFloat(1ull << exponent) : (1.0f / TargetFloat(1ull << -exponent)));
+						// See above re: clang -O2 miscompile, issue #937.
+						TargetFloat exponentiation = (exponent >= 0
+							? TargetFloat(1ull << exponent)
+							: std::ldexp(TargetFloat(1), exponent));
 						v = exponentiation * (TargetFloat(1.0) + f);
 					}
 					else {

--- a/static/float/cfloat/conversion/long_double_conversion.cpp
+++ b/static/float/cfloat/conversion/long_double_conversion.cpp
@@ -1,0 +1,97 @@
+// long_double_conversion.cpp: regression for issue #937.
+//
+// Prior to the fix, clang -O2 miscompiled the `1.0f / TargetFloat(1ull << N)`
+// pattern in `cfloat::to_native<long double>()` for values that require a
+// negative unbiased exponent (e.g. 0.125, 0.25, 0.5). The miscompile produced
+// NaN or the wrong magnitude. gcc and MSVC were unaffected; the bug slipped
+// through because no test in the cfloat conversion suite exercised
+// `static_cast<long double>(cfloat<>)` -- MSVC aliases long double to double,
+// so the broken path was untested.
+//
+// This file walks a sweep of representative cfloat<> configurations and asserts
+// `static_cast<long double>(cf{v}) == static_cast<double>(cf{v}) (as long double)`
+// for every value v in a fixed sample. The equality holds because every v in the
+// sample is exactly representable in the cfloat<> configuration under test.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+#define CFLOAT_THROW_ARITHMETIC_EXCEPTION 0
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#if LONG_DOUBLE_SUPPORT
+
+namespace {
+
+// Verify that cf -> long double matches cf -> double for a fixed sweep of
+// exactly-representable values. Any deviation indicates a regression of the
+// kind issue #937 was about: the long-double path producing different bits
+// than the double path for the same cfloat input.
+template <typename CfloatT>
+int verify_long_double_path(const std::string& tag) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+
+    // Exactly-representable test values across positive, negative, and a range
+    // of negative-exponent powers of two.
+    const double samples[] = {
+        0.0, 0.125, 0.25, 0.5, 1.0, 1.5, 2.0, 3.25, -1.5,
+        0.0625,   // 2^-4
+        0.015625, // 2^-6 (within half's normal range)
+    };
+
+    for (double v : samples) {
+        CfloatT cf{v};
+        // Skip values that aren't exactly representable in this cfloat config
+        // (we only want to detect conversion deviation, not rounding).
+        double  d_back  = static_cast<double>(cf);
+        if (d_back != v) continue;
+
+        long double via_ld = static_cast<long double>(cf);
+        long double via_d  = static_cast<long double>(static_cast<double>(cf));
+        if (via_ld != via_d) {
+            std::cout << tag << " mismatch on v=" << v
+                      << ": (long double) cf = " << static_cast<double>(via_ld)
+                      << " vs (double) cf as long double = " << static_cast<double>(via_d)
+                      << '\n';
+            ++nrFailures;
+        }
+    }
+    return nrFailures;
+}
+
+} // anonymous
+
+#endif // LONG_DOUBLE_SUPPORT
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "cfloat<> -> long double conversion (issue #937)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if LONG_DOUBLE_SUPPORT
+    // Standard small-format aliases
+    nrOfFailedTestCases += verify_long_double_path<half>("half");
+    // Configurable widths spanning typical custom hardware shapes
+    nrOfFailedTestCases += verify_long_double_path<cfloat<16, 5, std::uint16_t, true, false, false>>("cfloat<16,5>");
+    nrOfFailedTestCases += verify_long_double_path<cfloat<24, 5, std::uint16_t, true, false, false>>("cfloat<24,5>");
+    nrOfFailedTestCases += verify_long_double_path<cfloat<32, 8, std::uint32_t, true, false, false>>("cfloat<32,8>");
+    nrOfFailedTestCases += verify_long_double_path<cfloat<64, 11, std::uint64_t, true, false, false>>("cfloat<64,11>");
+#else
+    std::cout << test_suite << " SKIPPED (LONG_DOUBLE_SUPPORT == 0)\n";
+#endif
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

`cfloat::to_native<TargetFloat>()` used the pattern `1.0f / TargetFloat(1ull << -exponent)` to compute 2^(-N) for negative unbiased exponents. **clang miscompiles this expression** for `TargetFloat == long double` via a buggy direct-bit-pattern optimisation, producing NaN or the wrong magnitude.

## Reproduction (before fix)

```
v=0      half->(double)=0      half->(long double)=0
v=0.125  half->(double)=0.125  half->(long double)=NaN
v=0.25   half->(double)=0.25   half->(long double)=0.5
v=0.5    half->(double)=0.5    half->(long double)=NaN
v=1      half->(double)=1      half->(long double)=1
v=1.5    half->(double)=1.5    half->(long double)=1.5
v=2      half->(double)=2      half->(long double)=2
```

## Why it slipped past CI

- gcc and MSVC compile the original pattern correctly.
- MSVC aliases `long double` to `double`, so even with a correct compiler the path was invisible.
- The cfloat conversion test suite covered `static_cast<double>` exhaustively but **never** `static_cast<long double>`.

Discovered while writing Phase 3 EFT tests for elreal (#927 / PR #936). PR #936 sidestepped the bug via a `ref_t_for<FpType>` selector; that selector becomes obsolete once this PR merges.

## Changes

- `include/sw/universal/number/cfloat/cfloat_impl.hpp` (2 occurrences): replaced the negative-exponent branch with `std::ldexp(TargetFloat(1), exponent)` which clang compiles correctly. The positive-exponent branch retains the original bit shift for constexpr-friendliness.
- `static/float/cfloat/conversion/long_double_conversion.cpp`: new sweep test guarded by `LONG_DOUBLE_SUPPORT` so MSVC continues to pass.

## Test results

Full cfloat conversion suite (9 tests, including the new regression) in 4 configurations:

| Test | gcc debug | gcc release | clang debug | clang release |
|---|---|---|---|---|
| cfloat_long_double_conversion (new) | PASS | PASS | PASS | PASS |
| cfloat_double_conversion | PASS | PASS | PASS | PASS |
| cfloat_float_conversion | PASS | PASS | PASS | PASS |
| cfloat_assignment | PASS | PASS | PASS | PASS |
| cfloat_normalization | PASS | PASS | PASS | PASS |
| cfloat_ieee754_subnormals | PASS | PASS | PASS | PASS |
| cfloat_integer_conversion | PASS | PASS | PASS | PASS |
| cfloat_string_parse | PASS | PASS | PASS | PASS |
| cfloat_cfloat_to_cfloat_conversion | PASS | PASS | PASS | PASS |

Clang-release was the original failure mode.

## Out of scope

- Upstream LLVM bug report on the underlying clang miscompile.
- Mirror coverage for bfloat16 / half / posit -> long double (Universal has parallel code paths that may have the same issue; keeping this PR focused).
- Removing the `ref_t_for<FpType>` workaround from PR #936's elreal Phase 3 tests (do that after #936 merges).

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #937

Generated with [Claude Code](https://claude.com/claude-code)
