### PR TITLE
fix(ereal): IEEE 754 division-by-zero + special values (#968)

### DIFF
--- a/elastic/ereal/arithmetic/division.cpp
+++ b/elastic/ereal/arithmetic/division.cpp
@@ -199,42 +199,78 @@ namespace {
 			}
 		}
 
-		// --- Divide-by-zero boundary ---
-		//
-		// Current behavior: finite / 0 projects to a non-finite double (NaN in
-		// the present implementation). The IEEE-correct results (finite/0 =
-		// signed Inf, 0/0 = NaN) and the EREAL_THROW_ARITHMETIC_EXCEPTION
-		// throwing path are deferred to #968; the value-based guard below keeps
-		// the foundational suite green until that fix lands.
-		if (reportTestCases) std::cout << "  Divide-by-zero (non-finite)...\n";
+		// --- IEEE 754 special values + divide-by-zero (fixed by #968) ---
+		// The sign of a quotient is signbit(a) XOR signbit(b), including for
+		// zero and infinite results. In the default (non-throwing) mode a zero
+		// divisor produces a signed Inf (or NaN for 0/0); see the throw-mode
+		// block below for EREAL_THROW_ARITHMETIC_EXCEPTION behavior.
+
+		double qnan = std::numeric_limits<double>::quiet_NaN();
+		double pinf = std::numeric_limits<double>::infinity();
+
+		// NaN / finite = NaN; finite / NaN = NaN
+		if (reportTestCases) std::cout << "  NaN propagation...\n";
 		{
 			ereal<16> a(5.0);
-			ereal<16> zero(0.0);
-			double r = double(a / zero);
-			if (std::isfinite(r)) {
-				if (reportTestCases) std::cout << "    FAIL a/0 is finite: " << r << '\n';
+			ereal<16> n(qnan);
+			if (!std::isnan(double(a / n))) { if (reportTestCases) std::cout << "    FAIL a/NaN\n"; ++nrOfFailedTestCases; }
+			if (!std::isnan(double(n / a))) { if (reportTestCases) std::cout << "    FAIL NaN/a\n"; ++nrOfFailedTestCases; }
+		}
+
+#ifndef EREAL_THROW_ARITHMETIC_EXCEPTION
+#define EREAL_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+#if EREAL_THROW_ARITHMETIC_EXCEPTION
+		// Throw mode: a zero divisor throws ereal_divide_by_zero.
+		if (reportTestCases) std::cout << "  Divide-by-zero throws (exception mode)...\n";
+		{
+			bool threw = false;
+			try { ereal<16> q = ereal<16>(5.0) / ereal<16>(0.0); (void)q; }
+			catch (const ereal_divide_by_zero&) { threw = true; }
+			if (!threw) {
+				if (reportTestCases) std::cout << "    FAIL 5/0 did not throw\n";
 				++nrOfFailedTestCases;
 			}
 		}
-
-		// IEEE-correct divide-by-zero + EREAL_THROW_ARITHMETIC_EXCEPTION mode,
-		// gated pending #968. Value-based guard (`#if EREAL_TEST_ISSUE_968`, not
-		// `#if defined(...)`) so `-DEREAL_TEST_ISSUE_968=0` correctly disables it.
-#ifndef EREAL_TEST_ISSUE_968
-#define EREAL_TEST_ISSUE_968 0
-#endif
-#if EREAL_TEST_ISSUE_968
+#else
+		// Default mode: IEEE results. x/0 = signed Inf, 0/0 = NaN.
 		if (reportTestCases) std::cout << "  Divide-by-zero (IEEE)...\n";
 		{
 			ereal<16> zero(0.0);
 			double r1 = double(ereal<16>(5.0)  / zero);   // +Inf
-			if (!std::isinf(r1) || r1 < 0) { ++nrOfFailedTestCases; }
+			if (!std::isinf(r1) || r1 < 0) { if (reportTestCases) std::cout << "    FAIL 5/0 != +Inf\n"; ++nrOfFailedTestCases; }
 			double r2 = double(ereal<16>(-5.0) / zero);   // -Inf
-			if (!std::isinf(r2) || r2 > 0) { ++nrOfFailedTestCases; }
+			if (!std::isinf(r2) || r2 > 0) { if (reportTestCases) std::cout << "    FAIL -5/0 != -Inf\n"; ++nrOfFailedTestCases; }
 			double r3 = double(zero / zero);              // NaN
-			if (!std::isnan(r3)) { ++nrOfFailedTestCases; }
+			if (!std::isnan(r3)) { if (reportTestCases) std::cout << "    FAIL 0/0 != NaN\n"; ++nrOfFailedTestCases; }
 		}
 #endif
+
+		// Infinity operands (sign = XOR).
+		if (reportTestCases) std::cout << "  Infinity operands...\n";
+		{
+			ereal<16> pos(pinf);
+			ereal<16> neg(-pinf);
+			ereal<16> two(2.0);
+			if (!std::isnan(double(pos / pos))) { if (reportTestCases) std::cout << "    FAIL Inf/Inf != NaN\n"; ++nrOfFailedTestCases; }
+			double r1 = double(pos / two);   // +Inf
+			if (!std::isinf(r1) || r1 < 0) { if (reportTestCases) std::cout << "    FAIL Inf/2 != +Inf\n"; ++nrOfFailedTestCases; }
+			double r2 = double(neg / two);   // -Inf
+			if (!std::isinf(r2) || r2 > 0) { if (reportTestCases) std::cout << "    FAIL -Inf/2 != -Inf\n"; ++nrOfFailedTestCases; }
+			double r3 = double(two / pos);   // +0
+			if (r3 != 0.0 || std::signbit(r3)) { if (reportTestCases) std::cout << "    FAIL 2/Inf != +0\n"; ++nrOfFailedTestCases; }
+		}
+
+		// Signed-zero quotients: sign = signbit(a) XOR signbit(b).
+		if (reportTestCases) std::cout << "  Signed-zero quotients...\n";
+		{
+			double r1 = double(ereal<16>(-0.0) / ereal<16>(5.0));   // -0
+			if (r1 != 0.0 || !std::signbit(r1)) { if (reportTestCases) std::cout << "    FAIL -0/5 != -0\n"; ++nrOfFailedTestCases; }
+			double r2 = double(ereal<16>(0.0)  / ereal<16>(-5.0));  // -0
+			if (r2 != 0.0 || !std::signbit(r2)) { if (reportTestCases) std::cout << "    FAIL 0/-5 != -0\n"; ++nrOfFailedTestCases; }
+			double r3 = double(ereal<16>(0.0)  / ereal<16>(5.0));   // +0
+			if (r3 != 0.0 || std::signbit(r3)) { if (reportTestCases) std::cout << "    FAIL 0/5 != +0\n"; ++nrOfFailedTestCases; }
+		}
 
 		return nrOfFailedTestCases;
 	}

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -282,14 +282,18 @@ public:
 	}
 	ereal& operator/=(const ereal& rhs) {
 		using namespace expansion_ops;
+		// IEEE 754 special values (NaN/Inf/zero) and divide-by-zero must be
+		// resolved before the Newton-reciprocal quotient: reciprocal(0) is Inf
+		// and a * Inf renormalises to NaN, and any zero operand collapses to +0
+		// (issue #968).
+		if (apply_ieee754_div_special_values(rhs)) return *this;
 		_limb = expansion_quotient(_limb, rhs._limb);
 		return *this;
 	}
 	ereal& operator/=(double rhs) {
-		using namespace expansion_ops;
-		ereal<maxlimbs> rhs_expansion(rhs);
-		_limb = expansion_quotient(_limb, rhs_expansion._limb);
-		return *this;
+		// Delegate to the ereal overload so the IEEE 754 special-value table and
+		// divide-by-zero handling apply uniformly (matches operator*=(double)).
+		return operator/=(ereal<maxlimbs>(rhs));
 	}
 
 	// modifiers
