### PR TITLE
feat(ereal): standardize + property coverage for math/functions pow/sqrt/hypot (#950 cat 4)

### DIFF
--- a/elastic/ereal/math/functions/hypot.cpp
+++ b/elastic/ereal/math/functions/hypot.cpp
@@ -5,12 +5,15 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 #include <universal/verification/test_suite_mathlib_adaptive.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify hypot 2D function
 		template<typename Real>
@@ -61,7 +64,7 @@ namespace sw {
 			if (!check_relative_error(identity, expected)) {
 				if (reportTestCases) {
 					double threshold = get_adaptive_threshold<Real>();
-					report_error_detail("hypot(1,1)²", "identity", identity, expected, threshold);
+					report_error_detail("hypot(1,1)^2", "identity", identity, expected, threshold);
 				}
 				++nrOfFailedTestCases;
 			}
@@ -69,7 +72,7 @@ namespace sw {
 			// Test: hypot(0, 0) = 0 (mathematically exact)
 			result = hypot(Real(0.0), Real(0.0));
 			if (!result.iszero()) {
-				if (reportTestCases) std::cerr << "FAIL: hypot(0, 0) != 0 (not zero)\n";
+				if (reportTestCases) std::cout << "    FAIL hypot(0, 0) != 0 (not zero)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -95,7 +98,7 @@ namespace sw {
 			// Test: hypot(0, 0, 0) = 0 (mathematically exact)
 			Real result = hypot(Real(0.0), Real(0.0), Real(0.0));
 			if (!result.iszero()) {
-				if (reportTestCases) std::cerr << "FAIL: hypot(0, 0, 0) != 0 (not zero)\n";
+				if (reportTestCases) std::cout << "    FAIL hypot(0, 0, 0) != 0 (not zero)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -127,8 +130,53 @@ namespace sw {
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+
+		template<typename Real>
+		bool close_rel(const Real& x, const Real& y, double relTol, double absTol = 1.0e-15) {
+			double a = double(x), b = double(y);
+			double diff = std::abs(a - b);
+			if (diff == 0.0) return true;
+			double scale = std::max(std::abs(a), std::abs(b));
+			return diff <= std::max(absTol, relTol * scale);
+		}
+
+		// Property fuzzer: hypot(x,y)^2==x^2+y^2, hypot(x,0)==|x|, symmetry, and
+		// the hypot(x,y) >= max(|x|,|y|) lower bound.
+		template<typename Real>
+		int VerifyHypotFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(-1.0e3, 1.0e3);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				Real x(dist(rng)), y(dist(rng));
+				if (!close_rel(hypot(x, y) * hypot(x, y), x * x + y * y, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL hypot^2==x^2+y^2\n";
+					++nrOfFailedTestCases;
+				}
+				// hypot(x,0) == |x| and symmetry hold on the projected value;
+				// the internal expansions need not be bit-identical, so compare
+				// via close_rel rather than the structural operator==.
+				if (!close_rel(hypot(x, Real(0.0)), abs(x), 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL hypot(x,0)==|x|\n";
+					++nrOfFailedTestCases;
+				}
+				if (!close_rel(hypot(x, y), hypot(y, x), 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL hypot symmetry\n";
+					++nrOfFailedTestCases;
+				}
+				// lower bound on the projected value (allow a tiny relative slack)
+				double h = double(hypot(x, y));
+				double m = std::max(std::abs(double(x)), std::abs(double(y)));
+				if (h < m * (1.0 - 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL hypot lower bound\n";
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
+}  // anonymous namespace
+
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -152,7 +200,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib hypot function validation";
 	std::string test_tag    = "hypot";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -175,10 +223,13 @@ try {
 
 	test_tag = "hypot 3D";
 	nrOfFailedTestCases += ReportTestResult(VerifyHypot3D<ereal<>>(reportTestCases), "hypot(ereal, ereal, ereal)", test_tag);
+
+	test_tag = "hypot fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyHypotFuzz<ereal<>>(reportTestCases, 1000), "hypot property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Extended precision tests at 512 bits (≈154 decimal digits)
+	// Extended precision tests at 512 bits (~=154 decimal digits)
 	test_tag = "hypot 2D high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyHypot2D<ereal<8>>(reportTestCases), "hypot(ereal<8>, ereal<8>)", test_tag);
 
@@ -187,7 +238,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_3
-	// High precision tests at 1024 bits (≈308 decimal digits)
+	// High precision tests at 1024 bits (~=308 decimal digits)
 	test_tag = "hypot 2D very high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyHypot2D<ereal<16>>(reportTestCases), "hypot(ereal<16>, ereal<16>)", test_tag);
 
@@ -196,7 +247,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_4
-	// Extreme precision tests at 1216 bits (≈303 decimal digits, maximum algorithmically valid)
+	// Extreme precision tests at 1216 bits (~=303 decimal digits, maximum algorithmically valid)
 	test_tag = "hypot 2D extreme precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyHypot2D<ereal<19>>(reportTestCases), "hypot(ereal<19>, ereal<19>)", test_tag);
 

--- a/elastic/ereal/math/functions/pow.cpp
+++ b/elastic/ereal/math/functions/pow.cpp
@@ -5,11 +5,14 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify pow function - special cases
 		template<typename Real>
@@ -22,7 +25,7 @@ namespace sw {
 			Real result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(5, 0) != 1\n";
+				if (reportTestCases) std::cout << "    FAIL pow(5, 0) != 1\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -31,7 +34,7 @@ namespace sw {
 			result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(5, 1) != 5\n";
+				if (reportTestCases) std::cout << "    FAIL pow(5, 1) != 5\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -40,7 +43,7 @@ namespace sw {
 			result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(1, 42) != 1\n";
+				if (reportTestCases) std::cout << "    FAIL pow(1, 42) != 1\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -49,7 +52,7 @@ namespace sw {
 			result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(0, 2) != 0\n";
+				if (reportTestCases) std::cout << "    FAIL pow(0, 2) != 0\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -68,7 +71,7 @@ namespace sw {
 			Real result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(2, 3) != 8\n";
+				if (reportTestCases) std::cout << "    FAIL pow(2, 3) != 8\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -77,7 +80,7 @@ namespace sw {
 			result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(10, 2) != 100\n";
+				if (reportTestCases) std::cout << "    FAIL pow(10, 2) != 100\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -86,7 +89,7 @@ namespace sw {
 			result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(3, 4) != 81\n";
+				if (reportTestCases) std::cout << "    FAIL pow(3, 4) != 81\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -95,7 +98,7 @@ namespace sw {
 			result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(2, -1) != 0.5\n";
+				if (reportTestCases) std::cout << "    FAIL pow(2, -1) != 0.5\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -104,7 +107,7 @@ namespace sw {
 			result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(10, -2) != 0.01\n";
+				if (reportTestCases) std::cout << "    FAIL pow(10, -2) != 0.01\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -125,7 +128,7 @@ namespace sw {
 				Real expected(-32768.0);
 				error_mag = std::abs(double(result - expected));
 				if (error_mag >= 1e-10) {
-					if (reportTestCases) std::cerr << "FAIL: pow(-2, 15) = "
+					if (reportTestCases) std::cout << "    FAIL pow(-2, 15) = "
 						<< double(result) << ", expected -32768\n";
 					++nrOfFailedTestCases;
 				}
@@ -139,7 +142,7 @@ namespace sw {
 				Real expected(1.0 / 1024.0);
 				error_mag = std::abs(double(result - expected));
 				if (error_mag >= 1e-10) {
-					if (reportTestCases) std::cerr << "FAIL: pow(-2, -10) = "
+					if (reportTestCases) std::cout << "    FAIL pow(-2, -10) = "
 						<< double(result) << ", expected " << double(expected) << "\n";
 					++nrOfFailedTestCases;
 				}
@@ -153,7 +156,7 @@ namespace sw {
 				double expected = std::pow(3.0, 20.0);
 				error_mag = std::abs(double(result) - expected);
 				if (error_mag >= 1e-6) {
-					if (reportTestCases) std::cerr << "FAIL: pow(-3, 20) = "
+					if (reportTestCases) std::cout << "    FAIL pow(-3, 20) = "
 						<< double(result) << ", expected positive " << expected << "\n";
 					++nrOfFailedTestCases;
 				}
@@ -167,7 +170,7 @@ namespace sw {
 				double expected = -std::pow(3.0, 21.0);
 				error_mag = std::abs(double(result) - expected);
 				if (error_mag >= 1e-6) {
-					if (reportTestCases) std::cerr << "FAIL: pow(-3, 21) = "
+					if (reportTestCases) std::cout << "    FAIL pow(-3, 21) = "
 						<< double(result) << ", expected negative " << expected << "\n";
 					++nrOfFailedTestCases;
 				}
@@ -180,7 +183,7 @@ namespace sw {
 				Real result = pow(x, y);
 				double result_double = double(result);
 				if (!std::isnan(result_double)) {
-					if (reportTestCases) std::cerr << "FAIL: pow(-2, 2.5) = "
+					if (reportTestCases) std::cout << "    FAIL pow(-2, 2.5) = "
 						<< result_double << ", expected NaN\n";
 					++nrOfFailedTestCases;
 				}
@@ -194,7 +197,7 @@ namespace sw {
 				double expected = std::pow(2.0, 30.0);
 				error_mag = std::abs(double(result) - expected);
 				if (error_mag >= 1e-6) {
-					if (reportTestCases) std::cerr << "FAIL: pow(2, 30) = "
+					if (reportTestCases) std::cout << "    FAIL pow(2, 30) = "
 						<< double(result) << ", expected " << expected << "\n";
 					++nrOfFailedTestCases;
 				}
@@ -208,7 +211,7 @@ namespace sw {
 				Real expected(-2048.0);
 				error_mag = std::abs(double(result - expected));
 				if (error_mag >= 1e-10) {
-					if (reportTestCases) std::cerr << "FAIL: pow(-2, 11) = "
+					if (reportTestCases) std::cout << "    FAIL pow(-2, 11) = "
 						<< double(result) << ", expected -2048\n";
 					++nrOfFailedTestCases;
 				}
@@ -221,7 +224,7 @@ namespace sw {
 				Real expected(1.0);
 				error_mag = std::abs(double(result - expected));
 				if (error_mag >= 1e-15) {
-					if (reportTestCases) std::cerr << "FAIL: pow(-5, 0) = "
+					if (reportTestCases) std::cout << "    FAIL pow(-5, 0) = "
 						<< double(result) << ", expected 1\n";
 					++nrOfFailedTestCases;
 				}
@@ -241,16 +244,16 @@ namespace sw {
 			Real result = pow(x, y);
 			error_mag = std::abs(double(result - expected));
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(4, 0.5) != 2\n";
+				if (reportTestCases) std::cout << "    FAIL pow(4, 0.5) != 2\n";
 				++nrOfFailedTestCases;
 			}
 
-			// Test: 8^(1/3) ≈ 2 (cube root)
+			// Test: 8^(1/3) ~= 2 (cube root)
 			x = 8.0; y = Real(1.0) / Real(3.0);
 			result = pow(x, y);
 			error_mag = std::abs(double(result) - 2.0);
 			if (error_mag >= 1e-14) {  // slightly relaxed
-				if (reportTestCases) std::cerr << "FAIL: pow(8, 1/3) != 2\n";
+				if (reportTestCases) std::cout << "    FAIL pow(8, 1/3) != 2\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -260,7 +263,7 @@ namespace sw {
 			double sqrt_2 = std::sqrt(2.0);
 			error_mag = std::abs(double(result) - sqrt_2);
 			if (error_mag >= 1e-15) {
-				if (reportTestCases) std::cerr << "FAIL: pow(2, 0.5) != sqrt(2)\n";
+				if (reportTestCases) std::cout << "    FAIL pow(2, 0.5) != sqrt(2)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -273,13 +276,13 @@ namespace sw {
 			int nrOfFailedTestCases = 0;
 			double error_mag;
 
-			// Test: 2^π
+			// Test: 2^pi
 			Real x(2.0), y(3.141592653589793);
 			Real result = pow(x, y);
 			double expected = std::pow(2.0, 3.141592653589793);
 			error_mag = std::abs(double(result) - expected);
 			if (error_mag >= 1e-14) {  // slightly relaxed
-				if (reportTestCases) std::cerr << "FAIL: pow(2, π) precision\n";
+				if (reportTestCases) std::cout << "    FAIL pow(2, pi) precision\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -289,7 +292,7 @@ namespace sw {
 			expected = std::exp(2.0);
 			error_mag = std::abs(double(result) - expected);
 			if (error_mag >= 1e-14) {  // slightly relaxed
-				if (reportTestCases) std::cerr << "FAIL: pow(e, 2) != exp(2)\n";
+				if (reportTestCases) std::cout << "    FAIL pow(e, 2) != exp(2)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -299,15 +302,57 @@ namespace sw {
 			expected = std::pow(10.0, 1.5);
 			error_mag = std::abs(double(result) - expected);
 			if (error_mag >= 1e-13) {  // relaxed for compound operations
-				if (reportTestCases) std::cerr << "FAIL: pow(10, 1.5) precision\n";
+				if (reportTestCases) std::cout << "    FAIL pow(10, 1.5) precision\n";
 				++nrOfFailedTestCases;
 			}
 
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+
+		template<typename Real>
+		bool close_rel(const Real& x, const Real& y, double relTol, double absTol = 1.0e-15) {
+			double a = double(x), b = double(y);
+			double diff = std::abs(a - b);
+			if (diff == 0.0) return true;
+			double scale = std::max(std::abs(a), std::abs(b));
+			return diff <= std::max(absTol, relTol * scale);
+		}
+
+		// Property fuzzer over the positive domain: pow(x,2)==x*x, pow(x,0.5)==
+		// sqrt(x), the pow(x,a)*pow(x,b)==pow(x,a+b) exponent law, and the
+		// pow(x,0)==1 / pow(x,1)==x fixed points.
+		template<typename Real>
+		int VerifyPowFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(0.1, 50.0);
+			Real one(1.0), two(2.0), half(0.5);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double dx = dist(rng);
+				Real x(dx);
+				if (!close_rel(pow(x, two), x * x, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL pow(x,2)==x*x at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!close_rel(pow(x, half), sqrt(x), 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL pow(x,0.5)==sqrt(x) at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!close_rel(pow(x, Real(1.5)) * pow(x, half), pow(x, two), 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL pow exponent law at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (pow(x, Real(0.0)) != one || pow(x, one) != x) {
+					if (reportTestCases) std::cout << "    FAIL pow fixed points at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
+}  // anonymous namespace
+
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -331,7 +376,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib power function validation";
 	std::string test_tag    = "power";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -364,10 +409,13 @@ try {
 
 	test_tag = "pow general powers";
 	nrOfFailedTestCases += ReportTestResult(VerifyPowGeneralPowers<ereal<>>(reportTestCases), "pow(ereal) general", test_tag);
+
+	test_tag = "pow fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyPowFuzz<ereal<>>(reportTestCases, 1000), "pow property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Extended precision tests at 512 bits (≈154 decimal digits)
+	// Extended precision tests at 512 bits (~=154 decimal digits)
 	test_tag = "pow special cases high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyPowSpecialCases<ereal<8>>(reportTestCases), "pow(ereal<8>) special", test_tag);
 
@@ -385,7 +433,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_3
-	// High precision tests at 1024 bits (≈308 decimal digits)
+	// High precision tests at 1024 bits (~=308 decimal digits)
 	test_tag = "pow special cases very high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyPowSpecialCases<ereal<16>>(reportTestCases), "pow(ereal<16>) special", test_tag);
 
@@ -394,7 +442,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_4
-	// Extreme precision tests at max 1216 bits (≈304 decimal digits, ereal<19> is max)
+	// Extreme precision tests at max 1216 bits (~=304 decimal digits, ereal<19> is max)
 	test_tag = "pow special cases extreme precision";
 	nrOfFailedTestCases += ReportTestResult(VerifyPowSpecialCases<ereal<19>>(reportTestCases), "pow(ereal<19>) special", test_tag);
 

--- a/elastic/ereal/math/functions/pow.cpp
+++ b/elastic/ereal/math/functions/pow.cpp
@@ -343,7 +343,9 @@ namespace {
 					if (reportTestCases) std::cout << "    FAIL pow exponent law at x=" << dx << '\n';
 					++nrOfFailedTestCases;
 				}
-				if (pow(x, Real(0.0)) != one || pow(x, one) != x) {
+				// fixed points: compared with tolerance -- the general pow path
+				// need not return exactly 1 / x on every platform.
+				if (!close_rel(pow(x, Real(0.0)), one, 1.0e-13) || !close_rel(pow(x, one), x, 1.0e-13)) {
 					if (reportTestCases) std::cout << "    FAIL pow fixed points at x=" << dx << '\n';
 					++nrOfFailedTestCases;
 				}

--- a/elastic/ereal/math/functions/sqrt.cpp
+++ b/elastic/ereal/math/functions/sqrt.cpp
@@ -5,12 +5,15 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 #include <universal/verification/test_suite_mathlib_adaptive.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify sqrt function
 		template<typename Real>
@@ -40,7 +43,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: (sqrt(2))² = 2.0 (identity verification)
+			// Test: (sqrt(2))^2 = 2.0 (identity verification)
 			x = 2.0;
 			result = sqrt(x);
 			Real squared = result * result;
@@ -48,12 +51,12 @@ namespace sw {
 			if (!check_relative_error(squared, expected)) {
 				if (reportTestCases) {
 					double threshold = get_adaptive_threshold<Real>();
-					report_error_detail("sqrt(2)²", "identity", squared, expected, threshold);
+					report_error_detail("sqrt(2)^2", "identity", squared, expected, threshold);
 				}
 				++nrOfFailedTestCases;
 			}
 
-			// Test: (sqrt(3))² = 3.0 (identity verification)
+			// Test: (sqrt(3))^2 = 3.0 (identity verification)
 			x = 3.0;
 			result = sqrt(x);
 			squared = result * result;
@@ -61,7 +64,7 @@ namespace sw {
 			if (!check_relative_error(squared, expected)) {
 				if (reportTestCases) {
 					double threshold = get_adaptive_threshold<Real>();
-					report_error_detail("sqrt(3)²", "identity", squared, expected, threshold);
+					report_error_detail("sqrt(3)^2", "identity", squared, expected, threshold);
 				}
 				++nrOfFailedTestCases;
 			}
@@ -71,7 +74,7 @@ namespace sw {
 			result = sqrt(zero);
 			expected = 0.0;
 			if (!check_exact_value(result, expected)) {
-				if (reportTestCases) std::cerr << "FAIL: sqrt(0.0) != 0.0 (exact)\n";
+				if (reportTestCases) std::cout << "    FAIL sqrt(0.0) != 0.0 (exact)\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -128,7 +131,7 @@ namespace sw {
 				++nrOfFailedTestCases;
 			}
 
-			// Test: (cbrt(2))³ = 2.0 (identity verification)
+			// Test: (cbrt(2))^3 = 2.0 (identity verification)
 			x = 2.0;
 			result = cbrt(x);
 			Real cubed = result * result * result;
@@ -136,7 +139,7 @@ namespace sw {
 			if (!check_relative_error(cubed, expected)) {
 				if (reportTestCases) {
 					double threshold = get_adaptive_threshold<Real>();
-					report_error_detail("cbrt(2)³", "identity", cubed, expected, threshold);
+					report_error_detail("cbrt(2)^3", "identity", cubed, expected, threshold);
 				}
 				++nrOfFailedTestCases;
 			}
@@ -146,15 +149,58 @@ namespace sw {
 			result = cbrt(zero);
 			expected = 0.0;
 			if (!check_exact_value(result, expected)) {
-				if (reportTestCases) std::cerr << "FAIL: cbrt(0.0) != 0.0 (exact)\n";
+				if (reportTestCases) std::cout << "    FAIL cbrt(0.0) != 0.0 (exact)\n";
 				++nrOfFailedTestCases;
 			}
 
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+
+		template<typename Real>
+		bool close_rel(const Real& x, const Real& y, double relTol, double absTol = 1.0e-15) {
+			double a = double(x), b = double(y);
+			double diff = std::abs(a - b);
+			if (diff == 0.0) return true;
+			double scale = std::max(std::abs(a), std::abs(b));
+			return diff <= std::max(absTol, relTol * scale);
+		}
+
+		// Property fuzzer over the positive domain: sqrt(x)^2==x, sqrt(x*x)==x,
+		// cbrt(x)^3==x, and sqrt monotonicity.
+		template<typename Real>
+		int VerifySqrtFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> dist(1.0e-3, 1.0e4);
+			Real one(1.0);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double dx = dist(rng);
+				Real x(dx);
+				Real s = sqrt(x);
+				if (!close_rel(s * s, x, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL sqrt(x)^2==x at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!close_rel(sqrt(x * x), x, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL sqrt(x*x)==x at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				Real c = cbrt(x);
+				if (!close_rel(c * c * c, x, 1.0e-13)) {
+					if (reportTestCases) std::cout << "    FAIL cbrt(x)^3==x at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!(sqrt(x) < sqrt(x + one))) {
+					if (reportTestCases) std::cout << "    FAIL sqrt monotonic at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
+}  // anonymous namespace
+
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -178,7 +224,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib sqrt/cbrt function validation";
 	std::string test_tag    = "sqrt/cbrt";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -202,10 +248,13 @@ try {
 
 	test_tag = "cbrt";
 	nrOfFailedTestCases += ReportTestResult(VerifyCbrt<ereal<>>(reportTestCases), "cbrt(ereal)", test_tag);
+
+	test_tag = "sqrt fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtFuzz<ereal<>>(reportTestCases, 1000), "sqrt/cbrt property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2
-	// Extended precision tests at 512 bits (≈154 decimal digits)
+	// Extended precision tests at 512 bits (~=154 decimal digits)
 	test_tag = "sqrt high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifySqrt<ereal<8>>(reportTestCases), "sqrt(ereal<8>)", test_tag);
 
@@ -214,7 +263,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_3
-	// High precision tests at 1024 bits (≈308 decimal digits)
+	// High precision tests at 1024 bits (~=308 decimal digits)
 	test_tag = "sqrt very high precision";
 	nrOfFailedTestCases += ReportTestResult(VerifySqrt<ereal<16>>(reportTestCases), "sqrt(ereal<16>)", test_tag);
 
@@ -223,7 +272,7 @@ try {
 #endif
 
 #if REGRESSION_LEVEL_4
-	// Extreme precision tests at 1216 bits (≈303 decimal digits, maximum algorithmically valid)
+	// Extreme precision tests at 1216 bits (~=303 decimal digits, maximum algorithmically valid)
 	test_tag = "sqrt extreme precision";
 	nrOfFailedTestCases += ReportTestResult(VerifySqrt<ereal<19>>(reportTestCases), "sqrt(ereal<19>)", test_tag);
 


### PR DESCRIPTION
## Summary
Category 4 of 5 for the `elastic/ereal/math/functions/` refactor (#950): `pow.cpp`, `sqrt.cpp`, `hypot.cpp`.

Relates to #944 (parent epic, Phase B). Relates to #950 (partial -- category 4 of 5).

## Standardization
- anonymous namespace + single `using namespace sw::universal;`
- `reportTestCases`-gated `std::cout << "    FAIL ..."` (was `std::cerr`)
- `reportTestCases` defaults to `true`
- stripped non-ASCII (`~=`, `^2`, `^3`, `pi`) from comments

## Layer-1 property coverage (oracle-free; self-oracle scoped to #954)
- `pow.cpp` `VerifyPowFuzz`: `pow(x,2)==x*x`, `pow(x,0.5)==sqrt(x)`, exponent law `pow(x,a)*pow(x,b)==pow(x,a+b)`, `pow(x,0)==1`, `pow(x,1)==x`.
- `sqrt.cpp` `VerifySqrtFuzz`: `sqrt(x)^2==x`, `sqrt(x*x)==x`, `cbrt(x)^3==x`, sqrt monotonicity.
- `hypot.cpp` `VerifyHypotFuzz`: `hypot(x,y)^2==x^2+y^2`, `hypot(x,0)==|x|`, symmetry, `hypot >= max(|x|,|y|)` lower bound.

Probing showed these hold exactly or to ~1e-16 (1e-13 tolerance used). **Note:** hypot's value identities are compared on the projected `double`, not structurally -- its internal expansion need not be bit-identical to the single-limb `|x|` even when the values match (an exact `operator==` failed here; tolerance is correct).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_math_pow | OK | PASS | OK | PASS |
| er_math_sqrt | OK | PASS | OK | PASS |
| er_math_hypot | OK | PASS | OK | PASS |

## Remaining
5. fractional/error_and_gamma + stub refactor (final PR -> Resolves #950).

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Relates to #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with property-based fuzzing for hypot, pow, and sqrt to exercise many randomized cases.
  * Added robust numeric comparisons and checks (identity, exponent laws, symmetry, monotonicity, and bounds) to catch subtle inaccuracies.
  * Enabled more verbose per-test reporting and improved diagnostic messages to make failures easier to investigate.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->