### PR TITLE
feat(elreal): Phase 4 -- threeAdd + lazy ZBCL add() combinator

### DIFF
--- a/elastic/elreal/CMakeLists.txt
+++ b/elastic/elreal/CMakeLists.txt
@@ -3,12 +3,15 @@
 # Phase 1 (#925): block<FpType> representation.
 # Phase 2 (#926): ZBCL<FpType> co-list of blocks.
 # Phase 3 (#927): block-level EFTs (twoSum / twoMult / twoDiv).
-# Phase 4+ (#928-#933): stream arithmetic, math suite, real-FP conversion.
+# Phase 4 (#928): threeAdd helper + lazy ZBCL add() combinator.
+# Phase 5+ (#929-#933): infinite summation, math suite, real-FP conversion.
 
-file (GLOB BLOCK_SRCS      "./block/*.cpp")
-file (GLOB ZBCL_SRCS       "./zbcl/*.cpp")
-file (GLOB BLOCK_EFT_SRCS  "./block_eft/*.cpp")
+file (GLOB BLOCK_SRCS       "./block/*.cpp")
+file (GLOB ZBCL_SRCS        "./zbcl/*.cpp")
+file (GLOB BLOCK_EFT_SRCS   "./block_eft/*.cpp")
+file (GLOB ARITHMETIC_SRCS  "./arithmetic/*.cpp")
 
-compile_all("true" "el_block"     "Number Systems/elastic/floating-point/binary/elreal/block"     "${BLOCK_SRCS}")
-compile_all("true" "el_zbcl"      "Number Systems/elastic/floating-point/binary/elreal/zbcl"      "${ZBCL_SRCS}")
-compile_all("true" "el_block_eft" "Number Systems/elastic/floating-point/binary/elreal/block_eft" "${BLOCK_EFT_SRCS}")
+compile_all("true" "el_block"      "Number Systems/elastic/floating-point/binary/elreal/block"      "${BLOCK_SRCS}")
+compile_all("true" "el_zbcl"       "Number Systems/elastic/floating-point/binary/elreal/zbcl"       "${ZBCL_SRCS}")
+compile_all("true" "el_block_eft"  "Number Systems/elastic/floating-point/binary/elreal/block_eft"  "${BLOCK_EFT_SRCS}")
+compile_all("true" "el_arith"      "Number Systems/elastic/floating-point/binary/elreal/arithmetic" "${ARITHMETIC_SRCS}")

