### PR TITLE
feat(ereal): refactor math/constants/ tests to standard pattern (#949)

### DIFF
--- a/elastic/ereal/math/constants/constant_generation.cpp
+++ b/elastic/ereal/math/constants/constant_generation.cpp
@@ -1,497 +1,276 @@
-// constant_generation.cpp: Generate high-precision mathematical constants using ereal
+// constant_generation.cpp: regression tests for high-precision constant
+// generation with ereal.
+//
+// Verifies that the series/iterative generators (Machin pi, Taylor e,
+// Newton-Raphson sqrt, artanh ln2) produce expansions that
+//   1. project to the known double value, and
+//   2. satisfy Priest's non-overlap invariant |e[i+1]| <= ulp(e[i])/2 with no
+//      interior zero components,
+// and that the generated constants honor the algebraic round-trip identities.
+//
+// REGRESSION_LEVEL convention: the generators are deterministic, so a single
+// pass exercises every case at all levels.
+//
+// Pattern: elastic/ereal/arithmetic/addition.cpp (PR #943).
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
-#include <universal/utility/console_utf8.hpp>
-#include <universal/number/ereal/ereal.hpp>
-#include <math/constants/reference_constants.hpp>
-#include <universal/verification/test_suite.hpp>
+#include <algorithm>
 #include <cmath>
+#include <universal/number/ereal/ereal.hpp>
+#include <universal/verification/test_suite.hpp>
 
-namespace sw { namespace universal {
+namespace {
 
-	// ===================================================================
-	// COMPUTE PI using Machin's Formula
-	// ===================================================================
-	// π/4 = 4·arctan(1/5) - arctan(1/239)
+	using sw::universal::ereal;
 
-	// Compute arctan(x) for small x using Taylor series
-	// arctan(x) = x - x^3/3 + x^5/5 - x^7/7 + ...
+	// -------------------------------------------------------------------------
+	// Generators (pure compute, no I/O)
+	// -------------------------------------------------------------------------
+
+	// arctan(x) = x - x^3/3 + x^5/5 - x^7/7 + ...  (small x)
 	template<unsigned nlimbs>
-	ereal<nlimbs> compute_arctan_series(const ereal<nlimbs>& x, int terms = 100) {
+	ereal<nlimbs> compute_arctan_series(const ereal<nlimbs>& x, int terms) {
 		ereal<nlimbs> result(0.0);
-		ereal<nlimbs> x_power = x;  // Start with x^1
+		ereal<nlimbs> x_power = x;        // x^1
 		ereal<nlimbs> x_squared = x * x;
-
 		for (int n = 0; n < terms; ++n) {
 			int k = 2 * n + 1;
-			double sign = (n % 2 == 0) ? 1.0 : -1.0;
-			double coeff = sign / k;
-
-			// term = coeff * x_power
-			ereal<nlimbs> term = x_power * coeff;
-			result = result + term;
-
-			// x_power = x_power * x^2
+			double coeff = ((n % 2 == 0) ? 1.0 : -1.0) / k;
+			result = result + x_power * coeff;
 			x_power = x_power * x_squared;
 		}
-
 		return result;
 	}
 
+	// Machin's formula: pi/4 = 4*arctan(1/5) - arctan(1/239)
 	template<unsigned nlimbs>
 	ereal<nlimbs> compute_pi() {
-		std::cout << "Computing π using Machin's formula: π/4 = 4·arctan(1/5) - arctan(1/239)\n";
-
-		// Compute arctan(1/5)
-		ereal<nlimbs> one(1.0);
-		ereal<nlimbs> five(5.0);
-		ereal<nlimbs> one_fifth = one / five;
-		ereal<nlimbs> arctan_one_fifth = compute_arctan_series(one_fifth, 50);
-
-		std::cout << "  arctan(1/5) computed with " << arctan_one_fifth.limbs().size() << " components\n";
-
-		// Compute arctan(1/239)
-		ereal<nlimbs> two_three_nine(239.0);
-		ereal<nlimbs> one_over_239 = one / two_three_nine;
-		ereal<nlimbs> arctan_one_239 = compute_arctan_series(one_over_239, 30);
-
-		std::cout << "  arctan(1/239) computed with " << arctan_one_239.limbs().size() << " components\n";
-
-		// π/4 = 4·arctan(1/5) - arctan(1/239)
-		ereal<nlimbs> four(4.0);
-		ereal<nlimbs> four_arctan = four * arctan_one_fifth;
-		ereal<nlimbs> pi_over_4 = four_arctan - arctan_one_239;
-
-		// π = 4 · (π/4)
-		ereal<nlimbs> pi = four * pi_over_4;
-
-		std::cout << "  π computed with " << pi.limbs().size() << " components\n";
-		std::cout << "  π ≈ " << std::setprecision(20) << double(pi) << "    first double component\n";
-	    std::cout << "  π ≈ " << std::setprecision(320) << pi << '\n';
-	    std::cout << "  π r " << s_pi << '\n';
-	    std::cout << std::endl;
-
-		return pi;
+		ereal<nlimbs> one(1.0), five(5.0), ttn(239.0), four(4.0);
+		ereal<nlimbs> arctan_1_5   = compute_arctan_series(one / five, 50);
+		ereal<nlimbs> arctan_1_239 = compute_arctan_series(one / ttn, 30);
+		ereal<nlimbs> pi_over_4 = four * arctan_1_5 - arctan_1_239;
+		return four * pi_over_4;
 	}
 
-	// ===================================================================
-	// COMPUTE E using Taylor Series
-	// ===================================================================
-	// e = 1 + 1/1! + 1/2! + 1/3! + 1/4! + ...
-
+	// Taylor series: e = sum 1/n!
 	template<unsigned nlimbs>
 	ereal<nlimbs> compute_e() {
-		std::cout << "Computing e using Taylor series: e = Σ(1/n!)\n";
-
-		ereal<nlimbs> result(1.0);  // Start with 1
-		ereal<nlimbs> term(1.0);    // First term is 1/0! = 1
-
-		int terms = 50;
-		for (int n = 1; n <= terms; ++n) {
-			// term = term / n (each iteration divides by the next n)
+		ereal<nlimbs> result(1.0);   // 1/0!
+		ereal<nlimbs> term(1.0);
+		for (int n = 1; n <= 50; ++n) {
 			ereal<nlimbs> n_val(static_cast<double>(n));
 			term = term / n_val;
-
-			// Add to result
 			result = result + term;
-
-			// Check if term is negligible
-			double term_val = double(term);
-			if (std::abs(term_val) < 1.0e-100) {
-				std::cout << "  Converged after " << n << " terms\n";
-				break;
-			}
+			if (std::abs(double(term)) < 1.0e-100) break;
 		}
-
-		std::cout << "  e computed with " << result.limbs().size() << " components\n";
-	    std::cout << "  e ≈ " << std::setprecision(20) << double(result) << '\n';
-	    std::cout << "  e ≈ " << std::setprecision(320) << result << '\n';
-	    std::cout << "  e r " << s_e << '\n';
-	    std::cout << std::endl;
-
 		return result;
 	}
 
-	// ===================================================================
-	// COMPUTE √n using Newton-Raphson
-	// ===================================================================
-	// Solving x² = n, iterate: x_{n+1} = (x_n + n/x_n) / 2
-
+	// Newton-Raphson: x_{n+1} = (x_n + v/x_n) / 2 for sqrt(v).
 	template<unsigned nlimbs>
-	ereal<nlimbs> compute_sqrt(double n) {
-		std::cout << "Computing √" << n << " using Newton-Raphson: x = (x + n/x)/2\n";
-
-		ereal<nlimbs> x(std::sqrt(n));  // Initial guess
-		ereal<nlimbs> n_val(n);
-		ereal<nlimbs> two(2.0);
-
-		int iterations = 10;
-		for (int i = 0; i < iterations; ++i) {
-			// x = (x + n/x) / 2
-			ereal<nlimbs> n_over_x = n_val / x;
-			ereal<nlimbs> sum = x + n_over_x;
-			x = sum / two;
+	ereal<nlimbs> compute_sqrt(double v) {
+		ereal<nlimbs> x(std::sqrt(v)), v_val(v), two(2.0);
+		for (int i = 0; i < 10; ++i) {
+			x = (x + v_val / x) / two;
 		}
-
-		std::cout << "  √" << n << " computed with " << x.limbs().size() << " components\n";
-	    std::cout << "  √" << n << " ≈ " << std::setprecision(20) << double(x) << '\n';
-	    std::cout << std::endl;
-
 		return x;
 	}
 
-	// ===================================================================
-	// COMPUTE ln(2) using artanh series
-	// ===================================================================
-	// ln(2) = 2·artanh(1/3) where artanh(x) = x + x^3/3 + x^5/5 + ...
-
+	// ln(2) = 2*artanh(1/3), artanh(x) = x + x^3/3 + x^5/5 + ...
 	template<unsigned nlimbs>
 	ereal<nlimbs> compute_ln2() {
-		std::cout << "Computing ln(2) using artanh series: ln(2) = 2·artanh(1/3)\n";
-
-		// artanh(1/3) = 1/3 + (1/3)^3/3 + (1/3)^5/5 + ...
-		ereal<nlimbs> one(1.0);
-		ereal<nlimbs> three(3.0);
-		ereal<nlimbs> x = one / three;  // x = 1/3
-
+		ereal<nlimbs> one(1.0), three(3.0), two(2.0);
+		ereal<nlimbs> x = one / three;
 		ereal<nlimbs> result(0.0);
-		ereal<nlimbs> x_power = x;  // Start with x^1
+		ereal<nlimbs> x_power = x;
 		ereal<nlimbs> x_squared = x * x;
-
-		int terms = 50;
-		for (int n = 0; n < terms; ++n) {
+		for (int n = 0; n < 50; ++n) {
 			int k = 2 * n + 1;
-			double coeff = 1.0 / k;
-
-			// term = coeff * x_power
-			ereal<nlimbs> term = x_power * coeff;
-			result = result + term;
-
-			// x_power = x_power * x^2
+			result = result + x_power * (1.0 / k);
 			x_power = x_power * x_squared;
 		}
-
-		// ln(2) = 2 · artanh(1/3)
-		ereal<nlimbs> two(2.0);
-		ereal<nlimbs> ln2 = two * result;
-
-		std::cout << "  ln(2) computed with " << ln2.limbs().size() << " components\n";
-	    std::cout << "  ln(2) ≈ " << std::setprecision(20) << double(ln2) << '\n';
-	    std::cout << std::endl;
-
-		return ln2;
+		return two * result;
 	}
 
-	// ===================================================================
-	// HELPER: Extract N components from ereal for qd representation
-	// ===================================================================
-
-	template<unsigned nlimbs>
-	void print_qd_constant(const std::string& name, const ereal<nlimbs>& value) {
-		const std::vector<double>& expansion = value.limbs();
-
-		std::cout << "// " << name << "\n";
-		std::cout << "constexpr double " << name << "_qd[4] = {\n";
-
-		for (size_t i = 0; i < 4; ++i) {
-			if (i < expansion.size()) {
-				std::cout << "    " << std::setprecision(17) << std::scientific << expansion[i];
-			} else {
-				std::cout << "    " << std::setprecision(17) << std::scientific << 0.0;
-			}
-			if (i < 3) std::cout << ",";
-			std::cout << "\n";
+	// -------------------------------------------------------------------------
+	// Priest non-overlap invariant: |e[i+1]| <= ulp(e[i])/2, and no interior
+	// zero components (a renormalised non-zero expansion has none).
+	// -------------------------------------------------------------------------
+	bool priest_nonoverlap(const ereal<19>& v) {
+		const auto& L = v.limbs();
+		for (std::size_t i = 0; i + 1 < L.size(); ++i) {
+			if (L[i] == 0.0) return false;  // interior zero component
+			double half_ulp = std::ldexp(1.0, std::ilogb(L[i]) - 53);  // ulp(e[i])/2
+			if (std::abs(L[i + 1]) > half_ulp) return false;
 		}
-		std::cout << "};\n\n";
+		return true;
 	}
 
-}} // namespace sw::universal
+	// Relative-error check on the projected double.
+	bool close_rel(const ereal<19>& x, double expected, double relTol) {
+		double v = double(x);
+		double diff = std::abs(v - expected);
+		double scale = std::max(std::abs(v), std::abs(expected));
+		return diff <= std::max(1.0e-300, relTol * scale);
+	}
 
-// Main driver
+	// =========================================================================
+	// LEVEL 1: generator value + non-overlap, and algebraic round trips
+	// =========================================================================
+	int VerifyConstantGeneration(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTestCases = 0;
+
+		ereal<19> pi    = compute_pi<19>();
+		ereal<19> e     = compute_e<19>();
+		ereal<19> ln2   = compute_ln2<19>();
+		ereal<19> sqrt2 = compute_sqrt<19>(2.0);
+		ereal<19> sqrt3 = compute_sqrt<19>(3.0);
+		ereal<19> sqrt5 = compute_sqrt<19>(5.0);
+		ereal<19> sqrt7 = compute_sqrt<19>(7.0);
+
+		// --- Known-value projection ---
+		if (reportTestCases) std::cout << "  Generated values match known doubles...\n";
+		{
+			struct { const char* name; ereal<19> v; double known; } cases[] = {
+				{ "pi",    pi,    3.141592653589793 },
+				{ "e",     e,     2.718281828459045 },
+				{ "ln2",   ln2,   0.6931471805599453 },
+				{ "sqrt2", sqrt2, std::sqrt(2.0) },
+				{ "sqrt3", sqrt3, std::sqrt(3.0) },
+				{ "sqrt5", sqrt5, std::sqrt(5.0) },
+			};
+			for (const auto& c : cases) {
+				if (!close_rel(c.v, c.known, 1.0e-15)) {
+					if (reportTestCases) std::cout << "    FAIL " << c.name << " = "
+						<< double(c.v) << " expected " << c.known << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+		}
+
+		// --- Priest non-overlap invariant on every generated expansion ---
+		if (reportTestCases) std::cout << "  Generated expansions satisfy Priest non-overlap...\n";
+		{
+			struct { const char* name; ereal<19> v; } cases[] = {
+				{ "pi", pi }, { "e", e }, { "ln2", ln2 },
+				{ "sqrt2", sqrt2 }, { "sqrt3", sqrt3 }, { "sqrt5", sqrt5 }, { "sqrt7", sqrt7 },
+			};
+			for (const auto& c : cases) {
+				if (!priest_nonoverlap(c.v)) {
+					if (reportTestCases) std::cout << "    FAIL " << c.name
+						<< " violates non-overlap (" << c.v.limbs().size() << " limbs)\n";
+					++nrOfFailedTestCases;
+				}
+			}
+		}
+
+		// --- Round-trip identities on generated constants ---
+
+		// sqrt(n)^2 == n (relative, generated sqrt is many-limb accurate)
+		if (reportTestCases) std::cout << "  Square-root round trip sqrt(n)^2 == n...\n";
+		{
+			struct { double n; ereal<19> r; } cases[] = {
+				{ 2.0, sqrt2 }, { 3.0, sqrt3 }, { 5.0, sqrt5 }, { 7.0, sqrt7 },
+			};
+			for (const auto& c : cases) {
+				double result = double(c.r * c.r);
+				if (std::abs(result - c.n) / c.n > 1.0e-28) {
+					if (reportTestCases) std::cout << "    FAIL sqrt(" << c.n << ")^2 = " << result << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+		}
+
+		// (a*b)/b == a
+		if (reportTestCases) std::cout << "  Multiplicative round trip (a*b)/b == a...\n";
+		{
+			ereal<19> recovered = (pi * e) / e;
+			if (std::abs(double(pi) - double(recovered)) / std::abs(double(pi)) > 1.0e-25) {
+				if (reportTestCases) std::cout << "    FAIL (pi*e)/e != pi\n";
+				++nrOfFailedTestCases;
+			}
+		}
+
+		// (a+b)-b == a (exact)
+		if (reportTestCases) std::cout << "  Additive round trip (a+b)-b == a...\n";
+		{
+			ereal<19> recovered = (sqrt2 + sqrt3) - sqrt3;
+			if (recovered != sqrt2) {
+				if (reportTestCases) std::cout << "    FAIL (sqrt2+sqrt3)-sqrt3 != sqrt2\n";
+				++nrOfFailedTestCases;
+			}
+		}
+
+		// (p/q)*q == p
+		if (reportTestCases) std::cout << "  Rational round trip (p/q)*q == p...\n";
+		{
+			ereal<19> p(7.0), q(13.0);
+			ereal<19> recovered = (p / q) * q;
+			if (std::abs(double(p) - double(recovered)) / double(p) > 1.0e-28) {
+				if (reportTestCases) std::cout << "    FAIL (7/13)*13 != 7\n";
+				++nrOfFailedTestCases;
+			}
+		}
+
+		// ((a+b)*c)/c == a+b
+		if (reportTestCases) std::cout << "  Compound round trip ((a+b)*c)/c == a+b...\n";
+		{
+			ereal<19> sum = sqrt5 + sqrt7;
+			ereal<19> recovered = (sum * pi) / pi;
+			if (std::abs(double(sum) - double(recovered)) / std::abs(double(sum)) > 1.0e-14) {
+				if (reportTestCases) std::cout << "    FAIL ((sqrt5+sqrt7)*pi)/pi != sqrt5+sqrt7\n";
+				++nrOfFailedTestCases;
+			}
+		}
+
+		return nrOfFailedTestCases;
+	}
+
+}  // namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 1
+#	define REGRESSION_LEVEL_4 1
+#endif
+
 int main()
 try {
-	// enable UTF-8 output on Windows consoles
-	ConsoleUTF8 consoleutf8;  // RAII - reset console to original code page on destruction
 	using namespace sw::universal;
 
-	// Use nlimbs = 19 to allow expansions to grow as needed
-	constexpr unsigned nlimbs = 19;
+	std::string test_suite = "ereal constant generation";
+	bool        reportTestCases = true;
+	int         nrOfFailedTestCases = 0;
 
-	std::cout << "========================================================\n";
-	std::cout << "Mathematical Constant Generation using ereal<" << nlimbs << ">\n";
-	std::cout << "========================================================\n\n";
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// Compute fundamental constants
-	ereal<nlimbs> pi = compute_pi<nlimbs>();
-	ereal<nlimbs> e = compute_e<nlimbs>();
-	ereal<nlimbs> sqrt2 = compute_sqrt<nlimbs>(2.0);
-	ereal<nlimbs> ln2 = compute_ln2<nlimbs>();
+#if MANUAL_TESTING
 
-	// Compute additional square roots
-	ereal<nlimbs> sqrt3 = compute_sqrt<nlimbs>(3.0);
-	ereal<nlimbs> sqrt5 = compute_sqrt<nlimbs>(5.0);
-	ereal<nlimbs> sqrt7 = compute_sqrt<nlimbs>(7.0);
-	ereal<nlimbs> sqrt11 = compute_sqrt<nlimbs>(11.0);
+	nrOfFailedTestCases += ReportTestResult(VerifyConstantGeneration(reportTestCases), "ereal", "constant generation manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;  // ignore errors in manual mode
 
-	// ===================================================================
-	// VERIFY CONSTANTS with Mathematical Identities
-	// ===================================================================
+#else
 
-	std::cout << "========================================================\n";
-	std::cout << "VERIFYING CONSTANTS with Mathematical Identities\n";
-	std::cout << "========================================================\n\n";
+	// Deterministic generators -- one pass covers every regression level.
+	nrOfFailedTestCases += ReportTestResult(VerifyConstantGeneration(reportTestCases), "ereal", "constant generation");
 
-	int nrOfFailedTests = 0;
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 
-	// Test 1: Compare against known double values
-	{
-		double pi_val = double(pi);
-		double pi_known = 3.14159265358979323846;
-		double error = std::abs(pi_val - pi_known);
-
-		std::cout << "π compared to known value:\n";
-		std::cout << "  Computed: " << std::setprecision(20) << pi_val << "\n";
-		std::cout << "  Known:    " << std::setprecision(20) << pi_known << "\n";
-		std::cout << "  Error:    " << std::setprecision(6) << std::scientific << error << "\n";
-
-		if (error > 1.0e-15) {
-			std::cout << "  FAIL\n";
-			++nrOfFailedTests;
-		}
-		else {
-			std::cout << "  PASS\n";
-		}
-		std::cout << "\n";
-	}
-
-	{
-		double e_val = double(e);
-		double e_known = 2.71828182845904523536;
-		double error = std::abs(e_val - e_known);
-
-		std::cout << "e compared to known value:\n";
-		std::cout << "  Computed: " << std::setprecision(20) << e_val << "\n";
-		std::cout << "  Known:    " << std::setprecision(20) << e_known << "\n";
-		std::cout << "  Error:    " << std::setprecision(6) << std::scientific << error << "\n";
-
-		if (error > 1.0e-15) {
-			std::cout << "  FAIL\n";
-			++nrOfFailedTests;
-		}
-		else {
-			std::cout << "  PASS\n";
-		}
-		std::cout << "\n";
-	}
-
-	// ===================================================================
-	// ROUND-TRIP VALIDATION TESTS
-	// ===================================================================
-
-	std::cout << "========================================================\n";
-	std::cout << "ROUND-TRIP VALIDATION TESTS (No Oracle Required)\n";
-	std::cout << "========================================================\n\n";
-
-	// Test square roots: sqrt(n)² = n
-	std::cout << "--- Square Root Round-Trip: sqrt(n)² = n ---\n\n";
-
-	std::vector<std::pair<double, ereal<nlimbs>>> sqrt_tests = {
-		{2.0, sqrt2}, {3.0, sqrt3}, {5.0, sqrt5}, {7.0, sqrt7}, {11.0, sqrt11}
-	};
-
-	for (const auto& test : sqrt_tests) {
-		double n = test.first;
-		const ereal<nlimbs>& sqrt_n = test.second;
-
-		ereal<nlimbs> squared = sqrt_n * sqrt_n;
-		double result = double(squared);
-		double error = std::abs(result - n);
-		double rel_error = error / n;
-
-		std::cout << "√" << n << " × √" << n << " = " << n << ":\n";
-		std::cout << "  Result:        " << std::setprecision(20) << result << "\n";
-		std::cout << "  Expected:      " << std::setprecision(20) << n << "\n";
-		std::cout << "  Relative error: " << std::setprecision(6) << std::scientific << rel_error << "\n";
-
-		if (rel_error > 1.0e-28) {
-			std::cout << "  FAIL\n";
-			++nrOfFailedTests;
-		}
-		else {
-			std::cout << "  PASS\n";
-		}
-		std::cout << "\n";
-	}
-
-	// Test arithmetic identities: (a×b)/b = a
-	std::cout << "--- Arithmetic Round-Trip: (a×b)/b = a ---\n\n";
-
-	{
-		ereal<nlimbs> a = pi;
-		ereal<nlimbs> b = e;
-		ereal<nlimbs> product = a * b;
-		ereal<nlimbs> recovered = product / b;
-
-		double a_val = double(a);
-		double recovered_val = double(recovered);
-		double error = std::abs(a_val - recovered_val);
-		double rel_error = error / std::abs(a_val);
-
-		std::cout << "(π × e) / e = π:\n";
-		std::cout << "  Original:      " << std::setprecision(20) << a_val << "\n";
-		std::cout << "  Recovered:     " << std::setprecision(20) << recovered_val << "\n";
-		std::cout << "  Relative error: " << std::setprecision(6) << std::scientific << rel_error << "\n";
-
-		if (rel_error > 1.0e-25) {
-			std::cout << "  FAIL\n";
-			++nrOfFailedTests;
-		}
-		else {
-			std::cout << "  PASS\n";
-		}
-		std::cout << "\n";
-	}
-
-	// Test: (a+b)-b = a
-	std::cout << "--- Addition Round-Trip: (a+b)-b = a ---\n\n";
-
-	{
-		ereal<nlimbs> a = sqrt2;
-		ereal<nlimbs> b = sqrt3;
-		ereal<nlimbs> sum = a + b;
-		ereal<nlimbs> recovered = sum - b;
-
-		double a_val = double(a);
-		double recovered_val = double(recovered);
-		double error = std::abs(a_val - recovered_val);
-		double rel_error = error / std::abs(a_val);
-
-		std::cout << "(√2 + √3) - √3 = √2:\n";
-		std::cout << "  Original:      " << std::setprecision(20) << a_val << "\n";
-		std::cout << "  Recovered:     " << std::setprecision(20) << recovered_val << "\n";
-		std::cout << "  Relative error: " << std::setprecision(6) << std::scientific << rel_error << "\n";
-
-		if (rel_error > 1.0e-28) {
-			std::cout << "  FAIL\n";
-			++nrOfFailedTests;
-		}
-		else {
-			std::cout << "  PASS\n";
-		}
-		std::cout << "\n";
-	}
-
-	// Test rational round-trip: (p/q)×q = p
-	std::cout << "--- Rational Round-Trip: (p/q)×q = p ---\n\n";
-
-	{
-		ereal<nlimbs> p(7.0);
-		ereal<nlimbs> q(13.0);
-		ereal<nlimbs> quotient = p / q;
-		ereal<nlimbs> recovered = quotient * q;
-
-		double p_val = double(p);
-		double recovered_val = double(recovered);
-		double error = std::abs(p_val - recovered_val);
-		double rel_error = error / std::abs(p_val);
-
-		std::cout << "(7/13) × 13 = 7:\n";
-		std::cout << "  Original:      " << std::setprecision(20) << p_val << "\n";
-		std::cout << "  Recovered:     " << std::setprecision(20) << recovered_val << "\n";
-		std::cout << "  Relative error: " << std::setprecision(6) << std::scientific << rel_error << "\n";
-
-		if (rel_error > 1.0e-28) {
-			std::cout << "  FAIL\n";
-			++nrOfFailedTests;
-		}
-		else {
-			std::cout << "  PASS\n";
-		}
-		std::cout << "\n";
-	}
-
-	// Test compound operations: ((a+b)×c)/c = a+b
-	std::cout << "--- Compound Round-Trip: ((a+b)×c)/c = a+b ---\n\n";
-
-	{
-		ereal<nlimbs> a = sqrt5;
-		ereal<nlimbs> b = sqrt7;
-		ereal<nlimbs> c = pi;
-		ereal<nlimbs> sum = a + b;
-		ereal<nlimbs> product = sum * c;
-		ereal<nlimbs> recovered = product / c;
-
-		double sum_val = double(sum);
-		double recovered_val = double(recovered);
-		double error = std::abs(sum_val - recovered_val);
-		double rel_error = error / std::abs(sum_val);
-
-		std::cout << "((√5 + √7) × π) / π = √5 + √7:\n";
-		std::cout << "  Original:      " << std::setprecision(20) << sum_val << "\n";
-		std::cout << "  Recovered:     " << std::setprecision(20) << recovered_val << "\n";
-		std::cout << "  Relative error: " << std::setprecision(6) << std::scientific << rel_error << "\n";
-
-		// More lenient threshold for compound operations due to double conversion rounding
-		if (rel_error > 1.0e-14) {
-			std::cout << "  FAIL\n";
-			++nrOfFailedTests;
-		}
-		else {
-			std::cout << "  PASS\n";
-		}
-		std::cout << "\n";
-	}
-
-	if (nrOfFailedTests == 0) {
-		std::cout << "All validation tests PASSED ✓\n\n";
-	}
-	else {
-		std::cout << "FAILED: " << nrOfFailedTests << " validation tests failed\n\n";
-	}
-
-	// ===================================================================
-	// GENERATE 4-COMPONENT QD REPRESENTATIONS
-	// ===================================================================
-
-	std::cout << "========================================================\n";
-	std::cout << "4-COMPONENT QD REPRESENTATIONS\n";
-	std::cout << "========================================================\n\n";
-
-	std::cout << "// Copy these into your qd/qd_cascade constants file:\n\n";
-
-	print_qd_constant("pi", pi);
-	print_qd_constant("e", e);
-	print_qd_constant("sqrt2", sqrt2);
-	print_qd_constant("sqrt3", sqrt3);
-	print_qd_constant("sqrt5", sqrt5);
-	print_qd_constant("ln2", ln2);
-
-	// Derive related constants
-	ereal<nlimbs> two(2.0);
-	ereal<nlimbs> four(4.0);
-
-	ereal<nlimbs> pi_over_2 = pi / two;
-	print_qd_constant("pi_over_2", pi_over_2);
-
-	ereal<nlimbs> pi_over_4 = pi / four;
-	print_qd_constant("pi_over_4", pi_over_4);
-
-	ereal<nlimbs> one(1.0);
-	ereal<nlimbs> one_over_pi = one / pi;
-	print_qd_constant("one_over_pi", one_over_pi);
-
-	ereal<nlimbs> two_over_pi = two / pi;
-	print_qd_constant("two_over_pi", two_over_pi);
-
-	std::cout << "========================================================\n";
-	std::cout << "Constant generation complete!\n";
-	std::cout << "========================================================\n";
-
-	return (nrOfFailedTests > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& ex) {
 	std::cerr << "Caught exception: " << ex.what() << std::endl;

--- a/elastic/ereal/math/constants/reference_constants.cpp
+++ b/elastic/ereal/math/constants/reference_constants.cpp
@@ -1,51 +1,41 @@
-// reference_constants.cpp: validate ~320-digit reference strings against qd_constants.hpp
+// reference_constants.cpp: regression tests validating ~320-digit reference
+// strings against the precomputed qd expansions.
+//
+// Cross-validates the reference strings in
+// `include/sw/math/constants/reference_constants.hpp` against the precomputed
+// 4-component qd expansions in
+// `include/sw/universal/number/qd/math/constants/qd_constants.hpp` (issue #911).
+//
+// Parse-performance caveat (#913): `ereal<N>::parse()` parses the full
+// 320-digit reference strings in non-tractable time today (Horner accumulation
+// grows `_limb` past maxlimbs). This test therefore uses *truncated* 80-digit
+// substrings, which parse in under 1 ms and still fill the 4-component qd
+// expansion being cross-checked. The full 320-digit strings remain the source
+// of truth in the header (usable once #913 lands).
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-//
-// Resolves issue #911. Cross-validates the reference strings in
-// `include/sw/math/constants/reference_constants.hpp` against the
-// precomputed 4-component qd expansions in
-// `include/sw/universal/number/qd/math/constants/qd_constants.hpp`.
-//
-// IMPORTANT: parse-performance caveat (#913)
-// ------------------------------------------
-// `ereal<N>::parse()` parses the full 320-digit reference strings in
-// non-tractable time today -- the Horner accumulation makes `_limb`
-// grow past maxlimbs, and the per-step cost grows with it. This
-// validation test therefore uses *truncated* 80-digit substrings of
-// the 320-digit reference strings, which parse in under 1 ms and are
-// still enough to fill the 4-component qd expansion we cross-check
-// against.
-//
-// The full 320-digit strings remain the source of truth in the header
-// (they will become usable once #913 lands the parse-complexity fix);
-// this test exercises the strings against the 4-component qd
-// expansion only, which is the strongest cross-check available today.
-
 #include <universal/utility/directives.hpp>
-
+#include <cmath>
+#include <iomanip>
+#include <string>
+#include <string_view>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/number/qd/qd.hpp>
 #include <math/constants/reference_constants.hpp>
 #include <universal/verification/test_suite.hpp>
-
-#include <cmath>
-#include <iomanip>
-#include <iostream>
 
 namespace {
 
 	using sw::universal::ereal;
 	using sw::universal::qd;
 
-	// Parse the first N characters of `sv` into ereal<19>. The factory
-	// helpers in reference_constants.hpp would parse all 320 digits,
-	// which hits the ereal::parse perf cliff (#913); truncating to ~80
-	// chars keeps the cost in the sub-millisecond range while still
-	// producing enough limbs to cover the 4-component qd cross-check.
+	// Parse the first TRUNCATION characters of `sv` into ereal<19>. Parsing all
+	// 320 digits hits the ereal::parse perf cliff (#913); truncating to ~80
+	// chars keeps the cost sub-millisecond while still producing enough limbs to
+	// cover the 4-component qd cross-check.
 	constexpr std::size_t TRUNCATION = 80;
 
 	ereal<19> parse_truncated(std::string_view sv) {
@@ -56,16 +46,12 @@ namespace {
 	}
 
 	// Compare the first 4 components of the parsed ereal<19> against the
-	// 4-component qd expansion. Tolerance per component:
-	// - Leading component must match exactly (it is the leading double
-	//   produced by the parse, which itself comes from the same decimal
-	//   string).
-	// - Trailing components must match to within 2 ulp of the leading
-	//   (so |diff| <= ulp(component[0]) * 2^-52 * 2 = ~ 1e-31 for c0 ~ 1).
-	int compare_qd_expansion(const char* name,
-	                         const ereal<19>& v,
-	                         const qd& reference)
-	{
+	// 4-component qd expansion. The leading component must agree exactly (both
+	// are the IEEE-rounded leading double of the same decimal string); trailing
+	// components may drift a few ULP (different generation paths) and are checked
+	// against a relative tolerance of 1e-30 of the leading component.
+	int compare_qd_expansion(const char* name, const ereal<19>& v, const qd& reference,
+	                         bool reportTestCases) {
 		const auto& comps = v.limbs();
 		bool ok = true;
 
@@ -73,32 +59,23 @@ namespace {
 			double parsed = (static_cast<int>(comps.size()) > i) ? comps[static_cast<size_t>(i)] : 0.0;
 			double ref    = reference[i];
 			if (parsed != ref) {
-				// Trailing components can drift by a few ULP because the
-				// parse and the precomputed expansion came from different
-				// generation paths (qd_constants was hand-curated; the
-				// parse computes via expansion_sum). Allow a relative
-				// drift of 1e-30 of the leading component.
 				double tolerance = std::abs(reference[0]) * 1e-30;
 				if (tolerance == 0.0) tolerance = 1e-310;
 				double diff = std::abs(parsed - ref);
 				if (i == 0) {
-					// The leading component must agree exactly: the parse
-					// produces the IEEE-rounded leading double, and so
-					// does the precomputed table -- both round to the
-					// same value.
 					if (diff != 0.0) {
-						std::cerr << "FAIL " << name << " leading component:\n"
-							<< "  parsed   = " << std::setprecision(17) << parsed << "\n"
-							<< "  qd_expan = " << std::setprecision(17) << ref << "\n";
+						if (reportTestCases) std::cout << "    FAIL " << name << " leading component:"
+							<< " parsed=" << std::setprecision(17) << parsed
+							<< " qd_expan=" << ref << '\n';
 						ok = false;
 					}
 				}
 				else if (diff > tolerance) {
-					std::cerr << "FAIL " << name << " component[" << i << "] drift:\n"
-						<< "  parsed   = " << std::setprecision(17) << parsed << "\n"
-						<< "  qd_expan = " << std::setprecision(17) << ref << "\n"
-						<< "  diff     = " << std::setprecision(3)  << diff << "\n"
-						<< "  tol      = " << std::setprecision(3)  << tolerance << "\n";
+					if (reportTestCases) std::cout << "    FAIL " << name << " component[" << i << "] drift:"
+						<< " parsed=" << std::setprecision(17) << parsed
+						<< " qd_expan=" << ref
+						<< " diff=" << std::setprecision(3) << diff
+						<< " tol=" << tolerance << '\n';
 					ok = false;
 				}
 			}
@@ -106,143 +83,142 @@ namespace {
 		return ok ? 0 : 1;
 	}
 
-	int check_constant(const char* name,
-	                   const ereal<19>& parsed,
-	                   const qd& reference,
-	                   std::size_t min_components_expected)
-	{
+	int check_constant(const char* name, const ereal<19>& parsed, const qd& reference,
+	                   std::size_t min_components_expected, bool reportTestCases) {
 		int failures = 0;
 		const auto& comps = parsed.limbs();
 		if (comps.size() < min_components_expected) {
-			std::cerr << "FAIL " << name << ": parsed produced "
+			if (reportTestCases) std::cout << "    FAIL " << name << ": parsed produced "
 				<< comps.size() << " components, expected at least "
-				<< min_components_expected << "\n";
+				<< min_components_expected << '\n';
 			++failures;
 		}
-		failures += compare_qd_expansion(name, parsed, reference);
+		failures += compare_qd_expansion(name, parsed, reference, reportTestCases);
 		return failures;
 	}
 
+	// Sanity: parsed value (as double) matches the known double approximation
+	// within double precision. Catches gross parse errors for constants without
+	// a qd counterpart.
+	int check_double(const char* name, std::string_view sv, double expected, double tol,
+	                 bool reportTestCases) {
+		double sum = double(parse_truncated(sv));
+		if (std::abs(sum - expected) > tol) {
+			if (reportTestCases) std::cout << "    FAIL double(parse(" << name << "[80])) = "
+				<< std::setprecision(17) << sum << ", expected " << expected << '\n';
+			return 1;
+		}
+		return 0;
+	}
+
+	// =========================================================================
+	// LEVEL 1: each named reference constant cross-checked against qd_constants
+	// =========================================================================
+	int VerifyReferenceConstants(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTestCases = 0;
+
+		// The min-components argument is the minimum number of materialised
+		// components the parse must produce -- fewer than 4 means the parse is
+		// silently truncating.
+		constexpr std::size_t MIN_COMPS = 4;
+
+		if (reportTestCases) std::cout << "  pi family...\n";
+		nrOfFailedTestCases += check_constant("pi",     parse_truncated(s_pi),     qd_pi,   MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("pi_2",   parse_truncated(s_pi_2),   qd_pi_2, MIN_COMPS, reportTestCases);
+		// pi_3 cross-check skipped: qd_pi_3 holds the wrong leading value
+		// (~ pi/2) and only 2 components -- pre-existing transcription bug #914.
+		nrOfFailedTestCases += check_constant("pi_4",   parse_truncated(s_pi_4),   qd_pi_4, MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("two_pi", parse_truncated(s_two_pi), qd_2pi,  MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("inv_pi", parse_truncated(s_inv_pi), qd_1_pi, MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("two_inv_pi", parse_truncated(s_two_inv_pi), qd_2_pi, MIN_COMPS, reportTestCases);
+
+		if (reportTestCases) std::cout << "  e family...\n";
+		nrOfFailedTestCases += check_constant("e",     parse_truncated(s_e),     qd_e,   MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("inv_e", parse_truncated(s_inv_e), qd_1_e, MIN_COMPS, reportTestCases);
+
+		if (reportTestCases) std::cout << "  phi family...\n";
+		nrOfFailedTestCases += check_constant("phi",     parse_truncated(s_phi),     qd_phi,   MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("inv_phi", parse_truncated(s_inv_phi), qd_1_phi, MIN_COMPS, reportTestCases);
+
+		if (reportTestCases) std::cout << "  roots...\n";
+		nrOfFailedTestCases += check_constant("sqrt2",     parse_truncated(s_sqrt2),     qd_sqrt2,   MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("sqrt3",     parse_truncated(s_sqrt3),     qd_sqrt3,   MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("sqrt5",     parse_truncated(s_sqrt5),     qd_sqrt5,   MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("inv_sqrt2", parse_truncated(s_inv_sqrt2), qd_1_sqrt2, MIN_COMPS, reportTestCases);
+
+		if (reportTestCases) std::cout << "  logarithms...\n";
+		nrOfFailedTestCases += check_constant("ln2",  parse_truncated(s_ln2),  qd_ln2,  MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("ln10", parse_truncated(s_ln10), qd_ln10, MIN_COMPS, reportTestCases);
+		// qd_constants.hpp uses short names: qd_lge=log2(e), qd_lg10=log2(10),
+		// qd_loge=log10(e), qd_log2=log10(2). Pin each string to the right qd.
+		nrOfFailedTestCases += check_constant("log2e",   parse_truncated(s_log2e),   qd_lge,  MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("log2_10", parse_truncated(s_log2_10), qd_lg10, MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("log10e",  parse_truncated(s_log10e),  qd_loge, MIN_COMPS, reportTestCases);
+		nrOfFailedTestCases += check_constant("log10_2", parse_truncated(s_log10_2), qd_log2, MIN_COMPS, reportTestCases);
+
+		if (reportTestCases) std::cout << "  erf scaling...\n";
+		nrOfFailedTestCases += check_constant("two_over_sqrt_pi",
+		                                      parse_truncated(s_two_over_sqrt_pi), qd_2_sqrtpi, MIN_COMPS, reportTestCases);
+
+		// Constants with no qd counterpart (s_three_pi, s_euler_gamma) -- checked
+		// via the as-double sanity below.
+		if (reportTestCases) std::cout << "  as-double sanity...\n";
+		nrOfFailedTestCases += check_double("s_pi",          s_pi,          3.141592653589793, 1e-14, reportTestCases);
+		nrOfFailedTestCases += check_double("s_e",           s_e,           2.718281828459045, 1e-14, reportTestCases);
+		nrOfFailedTestCases += check_double("s_three_pi",    s_three_pi,    3.0 * 3.141592653589793, 1e-13, reportTestCases);
+		nrOfFailedTestCases += check_double("s_euler_gamma", s_euler_gamma, 0.5772156649015329, 1e-15, reportTestCases);
+
+		return nrOfFailedTestCases;
+	}
+
 }  // namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 1
+#	define REGRESSION_LEVEL_4 1
+#endif
 
 int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite = "issue #911: reference string constants vs qd_constants.hpp";
-	int nrOfFailedTestCases = 0;
+	std::string test_suite = "ereal reference constants";
+	bool        reportTestCases = true;
+	int         nrOfFailedTestCases = 0;
 
-	ReportTestSuiteHeader(test_suite, false);
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// Parse each reference string into ereal<19>; compare to qd_<name>
-	// for the constants that have a qd expansion. The min-components
-	// argument is the minimum number of materialised components the
-	// parse must produce -- anything less than 4 indicates the parse
-	// is silently truncating.
-	constexpr std::size_t MIN_COMPS = 4;
+#if MANUAL_TESTING
 
-	nrOfFailedTestCases += check_constant("pi",     parse_truncated(s_pi),     qd_pi,     MIN_COMPS);
-	nrOfFailedTestCases += check_constant("pi_2",   parse_truncated(s_pi_2),   qd_pi_2,   MIN_COMPS);
-	// pi_3 cross-check skipped: qd_pi_3 in qd_constants.hpp holds the
-	// wrong leading value (~ pi/2 instead of pi/3) and only 2 components
-	// instead of 4 -- a pre-existing transcription bug independent of
-	// this PR. Tracked in issue #914.
-	nrOfFailedTestCases += check_constant("pi_4",   parse_truncated(s_pi_4),   qd_pi_4,   MIN_COMPS);
-	nrOfFailedTestCases += check_constant("two_pi", parse_truncated(s_two_pi), qd_2pi,    MIN_COMPS);
+	nrOfFailedTestCases += ReportTestResult(VerifyReferenceConstants(reportTestCases), "ereal", "reference constants manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;  // ignore errors in manual mode
 
-	nrOfFailedTestCases += check_constant("inv_pi", parse_truncated(s_inv_pi), qd_1_pi,   MIN_COMPS);
-	nrOfFailedTestCases += check_constant("two_inv_pi", parse_truncated(s_two_inv_pi), qd_2_pi, MIN_COMPS);
+#else
 
-	nrOfFailedTestCases += check_constant("e",     parse_truncated(s_e),     qd_e,     MIN_COMPS);
-	nrOfFailedTestCases += check_constant("inv_e", parse_truncated(s_inv_e), qd_1_e,   MIN_COMPS);
-
-	nrOfFailedTestCases += check_constant("phi",     parse_truncated(s_phi),     qd_phi,     MIN_COMPS);
-	nrOfFailedTestCases += check_constant("inv_phi", parse_truncated(s_inv_phi), qd_1_phi,   MIN_COMPS);
-
-	nrOfFailedTestCases += check_constant("sqrt2",     parse_truncated(s_sqrt2),     qd_sqrt2,    MIN_COMPS);
-	nrOfFailedTestCases += check_constant("sqrt3",     parse_truncated(s_sqrt3),     qd_sqrt3,    MIN_COMPS);
-	nrOfFailedTestCases += check_constant("sqrt5",     parse_truncated(s_sqrt5),     qd_sqrt5,    MIN_COMPS);
-	nrOfFailedTestCases += check_constant("inv_sqrt2", parse_truncated(s_inv_sqrt2), qd_1_sqrt2,  MIN_COMPS);
-
-	nrOfFailedTestCases += check_constant("ln2",  parse_truncated(s_ln2),  qd_ln2,  MIN_COMPS);
-	nrOfFailedTestCases += check_constant("ln10", parse_truncated(s_ln10), qd_ln10, MIN_COMPS);
-
-	// log-related: qd_constants.hpp uses unusual short names -- qd_lge
-	// = log2(e), qd_lg10 = log2(10), qd_loge = log10(e), qd_log2 =
-	// log10(2). The mapping below pins each reference string to the
-	// correct qd constant despite the naming mismatch.
-	nrOfFailedTestCases += check_constant("log2e",   parse_truncated(s_log2e),   qd_lge,  MIN_COMPS);
-	nrOfFailedTestCases += check_constant("log2_10", parse_truncated(s_log2_10), qd_lg10, MIN_COMPS);
-	nrOfFailedTestCases += check_constant("log10e",  parse_truncated(s_log10e),  qd_loge, MIN_COMPS);
-	nrOfFailedTestCases += check_constant("log10_2", parse_truncated(s_log10_2), qd_log2, MIN_COMPS);
-
-	// erf scaling
-	nrOfFailedTestCases += check_constant("two_over_sqrt_pi",
-	                                      parse_truncated(s_two_over_sqrt_pi),
-	                                      qd_2_sqrtpi,
-	                                      MIN_COMPS);
-
-	// Constants with no qd counterpart in qd_constants.hpp -- skipped
-	// here, but exercised via the as-double sanity check below:
-	//   s_three_pi   -- no qd_3pi (only qd_3pi_4 = 3*pi/4)
-	//   s_euler_gamma -- no qd_euler_gamma
-
-	// Sanity: parsed value sums (as double) match the std::numbers
-	// approximation to within double precision. Catches gross parse
-	// errors.
-	{
-		ereal<19> pi19 = parse_truncated(s_pi);
-		double sum = double(pi19);
-		double expected = 3.141592653589793;  // double(pi)
-		if (std::abs(sum - expected) > 1e-14) {
-			std::cerr << "FAIL: double(parse(s_pi[80])) = "
-				<< std::setprecision(17) << sum
-				<< ", expected " << expected << "\n";
-			++nrOfFailedTestCases;
-		}
-	}
-	{
-		ereal<19> e19 = parse_truncated(s_e);
-		double sum = double(e19);
-		double expected = 2.718281828459045;  // double(e)
-		if (std::abs(sum - expected) > 1e-14) {
-			std::cerr << "FAIL: double(parse(s_e[80])) = "
-				<< std::setprecision(17) << sum
-				<< ", expected " << expected << "\n";
-			++nrOfFailedTestCases;
-		}
-	}
-	{
-		ereal<19> three_pi19 = parse_truncated(s_three_pi);
-		double sum = double(three_pi19);
-		double expected = 3.0 * 3.141592653589793;
-		if (std::abs(sum - expected) > 1e-13) {
-			std::cerr << "FAIL: double(parse(s_three_pi[80])) = "
-				<< std::setprecision(17) << sum
-				<< ", expected " << expected << "\n";
-			++nrOfFailedTestCases;
-		}
-	}
-	{
-		ereal<19> gamma19 = parse_truncated(s_euler_gamma);
-		double sum = double(gamma19);
-		double expected = 0.5772156649015329;
-		if (std::abs(sum - expected) > 1e-15) {
-			std::cerr << "FAIL: double(parse(s_euler_gamma[80])) = "
-				<< std::setprecision(17) << sum
-				<< ", expected " << expected << "\n";
-			++nrOfFailedTestCases;
-		}
-	}
+	// The cross-check is deterministic (parses fixed reference strings), so a
+	// single pass suffices at every regression level.
+	nrOfFailedTestCases += ReportTestResult(VerifyReferenceConstants(reportTestCases), "ereal", "reference constants");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
-}
-catch (char const* msg) {
-	std::cerr << "Caught ad-hoc exception: " << msg << '\n';
-	return EXIT_FAILURE;
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
 	std::cerr << "Caught exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception\n";
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
## Summary
Refactors both files in `elastic/ereal/math/constants/` to the standard regression framework (`MANUAL_TESTING` + `REGRESSION_LEVEL` guards, anonymous-namespace `Verify*`, `ReportTestSuiteHeader`/`ReportTestResult`/`ReportTestSuiteResults`, `reportTestCases`-gated output).

Relates to #944 (parent epic, Phase B). Resolves #949.

## Changes
- **`reference_constants.cpp`** -- wrap the qd cross-checks into `VerifyReferenceConstants(reportTestCases)`; the parse/compare helpers now take `reportTestCases` and emit standard `FAIL` lines instead of unconditional `std::cerr`. Grouped checks (pi/e/phi/roots/logs/erf) and folded the as-double sanity checks into a `check_double` helper. **Validation logic unchanged** (80-digit truncated parse vs the 4-component qd expansion, per the #913 caveat).
- **`constant_generation.cpp`** (demo -> regression test) -- keep the generators (Machin pi, Taylor e, Newton-Raphson sqrt, artanh ln2) but strip all `std::cout` narration, the qd-table printing, the `console_utf8` dependency, and every non-ASCII character. Add a `priest_nonoverlap()` predicate (`|e[i+1]| <= ulp(e[i])/2`, no interior zeros) and `VerifyConstantGeneration(reportTestCases)` that checks each generated constant against (1) its known double and (2) the non-overlap invariant, plus the algebraic round-trip identities.

## Coverage (per #949)
- `reference_constants.cpp`: each named constant (pi, e, ln2, phi, roots, logs, erf scaling) cross-checked against `qd_constants.hpp`; as-double sanity for the qd-less constants.
- `constant_generation.cpp`: generators verified to produce blocks satisfying **Priest's non-overlap invariant**, plus known-value and round-trip checks.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_const_reference_constants | OK | PASS | OK | PASS |
| er_const_constant_generation | OK | PASS | OK | PASS |

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)