### PR TITLE
fix(ereal): apply IEEE 754 rules for Inf/NaN in operator+= / operator-=

### DIFF
--- a/elastic/ereal/arithmetic/addition.cpp
+++ b/elastic/ereal/arithmetic/addition.cpp
@@ -186,20 +186,54 @@ namespace {
 			}
 		}
 
-		// +Inf + finite = +Inf  -- KNOWN FAILURE gated by #957
-		if (reportTestCases) std::cout << "  +Inf + finite... (gated by #957)\n";
+		// +Inf + finite = +Inf  (fixed in #957)
+		if (reportTestCases) std::cout << "  +Inf + finite...\n";
 		{
 			ereal<16> a(1.0);
 			ereal<16> inf(pinf);
 			ereal<16> result = a + inf;
 			double r = double(result);
-			(void)r;
-#if 0  // re-enable when #957 is fixed
 			if (!std::isinf(r) || r < 0) {
 				if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
 				++nrOfFailedTestCases;
 			}
-#endif
+		}
+
+		// -Inf + finite = -Inf
+		if (reportTestCases) std::cout << "  -Inf + finite...\n";
+		{
+			ereal<16> a(1.0);
+			ereal<16> inf(ninf);
+			ereal<16> result = a + inf;
+			double r = double(result);
+			if (!std::isinf(r) || r > 0) {
+				if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
+				++nrOfFailedTestCases;
+			}
+		}
+
+		// +Inf + +Inf = +Inf
+		if (reportTestCases) std::cout << "  +Inf + +Inf...\n";
+		{
+			ereal<16> a(pinf);
+			ereal<16> b(pinf);
+			double r = double(a + b);
+			if (!std::isinf(r) || r < 0) {
+				if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
+				++nrOfFailedTestCases;
+			}
+		}
+
+		// -Inf + -Inf = -Inf
+		if (reportTestCases) std::cout << "  -Inf + -Inf...\n";
+		{
+			ereal<16> a(ninf);
+			ereal<16> b(ninf);
+			double r = double(a + b);
+			if (!std::isinf(r) || r > 0) {
+				if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
+				++nrOfFailedTestCases;
+			}
 		}
 
 		// -Inf + +Inf = NaN (IEEE 754)

--- a/elastic/ereal/arithmetic/addition.cpp
+++ b/elastic/ereal/arithmetic/addition.cpp
@@ -187,28 +187,33 @@ namespace {
 		}
 
 		// +Inf + finite = +Inf  (fixed in #957)