--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -1,0 +1,162 @@
+// addition.cpp: tests for the lazy ZBCL add() combinator.
+//
+// Verifies:
+//   - Value preservation: take(N) of add(x, y) sums to approximately x + y in
+//     long double (to leading O(k) bits per emitted block).
+//   - 0-overlap: every adjacent pair of emitted blocks satisfies zero_overlap.
+//   - No-renormalisation: take(N-1) returns the same first N-1 blocks as the
+//     prefix of take(N) (emitted blocks are final once committed).
+//   - Laziness: thunks are forced only when downstream consumers ask for blocks.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_value(double a, double b, const std::string& tag,
+                 double leading_bits_tol_factor = 4.0) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+
+    auto x = from_native<FpType>(a);
+    auto y = from_native<FpType>(b);
+    auto z = add(x, y);
+
+    // Sum the first 4 blocks as a long-double approximation
+    auto blocks = z.take(4);
+    long double got = 0.0L;
+    for (const auto& blk : blocks) {
+        got += static_cast<long double>(blk.v);
+    }
+    long double ref = static_cast<long double>(a) + static_cast<long double>(b);
+
+    // Leading-bits tolerance: per FpType, the first block carries ~k bits of
+    // accuracy. The sum of 4 blocks should agree with ref to within a small
+    // multiple of FpType's ulp at the magnitude of the result.
+    constexpr int p = std::numeric_limits<FpType>::digits;
+    long double scale = std::fmax(std::fabs(ref), 1.0L);
+    long double tol = scale * std::ldexp(1.0L, -p) * leading_bits_tol_factor;
+    if (std::fabs(ref - got) > tol) {
+        std::cout << tag << " value mismatch: ref=" << ref
+                  << " got=" << got
+                  << " diff=" << std::fabs(ref - got)
+                  << " tol=" << tol << '\n';
+        ++nrFailures;
+    }
+    return nrFailures;
+}
+
+template <typename FpType>
+int verify_zero_overlap_on_output(double a, double b, const std::string& tag) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+    auto z = add(from_native<FpType>(a), from_native<FpType>(b));
+    auto blocks = z.take(6);
+    for (std::size_t i = 0; i + 1 < blocks.size(); ++i) {
+        if (!blocks[i].is_zero_block() && !blocks[i + 1].is_zero_block()
+            && !zero_overlap(blocks[i], blocks[i + 1])) {
+            std::cout << tag << " 0-overlap FAILED at position " << i
+                      << " (a=" << a << " b=" << b << ")\n";
+            ++nrFailures;
+        }
+    }
+    return nrFailures;
+}
+
+// no-renormalisation: take(n) and take(n+k) must agree on the first n blocks.
+template <typename FpType>
+int verify_no_renormalisation(double a, double b, const std::string& tag) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+    auto z = add(from_native<FpType>(a), from_native<FpType>(b));
+    auto first3 = z.take(3);
+    auto first6 = z.take(6);
+    for (std::size_t i = 0; i < first3.size() && i < first6.size(); ++i) {
+        if (first3[i].v != first6[i].v
+            || first3[i].exp_offset != first6[i].exp_offset) {
+            std::cout << tag << " take(3) and take(6) disagree at position " << i << '\n';
+            ++nrFailures;
+        }
+    }
+    return nrFailures;
+}
+
+template <typename FpType>
+int verify_add(const std::string& tag) {
+    int nrFailures = 0;
+    // Representative inputs
+    nrFailures += verify_value<FpType>(1.0, 0.25, tag + " 1+0.25");
+    nrFailures += verify_value<FpType>(3.5, -1.5, tag + " 3.5-1.5");
+    nrFailures += verify_value<FpType>(1e3, 1.0, tag + " 1000+1");
+    nrFailures += verify_value<FpType>(-2.5, -7.5, tag + " -2.5-7.5");
+
+    nrFailures += verify_zero_overlap_on_output<FpType>(1.0, 0.25, tag);
+    nrFailures += verify_zero_overlap_on_output<FpType>(7.0, 13.0, tag);
+
+    nrFailures += verify_no_renormalisation<FpType>(1.5, 2.5, tag);
+    nrFailures += verify_no_renormalisation<FpType>(100.0, 0.0625, tag);
+
+    // Empty + non-empty
+    {
+        using namespace sw::universal;
+        auto e = empty<FpType>();
+        auto x = from_native<FpType>(3.25);
+        auto z = add(e, x);
+        auto blocks = z.take(4);
+        if (blocks.empty()) {
+            std::cout << tag << " empty + non-empty produced empty result\n";
+            ++nrFailures;
+        }
+        // First block should approximate 3.25
+        if (!blocks.empty()
+            && std::fabs(static_cast<double>(blocks[0].v) - 3.25) > 0.1) {
+            std::cout << tag << " empty + 3.25 first block wrong\n";
+            ++nrFailures;
+        }
+    }
+
+    // Empty + empty
+    {
+        using namespace sw::universal;
+        auto z = add(empty<FpType>(), empty<FpType>());
+        if (!z.is_empty()) {
+            std::cout << tag << " empty + empty produced non-empty\n";
+            ++nrFailures;
+        }
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal ZBCL add() combinator";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_add<double>("add<double>");
+    nrOfFailedTestCases += verify_add<float>("add<float>");
+    nrOfFailedTestCases += verify_add<bfloat16>("add<bfloat16>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/threeAdd.cpp
+++ b/elastic/elreal/arithmetic/threeAdd.cpp
@@ -1,0 +1,154 @@
+// threeAdd.cpp: unit tests for the threeAdd helper.
+//
+// Verifies:
+//   - Value preservation: o1 + o2 + o3 == a + b + w (exact, in long double).
+//   - Gap preservation: zero_overlap(o1, o2) and zero_overlap(o2, o3).
+//   - All outputs share the input exp_offset.
+//   - Edge cases: zero inputs, opposite-sign cancellation, residual-producing
+//     combinations, non-zero exp_offset.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <random>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify_one(const sw::universal::block<FpType>& a,
+               const sw::universal::block<FpType>& b,
+               const sw::universal::block<FpType>& w,
+               const std::string& tag) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+
+    auto res = threeAdd(a, b, w);
+
+    // Value preservation
+    long double ref = static_cast<long double>(a.v)
+                    + static_cast<long double>(b.v)
+                    + static_cast<long double>(w.v);
+    long double got = static_cast<long double>(res.out1.v)
+                    + static_cast<long double>(res.out2.v)
+                    + static_cast<long double>(res.out3.v);
+    long double diff = std::fabs(ref - got);
+    constexpr int p = std::numeric_limits<FpType>::digits;
+    long double ulp_sq = std::ldexp(1.0L, -2 * p);
+    long double tol = ulp_sq * std::fmax(std::fabs(ref), 1.0L) * 256;
+    if (diff > tol) {
+        std::cout << tag << " value preservation: ref=" << ref
+                  << " got=" << got << " diff=" << diff << " tol=" << tol
+                  << " (a=" << static_cast<double>(a.v)
+                  << " b=" << static_cast<double>(b.v)
+                  << " w=" << static_cast<double>(w.v) << ")\n";
+        ++nrFailures;
+    }
+
+    // exp_offset preserved
+    std::int32_t off = a.exp_offset;
+    if (res.out1.exp_offset != off
+        || res.out2.exp_offset != off
+        || res.out3.exp_offset != off) {
+        std::cout << tag << " exp_offset not preserved\n";
+        ++nrFailures;
+    }
+
+    // 0-overlap chain (skip zero blocks: they trivially overlap)
+    if (!res.out1.is_zero_block() && !res.out2.is_zero_block()
+        && !zero_overlap(res.out1, res.out2)) {
+        std::cout << tag << " 0-overlap(out1, out2) FAILED\n"; ++nrFailures;
+    }
+    if (!res.out2.is_zero_block() && !res.out3.is_zero_block()
+        && !zero_overlap(res.out2, res.out3)) {
+        std::cout << tag << " 0-overlap(out2, out3) FAILED\n"; ++nrFailures;
+    }
+    return nrFailures;
+}
+
+template <typename FpType>
+int verify_threeAdd(const std::string& tag) {
+    using namespace sw::universal;
+    using B = block<FpType>;
+    int nrFailures = 0;
+
+    // All zero -> all zero output
+    {
+        B z{ FpType{0}, 0 };
+        nrFailures += verify_one(z, z, z, tag + " all-zero");
+        auto res = threeAdd(z, z, z);
+        if (!res.out1.is_zero_block() || !res.out2.is_zero_block() || !res.out3.is_zero_block()) {
+            std::cout << tag << " all-zero produced non-zero outputs\n";
+            ++nrFailures;
+        }
+    }
+    // Two blocks cancel
+    {
+        B a{ FpType{1.5},  0 };
+        B b{ FpType{-1.5}, 0 };
+        B w{ FpType{1.25}, 0 };
+        nrFailures += verify_one(a, b, w, tag + " a+(-a)+w");
+    }
+    // Residual-producing sum
+    {
+        constexpr int p = std::numeric_limits<FpType>::digits;
+        B a{ FpType{1}, 0 };
+        FpType tiny = static_cast<FpType>(std::ldexp(1.0, -p));
+        if (tiny != FpType{0}) {
+            B b{ tiny, 0 };
+            B w{ FpType{0.5}, 0 };
+            nrFailures += verify_one(a, b, w, tag + " 1+2^-p+0.5");
+        }
+    }
+    // Non-zero exp_offset
+    {
+        B a{ FpType{1.5}, 5 };
+        B b{ FpType{2.5}, 5 };
+        B w{ FpType{0.5}, 5 };
+        nrFailures += verify_one(a, b, w, tag + " offset=5");
+    }
+    // Random sweep
+    std::mt19937_64 rng(0xc0ffeecafeULL);
+    std::uniform_real_distribution<double> ud(-20.0, 20.0);
+    int N = 100;
+    for (int i = 0; i < N; ++i) {
+        FpType av = static_cast<FpType>(ud(rng));
+        FpType bv = static_cast<FpType>(ud(rng));
+        FpType wv = static_cast<FpType>(ud(rng));
+        if (av == FpType{0} || bv == FpType{0} || wv == FpType{0}) continue;
+        B a{ av, 0 }, b{ bv, 0 }, w{ wv, 0 };
+        nrFailures += verify_one(a, b, w, tag + " rand");
+    }
+
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal threeAdd helper";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_threeAdd<double>("threeAdd<double>");
+    nrOfFailedTestCases += verify_threeAdd<float>("threeAdd<float>");
+    nrOfFailedTestCases += verify_threeAdd<bfloat16>("threeAdd<bfloat16>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/block_eft/two_div.cpp
+++ b/elastic/elreal/block_eft/two_div.cpp
@@ -25,15 +25,9 @@
 
 namespace {
 
-// See two_sum.cpp for why we pick double (instead of long double) as the
-// reference type for Universal-wrapped FpTypes.
-template <typename FpType>
-using ref_t_for = std::conditional_t<
-    sw::universal::has_universal_fp_api_v<FpType>
-        || (std::numeric_limits<FpType>::digits < 53),
-    double,
-    long double>;
-
+// Reference type: long double everywhere. The Phase 3 ref_t_for workaround
+// has been removed now that #937 / #938 fixed the cfloat -> long double
+// conversion.
 template <typename FpType>
 int verify_two_div_one(const sw::universal::block<FpType>& a,
                        const sw::universal::block<FpType>& b,
@@ -45,14 +39,12 @@ int verify_two_div_one(const sw::universal::block<FpType>& a,
 
     auto [q, r] = block_two_div(a, b);
 
-    using R = ref_t_for<FpType>;
-    R ref = static_cast<R>(a.v) / static_cast<R>(b.v);
-    R got = static_cast<R>(q.v) + static_cast<R>(r.v);
-    R err = std::fabs(ref - got);
-    R tol = static_cast<R>(std::abs(static_cast<double>(q.v)))
-          * static_cast<R>(std::ldexp(1.0,
-                -std::numeric_limits<FpType>::digits + 1))
-          * static_cast<R>(tol_ulps_of_q);
+    long double ref = static_cast<long double>(a.v) / static_cast<long double>(b.v);
+    long double got = static_cast<long double>(q.v) + static_cast<long double>(r.v);
+    long double err = std::fabs(ref - got);
+    long double tol = std::fabs(static_cast<long double>(q.v))
+                    * std::ldexp(1.0L, -std::numeric_limits<FpType>::digits + 1)
+                    * static_cast<long double>(tol_ulps_of_q);
     if (err > tol) {
         std::cout << tag << " value error " << err
                   << " > tol " << tol

--- a/elastic/elreal/block_eft/two_mult.cpp
+++ b/elastic/elreal/block_eft/two_mult.cpp
@@ -22,22 +22,14 @@
 
 namespace {
 
-// See two_sum.cpp for why we pick double (instead of long double) as the
-// reference type for Universal-wrapped FpTypes: their long-double conversion
-// is currently broken.
+// Reference type: long double everywhere. The Phase 3 ref_t_for workaround
+// has been removed now that #937 / #938 fixed the cfloat -> long double
+// conversion.
 template <typename FpType>
-using ref_t_for = std::conditional_t<
-    sw::universal::has_universal_fp_api_v<FpType>
-        || (std::numeric_limits<FpType>::digits < 53),
-    double,
-    long double>;
-
-template <typename FpType>
-inline ref_t_for<FpType>
+inline long double
 reference_prod(const sw::universal::block<FpType>& a,
                const sw::universal::block<FpType>& b) {
-    using R = ref_t_for<FpType>;
-    return static_cast<R>(a.v) * static_cast<R>(b.v);
+    return static_cast<long double>(a.v) * static_cast<long double>(b.v);
 }
 
 template <typename FpType>
@@ -56,18 +48,17 @@ int verify_two_mult_one(const sw::universal::block<FpType>& a,
     // compute. For native float/double the relative error must be effectively
     // zero, and the tolerance below catches algorithm-level mistakes (which
     // would be many orders of magnitude larger).
-    using R = ref_t_for<FpType>;
-    R ref  = reference_prod(a, b);
-    R got  = static_cast<R>(high.v) + static_cast<R>(low.v);
+    long double ref  = reference_prod(a, b);
+    long double got  = static_cast<long double>(high.v) + static_cast<long double>(low.v);
     // Tolerance: scaled multiple of ulp^2. Ideal IEEE arithmetic gives an
     // exact EFT (diff = 0); imperfect host arithmetic (e.g., Universal's
     // wider cfloat<>) can leak a few ulp^2 from rounding in the intermediate
     // product. We allow ~128 * ulp^2 -- still 1000x smaller than a single
     // ulp, so any genuine algorithm regression (off-by-1-ulp) will be caught.
-    R diff = std::fabs(ref - got);
+    long double diff = std::fabs(ref - got);
     constexpr int p  = std::numeric_limits<FpType>::digits;
-    R ulp_sq = static_cast<R>(std::ldexp(1.0, -2 * p));
-    R tol  = ulp_sq * std::fmax(std::fabs(ref), R{1}) * 128;
+    long double ulp_sq = std::ldexp(1.0L, -2 * p);
+    long double tol  = ulp_sq * std::fmax(std::fabs(ref), 1.0L) * 128;
     if (diff > tol) {
         std::cout << tag << " value preservation: ref=" << ref
                   << " got=" << got

--- a/elastic/elreal/block_eft/two_sum.cpp
+++ b/elastic/elreal/block_eft/two_sum.cpp
@@ -23,29 +23,14 @@
 
 namespace {
 
-// Reference type: long double for native double (so we can detect sub-ulp
-// residual errors), double for everything else. We avoid long double for
-// Universal cfloat<>/half/bfloat16 because their static_cast<long double>
-// conversion is currently broken (returns nan or wrong values for some
-// inputs); their values comfortably fit in double for the test sweep.
-//
-// The first clause (`has_universal_fp_api_v`) routes ALL Universal-wrapped
-// FpTypes to double regardless of their precision -- this future-proofs the
-// selector against testing wider Universal types where the broken
-// long-double conversion would still apply.
+// Reference type: long double everywhere. The Phase 3 workaround that routed
+// Universal-wrapped FpTypes to double has been removed now that #937 / #938
+// fixed the cfloat -> long double conversion.
 template <typename FpType>
-using ref_t_for = std::conditional_t<
-    sw::universal::has_universal_fp_api_v<FpType>
-        || (std::numeric_limits<FpType>::digits < 53),
-    double,
-    long double>;
-
-template <typename FpType>
-inline ref_t_for<FpType>
+inline long double
 reference_sum(const sw::universal::block<FpType>& a,
               const sw::universal::block<FpType>& b) {
-    using R = ref_t_for<FpType>;
-    return static_cast<R>(a.v) + static_cast<R>(b.v);
+    return static_cast<long double>(a.v) + static_cast<long double>(b.v);
 }
 
 template <typename FpType>
@@ -60,13 +45,12 @@ int verify_two_sum_one(const sw::universal::block<FpType>& a,
     // residual (diff = 0). Universal's wider cfloat<> sums can leak a few
     // ulp^2 from imperfect intermediate precision; we tolerate up to
     // ~128 * ulp^2, still 1000x smaller than a single ulp.
-    using R = ref_t_for<FpType>;
-    R ref  = reference_sum(a, b);
-    R got  = static_cast<R>(high.v) + static_cast<R>(low.v);
-    R diff = std::fabs(ref - got);
+    long double ref  = reference_sum(a, b);
+    long double got  = static_cast<long double>(high.v) + static_cast<long double>(low.v);
+    long double diff = std::fabs(ref - got);
     constexpr int p  = std::numeric_limits<FpType>::digits;
-    R ulp_sq = static_cast<R>(std::ldexp(1.0, -2 * p));
-    R tol  = ulp_sq * std::fmax(std::fabs(ref), R{1}) * 128;
+    long double ulp_sq = std::ldexp(1.0L, -2 * p);
+    long double tol  = ulp_sq * std::fmax(std::fabs(ref), 1.0L) * 128;
     if (diff > tol) {
         std::cout << tag << " value preservation: ref=" << ref
                   << " got=" << got

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -6,9 +6,10 @@
 //                   to_double_approx helpers.
 //   Phase 3 (#927): block-level EFTs (block_two_sum / _mult / _div + RN
 //                   variants).
+//   Phase 4 (#928): threeAdd helper + lazy ZBCL add() combinator.
 //
-// Higher-level pieces (stream arithmetic, math suite, real-FP conversion)
-// arrive in later phases (#928-#933 under epic #923).
+// Higher-level pieces (stream arithmetic refinement, math suite, real-FP
+// conversion) arrive in later phases (#929-#933 under epic #923).
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -23,3 +24,4 @@
 #include <universal/number/elreal/zbcl.hpp>
 #include <universal/number/elreal/zbcl_helpers.hpp>
 #include <universal/number/elreal/block_eft.hpp>
+#include <universal/number/elreal/threeAdd.hpp>

--- a/include/sw/universal/number/elreal/threeAdd.hpp
+++ b/include/sw/universal/number/elreal/threeAdd.hpp
@@ -1,0 +1,172 @@
+// threeAdd.hpp: McCleeary LFPERA threeAdd helper + lazy ZBCL addition.
+//
+// Phase 4 (#928) of the McCleeary reimplementation (epic #923).
+//
+// threeAdd<FpType>(a, b, w) takes three blocks (one from each input ZBCL plus
+// a workspace block) and produces three output blocks (out1, out2, out3) with:
+//
+//   - Value preservation: out1 + out2 + out3 = a + b + w  (exactly)
+//   - Gap preservation:   zero_overlap(out1, out2)
+//                         zero_overlap(out2, out3)
+//   - Magnitude ordering: |out1| >= |out2| >= |out3|
+//
+// Algorithm (Priest-style 3-element addition + renormalisation):
+//
+//   (s,  e1) = block_two_sum(a, b)         // a + b = s + e1 (exact)
+//   (t,  e2) = block_two_sum(s, w)         // s + w = t + e2 (exact)
+//   (m0, l)  = block_two_sum(e1, e2)       // e1 + e2 = m0 + l (exact)
+//   (o1, m1) = block_two_sum(t, m0)        // t + m0 = o1 + m1 (exact)
+//   (o2, o3) = block_two_sum(m1, l)        // m1 + l = o2 + o3 (exact)
+//
+// Validity sketch:
+//   - Total value: o1 + o2 + o3 = (o1 + m1) + (-m1 + (o2 + o3))
+//                              = t + m0 + (m1 + l) - m1
+//                              = t + (m0 + l)
+//                              = t + e1 + e2
+//                              = (s + w) + e1
+//                              = (a + b) + w   QED
+//   - Gap (o1, o2): block_two_sum(t, m0) guarantees |m1| <= ulp(o1) / 2, so
+//     E(m1) <= E(o1) - k - 1.  block_two_sum(m1, l) gives E(o2) <= E(m1) so
+//     E(o2) <= E(o1) - k - 1 < E(o1) - k, i.e. zero_overlap(o1, o2).
+//   - Gap (o2, o3): direct from block_two_sum's contract.
+//
+// Note: this is approximately McCleeary's threeAdd, not bit-identical. The
+// dissertation's variant produces blocks satisfying additional exponent
+// bounds and a no-shrink guarantee that aren't enforced here. The simpler
+// renormalisation suffices for value preservation + 0-overlap, which is what
+// the Phase 4 acceptance test exercises.
+//
+// Precondition: all three inputs share the same exp_offset. Cross-exp_offset
+// addition is a Phase 5+ concern (the threeAdd contract above assumes blocks
+// in the same exponent range).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <tuple>
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/block_eft.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+
+namespace sw { namespace universal {
+
+template <typename FpType>
+struct threeAdd_result {
+    block<FpType> out1;
+    block<FpType> out2;
+    block<FpType> out3;
+};
+
+template <typename FpType>
+inline threeAdd_result<FpType>
+threeAdd(const block<FpType>& a,
+         const block<FpType>& b,
+         const block<FpType>& w) {
+    assert(a.exp_offset == b.exp_offset
+        && b.exp_offset == w.exp_offset
+        && "threeAdd precondition: all inputs must share exp_offset");
+
+    auto [s,  e1] = block_two_sum(a, b);
+    auto [t,  e2] = block_two_sum(s, w);
+    auto [m0, l]  = block_two_sum(e1, e2);
+    auto [o1, m1] = block_two_sum(t, m0);
+    auto [o2, o3] = block_two_sum(m1, l);
+
+    return { o1, o2, o3 };
+}
+
+// add(x, y) -- lazy ZBCL-level addition combinator.
+//
+// At each step the combinator:
+//   1. Pulls one block from x (or a zero block if x is exhausted),
+//   2. Pulls one block from y (or zero if exhausted),
+//   3. Combines with a workspace block via threeAdd,
+//   4. Emits the highest-magnitude output as the next block of the stream,
+//   5. Folds the two smaller outputs back into the workspace via twoSum.
+//
+// Step 5 collapses 2 blocks into 1 by EFT, which preserves the leading
+// significant bits but drops the residual. For an infinite-precision result,
+// the dropped bits must reappear via further refinement -- Phase 5 (infinite
+// summation) tackles that. For Phase 4 the contract is:
+//   - The leading O(k) bits of each emitted block match the true sum (a + b).
+//   - 0-overlap holds across every emitted prefix.
+//   - The combinator is lazy: thunks fire only when forced.
+//
+// Workspace exp_offset: inherits from the first non-empty input's head; zero
+// inputs imply a zero-block workspace.
+template <typename FpType>
+inline ZBCL<FpType> add(ZBCL<FpType> x, ZBCL<FpType> y) {
+    using B = block<FpType>;
+    using Z = ZBCL<FpType>;
+
+    struct State {
+        Z cur_x;
+        Z cur_y;
+        B  w;
+        bool w_initialised;
+    };
+
+    auto state = std::make_shared<State>(State{std::move(x), std::move(y), B{}, false});
+
+    // step(): produce the next block of the result, advancing the state.
+    // Returns empty optional when both inputs and workspace are exhausted.
+    auto step = [state]() -> std::optional<B> {
+        bool x_empty = state->cur_x.is_empty();
+        bool y_empty = state->cur_y.is_empty();
+        bool w_zero  = !state->w_initialised || state->w.is_zero_block();
+        if (x_empty && y_empty && w_zero) return std::nullopt;
+
+        // Determine the shared exp_offset for this step. All blocks at this
+        // step share the same offset (Phase 4 precondition). Use the offset
+        // of whichever non-empty source provides it.
+        std::int32_t off = 0;
+        if (!x_empty)            off = state->cur_x.head().exp_offset;
+        else if (!y_empty)       off = state->cur_y.head().exp_offset;
+        else if (state->w_initialised) off = state->w.exp_offset;
+
+        B a = x_empty ? B{FpType{0}, off} : state->cur_x.head();
+        B b = y_empty ? B{FpType{0}, off} : state->cur_y.head();
+        B w = state->w_initialised ? state->w : B{FpType{0}, off};
+
+        auto [o1, o2, o3] = threeAdd(a, b, w);
+
+        // Advance input cursors
+        if (!x_empty) state->cur_x = state->cur_x.tail();
+        if (!y_empty) state->cur_y = state->cur_y.tail();
+
+        // Fold (o2, o3) into the new workspace via twoSum (lossy: drops o3's
+        // residual contribution beyond the leading bits of o2 + o3).
+        auto [new_w, _drop] = block_two_sum(o2, o3);
+        state->w = new_w;
+        state->w_initialised = true;
+
+        return o1;
+    };
+
+    // Build the lazy stream. We need a recursive thunk: each "next block"
+    // call produces a ZBCL whose tail is again "next block". Hold the
+    // recursion via a shared_ptr<std::function> so the lambda can capture
+    // and call itself across activations.
+    auto loop = std::make_shared<std::function<Z()>>();
+    *loop = [state, step, loop]() -> Z {
+        auto next = step();
+        if (!next) return Z{};
+        return Z::cons(*next, [loop]() { return (*loop)(); });
+    };
+
+    // Kick: produce the first block (or return empty if the inputs are empty).
+    auto first = step();
+    if (!first) return Z{};
+    return Z::cons(*first, [loop]() { return (*loop)(); });
+}
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary

Phase 4 of the McCleeary LFPERA reimplementation (epic #923). Lands two deliverables plus a Phase 3 cleanup.

| | What | Where |
|---|---|---|
| `threeAdd(a, b, w)` | 3-block → 3-block helper with value preservation, gap preservation, magnitude ordering | `threeAdd.hpp` |
| `add(x, y)` | Lazy ZBCL-level addition combinator (driven by `threeAdd` at each step) | `threeAdd.hpp` |
| Phase 3 cleanup | Remove the `ref_t_for<FpType>` workaround now that #937/#938 fixed the cfloat → long double conversion | `block_eft/*.cpp` |

## Design notes

**`threeAdd` algorithm**: cascaded `block_two_sum` + Priest-style 3-element renormalisation. The inline validity sketch shows why `zero_overlap(out1, out2)` holds (the residual `m1` of the inner `(t, m0)` step is bounded by `ulp(o1)/2`, so any subsequent `(m1, l)` combination has `E(out2) <= E(m1) <= E(o1) - k - 1`).

**`add` combinator**: state captured in a `shared_ptr<State>` (current x, current y, workspace block). Each step pulls one block from each input + the workspace, runs `threeAdd`, emits the largest output, folds the smaller two into a new single-block workspace via `block_two_sum`. The lazy stream is constructed via a `shared_ptr<std::function>` to allow the thunk to recurse.

## Approximations vs. the dissertation

- `threeAdd` uses Priest-style renormalisation rather than McCleeary's specific exponent-aware version. Value preservation and 0-overlap hold; the additional exponent bounds (`E(a) - k <= E(out1) <= E(a) + 2`) and no-shrink guarantees from §4.2.1 are not enforced.
- `add`'s workspace is one block (folded from `(o2, o3)` via `twoSum`, dropping that twoSum's residual). True McCleeary `add` keeps 2 workspace blocks. The simplification trades tail precision for implementation simplicity; the leading O(k) bits of each emitted block remain correct, which is what the Phase 4 acceptance exercises.

## Test results

| Target | gcc-debug | gcc-release | clang-debug | clang-release |
|---|---|---|---|---|
| `el_arith_threeAdd` (new) | PASS | PASS | PASS | PASS |
| `el_arith_addition` (new) | PASS | PASS | PASS | PASS |
| Phase 1-3 regression (12 tests) | PASS | PASS | PASS | PASS |

Sweep: `double`, `float`, `bfloat16`. Clang-release was the historical bug-finder for the EFT phase (#937).

## Tests added

- `arithmetic/threeAdd.cpp`: value preservation in long double + `zero_overlap` on every output pair + `exp_offset` preservation + edge cases (all-zero, cancellation, residual-producing sum, non-zero offset) + 100-sample random sweep per FpType.
- `arithmetic/addition.cpp`: leading-bits value match + `zero_overlap` on every adjacent pair of the emitted prefix + no-renormalisation (`take(3)` matches the first 3 of `take(6)`) + empty-stream edge cases.

## Out of scope

- Infinite summation — Phase 5 (#929).
- Negation, multiplication, division on ZBCL — Phase 6 (#930).
- Math suite and transcendentals — Phase 7 (#931).

Resolves #928

Generated with [Claude Code](https://claude.com/claude-code)
