### PR TITLE
fix(ereal): IEEE 754 signed-zero subtraction (#962)

### DIFF
--- a/elastic/ereal/arithmetic/subtraction.cpp
+++ b/elastic/ereal/arithmetic/subtraction.cpp
@@ -345,16 +345,7 @@ namespace {
 		}
 
 		// -0 - +0 = -0  (per IEEE 754-2008 6.3: signs differ in subtraction)
-		// Gated pending fix for #962 -- ereal currently returns +0. The case
-		// is left in place documenting the expected behavior so re-enabling
-		// is a one-line edit once the signed-zero path is fixed.
-		//
-		// Value-based guard: `#if EREAL_TEST_ISSUE_962` (not `#if defined(...)`)
-		// so that `-DEREAL_TEST_ISSUE_962=0` correctly disables the case.
-#ifndef EREAL_TEST_ISSUE_962
-#define EREAL_TEST_ISSUE_962 0
-#endif
-#if EREAL_TEST_ISSUE_962
+		// Fixed by #962: signed-zero subtraction now follows IEEE 754.
 		if (reportTestCases) std::cout << "  -0 - +0...\n";
 		{
 			ereal<16> n(-0.0);
@@ -365,7 +356,18 @@ namespace {
 				++nrOfFailedTestCases;
 			}
 		}
-#endif
+
+		// -0 - -0 = +0  (signs match in subtraction -> positive zero)
+		if (reportTestCases) std::cout << "  -0 - -0...\n";
+		{
+			ereal<16> n(-0.0);
+			ereal<16> m(-0.0);
+			double r = double(n - m);
+			if (r != 0.0 || std::signbit(r)) {
+				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n';
+				++nrOfFailedTestCases;
+			}
+		}
 
 		return nrOfFailedTestCases;
 	}

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -694,6 +694,17 @@ protected:
 			this->setinf(rhs.signbit());
 			return true;
 		}
+		// Signed zero: when both operands are zero, IEEE 754 round-to-nearest
+		// gives -0 only if both addends are -0, otherwise +0. operator-= routes
+		// here on the sign-flipped RHS, so this single rule yields the correct
+		// subtraction table (e.g. -0 - +0 = -0 + -0 = -0). The general sum path
+		// would otherwise renormalise any zero result to +0.
+		if (this->iszero() && rhs.iszero()) {
+			bool negzero = this->signbit() && rhs.signbit();
+			clear();
+			_limb[0] = negzero ? -0.0 : 0.0;
+			return true;
+		}
 		return false;
 	}
 
@@ -735,10 +746,15 @@ protected:
 	template<typename Real,
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
 	Real convert_to_ieee754() const noexcept {
-		// Sum all components to get the full value
-		Real sum = 0.0;
-		for (const auto& component : _limb) {
-			sum += static_cast<Real>(component);
+		if (_limb.empty()) return Real(0);
+		// Seed the accumulator with the leading (largest-magnitude) component
+		// rather than +0. Starting from +0 would discard the sign of a signed
+		// zero (IEEE 754: +0 + -0 == +0), turning a stored -0 into +0. Seeding
+		// from _limb[0] is numerically identical for non-zero expansions since
+		// _limb[0] is the dominant term.
+		Real sum = static_cast<Real>(_limb[0]);
+		for (std::size_t i = 1; i < _limb.size(); ++i) {
+			sum += static_cast<Real>(_limb[i]);
 		}
 		return sum;
 	}


### PR DESCRIPTION
Closes #962.

## Problem

IEEE 754-2008 6.3 prescribes the sign of a zero difference under round-to-nearest-even. `ereal` got `-0 - +0` wrong:

| operation | IEEE 754 | ereal (before) | ereal (after) |
|-----------|----------|----------------|---------------|
| `+0 - +0` | `+0` | `+0` | `+0` |
| `+0 - -0` | `+0` | `+0` | `+0` |
| `-0 - +0` | `-0` | `+0` (BUG) | `-0` |
| `-0 - -0` | `+0` | (untested) | `+0` |

## Root cause -- two defects on the signed-zero path

1. **`apply_ieee754_add_special_values()`** had no both-operands-zero branch, so a zero result fell through to the general `renormalize_expansion` path, which collapses any zero to `+0`.
2. **`convert_to_ieee754()`** seeded its accumulator with `+0`; since IEEE `+0 + -0 == +0`, a correctly stored `-0` was discarded on conversion to `double`.

## Fix

1. Add the IEEE 754 rule to the add special-value handler: a sum of two zeros is `-0` iff **both** addends are `-0`. `operator-=` routes through this on the sign-flipped RHS, so the single rule yields the full subtraction table.
2. Seed `convert_to_ieee754()` from the leading (dominant) component instead of `+0` -- numerically identical for non-zero expansions, sign-preserving for zero.

## Tests

- Unskipped the `-0 - +0` case in `elastic/ereal/arithmetic/subtraction.cpp` (removed the `EREAL_TEST_ISSUE_962` gate) and added the `-0 - -0 = +0` case.
- Foundational (`REGRESSION_LEVEL_1`) subtraction tests pass on **gcc-13** and **clang-18**.

## Acceptance (from #962)

- [x] `-0 - +0 == -0` (signbit set)
- [x] `-0 - -0 == +0` (signbit clear)
- [x] signed-zero subtraction case unskipped and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed signed-zero handling in arithmetic operations to comply with IEEE-754 standard. Negative zero is now correctly preserved in subtraction and addition operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->