-		if (reportTestCases) std::cout << "  +Inf + finite...\n";
+		// Exercise both operand orderings: a + inf hits the rhs-Inf branch
+		// of apply_ieee754_add_special_values; inf + a hits the lhs-Inf
+		// branch (because operator+ copies lhs then calls operator+= on it).
+		if (reportTestCases) std::cout << "  +Inf + finite (both orderings)...\n";
 		{
 			ereal<16> a(1.0);
 			ereal<16> inf(pinf);
-			ereal<16> result = a + inf;
-			double r = double(result);
-			if (!std::isinf(r) || r < 0) {
-				if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
-				++nrOfFailedTestCases;
+			for (auto& result : { a + inf, inf + a }) {
+				double r = double(result);
+				if (!std::isinf(r) || r < 0) {
+					if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
+					++nrOfFailedTestCases;
+				}
 			}
 		}
 
-		// -Inf + finite = -Inf
-		if (reportTestCases) std::cout << "  -Inf + finite...\n";
+		// -Inf + finite = -Inf  (both orderings)
+		if (reportTestCases) std::cout << "  -Inf + finite (both orderings)...\n";
 		{
 			ereal<16> a(1.0);
 			ereal<16> inf(ninf);
-			ereal<16> result = a + inf;
-			double r = double(result);
-			if (!std::isinf(r) || r > 0) {
-				if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
-				++nrOfFailedTestCases;
+			for (auto& result : { a + inf, inf + a }) {
+				double r = double(result);
+				if (!std::isinf(r) || r > 0) {
+					if (reportTestCases) std::cout << "    FAIL got " << r << '\n';
+					++nrOfFailedTestCases;
+				}
 			}
 		}
 

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -216,49 +216,6 @@ public:
 		return negated;
 	}
 
-	// apply_ieee754_add_special_values: IEEE 754 special-value rules for
-	// addition (resolves issue #957). If either operand is NaN or +/-Inf, set
-	// `*this` to the IEEE 754 result and return true. Otherwise return false
-	// and let the EFT-based merge handle the finite-finite case.
-	//
-	// Rules:
-	//   NaN + anything           = NaN
-	//   anything + NaN           = NaN
-	//   +Inf + +Inf              = +Inf
-	//   -Inf + -Inf              = -Inf
-	//   +Inf + -Inf              = NaN
-	//   +/-Inf + finite          = +/-Inf
-	//   finite + +/-Inf          = +/-Inf
-	bool apply_ieee754_add_special_values(const ereal& rhs) {
-		bool a_nan = this->isnan();
-		bool b_nan = rhs.isnan();
-		if (a_nan || b_nan) {
-			this->setnan();
-			return true;
-		}
-		bool a_inf = this->isinf();
-		bool b_inf = rhs.isinf();
-		if (a_inf && b_inf) {
-			// Same sign -> keep that infinity; opposite sign -> NaN
-			if (this->signbit() == rhs.signbit()) {
-				// Already +/-Inf of the correct sign; leave *this unchanged.
-				return true;
-			}
-			this->setnan();
-			return true;
-		}
-		if (a_inf) {
-			// *this is +/-Inf, rhs is finite: result is *this unchanged.
-			return true;
-		}
-		if (b_inf) {
-			// *this is finite, rhs is +/-Inf: result is rhs.
-			*this = rhs;
-			return true;
-		}
-		return false;
-	}
-
 	// arithmetic operators
 	//
 	// `linear_expansion_sum` (Shewchuk Figure 7) returns a non-overlapping
@@ -690,6 +647,55 @@ protected:
 	std::vector<double> _limb;     // components of the real value
 
 	// HELPER methods
+
+	// apply_ieee754_add_special_values: IEEE 754 special-value rules for
+	// addition (resolves issue #957). If either operand is NaN or +/-Inf,
+	// canonicalise `*this` to the single-limb IEEE 754 result and return
+	// true. Otherwise return false and let the EFT-based merge handle the
+	// finite-finite case.
+	//
+	// Rules:
+	//   NaN + anything           = NaN
+	//   anything + NaN           = NaN
+	//   +Inf + +Inf              = +Inf
+	//   -Inf + -Inf              = -Inf
+	//   +Inf + -Inf              = NaN
+	//   +/-Inf + finite          = +/-Inf
+	//   finite + +/-Inf          = +/-Inf
+	//
+	// All special-value branches set *this to a canonical single-limb
+	// representation via setinf()/setnan() so any pre-existing multi-limb
+	// state is normalised, regardless of which operand is the special value.
+	bool apply_ieee754_add_special_values(const ereal& rhs) {
+		bool a_nan = this->isnan();
+		bool b_nan = rhs.isnan();
+		if (a_nan || b_nan) {
+			this->setnan();
+			return true;
+		}
+		bool a_inf = this->isinf();
+		bool b_inf = rhs.isinf();
+		if (a_inf && b_inf) {
+			// Same sign -> keep that infinity; opposite sign -> NaN
+			if (this->signbit() == rhs.signbit()) {
+				this->setinf(this->signbit());
+				return true;
+			}
+			this->setnan();
+			return true;
+		}
+		if (a_inf) {
+			// *this is +/-Inf, rhs is finite: result is +/-Inf with this's sign.
+			this->setinf(this->signbit());
+			return true;
+		}
+		if (b_inf) {
+			// *this is finite, rhs is +/-Inf: result is +/-Inf with rhs's sign.
+			this->setinf(rhs.signbit());
+			return true;
+		}
+		return false;
+	}
 
 	// convert arithmetic types into an elastic floating-point
 	template<typename SignedInt,

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -216,6 +216,49 @@ public:
 		return negated;
 	}
 
+	// apply_ieee754_add_special_values: IEEE 754 special-value rules for
+	// addition (resolves issue #957). If either operand is NaN or +/-Inf, set
+	// `*this` to the IEEE 754 result and return true. Otherwise return false
+	// and let the EFT-based merge handle the finite-finite case.
+	//
+	// Rules:
+	//   NaN + anything           = NaN
+	//   anything + NaN           = NaN
+	//   +Inf + +Inf              = +Inf
+	//   -Inf + -Inf              = -Inf
+	//   +Inf + -Inf              = NaN
+	//   +/-Inf + finite          = +/-Inf
+	//   finite + +/-Inf          = +/-Inf
+	bool apply_ieee754_add_special_values(const ereal& rhs) {
+		bool a_nan = this->isnan();
+		bool b_nan = rhs.isnan();
+		if (a_nan || b_nan) {
+			this->setnan();
+			return true;
+		}
+		bool a_inf = this->isinf();
+		bool b_inf = rhs.isinf();
+		if (a_inf && b_inf) {
+			// Same sign -> keep that infinity; opposite sign -> NaN
+			if (this->signbit() == rhs.signbit()) {
+				// Already +/-Inf of the correct sign; leave *this unchanged.
+				return true;
+			}
+			this->setnan();
+			return true;
+		}
+		if (a_inf) {
+			// *this is +/-Inf, rhs is finite: result is *this unchanged.
+			return true;
+		}
+		if (b_inf) {
+			// *this is finite, rhs is +/-Inf: result is rhs.
+			*this = rhs;
+			return true;
+		}
+		return false;
+	}
+
 	// arithmetic operators
 	//
 	// `linear_expansion_sum` (Shewchuk Figure 7) returns a non-overlapping
@@ -230,23 +273,35 @@ public:
 	// `renormalize_expansion` rebuilds the expansion via grow_expansion so
 	// that equal values produce equal limb sequences. This restores the
 	// algebraic invariants at the cost of an extra O(m) pass per operation.
