### PR TITLE
feat(ereal): standardize math/functions classify/numerics/truncate/minmax/next (#950 cat 1)

### DIFF
--- a/elastic/ereal/math/functions/classify.cpp
+++ b/elastic/ereal/math/functions/classify.cpp
@@ -8,8 +8,8 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify isfinite function
 		template<typename Real>
@@ -19,21 +19,21 @@ namespace sw {
 			// Test: isfinite(2.0) == true
 			Real x(2.0);
 			if (!isfinite(x)) {
-				if (reportTestCases) std::cerr << "FAIL: isfinite(2.0) != true\n";
+				if (reportTestCases) std::cout << "    FAIL isfinite(2.0) != true\n";
 				++nrOfFailedTestCases;
 			}
 
 			// Test: isfinite(-1.0) == true
 			x = -1.0;
 			if (!isfinite(x)) {
-				if (reportTestCases) std::cerr << "FAIL: isfinite(-1.0) != true\n";
+				if (reportTestCases) std::cout << "    FAIL isfinite(-1.0) != true\n";
 				++nrOfFailedTestCases;
 			}
 
 			// Test: isfinite(0.0) == true
 			Real zero(0.0);
 			if (!isfinite(zero)) {
-				if (reportTestCases) std::cerr << "FAIL: isfinite(0.0) != true\n";
+				if (reportTestCases) std::cout << "    FAIL isfinite(0.0) != true\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -48,7 +48,7 @@ namespace sw {
 			// Test: isnan(2.0) == false (normal values are not NaN)
 			Real x(2.0);
 			if (isnan(x)) {
-				if (reportTestCases) std::cerr << "FAIL: isnan(2.0) != false\n";
+				if (reportTestCases) std::cout << "    FAIL isnan(2.0) != false\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -63,7 +63,7 @@ namespace sw {
 			// Test: isinf(2.0) == false (normal values are not infinite)
 			Real x(2.0);
 			if (isinf(x)) {
-				if (reportTestCases) std::cerr << "FAIL: isinf(2.0) != false\n";
+				if (reportTestCases) std::cout << "    FAIL isinf(2.0) != false\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -78,21 +78,21 @@ namespace sw {
 			// Test: isnormal(2.0) == true
 			Real x(2.0);
 			if (!isnormal(x)) {
-				if (reportTestCases) std::cerr << "FAIL: isnormal(2.0) != true\n";
+				if (reportTestCases) std::cout << "    FAIL isnormal(2.0) != true\n";
 				++nrOfFailedTestCases;
 			}
 
 			// Test: isnormal(-1.0) == true
 			x = -1.0;
 			if (!isnormal(x)) {
-				if (reportTestCases) std::cerr << "FAIL: isnormal(-1.0) != true\n";
+				if (reportTestCases) std::cout << "    FAIL isnormal(-1.0) != true\n";
 				++nrOfFailedTestCases;
 			}
 
 			// Test: isnormal(0.0) == false (zero is not normal)
 			Real zero(0.0);
 			if (isnormal(zero)) {
-				if (reportTestCases) std::cerr << "FAIL: isnormal(0.0) != false\n";
+				if (reportTestCases) std::cout << "    FAIL isnormal(0.0) != false\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -107,21 +107,21 @@ namespace sw {
 			// Test: signbit(2.0) == false
 			Real pos(2.0);
 			if (signbit(pos)) {
-				if (reportTestCases) std::cerr << "FAIL: signbit(2.0) != false\n";
+				if (reportTestCases) std::cout << "    FAIL signbit(2.0) != false\n";
 				++nrOfFailedTestCases;
 			}
 
 			// Test: signbit(-1.0) == true
 			Real neg(-1.0);
 			if (!signbit(neg)) {
-				if (reportTestCases) std::cerr << "FAIL: signbit(-1.0) != true\n";
+				if (reportTestCases) std::cout << "    FAIL signbit(-1.0) != true\n";
 				++nrOfFailedTestCases;
 			}
 
 			// Test: signbit(0.0) == false
 			Real zero(0.0);
 			if (signbit(zero)) {
-				if (reportTestCases) std::cerr << "FAIL: signbit(0.0) != false\n";
+				if (reportTestCases) std::cout << "    FAIL signbit(0.0) != false\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -136,22 +136,21 @@ namespace sw {
 			// Test: fpclassify(2.0) == FP_NORMAL
 			Real normal(2.0);
 			if (fpclassify(normal) != FP_NORMAL) {
-				if (reportTestCases) std::cerr << "FAIL: fpclassify(2.0) != FP_NORMAL\n";
+				if (reportTestCases) std::cout << "    FAIL fpclassify(2.0) != FP_NORMAL\n";
 				++nrOfFailedTestCases;
 			}
 
 			// Test: fpclassify(0.0) == FP_ZERO
 			Real zero(0.0);
 			if (fpclassify(zero) != FP_ZERO) {
-				if (reportTestCases) std::cerr << "FAIL: fpclassify(0.0) != FP_ZERO\n";
+				if (reportTestCases) std::cout << "    FAIL fpclassify(0.0) != FP_ZERO\n";
 				++nrOfFailedTestCases;
 			}
 
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+}  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -175,7 +174,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib classification function validation";
 	std::string test_tag    = "classification";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);

--- a/elastic/ereal/math/functions/classify.cpp
+++ b/elastic/ereal/math/functions/classify.cpp
@@ -8,6 +8,10 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <cmath>
+#include <limits>
+#include <random>
+
 namespace {
 	using namespace sw::universal;
 
@@ -52,6 +56,13 @@ namespace {
 				++nrOfFailedTestCases;
 			}
 
+			// Special value: isnan(NaN) == true
+			Real nan(std::numeric_limits<double>::quiet_NaN());
+			if (!isnan(nan)) {
+				if (reportTestCases) std::cout << "    FAIL isnan(NaN) != true\n";
+				++nrOfFailedTestCases;
+			}
+
 			return nrOfFailedTestCases;
 		}
 
@@ -64,6 +75,18 @@ namespace {
 			Real x(2.0);
 			if (isinf(x)) {
 				if (reportTestCases) std::cout << "    FAIL isinf(2.0) != false\n";
+				++nrOfFailedTestCases;
+			}
+
+			// Special values: isinf(+/-Inf) == true and isfinite(Inf) == false
+			Real pinf(std::numeric_limits<double>::infinity());
+			Real ninf(-std::numeric_limits<double>::infinity());
+			if (!isinf(pinf) || !isinf(ninf)) {
+				if (reportTestCases) std::cout << "    FAIL isinf(+/-Inf) != true\n";
+				++nrOfFailedTestCases;
+			}
+			if (isfinite(pinf)) {
+				if (reportTestCases) std::cout << "    FAIL isfinite(Inf) != false\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -147,6 +170,49 @@ namespace {
 				++nrOfFailedTestCases;
 			}
 
+			// Special values: fpclassify(Inf) == FP_INFINITE, fpclassify(NaN) == FP_NAN
+			Real inf(std::numeric_limits<double>::infinity());
+			if (fpclassify(inf) != FP_INFINITE) {
+				if (reportTestCases) std::cout << "    FAIL fpclassify(Inf) != FP_INFINITE\n";
+				++nrOfFailedTestCases;
+			}
+			Real nan(std::numeric_limits<double>::quiet_NaN());
+			if (fpclassify(nan) != FP_NAN) {
+				if (reportTestCases) std::cout << "    FAIL fpclassify(NaN) != FP_NAN\n";
+				++nrOfFailedTestCases;
+			}
+
+			return nrOfFailedTestCases;
+		}
+
+		// Property fuzzer: over random finite values, the classification
+		// predicates are mutually consistent and signbit matches the projection.
+		template<typename Real>
+		int VerifyClassifyFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(-1.0e6, 1.0e6);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double d = dist(rng);
+				Real x(d);
+				// finite normal/zero inputs: finite and not nan/inf
+				if (!isfinite(x) || isnan(x) || isinf(x)) {
+					if (reportTestCases) std::cout << "    FAIL classify consistency at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+				// signbit agrees with the double projection
+				if (signbit(x) != std::signbit(d)) {
+					if (reportTestCases) std::cout << "    FAIL signbit mismatch at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+				// exactly one of {normal, zero} holds for a finite value
+				bool normal = isnormal(x);
+				bool zero = (d == 0.0);
+				if (normal == zero) {
+					if (reportTestCases) std::cout << "    FAIL normal/zero partition at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
 			return nrOfFailedTestCases;
 		}
 
@@ -214,7 +280,8 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Future: Tests with special values (if supported)
+	test_tag = "classify fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyClassifyFuzz<ereal<>>(reportTestCases, 1000), "classify(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/minmax.cpp
+++ b/elastic/ereal/math/functions/minmax.cpp
@@ -8,8 +8,8 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify min function
 		template<typename Real>
@@ -20,7 +20,7 @@ namespace sw {
 			Real x(3.0), y(4.0);
 			Real result = min(x, y);
 			if (result != x) {
-				if (reportTestCases) std::cerr << "FAIL: min(3.0, 4.0) != 3.0\n";
+				if (reportTestCases) std::cout << "    FAIL min(3.0, 4.0) != 3.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -28,7 +28,7 @@ namespace sw {
 			x = 5.0; y = 5.0;
 			result = min(x, y);
 			if (result != x) {
-				if (reportTestCases) std::cerr << "FAIL: min(5.0, 5.0) != 5.0\n";
+				if (reportTestCases) std::cout << "    FAIL min(5.0, 5.0) != 5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -36,7 +36,7 @@ namespace sw {
 			x = -3.0; y = -1.0;
 			result = min(x, y);
 			if (result != x) {
-				if (reportTestCases) std::cerr << "FAIL: min(-3.0, -1.0) != -3.0\n";
+				if (reportTestCases) std::cout << "    FAIL min(-3.0, -1.0) != -3.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -44,7 +44,7 @@ namespace sw {
 			Real zero(0.0), pos(1.0);
 			result = min(zero, pos);
 			if (result != zero) {
-				if (reportTestCases) std::cerr << "FAIL: min(0.0, 1.0) != 0.0\n";
+				if (reportTestCases) std::cout << "    FAIL min(0.0, 1.0) != 0.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -52,7 +52,7 @@ namespace sw {
 			Real neg(-1.0);
 			result = min(neg, zero);
 			if (result != neg) {
-				if (reportTestCases) std::cerr << "FAIL: min(-1.0, 0.0) != -1.0\n";
+				if (reportTestCases) std::cout << "    FAIL min(-1.0, 0.0) != -1.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -68,7 +68,7 @@ namespace sw {
 			Real x(3.0), y(4.0);
 			Real result = max(x, y);
 			if (result != y) {
-				if (reportTestCases) std::cerr << "FAIL: max(3.0, 4.0) != 4.0\n";
+				if (reportTestCases) std::cout << "    FAIL max(3.0, 4.0) != 4.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -76,7 +76,7 @@ namespace sw {
 			x = 5.0; y = 5.0;
 			result = max(x, y);
 			if (result != x) {
-				if (reportTestCases) std::cerr << "FAIL: max(5.0, 5.0) != 5.0\n";
+				if (reportTestCases) std::cout << "    FAIL max(5.0, 5.0) != 5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -84,7 +84,7 @@ namespace sw {
 			x = -3.0; y = -1.0;
 			result = max(x, y);
 			if (result != y) {
-				if (reportTestCases) std::cerr << "FAIL: max(-3.0, -1.0) != -1.0\n";
+				if (reportTestCases) std::cout << "    FAIL max(-3.0, -1.0) != -1.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -92,7 +92,7 @@ namespace sw {
 			Real zero(0.0), pos(1.0);
 			result = max(zero, pos);
 			if (result != pos) {
-				if (reportTestCases) std::cerr << "FAIL: max(0.0, 1.0) != 1.0\n";
+				if (reportTestCases) std::cout << "    FAIL max(0.0, 1.0) != 1.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -100,15 +100,14 @@ namespace sw {
 			Real neg(-1.0);
 			result = max(neg, zero);
 			if (result != zero) {
-				if (reportTestCases) std::cerr << "FAIL: max(-1.0, 0.0) != 0.0\n";
+				if (reportTestCases) std::cout << "    FAIL max(-1.0, 0.0) != 0.0\n";
 				++nrOfFailedTestCases;
 			}
 
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+}  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -132,7 +131,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib min/max function validation";
 	std::string test_tag    = "minmax";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);

--- a/elastic/ereal/math/functions/minmax.cpp
+++ b/elastic/ereal/math/functions/minmax.cpp
@@ -8,6 +8,10 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <cmath>
+#include <limits>
+#include <random>
+
 namespace {
 	using namespace sw::universal;
 
@@ -107,6 +111,40 @@ namespace {
 			return nrOfFailedTestCases;
 		}
 
+		// Property fuzzer: ordering, the min+max == a+b conservation, commutativity,
+		// and the min(a,b) == -max(-a,-b) reflection, over random pairs.
+		template<typename Real>
+		int VerifyMinMaxFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(-1.0e6, 1.0e6);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				Real a(dist(rng)), b(dist(rng));
+				Real mn = min(a, b), mx = max(a, b);
+				// ordering: mn <= a,b and mx >= a,b
+				if (mn > a || mn > b || mx < a || mx < b) {
+					if (reportTestCases) std::cout << "    FAIL ordering\n";
+					++nrOfFailedTestCases;
+				}
+				// conservation: {mn,mx} is a permutation of {a,b}, so mn+mx == a+b exactly
+				if (mn + mx != a + b) {
+					if (reportTestCases) std::cout << "    FAIL min+max != a+b\n";
+					++nrOfFailedTestCases;
+				}
+				// commutativity
+				if (min(a, b) != min(b, a) || max(a, b) != max(b, a)) {
+					if (reportTestCases) std::cout << "    FAIL commutativity\n";
+					++nrOfFailedTestCases;
+				}
+				// reflection: min(a,b) == -max(-a,-b)
+				if (min(a, b) != -max(-a, -b)) {
+					if (reportTestCases) std::cout << "    FAIL min/max reflection\n";
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
 }  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
@@ -158,7 +196,8 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Future: Extended tests with special values
+	test_tag = "minmax fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyMinMaxFuzz<ereal<>>(reportTestCases, 1000), "minmax(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/next.cpp
+++ b/elastic/ereal/math/functions/next.cpp
@@ -8,8 +8,8 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 	// Verify nextafter function
     template<typename Real>
@@ -29,7 +29,7 @@ namespace sw {
 	    // error_mag = std::abs(double(result - expected));
 	    if (!result.iszero()) {
 		    if (reportTestCases)
-			    std::cerr << "FAIL: nextafter(0, 0) != 0\n";
+			    std::cout << "    FAIL nextafter(0, 0) != 0\n";
 		    ++nrOfFailedTestCases;
 	    }
 
@@ -40,7 +40,7 @@ namespace sw {
 	    result    = nextafter(x, y);
 	    if (result != expected) {
 		    if (reportTestCases) {
-			    std::cerr << "FAIL: nextafter(1.0, 2.0) != 1.0 + ulp(1.0)\n";
+			    std::cout << "    FAIL nextafter(1.0, 2.0) != 1.0 + ulp(1.0)\n";
 			    std::cerr << "  expected: " << to_binary(expected) << " : " << expected << '\n';
 			    std::cerr << "    result: " << to_binary(result) << " : " << result << '\n';
 		    }
@@ -54,7 +54,7 @@ namespace sw {
 	    result   = nextafter(x, y);
 	    if (result != expected) {
 		    if (reportTestCases) {
-			    std::cerr << "FAIL: nextafter(1.0, 0.5) != 1.0 - ulp(1.0)\n";
+			    std::cout << "    FAIL nextafter(1.0, 0.5) != 1.0 - ulp(1.0)\n";
 				std::cerr << "  expected: " << to_binary(expected) << " : " << expected << '\n';
 				std::cerr << "    result: " << to_binary(result) << " : " << result << '\n';
 			}
@@ -64,9 +64,7 @@ namespace sw {
 	    return nrOfFailedTestCases;
     }
 
-	} // namespace universal
- }  // namespace sw
-
+}  // anonymous namespace
     // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
 // REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity

--- a/elastic/ereal/math/functions/next.cpp
+++ b/elastic/ereal/math/functions/next.cpp
@@ -8,6 +8,10 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <cmath>
+#include <limits>
+#include <random>
+
 namespace {
 	using namespace sw::universal;
 
@@ -41,8 +45,8 @@ namespace {
 	    if (result != expected) {
 		    if (reportTestCases) {
 			    std::cout << "    FAIL nextafter(1.0, 2.0) != 1.0 + ulp(1.0)\n";
-			    std::cerr << "  expected: " << to_binary(expected) << " : " << expected << '\n';
-			    std::cerr << "    result: " << to_binary(result) << " : " << result << '\n';
+			    std::cout << "      expected: " << to_binary(expected) << " : " << expected << '\n';
+			    std::cout << "      result:   " << to_binary(result) << " : " << result << '\n';
 		    }
 		    ++nrOfFailedTestCases;
 	    }
@@ -55,14 +59,45 @@ namespace {
 	    if (result != expected) {
 		    if (reportTestCases) {
 			    std::cout << "    FAIL nextafter(1.0, 0.5) != 1.0 - ulp(1.0)\n";
-				std::cerr << "  expected: " << to_binary(expected) << " : " << expected << '\n';
-				std::cerr << "    result: " << to_binary(result) << " : " << result << '\n';
+				std::cout << "      expected: " << to_binary(expected) << " : " << expected << '\n';
+				std::cout << "      result:   " << to_binary(result) << " : " << result << '\n';
 			}
 		    ++nrOfFailedTestCases;
 	    }
 
 	    return nrOfFailedTestCases;
     }
+
+	// Property fuzzer: nextafter(x,x) is a no-op, stepping toward +/-Inf is
+	// strictly monotone, and one step up then one step down round-trips.
+	template<typename Real>
+	int VerifyNextFuzz(bool reportTestCases, unsigned nrIterations) {
+		int nrOfFailedTestCases = 0;
+		std::mt19937_64 rng(0xC1A55'1FFEULL);
+		std::uniform_real_distribution<double> dist(-1.0e6, 1.0e6);
+		Real pinf(std::numeric_limits<double>::infinity());
+		Real ninf(-std::numeric_limits<double>::infinity());
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			Real x(dist(rng));
+			if (nextafter(x, x) != x) {
+				if (reportTestCases) std::cout << "    FAIL nextafter(x,x) != x\n";
+				++nrOfFailedTestCases;
+			}
+			if (!(nextafter(x, pinf) > x)) {
+				if (reportTestCases) std::cout << "    FAIL nextafter(x,+Inf) not > x\n";
+				++nrOfFailedTestCases;
+			}
+			if (!(nextafter(x, ninf) < x)) {
+				if (reportTestCases) std::cout << "    FAIL nextafter(x,-Inf) not < x\n";
+				++nrOfFailedTestCases;
+			}
+			if (nextafter(nextafter(x, pinf), ninf) != x) {
+				if (reportTestCases) std::cout << "    FAIL nextafter up/down roundtrip\n";
+				++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
 
 }  // anonymous namespace
     // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
@@ -124,7 +159,8 @@ try {
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	// Extended precision nextafter/nexttoward functionality
+	nrOfFailedTestCases +=
+	    ReportTestResult(VerifyNextFuzz<ereal<>>(reportTestCases, 1000), "nextafter(ereal) fuzz", test_tag);
 #	endif
 
 #	if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/numerics.cpp
+++ b/elastic/ereal/math/functions/numerics.cpp
@@ -8,8 +8,8 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify copysign function
 		template<typename Real>
@@ -20,7 +20,7 @@ namespace sw {
 			Real x(5.0), y(-3.0), expected(-5.0);
 			Real result = copysign(x, y);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: copysign(5.0, -3.0) != -5.0\n";
+				if (reportTestCases) std::cout << "    FAIL copysign(5.0, -3.0) != -5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -28,7 +28,7 @@ namespace sw {
 			x = -5.0; y = 3.0; expected = 5.0;
 			result = copysign(x, y);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: copysign(-5.0, 3.0) != 5.0\n";
+				if (reportTestCases) std::cout << "    FAIL copysign(-5.0, 3.0) != 5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -36,7 +36,7 @@ namespace sw {
 			x = 5.0; y = 3.0; expected = 5.0;
 			result = copysign(x, y);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: copysign(5.0, 3.0) != 5.0\n";
+				if (reportTestCases) std::cout << "    FAIL copysign(5.0, 3.0) != 5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -44,7 +44,7 @@ namespace sw {
 			x = -5.0; y = -3.0; expected = -5.0;
 			result = copysign(x, y);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: copysign(-5.0, -3.0) != -5.0\n";
+				if (reportTestCases) std::cout << "    FAIL copysign(-5.0, -3.0) != -5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -60,7 +60,7 @@ namespace sw {
 			Real x(1.0), expected(8.0);
 			Real result = ldexp(x, 3);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: ldexp(1.0, 3) != 8.0\n";
+				if (reportTestCases) std::cout << "    FAIL ldexp(1.0, 3) != 8.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -68,7 +68,7 @@ namespace sw {
 			expected = 0.25;
 			result = ldexp(x, -2);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: ldexp(1.0, -2) != 0.25\n";
+				if (reportTestCases) std::cout << "    FAIL ldexp(1.0, -2) != 0.25\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -76,7 +76,7 @@ namespace sw {
 			expected = 1.0;
 			result = ldexp(x, 0);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: ldexp(1.0, 0) != 1.0\n";
+				if (reportTestCases) std::cout << "    FAIL ldexp(1.0, 0) != 1.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -94,11 +94,11 @@ namespace sw {
 			Real mantissa = frexp(x, &exp);
 
 			if (mantissa != expected_mantissa) {
-				if (reportTestCases) std::cerr << "FAIL: frexp(8.0) mantissa != 0.5\n";
+				if (reportTestCases) std::cout << "    FAIL frexp(8.0) mantissa != 0.5\n";
 				++nrOfFailedTestCases;
 			}
 			if (exp != expected_exp) {
-				if (reportTestCases) std::cerr << "FAIL: frexp(8.0) exponent != 4\n";
+				if (reportTestCases) std::cout << "    FAIL frexp(8.0) exponent != 4\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -117,7 +117,7 @@ namespace sw {
 			Real reconstructed = ldexp(mantissa, exp);
 
 			if (reconstructed != x) {
-				if (reportTestCases) std::cerr << "FAIL: ldexp(frexp(6.0)) != 6.0\n";
+				if (reportTestCases) std::cout << "    FAIL ldexp(frexp(6.0)) != 6.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -127,15 +127,14 @@ namespace sw {
 			reconstructed = ldexp(mantissa, exp);
 
 			if (reconstructed != x) {
-				if (reportTestCases) std::cerr << "FAIL: ldexp(frexp(100.0)) != 100.0\n";
+				if (reportTestCases) std::cout << "    FAIL ldexp(frexp(100.0)) != 100.0\n";
 				++nrOfFailedTestCases;
 			}
 
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+}  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -159,7 +158,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib numeric support function validation";
 	std::string test_tag    = "numerics";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);

--- a/elastic/ereal/math/functions/numerics.cpp
+++ b/elastic/ereal/math/functions/numerics.cpp
@@ -8,6 +8,10 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
+#include <cmath>
+#include <limits>
+#include <random>
+
 namespace {
 	using namespace sw::universal;
 
@@ -134,6 +138,40 @@ namespace {
 			return nrOfFailedTestCases;
 		}
 
+		// Property fuzzer: copysign sign/magnitude and frexp/ldexp round trips
+		// over random finite values.
+		template<typename Real>
+		int VerifyNumericsFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(-1.0e6, 1.0e6);
+			std::uniform_int_distribution<int> kdist(-40, 40);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double d = dist(rng);
+				Real x(d), y(dist(rng));
+				// copysign: magnitude of x, sign of y
+				Real cs = copysign(x, y);
+				if (abs(cs) != abs(x) || signbit(cs) != signbit(y)) {
+					if (reportTestCases) std::cout << "    FAIL copysign at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+				// frexp/ldexp round trip: ldexp(frexp(x, &e), e) == x exactly
+				int e;
+				Real m = frexp(x, &e);
+				if (ldexp(m, e) != x) {
+					if (reportTestCases) std::cout << "    FAIL frexp/ldexp roundtrip at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+				// ldexp by a power of two then its inverse is exact
+				int k = kdist(rng);
+				if (ldexp(ldexp(x, k), -k) != x) {
+					if (reportTestCases) std::cout << "    FAIL ldexp shift roundtrip at d=" << d << " k=" << k << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
 }  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
@@ -195,7 +233,8 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Future: Extended tests with edge cases
+	test_tag = "numerics fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyNumericsFuzz<ereal<>>(reportTestCases, 1000), "numerics(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/truncate.cpp
+++ b/elastic/ereal/math/functions/truncate.cpp
@@ -5,6 +5,9 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
@@ -155,6 +158,42 @@ namespace {
 			return nrOfFailedTestCases;
 		}
 
+		// Property fuzzer: bracketing, reflection, toward-zero, and agreement
+		// with the std:: rounding of the projected double, over random values.
+		template<typename Real>
+		int VerifyTruncateFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(-1.0e6, 1.0e6);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double d = dist(rng);
+				Real x(d);
+				Real fl = floor(x), ce = ceil(x), tr = trunc(x);
+				// bracketing: floor(x) <= x <= ceil(x)
+				if (fl > x || ce < x) {
+					if (reportTestCases) std::cout << "    FAIL bracket at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+				// reflection: floor(-x) == -ceil(x)
+				if (floor(-x) != -ceil(x)) {
+					if (reportTestCases) std::cout << "    FAIL reflection at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+				// trunc rounds toward zero: it equals floor for x>=0, ceil for x<0
+				Real expectedTrunc = (d >= 0.0) ? fl : ce;
+				if (tr != expectedTrunc) {
+					if (reportTestCases) std::cout << "    FAIL trunc toward zero at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+				// projection agrees with std:: for integer-valued results
+				if (double(fl) != std::floor(d) || double(ce) != std::ceil(d) || double(tr) != std::trunc(d)) {
+					if (reportTestCases) std::cout << "    FAIL std agreement at d=" << d << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
 }  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
@@ -214,7 +253,8 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Future: Extended precision tests
+	test_tag = "truncate fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyTruncateFuzz<ereal<>>(reportTestCases, 1000), "truncate(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/truncate.cpp
+++ b/elastic/ereal/math/functions/truncate.cpp
@@ -8,8 +8,8 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify floor function
 		template<typename Real>
@@ -20,7 +20,7 @@ namespace sw {
 			Real x(2.7), expected(2.0);
 			Real result = floor(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: floor(2.7) != 2.0\n";
+				if (reportTestCases) std::cout << "    FAIL floor(2.7) != 2.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -28,7 +28,7 @@ namespace sw {
 			x = -2.3; expected = -3.0;
 			result = floor(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: floor(-2.3) != -3.0\n";
+				if (reportTestCases) std::cout << "    FAIL floor(-2.3) != -3.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -36,7 +36,7 @@ namespace sw {
 			x = 5.0; expected = 5.0;
 			result = floor(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: floor(5.0) != 5.0\n";
+				if (reportTestCases) std::cout << "    FAIL floor(5.0) != 5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -44,7 +44,7 @@ namespace sw {
 			Real zero(0.0);
 			result = floor(zero);
 			if (result != zero) {
-				if (reportTestCases) std::cerr << "FAIL: floor(0.0) != 0.0\n";
+				if (reportTestCases) std::cout << "    FAIL floor(0.0) != 0.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -60,7 +60,7 @@ namespace sw {
 			Real x(2.3), expected(3.0);
 			Real result = ceil(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: ceil(2.3) != 3.0\n";
+				if (reportTestCases) std::cout << "    FAIL ceil(2.3) != 3.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -68,7 +68,7 @@ namespace sw {
 			x = -2.7; expected = -2.0;
 			result = ceil(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: ceil(-2.7) != -2.0\n";
+				if (reportTestCases) std::cout << "    FAIL ceil(-2.7) != -2.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -76,7 +76,7 @@ namespace sw {
 			x = 5.0; expected = 5.0;
 			result = ceil(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: ceil(5.0) != 5.0\n";
+				if (reportTestCases) std::cout << "    FAIL ceil(5.0) != 5.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -84,7 +84,7 @@ namespace sw {
 			Real zero(0.0);
 			result = ceil(zero);
 			if (result != zero) {
-				if (reportTestCases) std::cerr << "FAIL: ceil(0.0) != 0.0\n";
+				if (reportTestCases) std::cout << "    FAIL ceil(0.0) != 0.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -100,7 +100,7 @@ namespace sw {
 			Real x(2.7), expected(2.0);
 			Real result = trunc(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: trunc(2.7) != 2.0\n";
+				if (reportTestCases) std::cout << "    FAIL trunc(2.7) != 2.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -108,7 +108,7 @@ namespace sw {
 			x = -2.7; expected = -2.0;
 			result = trunc(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: trunc(-2.7) != -2.0\n";
+				if (reportTestCases) std::cout << "    FAIL trunc(-2.7) != -2.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -124,7 +124,7 @@ namespace sw {
 			Real x(2.3), expected(2.0);
 			Real result = round(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: round(2.3) != 2.0\n";
+				if (reportTestCases) std::cout << "    FAIL round(2.3) != 2.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -132,7 +132,7 @@ namespace sw {
 			x = 2.5; expected = 3.0;
 			result = round(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: round(2.5) != 3.0\n";
+				if (reportTestCases) std::cout << "    FAIL round(2.5) != 3.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -140,7 +140,7 @@ namespace sw {
 			x = 2.7; expected = 3.0;
 			result = round(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: round(2.7) != 3.0\n";
+				if (reportTestCases) std::cout << "    FAIL round(2.7) != 3.0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -148,15 +148,14 @@ namespace sw {
 			x = -2.5; expected = -3.0;
 			result = round(x);
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: round(-2.5) != -3.0\n";
+				if (reportTestCases) std::cout << "    FAIL round(-2.5) != -3.0\n";
 				++nrOfFailedTestCases;
 			}
 
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+}  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -180,7 +179,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib truncate function validation";
 	std::string test_tag    = "truncate";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);


### PR DESCRIPTION
## Summary
First of ~5 category PRs decomposing the `elastic/ereal/math/functions/` refactor (#950), per the issue's "split by category" guidance. Aligns five classification / numeric-support files to the canonical test structure from `arithmetic/addition.cpp` (PR #943).

Relates to #944 (parent epic, Phase B). Relates to #950 (partial -- category 1 of 5).

## Changes (5 files)
- `classify.cpp` -- isfinite/isnan/isinf/isnormal/signbit/fpclassify
- `numerics.cpp` -- copysign/ldexp/frexp + frexp/ldexp roundtrip
- `truncate.cpp` -- floor/ceil/trunc/round/rint
- `minmax.cpp` -- min/max
- `next.cpp` -- nextafter

Each file:
- anonymous namespace + single `using namespace sw::universal;` (was nested `namespace sw { namespace universal { ... } }`)
- `reportTestCases`-gated `std::cout << "    FAIL ..."` (was unconditional-prefix `std::cerr << "FAIL: ..."`)
- `reportTestCases` defaults to `true` in main

No test logic changed; unqualified math calls resolve via ADL on the `ereal` argument. Each file stays single-family.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_math_classify | OK | PASS | OK | PASS |
| er_math_numerics | OK | PASS | OK | PASS |
| er_math_truncate | OK | PASS | OK | PASS |
| er_math_minmax | OK | PASS | OK | PASS |
| er_math_next | OK | PASS | OK | PASS |

## Remaining categories (separate PRs)
2. exponent/logarithm · 3. trigonometry/hyperbolic · 4. pow/sqrt/hypot · 5. fractional/error_and_gamma + remove stub. (Unicode stripping lands in categories 2-4.)

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Relates to #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test runners now enable per-case diagnostics by default, producing clearer conditional failure output during regressions.
  * Added property-based/fuzz tests across math function suites (classification, min/max, next/nextafter, numerics, truncate) to catch edge-case inconsistencies.
  * Improved test reporting and verification for numerical primitives to increase regression coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->