@@ -755,6 +759,64 @@ protected:
 		if (a_zero || b_zero) {
 			// Product with a zero operand is a zero whose sign is the XOR of the
 			// operand signs; expansion_product would otherwise always yield +0.
+			clear();
+			_limb[0] = resultSign ? -0.0 : 0.0;
+			return true;
+		}
+		return false;
+	}
+
+	// apply_ieee754_div_special_values: IEEE 754 special-value rules for
+	// division (resolves issue #968). If the operands are special (NaN/Inf/
+	// zero), canonicalise `*this` to the single-limb IEEE 754 result and return
+	// true. Otherwise return false and let expansion_quotient handle the
+	// finite-nonzero / finite-nonzero case.
+	//
+	// The sign of a quotient is signbit(a) XOR signbit(b) -- including for zero
+	// and infinite results. The Newton-reciprocal path cannot express this:
+	// reciprocal(0) yields Inf, then a * Inf renormalises to NaN, and any zero
+	// operand collapses to a positive +0.
+	//
+	// Rules (a / b), default (non-throwing) mode:
+	//   NaN / x, x / NaN          = NaN
+	//   x / 0 (x != 0)            = Inf, sign = a ^ b
+	//   0 / 0                     = NaN
+	//   Inf / Inf                 = NaN
+	//   Inf / finite-nonzero      = Inf, sign = a ^ b
+	//   finite / Inf              = 0,   sign = a ^ b
+	//   0 / finite-nonzero        = 0,   sign = a ^ b
+	//
+	// When EREAL_THROW_ARITHMETIC_EXCEPTION is enabled, a zero divisor throws
+	// ereal_divide_by_zero instead of returning a non-finite value.
+	bool apply_ieee754_div_special_values(const ereal& rhs) {
+		if (this->isnan() || rhs.isnan()) {
+			this->setnan();
+			return true;
+		}
+		bool a_inf  = this->isinf();
+		bool b_inf  = rhs.isinf();
+		bool a_zero = this->iszero();
+		bool b_zero = rhs.iszero();
+		bool resultSign = this->signbit() != rhs.signbit();  // XOR of signs
+		if (b_zero) {
+#if EREAL_THROW_ARITHMETIC_EXCEPTION
+			throw ereal_divide_by_zero();
+#else
+			// 0/0 is NaN; any other x/0 is a signed infinity.
+			if (a_zero) { this->setnan(); return true; }
+			this->setinf(resultSign);
+			return true;
+#endif
+		}
+		if (a_inf) {
+			// Inf / Inf is NaN; Inf / finite-nonzero is a signed infinity.
+			if (b_inf) { this->setnan(); return true; }
+			this->setinf(resultSign);
+			return true;
+		}
+		if (b_inf || a_zero) {
+			// finite / Inf and 0 / finite-nonzero are signed zeros; the quotient
+			// path would otherwise drop the sign.
 			clear();
 			_limb[0] = resultSign ? -0.0 : 0.0;
 			return true;


### PR DESCRIPTION
## Summary
- Fixes `ereal` division for IEEE 754 special-value operands and divide-by-zero. `operator/=` routed straight into `expansion_quotient` (= `e * reciprocal(f)`), which has no special-value handling: `reciprocal(0)` returns `Inf`, then `a * Inf` renormalizes to `NaN`, and any zero operand collapses to a positive `+0` limb. `EREAL_THROW_ARITHMETIC_EXCEPTION` was never consulted.

Resolves #968.

## Before -> after (gcc + clang)
| operation | before | after |
|-----------|--------|-------|
| `5 / 0`   | `NaN`  | `+Inf` |
| `-5 / 0`  | `NaN`  | `-Inf` |
| `0 / 0`   | `+0`   | `NaN` |
| `Inf / Inf` | `NaN` | `NaN` |
| `Inf / 2` | (broken) | `+Inf` |
| `2 / Inf` | (broken) | `+0` |
| `-0 / 5`  | `+0`   | `-0` |
| `0 / -5`  | `+0`   | `-0` |

## Fix
Add `apply_ieee754_div_special_values()` (sibling to the add/mul handlers from #960/#964/#966) and call it in `operator/=` before the Newton-reciprocal quotient. Sign of quotient = `signbit(a) XOR signbit(b)`:

- `NaN / x`, `x / NaN` -> `NaN`
- `x / 0` (x != 0) -> signed `Inf` **or throw** `ereal_divide_by_zero` when `EREAL_THROW_ARITHMETIC_EXCEPTION` is set
- `0 / 0` -> `NaN`
- `Inf / Inf` -> `NaN`; `Inf / finite-nonzero` -> signed `Inf`
- `finite / Inf` -> signed `0`; `0 / finite-nonzero` -> signed `0`

`operator/=(double)` now delegates to the ereal overload so the table applies uniformly (matches `*=`/`-=`). The `ereal_divide_by_zero` exception type already existed but was previously only thrown from `fmod`/`remainder`.

## Changes
- `include/sw/universal/number/ereal/ereal_impl.hpp` -- add `apply_ieee754_div_special_values`; wire both `operator/=` overloads.
- `elastic/ereal/arithmetic/division.cpp` -- un-gate the deferred divide-by-zero block; add NaN propagation, the full IEEE divide-by-zero table, infinity operands, signed-zero quotients, and a throw-mode block guarded by `EREAL_THROW_ARITHMETIC_EXCEPTION`.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_arith_division (default mode) | OK | PASS | OK | PASS |
| er_arith_division (`-DEREAL_THROW_ARITHMETIC_EXCEPTION=1`) | OK | PASS | OK | PASS |
| er_arith_addition / subtraction / multiplication (regression) | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved division operation handling for special values (NaN, infinity, zero) to comply with IEEE 754 standards.
  * Fixed divide-by-zero behavior with proper exception handling and IEEE result modes.
  * Corrected signed-zero quotient sign handling in division operations.

* **Tests**
  * Enhanced regression test coverage for division special cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->