+	//
+	// Special-value short-circuit (issue #957): Shewchuk's EFT-based merge
+	// computes residuals via expressions like `s - a` and `a - (s - bb)`,
+	// which produce `Inf - Inf = NaN` when an operand is +/-Inf. The
+	// resulting expansion has `Inf` in the leading limb and `NaN` in the
+	// residual, and `convert_to_ieee754` sums them back to NaN. To avoid
+	// this, we apply IEEE 754 addition rules to special values BEFORE the
+	// EFT chain runs.
 	ereal& operator+=(const ereal& rhs) {
 		using namespace expansion_ops;
+		if (apply_ieee754_add_special_values(rhs)) return *this;
 		_limb = renormalize_expansion(linear_expansion_sum(_limb, rhs._limb));
 		return *this;
 	}
 	ereal& operator+=(double rhs) {
 		using namespace expansion_ops;
 		ereal<maxlimbs> rhs_expansion(rhs);
+		if (apply_ieee754_add_special_values(rhs_expansion)) return *this;
 		_limb = renormalize_expansion(linear_expansion_sum(_limb, rhs_expansion._limb));
 		return *this;
 	}
 	ereal& operator-=(const ereal& rhs) {
 		using namespace expansion_ops;
-		// Negate rhs components and add (same canonicalisation as +=).
-		std::vector<double> neg_rhs = rhs._limb;
-		for (auto& v : neg_rhs) v = -v;
-		_limb = renormalize_expansion(linear_expansion_sum(_limb, neg_rhs));
+		// Subtraction is a + (-b). Apply the special-value rules to the
+		// effective sign-flipped RHS so e.g. (+Inf) - (-Inf) = +Inf + +Inf,
+		// not (+Inf) + (-Inf) = NaN.
+		ereal<maxlimbs> neg_rhs_e = -rhs;
+		if (apply_ieee754_add_special_values(neg_rhs_e)) return *this;
+		_limb = renormalize_expansion(linear_expansion_sum(_limb, neg_rhs_e._limb));
 		return *this;
 	}
 	ereal& operator-=(double rhs) {


### PR DESCRIPTION
## Summary

Resolves the `+Inf + finite -> NaN` bug surfaced by the corner-case fuzzer in PR #958.

## Root cause

Shewchuk's expansion arithmetic in `linear_expansion_sum` uses `two_sum` internally. For an `Inf` operand, the EFT residual extraction does `Inf - Inf = NaN`. The leading limb is correctly `+/-Inf` but the residual limb is `NaN`, and `convert_to_ieee754` sums them and returns NaN.

## Fix

Short-circuit IEEE 754 special-value cases BEFORE the EFT chain runs. New private member `apply_ieee754_add_special_values(rhs)` sets `*this` to the IEEE 754 result and returns true when either operand is `NaN` or `+/-Inf`; otherwise returns false and the existing finite-finite EFT path runs.

Rules implemented:

| Inputs | Result |
|---|---|
| `NaN + anything` (or vice versa) | `NaN` |
| `+Inf + +Inf` | `+Inf` |
| `-Inf + -Inf` | `-Inf` |
| `+Inf + -Inf` (or vice versa) | `NaN` |
| `+/-Inf + finite` (or vice versa) | `+/-Inf` |
| `finite + finite` | (existing EFT path) |

Subtraction `a - b` is handled as `a + (-b)`; the sign-flip on the RHS correctly turns `+Inf - -Inf` into `+Inf + +Inf = +Inf` rather than the naive `+Inf + -Inf = NaN`.

## Changes

- `include/sw/universal/number/ereal/ereal_impl.hpp` -- new `apply_ieee754_add_special_values` private helper; `operator+=(ereal)`, `operator+=(double)`, `operator-=(ereal)` call it before the EFT path.
- `elastic/ereal/arithmetic/addition.cpp` -- un-gated the `+Inf + finite` assertion that PR #958 deferred behind `#if 0`; added complementary `-Inf + finite`, `+Inf + +Inf`, `-Inf + -Inf` tests to exercise the full Inf-handling matrix.

## Test Results

| Target | gcc debug | gcc release | clang debug | clang release |
|---|---|---|---|---|
| `er_arith_addition` (all 4 LEVELs) | PASS | PASS | PASS | PASS |
| Full ereal regression (38 tests) | PASS | PASS | PASS | PASS |

The fuzzer at LEVELs 2-4 (1k / 100k / 10M iterations) continues to pass; the un-gated +Inf assertion now fires on every test run.

## Test plan
- [x] Fast CI passes (gcc + clang)
- [x] Promote to ready when satisfied

Resolves #957

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Arithmetic now short-circuits and correctly handles IEEE 754 special values (NaN and ±Infinity), preserving signs and propagation across addition/subtraction.

* **Tests**
  * Re-enabled and expanded regression tests covering ±Infinity combinations and finite operands, plus explicit checks for same-sign infinities to validate observed results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->