### PR TITLE
fix(ereal): IEEE 754 special values for multiplication (#966)

### DIFF
--- a/elastic/ereal/arithmetic/addition.cpp
+++ b/elastic/ereal/arithmetic/addition.cpp
@@ -381,10 +381,11 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition(reportTestCases), "ereal", "addition foundational");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 1000), "ereal", "addition fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 1000), "ereal", "addition fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 10000), "ereal", "addition fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
@@ -392,7 +393,7 @@ int main() try {
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 10000000), "ereal", "addition fuzz x10M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 1000000), "ereal", "addition fuzz x1M");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/multiplication.cpp
+++ b/elastic/ereal/arithmetic/multiplication.cpp
@@ -229,6 +229,129 @@ namespace {
 			}
 		}
 
+		// --- IEEE 754 special values (fixed by #966) ---
+		// The sign of a product is signbit(a) XOR signbit(b), including for
+		// zero and infinite results. Inf * 0 is NaN.
+
+		double qnan = std::numeric_limits<double>::quiet_NaN();
+		double pinf = std::numeric_limits<double>::infinity();
+		double ninf = -pinf;
+
+		// NaN * finite = NaN (both orderings)
+		if (reportTestCases) std::cout << "  NaN * finite (both orderings)...\n";
+		{
+			ereal<16> a(2.0);
+			ereal<16> n(qnan);
+			if (!std::isnan(double(a * n))) {
+				if (reportTestCases) std::cout << "    FAIL a * NaN\n"; ++nrOfFailedTestCases;
+			}
+			if (!std::isnan(double(n * a))) {
+				if (reportTestCases) std::cout << "    FAIL NaN * a\n"; ++nrOfFailedTestCases;
+			}
+		}
+
+		// Inf * finite-nonzero = signed Inf (sign = XOR)
+		if (reportTestCases) std::cout << "  Inf * finite-nonzero (sign = XOR)...\n";
+		{
+			ereal<16> two(2.0);
+			ereal<16> negtwo(-2.0);
+			ereal<16> pos(pinf);
+			ereal<16> neg(ninf);
+			double r1 = double(two * pos);     // +Inf
+			if (!std::isinf(r1) || r1 < 0) {
+				if (reportTestCases) std::cout << "    FAIL 2 * +Inf got " << r1 << '\n'; ++nrOfFailedTestCases;
+			}
+			double r2 = double(negtwo * pos);  // -Inf
+			if (!std::isinf(r2) || r2 > 0) {
+				if (reportTestCases) std::cout << "    FAIL -2 * +Inf got " << r2 << '\n'; ++nrOfFailedTestCases;
+			}
+			double r3 = double(two * neg);     // -Inf
+			if (!std::isinf(r3) || r3 > 0) {
+				if (reportTestCases) std::cout << "    FAIL 2 * -Inf got " << r3 << '\n'; ++nrOfFailedTestCases;
+			}
+		}
+
+		// Inf * Inf = signed Inf (sign = XOR)
+		if (reportTestCases) std::cout << "  Inf * Inf (sign = XOR)...\n";
+		{
+			ereal<16> pos(pinf);
+			ereal<16> neg(ninf);
+			double r1 = double(pos * pos);  // +Inf
+			if (!std::isinf(r1) || r1 < 0) {
+				if (reportTestCases) std::cout << "    FAIL +Inf * +Inf got " << r1 << '\n'; ++nrOfFailedTestCases;
+			}
+			double r2 = double(pos * neg);  // -Inf
+			if (!std::isinf(r2) || r2 > 0) {
+				if (reportTestCases) std::cout << "    FAIL +Inf * -Inf got " << r2 << '\n'; ++nrOfFailedTestCases;
+			}
+			double r3 = double(neg * neg);  // +Inf
+			if (!std::isinf(r3) || r3 < 0) {
+				if (reportTestCases) std::cout << "    FAIL -Inf * -Inf got " << r3 << '\n'; ++nrOfFailedTestCases;
+			}
+		}
+
+		// Inf * 0 = NaN (both orderings)
+		if (reportTestCases) std::cout << "  Inf * 0 = NaN (both orderings)...\n";
+		{
+			ereal<16> inf(pinf);
+			ereal<16> zero(0.0);
+			if (!std::isnan(double(inf * zero))) {
+				if (reportTestCases) std::cout << "    FAIL Inf * 0\n"; ++nrOfFailedTestCases;
+			}
+			if (!std::isnan(double(zero * inf))) {
+				if (reportTestCases) std::cout << "    FAIL 0 * Inf\n"; ++nrOfFailedTestCases;
+			}
+		}
+
+		// Signed-zero products: sign = signbit(a) XOR signbit(b)
+		// finite * -0 carries the sign through
+		if (reportTestCases) std::cout << "  finite * -0 = -0...\n";
+		{
+			ereal<16> a(3.0);
+			ereal<16> n(-0.0);
+			double r = double(a * n);
+			if (r != 0.0 || !std::signbit(r)) {
+				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n'; ++nrOfFailedTestCases;
+			}
+		}
+
+		// +0 * +0 = +0
+		if (reportTestCases) std::cout << "  +0 * +0 = +0...\n";
+		{
+			ereal<16> p(0.0);
+			ereal<16> q(0.0);
+			double r = double(p * q);
+			if (r != 0.0 || std::signbit(r)) {
+				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n'; ++nrOfFailedTestCases;
+			}
+		}
+
+		// +0 * -0 = -0  and  -0 * +0 = -0
+		if (reportTestCases) std::cout << "  +0 * -0 = -0, -0 * +0 = -0...\n";
+		{
+			ereal<16> p(0.0);
+			ereal<16> n(-0.0);
+			double r1 = double(p * n);
+			if (r1 != 0.0 || !std::signbit(r1)) {
+				if (reportTestCases) std::cout << "    FAIL +0 * -0 signbit=" << std::signbit(r1) << '\n'; ++nrOfFailedTestCases;
+			}
+			double r2 = double(n * p);
+			if (r2 != 0.0 || !std::signbit(r2)) {
+				if (reportTestCases) std::cout << "    FAIL -0 * +0 signbit=" << std::signbit(r2) << '\n'; ++nrOfFailedTestCases;
+			}
+		}
+
+		// -0 * -0 = +0
+		if (reportTestCases) std::cout << "  -0 * -0 = +0...\n";
+		{
+			ereal<16> n(-0.0);
+			ereal<16> m(-0.0);
+			double r = double(n * m);
+			if (r != 0.0 || std::signbit(r)) {
+				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n'; ++nrOfFailedTestCases;
+			}
+		}
+
 		return nrOfFailedTestCases;
 	}
 
