### PR TITLE
feat(ereal): standardize + property coverage for math/functions exp/log (#950 cat 2)

### DIFF
--- a/elastic/ereal/math/functions/ereal_math_stub_test.cpp
+++ b/elastic/ereal/math/functions/ereal_math_stub_test.cpp
@@ -5,12 +5,11 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <universal/number/ereal/ereal.hpp>
+
 #include <iostream>
 #include <iomanip>
 #include <string>
-
-// Configure ereal
-#include <universal/number/ereal/ereal.hpp>
 
 // Test helpers
 constexpr unsigned COLWIDTH = 20;

--- a/elastic/ereal/math/functions/exponent.cpp
+++ b/elastic/ereal/math/functions/exponent.cpp
@@ -5,12 +5,15 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 #include <universal/verification/test_suite_mathlib_adaptive.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify exp function
 		template<typename Real>
@@ -21,11 +24,11 @@ namespace sw {
 			Real x(0.0), expected(1.0);
 			Real result = exp(x);
 			if (!check_exact_value(result, expected)) {
-				if (reportTestCases) std::cerr << "FAIL: exp(0) != 1 (exact)\n";
+				if (reportTestCases) std::cout << "    FAIL exp(0) != 1 (exact)\n";
 				++nrOfFailedTestCases;
 			}
 
-			// Test: exp(1) = e ≈ 2.718281828 (approximate)
+			// Test: exp(1) = e ~= 2.718281828 (approximate)
 			x = 1.0;
 			double exp_1 = std::exp(1.0);
 			expected = Real(exp_1);
@@ -38,7 +41,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: exp(2) = e² ≈ 7.389056099 (approximate)
+			// Test: exp(2) = e^2 ~= 7.389056099 (approximate)
 			x = 2.0;
 			double exp_2 = std::exp(2.0);
 			expected = Real(exp_2);
@@ -51,7 +54,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: exp(-1) = 1/e ≈ 0.367879441 (approximate)
+			// Test: exp(-1) = 1/e ~= 0.367879441 (approximate)
 			x = -1.0;
 			double exp_neg1 = std::exp(-1.0);
 			expected = Real(exp_neg1);
@@ -156,7 +159,7 @@ namespace sw {
 			Real x(0.0), expected(0.0);
 			Real result = expm1(x);
 			if (!check_exact_value(result, expected)) {
-				if (reportTestCases) std::cerr << "FAIL: expm1(0) != 0 (exact)\n";
+				if (reportTestCases) std::cout << "    FAIL expm1(0) != 0 (exact)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -173,7 +176,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: expm1(1) ≈ e - 1 ≈ 1.718281828 (approximate)
+			// Test: expm1(1) ~= e - 1 ~= 1.718281828 (approximate)
 			// Note: expm1 implementation limited by underlying double precision (~15 digits)
 			x = 1.0;
 			std_expm1 = std::expm1(1.0);
@@ -196,7 +199,7 @@ namespace sw {
 			int nrOfFailedTestCases = 0;
 			double error_mag;
 
-			// Test: log(exp(x)) ≈ x for various x
+			// Test: log(exp(x)) ~= x for various x
 			double test_values[] = {0.1, 0.5, 1.0, 2.0, 3.0};
 
 			for (double val : test_values) {
@@ -205,7 +208,7 @@ namespace sw {
 				error_mag = std::abs(double(result - x));
 				if (error_mag >= 1e-14) {
 					if (reportTestCases) {
-						std::cerr << "FAIL: log(exp(" << val << ")) roundtrip error = " << error_mag << "\n";
+						std::cout << "    FAIL log(exp(" << val << ")) roundtrip error = " << error_mag << "\n";
 					}
 					++nrOfFailedTestCases;
 				}
@@ -214,8 +217,56 @@ namespace sw {
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+
+		// Compare via the double projection within a relative tolerance, with an
+		// absolute floor so near-zero results do not make the test spuriously strict.
+		template<typename Real>
+		bool close_rel(const Real& x, const Real& y, double relTol, double absTol = 1.0e-15) {
+			double a = double(x), b = double(y);
+			double diff = std::abs(a - b);
+			if (diff == 0.0) return true;
+			double scale = std::max(std::abs(a), std::abs(b));
+			return diff <= std::max(absTol, relTol * scale);
+		}
+
+		// Property fuzzer: exp/log inverse, the exp(a+b)==exp(a)*exp(b) addition
+		// theorem, exp(-x)==1/exp(x), expm1(x)==exp(x)-1, and monotonicity.
+		template<typename Real>
+		int VerifyExponentFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(-5.0, 5.0);
+			Real one(1.0);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double dx = dist(rng);
+				Real x(dx);
+				if (!close_rel(log(exp(x)), x, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL log(exp(x)) at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!close_rel(exp(-x), one / exp(x), 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL exp(-x)==1/exp(x) at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!close_rel(expm1(x), exp(x) - one, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL expm1==exp-1 at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				Real y(dist(rng));
+				if (!close_rel(exp(x + y), exp(x) * exp(y), 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL exp(a+b)==exp(a)exp(b) at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!(exp(x) < exp(x + one))) {
+					if (reportTestCases) std::cout << "    FAIL exp monotonic at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
+}  // anonymous namespace
+
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -239,7 +290,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib exponential function validation";
 	std::string test_tag    = "exponential";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -273,10 +324,13 @@ try {
 
 	test_tag = "exp/log roundtrip";
 	nrOfFailedTestCases += ReportTestResult(VerifyExpLogRoundtrip<ereal<>>(reportTestCases), "log(exp(x)) roundtrip", test_tag);
+
+	test_tag = "exp/log fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyExponentFuzz<ereal<>>(reportTestCases, 1000), "exp/log property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Extended precision tests at 512 bits (≈154 decimal digits)
+	// Extended precision tests at 512 bits (~=154 decimal digits)
 	test_tag = "exp high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyExp<ereal<8>>(reportTestCases), "exp(ereal<8>)", test_tag);
 
@@ -291,7 +345,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_3
-	// High precision tests at 1024 bits (≈308 decimal digits)
+	// High precision tests at 1024 bits (~=308 decimal digits)
 	test_tag = "exp very high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyExp<ereal<16>>(reportTestCases), "exp(ereal<16>)", test_tag);
 
@@ -300,7 +354,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_4
-	// Maximum precision tests at ereal<19> (≈303 decimal digits, maximum algorithmically valid)
+	// Maximum precision tests at ereal<19> (~=303 decimal digits, maximum algorithmically valid)
 	test_tag = "exp maximum precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyExp<ereal<19>>(reportTestCases), "exp(ereal<19>)", test_tag);
 

--- a/elastic/ereal/math/functions/logarithm.cpp
+++ b/elastic/ereal/math/functions/logarithm.cpp
@@ -5,12 +5,15 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 #include <universal/verification/test_suite_mathlib_adaptive.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify log function
 		template<typename Real>
@@ -21,7 +24,7 @@ namespace sw {
 			Real x(1.0), expected(0.0);
 			Real result = log(x);
 			if (!check_exact_value(result, expected)) {
-				if (reportTestCases) std::cerr << "FAIL: log(1) != 0 (exact)\n";
+				if (reportTestCases) std::cout << "    FAIL log(1) != 0 (exact)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -40,7 +43,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: log(2) ≈ 0.693147181 (approximate)
+			// Test: log(2) ~= 0.693147181 (approximate)
 			x = 2.0;
 			double log_2 = std::log(2.0);
 			expected = Real(log_2);
@@ -55,7 +58,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: log(10) ≈ 2.302585093 (approximate)
+			// Test: log(10) ~= 2.302585093 (approximate)
 			x = 10.0;
 			double log_10 = std::log(10.0);
 			expected = Real(log_10);
@@ -162,7 +165,7 @@ namespace sw {
 			Real x(0.0), expected(0.0);
 			Real result = log1p(x);
 			if (!check_exact_value(result, expected)) {
-				if (reportTestCases) std::cerr << "FAIL: log1p(0) != 0 (exact)\n";
+				if (reportTestCases) std::cout << "    FAIL log1p(0) != 0 (exact)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -180,7 +183,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: log1p(1) = log(2) ≈ 0.693147181 (approximate)
+			// Test: log1p(1) = log(2) ~= 0.693147181 (approximate)
 			x = 1.0;
 			std_log1p = std::log1p(1.0);
 			expected = Real(std_log1p);
@@ -214,7 +217,7 @@ namespace sw {
 				Real result = exp(log(x));
 				if (!check_relative_error(result, x, threshold)) {
 					if (reportTestCases) {
-						std::cerr << "FAIL: exp(log(" << val << ")) roundtrip\n";
+						std::cout << "    FAIL exp(log(" << val << ")) roundtrip\n";
 						report_error_detail("exp(log(x))", std::to_string(val), result, x, threshold);
 					}
 					++nrOfFailedTestCases;
@@ -224,8 +227,55 @@ namespace sw {
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+
+		// Compare via the double projection within a relative tolerance, with an
+		// absolute floor so near-zero results do not make the test spuriously strict.
+		template<typename Real>
+		bool close_rel(const Real& x, const Real& y, double relTol, double absTol = 1.0e-15) {
+			double a = double(x), b = double(y);
+			double diff = std::abs(a - b);
+			if (diff == 0.0) return true;
+			double scale = std::max(std::abs(a), std::abs(b));
+			return diff <= std::max(absTol, relTol * scale);
+		}
+
+		// Property fuzzer over the positive domain: exp/log inverse, the
+		// log(a*b)==log(a)+log(b) product rule, and monotonicity. log1p is checked
+		// with a loose tolerance -- its current accuracy is ~1e-5 (precision
+		// improvement tracked under #954).
+		template<typename Real>
+		int VerifyLogarithmFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(1.0e-2, 1.0e3);
+			Real one(1.0);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double dx = dist(rng);
+				Real x(dx);
+				if (!close_rel(exp(log(x)), x, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL exp(log(x)) at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				Real y(dist(rng));
+				if (!close_rel(log(x * y), log(x) + log(y), 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL log(a*b)==log(a)+log(b) at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!(log(x) < log(x + one))) {
+					if (reportTestCases) std::cout << "    FAIL log monotonic at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				// log1p(x) == log(1+x); loose tolerance pending the #954 precision work
+				if (!close_rel(log1p(x), log(one + x), 1.0e-4)) {
+					if (reportTestCases) std::cout << "    FAIL log1p(x)==log(1+x) at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
+}  // anonymous namespace
+
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -249,7 +299,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib logarithm function validation";
 	std::string test_tag    = "logarithm";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -283,10 +333,13 @@ try {
 
 	test_tag = "log/exp roundtrip";
 	nrOfFailedTestCases += ReportTestResult(VerifyLogExpRoundtrip<ereal<>>(reportTestCases), "exp(log(x)) roundtrip", test_tag);
+
+	test_tag = "log property fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyLogarithmFuzz<ereal<>>(reportTestCases, 1000), "log property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Extended precision tests at 512 bits (≈154 decimal digits)
+	// Extended precision tests at 512 bits (~=154 decimal digits)
 	test_tag = "log high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyLog<ereal<8>>(reportTestCases), "log(ereal<8>)", test_tag);
 
@@ -301,7 +354,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_3
-	// High precision tests at 1024 bits (≈308 decimal digits)
+	// High precision tests at 1024 bits (~=308 decimal digits)
 	test_tag = "log very high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyLog<ereal<16>>(reportTestCases), "log(ereal<16>)", test_tag);
 
@@ -310,7 +363,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_4
-	// Maximum precision tests at ereal<19> (≈303 decimal digits, maximum algorithmically valid)
+	// Maximum precision tests at ereal<19> (~=303 decimal digits, maximum algorithmically valid)
 	test_tag = "log maximum precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyLog<ereal<19>>(reportTestCases), "log(ereal<19>)", test_tag);
 


### PR DESCRIPTION
## Summary
Category 2 of 5 for the `elastic/ereal/math/functions/` refactor (#950): `exponent.cpp` and `logarithm.cpp`.

Relates to #944 (parent epic, Phase B). Relates to #950 (partial -- category 2 of 5).

## Standardization
- anonymous namespace + single `using namespace sw::universal;`
- `reportTestCases`-gated `std::cout << "    FAIL ..."` (was `std::cerr`)
- `reportTestCases` defaults to `true`
- stripped non-ASCII (`~=`, `^2`) from comments

## Layer-1 property coverage (oracle-free; self-oracle scoped to #954)
- `exponent.cpp` `VerifyExponentFuzz`: `log(exp(x))==x`, `exp(-x)==1/exp(x)`, `expm1(x)==exp(x)-1`, `exp(a+b)==exp(a)*exp(b)`, monotonicity.
- `logarithm.cpp` `VerifyLogarithmFuzz`: `exp(log(x))==x`, `log(a*b)==log(a)+log(b)` (relative tol + absolute floor), monotonicity, `log1p(x)==log(1+x)`.

**Precision note:** `log1p` is only accurate to ~1e-5 today, so its identity is checked with a loose tolerance; tightening it is precision work tracked under **#954**. `exp`/`log` and the addition theorems are accurate to ~1e-16 (the theorems exact). The existing multi-precision (`ereal<8/16/19>`) tests at LEVEL 2-4 are preserved.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_math_exponent | OK | PASS | OK | PASS |
| er_math_logarithm | OK | PASS | OK | PASS |

## Remaining categories
3. trigonometry/hyperbolic · 4. pow/sqrt/hypot · 5. fractional/error_and_gamma + stub decision (final PR -> Resolves #950).

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Relates to #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced verification coverage for exponential and logarithmic functions with property-based fuzz testing.
  * Added randomized input testing to validate mathematical identities and relationships for `exp`, `log`, `expm1`, and `log1p`.
  * Improved test output reporting for better diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->