@@ -364,10 +487,11 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication(reportTestCases), "ereal", "multiplication foundational");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 1000), "ereal", "multiplication fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 1000), "ereal", "multiplication fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 10000), "ereal", "multiplication fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
@@ -375,7 +499,7 @@ int main() try {
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 10000000), "ereal", "multiplication fuzz x10M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 1000000), "ereal", "multiplication fuzz x1M");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/subtraction.cpp
+++ b/elastic/ereal/arithmetic/subtraction.cpp
@@ -502,10 +502,11 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction(reportTestCases), "ereal", "subtraction foundational");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 1000), "ereal", "subtraction fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 1000), "ereal", "subtraction fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 10000), "ereal", "subtraction fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
@@ -513,7 +514,7 @@ int main() try {
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 10000000), "ereal", "subtraction fuzz x10M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 1000000), "ereal", "subtraction fuzz x1M");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -266,13 +266,19 @@ public:
 	}
 	ereal& operator*=(const ereal& rhs) {
 		using namespace expansion_ops;
+		// IEEE 754 special values (NaN/Inf/signed-zero) must be resolved before
+		// the EFT product: expansion_product turns finite * Inf into Inf - Inf
+		// = NaN and collapses any zero operand to +0 (issue #966).
+		if (apply_ieee754_mul_special_values(rhs)) return *this;
 		_limb = expansion_product(_limb, rhs._limb);
 		return *this;
 	}
 	ereal& operator*=(double rhs) {
-		using namespace expansion_ops;
-		_limb = scale_expansion(_limb, rhs);
-		return *this;
+		// Delegate to the ereal overload so the IEEE 754 special-value table is
+		// applied uniformly (matches operator-=(double)). The free operator*
+		// overloads already construct an ereal for the scalar, so this keeps
+		// in-place `*= scalar` consistent with `x = x * scalar`.
+		return operator*=(ereal<maxlimbs>(rhs));
 	}
 	ereal& operator/=(const ereal& rhs) {
 		using namespace expansion_ops;
@@ -703,6 +709,54 @@ protected:
 			bool negzero = this->signbit() && rhs.signbit();
 			clear();
 			_limb[0] = negzero ? -0.0 : 0.0;
+			return true;
+		}
+		return false;
+	}
+
+	// apply_ieee754_mul_special_values: IEEE 754 special-value rules for
+	// multiplication (resolves issue #966). If either operand is NaN, +/-Inf,
+	// or zero, canonicalise `*this` to the single-limb IEEE 754 result and
+	// return true. Otherwise return false and let expansion_product handle the
+	// finite-nonzero * finite-nonzero case.
+	//
+	// The sign of a product is signbit(a) XOR signbit(b) -- including for zero
+	// and infinite results. The general expansion_product path cannot express
+	// this: it would turn finite * Inf into Inf - Inf = NaN, and short-circuit
+	// any zero operand to a positive +0 limb.
+	//
+	// Rules:
+	//   NaN * anything           = NaN
+	//   anything * NaN           = NaN
+	//   Inf * 0  (either order)  = NaN
+	//   Inf * Inf                = Inf, sign = a ^ b
+	//   Inf * finite-nonzero     = Inf, sign = a ^ b
+	//   finite-nonzero * Inf     = Inf, sign = a ^ b
+	//   0 * finite / finite * 0  = 0,   sign = a ^ b   (signed-zero rule)
+	bool apply_ieee754_mul_special_values(const ereal& rhs) {
+		if (this->isnan() || rhs.isnan()) {
+			this->setnan();
+			return true;
+		}
+		bool a_inf  = this->isinf();
+		bool b_inf  = rhs.isinf();
+		bool a_zero = this->iszero();
+		bool b_zero = rhs.iszero();
+		bool resultSign = this->signbit() != rhs.signbit();  // XOR of signs
+		if (a_inf || b_inf) {
+			// Inf times zero is NaN regardless of order; otherwise signed Inf.
+			if ((a_inf && b_zero) || (b_inf && a_zero)) {
+				this->setnan();
+				return true;
+			}
+			this->setinf(resultSign);
+			return true;
+		}
+		if (a_zero || b_zero) {
+			// Product with a zero operand is a zero whose sign is the XOR of the
+			// operand signs; expansion_product would otherwise always yield +0.
+			clear();
+			_limb[0] = resultSign ? -0.0 : 0.0;
 			return true;
 		}
 		return false;


### PR DESCRIPTION
## Summary
- Fixes `ereal` multiplication for IEEE 754 special-value operands. `operator*=` routed straight into `expansion_product`, which has no special-value handling: `finite * Inf` produced `Inf - Inf` cross terms that renormalized to NaN, `Inf * Inf` collapsed to NaN, and any zero operand was short-circuited to a positive `+0` limb (sign lost).

Resolves #966.

## Root cause
`expansion_product` is an error-free-transform kernel with only a finite/zero fast path. It cannot express the IEEE rule that the sign of a product is `signbit(a) XOR signbit(b)`, and `Inf * finite` degenerates to `Inf - Inf = NaN` during the cross-term sum.

## Fix
Add `apply_ieee754_mul_special_values()` (sibling to the addition handler landed in #960/#964) and call it from `operator*=` before the EFT product:

| operation | result |
|-----------|--------|
| `NaN * x` | `NaN` |
| `Inf * 0` (either order) | `NaN` |
| `Inf * Inf` | `Inf`, sign = a^b |
| `Inf * finite-nonzero` | `Inf`, sign = a^b |
| `0 * finite` / `finite * 0` | `0`, sign = a^b |

`operator*=(double)` now delegates to the ereal overload (matching `operator-=(double)`) so the table applies uniformly. The signed-zero result projects correctly to `double` via the `convert_to_ieee754` seeding fixed in #964.

## Changes
- `include/sw/universal/number/ereal/ereal_impl.hpp` -- add `apply_ieee754_mul_special_values`; call from `operator*=(const ereal&)`; `operator*=(double)` delegates to the ereal overload.
- `elastic/ereal/arithmetic/multiplication.cpp` -- IEEE 754 special-value test block (NaN, Inf*finite, Inf*Inf, Inf*0, signed-zero products) now exercised (deferred by the #946 refactor).

Note: this branch also carries commit `a85144fb` (author: repo owner) which retunes the fuzz-iteration ladder across addition/subtraction/multiplication (x1k into L1, L2->x10k, L4 x10M->x1M) to cut CI time.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_arith_multiplication | OK | PASS | OK | PASS |
| er_arith_addition (regression) | OK | PASS | OK | PASS |
| er_arith_subtraction (regression) | OK | PASS | OK | PASS |

Validated foundational + fuzz (x1k/x10k/x100k) on gcc-13 and clang-18.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multiplication handling of IEEE 754 special values, including correct behavior for NaN, infinities, signed zeros, and Inf×0 operations.
  * Improved consistency in special-value handling across arithmetic operations.

* **Tests**
  * Enhanced regression test coverage for multiplication with IEEE 754 special values.
  * Reorganized regression test intensity levels across arithmetic operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->