### PR TITLE
feat(ereal): standardize math/functions fractional/error_gamma + smoke (#950 cat 5, final)

### DIFF
--- a/elastic/ereal/math/functions/ereal_math_stub_test.cpp
+++ b/elastic/ereal/math/functions/ereal_math_stub_test.cpp
@@ -1,4 +1,10 @@
-// ereal_math_stub_test.cpp: test suite for ereal mathlib stub implementations
+// ereal_math_stub_test.cpp: cross-cutting smoke test for the ereal mathlib.
+//
+// Calls every mathlib function once on a representative in-domain input and
+// asserts the result is finite. This is a breadth-first "is everything wired
+// and callable" regression that complements the per-function property files
+// (classify/numerics/.../error_and_gamma); it deliberately does not re-test
+// accuracy. Standardized as part of #950.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -7,195 +13,125 @@
 #include <universal/utility/directives.hpp>
 #include <universal/number/ereal/ereal.hpp>
 
-#include <iostream>
-#include <iomanip>
-#include <string>
+#include <cmath>
+#include <universal/verification/test_suite.hpp>
 
-// Test helpers
-constexpr unsigned COLWIDTH = 20;
+namespace {
+	using namespace sw::universal;
+
+	// Smoke test: each function evaluated on a valid input must produce a finite
+	// result (catches link/dispatch regressions and gross NaN/Inf failures).
+	template<typename Real>
+	int VerifyMathSmoke(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+		Real x(2.0), y(3.0);
+
+		auto finite = [&](const char* name, const Real& z) {
+			if (!std::isfinite(double(z))) {
+				if (reportTestCases) std::cout << "    FAIL " << name << " is not finite\n";
+				++nrOfFailedTestCases;
+			}
+		};
+
+		// numeric support
+		int e;
+		finite("frexp", frexp(x, &e));
+		finite("ldexp", ldexp(x, 3));
+		finite("copysign", copysign(x, Real(-1.0)));
+		finite("abs", abs(Real(-2.0)));
+		// truncation
+		finite("floor", floor(Real(2.7)));
+		finite("ceil", ceil(Real(2.3)));
+		finite("trunc", trunc(Real(2.7)));
+		finite("round", round(Real(2.5)));
+		// min/max
+		finite("min", min(x, y));
+		finite("max", max(x, y));
+		// fractional
+		finite("fmod", fmod(Real(7.0), Real(3.0)));
+		finite("remainder", remainder(Real(7.0), Real(3.0)));
+		// hypot
+		finite("hypot2", hypot(x, y));
+		finite("hypot3", hypot(x, y, Real(4.0)));
+		// roots
+		finite("sqrt", sqrt(x));
+		finite("cbrt", cbrt(Real(8.0)));
+		// exponentials
+		finite("exp", exp(x));
+		finite("exp2", exp2(x));
+		finite("exp10", exp10(x));
+		finite("expm1", expm1(Real(0.1)));
+		// logarithms
+		finite("log", log(x));
+		finite("log2", log2(x));
+		finite("log10", log10(x));
+		finite("log1p", log1p(Real(0.1)));
+		// powers
+		finite("pow", pow(x, y));
+		finite("pown", pown(x, 3));
+		// trigonometric
+		finite("sin", sin(Real(1.0)));
+		finite("cos", cos(Real(1.0)));
+		finite("tan", tan(Real(1.0)));
+		finite("asin", asin(Real(0.5)));
+		finite("acos", acos(Real(0.5)));
+		finite("atan", atan(Real(1.0)));
+		finite("atan2", atan2(y, x));
+		// hyperbolic
+		finite("sinh", sinh(x));
+		finite("cosh", cosh(x));
+		finite("tanh", tanh(x));
+		finite("asinh", asinh(x));
+		finite("acosh", acosh(x));
+		finite("atanh", atanh(Real(0.5)));
+		// error and gamma
+		finite("erf", erf(x));
+		finite("erfc", erfc(x));
+		finite("tgamma", tgamma(x));
+		finite("lgamma", lgamma(x));
+		// next
+		finite("nextafter", nextafter(x, y));
+
+		return nrOfFailedTestCases;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 1
+#	define REGRESSION_LEVEL_4 1
+#endif
 
 int main()
 try {
 	using namespace sw::universal;
 
-	std::cout << "ereal mathlib stub function validation\n";
-	std::cout << "========================================\n\n";
+	std::string test_suite  = "ereal mathlib smoke test";
+	std::string test_tag    = "mathlib smoke";
+	bool reportTestCases    = true;
+	int nrOfFailedTestCases = 0;
 
-	// Use default maxlimbs parameter
-	using Real = ereal<>;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	int nrOfFailures = 0;
+	nrOfFailedTestCases += ReportTestResult(VerifyMathSmoke<ereal<>>(reportTestCases), "mathlib(ereal) smoke", test_tag);
 
-	// Test values
-	Real x(2.0);
-	Real y(3.0);
-	Real z;
-
-	std::cout << std::setw(COLWIDTH) << "Function" << " : " << "Result\n";
-	std::cout << std::string(COLWIDTH + 20, '-') << '\n';
-
-	// Classification functions
-	std::cout << "\nClassification Functions:\n";
-	std::cout << std::setw(COLWIDTH) << "isfinite(2.0)" << " : " << (isfinite(x) ? "true" : "false") << '\n';
-	std::cout << std::setw(COLWIDTH) << "isnan(2.0)" << " : " << (isnan(x) ? "true" : "false") << '\n';
-	std::cout << std::setw(COLWIDTH) << "isinf(2.0)" << " : " << (isinf(x) ? "true" : "false") << '\n';
-	std::cout << std::setw(COLWIDTH) << "isnormal(2.0)" << " : " << (isnormal(x) ? "true" : "false") << '\n';
-	std::cout << std::setw(COLWIDTH) << "signbit(2.0)" << " : " << (signbit(x) ? "true" : "false") << '\n';
-
-	// Numeric operations
-	std::cout << "\nNumeric Operations:\n";
-	int exponent;
-	z = frexp(x, &exponent);
-	std::cout << std::setw(COLWIDTH) << "frexp(2.0)" << " : " << z << " * 2^" << exponent << '\n';
-	z = ldexp(x, 3);
-	std::cout << std::setw(COLWIDTH) << "ldexp(2.0, 3)" << " : " << z << '\n';
-	z = copysign(x, Real(-1.0));
-	std::cout << std::setw(COLWIDTH) << "copysign(2.0, -1)" << " : " << z << '\n';
-	z = abs(Real(-2.0));
-	std::cout << std::setw(COLWIDTH) << "abs(-2.0)" << " : " << z << '\n';
-
-	// Truncation functions
-	std::cout << "\nTruncation Functions:\n";
-	z = floor(Real(2.7));
-	std::cout << std::setw(COLWIDTH) << "floor(2.7)" << " : " << z << '\n';
-	z = ceil(Real(2.3));
-	std::cout << std::setw(COLWIDTH) << "ceil(2.3)" << " : " << z << '\n';
-	z = trunc(Real(2.7));
-	std::cout << std::setw(COLWIDTH) << "trunc(2.7)" << " : " << z << '\n';
-	z = round(Real(2.5));
-	std::cout << std::setw(COLWIDTH) << "round(2.5)" << " : " << z << '\n';
-
-	// Min/Max functions
-	std::cout << "\nMin/Max Functions:\n";
-	z = min(x, y);
-	std::cout << std::setw(COLWIDTH) << "min(2.0, 3.0)" << " : " << z << '\n';
-	z = max(x, y);
-	std::cout << std::setw(COLWIDTH) << "max(2.0, 3.0)" << " : " << z << '\n';
-
-	// Fractional functions
-	std::cout << "\nFractional Functions:\n";
-	z = fmod(Real(7.0), Real(3.0));
-	std::cout << std::setw(COLWIDTH) << "fmod(7.0, 3.0)" << " : " << z << '\n';
-	z = remainder(Real(7.0), Real(3.0));
-	std::cout << std::setw(COLWIDTH) << "remainder(7.0, 3.0)" << " : " << z << '\n';
-
-	// Hypot function
-	std::cout << "\nHypot Function:\n";
-	z = hypot(x, y);
-	std::cout << std::setw(COLWIDTH) << "hypot(2.0, 3.0)" << " : " << z << '\n';
-	z = hypot(x, y, Real(4.0));
-	std::cout << std::setw(COLWIDTH) << "hypot(2,3,4)" << " : " << z << '\n';
-
-	// Root functions
-	std::cout << "\nRoot Functions:\n";
-	z = sqrt(x);
-	std::cout << std::setw(COLWIDTH) << "sqrt(2.0)" << " : " << z << '\n';
-	z = cbrt(Real(8.0));
-	std::cout << std::setw(COLWIDTH) << "cbrt(8.0)" << " : " << z << '\n';
-
-	// Exponential functions
-	std::cout << "\nExponential Functions:\n";
-	z = exp(x);
-	std::cout << std::setw(COLWIDTH) << "exp(2.0)" << " : " << z << '\n';
-	z = exp2(x);
-	std::cout << std::setw(COLWIDTH) << "exp2(2.0)" << " : " << z << '\n';
-	z = exp10(x);
-	std::cout << std::setw(COLWIDTH) << "exp10(2.0)" << " : " << z << '\n';
-	z = expm1(Real(0.1));
-	std::cout << std::setw(COLWIDTH) << "expm1(0.1)" << " : " << z << '\n';
-
-	// Logarithm functions
-	std::cout << "\nLogarithm Functions:\n";
-	z = log(x);
-	std::cout << std::setw(COLWIDTH) << "log(2.0)" << " : " << z << '\n';
-	z = log2(x);
-	std::cout << std::setw(COLWIDTH) << "log2(2.0)" << " : " << z << '\n';
-	z = log10(x);
-	std::cout << std::setw(COLWIDTH) << "log10(2.0)" << " : " << z << '\n';
-	z = log1p(Real(0.1));
-	std::cout << std::setw(COLWIDTH) << "log1p(0.1)" << " : " << z << '\n';
-
-	// Power functions
-	std::cout << "\nPower Functions:\n";
-	z = pow(x, y);
-	std::cout << std::setw(COLWIDTH) << "pow(2.0, 3.0)" << " : " << z << '\n';
-	z = pown(x, 3);
-	std::cout << std::setw(COLWIDTH) << "pown(2.0, 3)" << " : " << z << '\n';
-
-	// Trigonometric functions
-	std::cout << "\nTrigonometric Functions:\n";
-	z = sin(Real(1.0));
-	std::cout << std::setw(COLWIDTH) << "sin(1.0)" << " : " << z << '\n';
-	z = cos(Real(1.0));
-	std::cout << std::setw(COLWIDTH) << "cos(1.0)" << " : " << z << '\n';
-	z = tan(Real(1.0));
-	std::cout << std::setw(COLWIDTH) << "tan(1.0)" << " : " << z << '\n';
-	z = asin(Real(0.5));
-	std::cout << std::setw(COLWIDTH) << "asin(0.5)" << " : " << z << '\n';
-	z = acos(Real(0.5));
-	std::cout << std::setw(COLWIDTH) << "acos(0.5)" << " : " << z << '\n';
-	z = atan(Real(1.0));
-	std::cout << std::setw(COLWIDTH) << "atan(1.0)" << " : " << z << '\n';
-	z = atan2(y, x);
-	std::cout << std::setw(COLWIDTH) << "atan2(3.0, 2.0)" << " : " << z << '\n';
-
-	// Hyperbolic functions
-	std::cout << "\nHyperbolic Functions:\n";
-	z = sinh(x);
-	std::cout << std::setw(COLWIDTH) << "sinh(2.0)" << " : " << z << '\n';
-	z = cosh(x);
-	std::cout << std::setw(COLWIDTH) << "cosh(2.0)" << " : " << z << '\n';
-	z = tanh(x);
-	std::cout << std::setw(COLWIDTH) << "tanh(2.0)" << " : " << z << '\n';
-	z = asinh(x);
-	std::cout << std::setw(COLWIDTH) << "asinh(2.0)" << " : " << z << '\n';
-	z = acosh(x);
-	std::cout << std::setw(COLWIDTH) << "acosh(2.0)" << " : " << z << '\n';
-	z = atanh(Real(0.5));
-	std::cout << std::setw(COLWIDTH) << "atanh(0.5)" << " : " << z << '\n';
-
-	// Error and Gamma functions
-	std::cout << "\nError and Gamma Functions:\n";
-	z = erf(x);
-	std::cout << std::setw(COLWIDTH) << "erf(2.0)" << " : " << z << '\n';
-	z = erfc(x);
-	std::cout << std::setw(COLWIDTH) << "erfc(2.0)" << " : " << z << '\n';
-	z = tgamma(x);
-	std::cout << std::setw(COLWIDTH) << "tgamma(2.0)" << " : " << z << '\n';
-	z = lgamma(x);
-	std::cout << std::setw(COLWIDTH) << "lgamma(2.0)" << " : " << z << '\n';
-
-	// Next functions
-	std::cout << "\nNext Functions:\n";
-	z = nextafter(x, y);
-	std::cout << std::setw(COLWIDTH) << "nextafter(2,3)" << " : " << z << '\n';
-
-	std::cout << "\n========================================\n";
-	if (nrOfFailures == 0) {
-		std::cout << "All stub functions compiled and executed successfully.\n";
-		std::cout << "Phase 0 infrastructure validation: PASS\n";
-	}
-	else {
-		std::cout << "Phase 0 infrastructure validation: FAIL\n";
-		std::cout << "Number of failures: " << nrOfFailures << '\n';
-	}
-
-	return (nrOfFailures > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }
 catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::universal::universal_arithmetic_exception& err) {
-	std::cerr << "Caught unexpected universal arithmetic exception: " << err.what() << std::endl;
-	return EXIT_FAILURE;
-}
-catch (const sw::universal::universal_internal_exception& err) {
-	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
-	return EXIT_FAILURE;
-}
-catch (const std::runtime_error& err) {
-	std::cerr << "Caught unexpected runtime exception: " << err.what() << std::endl;
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/elastic/ereal/math/functions/error_and_gamma.cpp
+++ b/elastic/ereal/math/functions/error_and_gamma.cpp
@@ -1,27 +1,160 @@
-// error_and_gamma.cpp: test suite runner for error and gamma functions for ereal adaptive-precision
+// error_and_gamma.cpp: regression tests for the error and gamma functions of
+// ereal adaptive-precision.
+//
+// Standardized as part of #950 (math/functions refactor). The previous file was
+// a Phase-0 MANUAL_TESTING smoke stub; erf/erfc/tgamma/lgamma are in fact
+// implemented and accurate, so this exercises them with hand-curated identities
+// and an oracle-free property fuzzer (the precision-lifting self-oracle remains
+// scoped to #954).
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
-#define MANUAL_TESTING 1
-// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
-// It is the responsibility of the regression test to organize the tests in a quartile progression.
-//#undef REGRESSION_LEVEL_OVERRIDE
+namespace {
+	using namespace sw::universal;
+
+	template<typename Real>
+	bool close_rel(const Real& x, const Real& y, double relTol, double absTol = 1.0e-15) {
+		double a = double(x), b = double(y);
+		double diff = std::abs(a - b);
+		if (diff == 0.0) return true;
+		double scale = std::max(std::abs(a), std::abs(b));
+		return diff <= std::max(absTol, relTol * scale);
+	}
+
+	// erf/erfc: fixed point, parity, and the erf(x)+erfc(x)==1 complement.
+	template<typename Real>
+	int VerifyErrorFunction(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+
+		// erf(0) == 0, erfc(0) == 1
+		if (!erf(Real(0.0)).iszero()) {
+			if (reportTestCases) std::cout << "    FAIL erf(0) != 0\n"; ++nrOfFailedTestCases;
+		}
+		if (!close_rel(erfc(Real(0.0)), Real(1.0), 1.0e-14)) {
+			if (reportTestCases) std::cout << "    FAIL erfc(0) != 1\n"; ++nrOfFailedTestCases;
+		}
+		// erf matches the std::erf reference for representative points
+		for (double v : {0.5, 1.0, 2.0}) {
+			if (!close_rel(erf(Real(v)), Real(std::erf(v)), 1.0e-13)) {
+				if (reportTestCases) std::cout << "    FAIL erf(" << v << ") mismatch\n"; ++nrOfFailedTestCases;
+			}
+		}
+		// parity: erf(-x) == -erf(x); complement: erf(x)+erfc(x) == 1
+		for (double v : {0.3, 1.0, 2.5}) {
+			Real x(v);
+			if (!close_rel(erf(-x), -erf(x), 1.0e-14)) {
+				if (reportTestCases) std::cout << "    FAIL erf parity at " << v << "\n"; ++nrOfFailedTestCases;
+			}
+			if (!close_rel(erf(x) + erfc(x), Real(1.0), 1.0e-14)) {
+				if (reportTestCases) std::cout << "    FAIL erf+erfc != 1 at " << v << "\n"; ++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	// tgamma: factorial fixed points, the reflection-free recurrence
+	// tgamma(x+1)==x*tgamma(x), and tgamma(1/2)^2 == pi.
+	template<typename Real>
+	int VerifyTgamma(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+
+		// tgamma(n) == (n-1)!
+		double fact = 1.0;  // (n-1)! ; starts at 0!=1 for n=1
+		for (int n = 1; n <= 7; ++n) {
+			if (n > 1) fact *= (n - 1);
+			if (!close_rel(tgamma(Real(double(n))), Real(fact), 1.0e-13)) {
+				if (reportTestCases) std::cout << "    FAIL tgamma(" << n << ") != " << fact << "\n"; ++nrOfFailedTestCases;
+			}
+		}
+		// tgamma(1/2)^2 == pi
+		Real g = tgamma(Real(0.5));
+		if (!close_rel(g * g, Real(std::acos(-1.0)), 1.0e-13)) {
+			if (reportTestCases) std::cout << "    FAIL tgamma(1/2)^2 != pi\n"; ++nrOfFailedTestCases;
+		}
+		// recurrence: tgamma(x+1) == x*tgamma(x)
+		for (double v : {1.5, 2.7, 4.2}) {
+			Real x(v);
+			if (!close_rel(tgamma(x + Real(1.0)), x * tgamma(x), 1.0e-13)) {
+				if (reportTestCases) std::cout << "    FAIL gamma recurrence at " << v << "\n"; ++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	// lgamma: fixed points and agreement with log(tgamma) / std::lgamma.
+	template<typename Real>
+	int VerifyLgamma(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+
+		// lgamma(1) == 0 and lgamma(2) == 0
+		if (!lgamma(Real(1.0)).iszero() || !lgamma(Real(2.0)).iszero()) {
+			if (reportTestCases) std::cout << "    FAIL lgamma(1) or lgamma(2) != 0\n"; ++nrOfFailedTestCases;
+		}
+		// lgamma(x) == log(tgamma(x)) for x where tgamma is moderate
+		for (double v : {1.5, 3.0, 5.0}) {
+			Real x(v);
+			if (!close_rel(lgamma(x), log(tgamma(x)), 1.0e-12)) {
+				if (reportTestCases) std::cout << "    FAIL lgamma != log(tgamma) at " << v << "\n"; ++nrOfFailedTestCases;
+			}
+			// agreement with the std::lgamma reference
+			if (!close_rel(lgamma(x), Real(std::lgamma(v)), 1.0e-12)) {
+				if (reportTestCases) std::cout << "    FAIL lgamma(" << v << ") vs std\n"; ++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	// Property fuzzer: erf parity / complement / monotonicity, and the gamma
+	// recurrence, over random inputs.
+	template<typename Real>
+	int VerifyErrorGammaFuzz(bool reportTestCases, unsigned nrIterations) {
+		int nrOfFailedTestCases = 0;
+		std::mt19937_64 rng(0xC1A55'1FFEULL);
+		std::uniform_real_distribution<double> edist(-3.0, 3.0);
+		std::uniform_real_distribution<double> gdist(0.5, 6.0);
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			double e = edist(rng);
+			Real x(e);
+			if (!close_rel(erf(-x), -erf(x), 1.0e-13)) {
+				if (reportTestCases) std::cout << "    FAIL erf parity at " << e << "\n"; ++nrOfFailedTestCases;
+			}
+			if (!close_rel(erf(x) + erfc(x), Real(1.0), 1.0e-13)) {
+				if (reportTestCases) std::cout << "    FAIL erf+erfc != 1 at " << e << "\n"; ++nrOfFailedTestCases;
+			}
+			if (!(erf(x) < erf(x + Real(0.5)))) {   // erf strictly increasing
+				if (reportTestCases) std::cout << "    FAIL erf monotonic at " << e << "\n"; ++nrOfFailedTestCases;
+			}
+			double g = gdist(rng);
+			Real y(g);
+			if (!close_rel(tgamma(y + Real(1.0)), y * tgamma(y), 1.0e-12)) {
+				if (reportTestCases) std::cout << "    FAIL gamma recurrence at " << g << "\n"; ++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
 #ifndef REGRESSION_LEVEL_OVERRIDE
-#undef REGRESSION_LEVEL_1
-#undef REGRESSION_LEVEL_2
-#undef REGRESSION_LEVEL_3
-#undef REGRESSION_LEVEL_4
-#define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 1
+#	define REGRESSION_LEVEL_4 1
 #endif
 
 int main()
@@ -30,38 +163,40 @@ try {
 
 	std::string test_suite  = "ereal mathlib error and gamma function validation";
 	std::string test_tag    = "erf/erfc/tgamma/lgamma";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 #if MANUAL_TESTING
 
-	// Phase 0: Minimal smoke test - verify functions are callable
-	// TODO Phase 2: Implement using Taylor series or continued fractions
-	// TODO Phase 2: Implement tgamma using Lanczos approximation or Stirling series
-	// TODO Phase 2: Add precision validation tests
-
-	ereal<> x(2.0);
-
-	std::cout << "Testing error and gamma functions...\n";
-	std::cout << "erf(" << x << ") = " << erf(x) << '\n';
-	std::cout << "erfc(" << x << ") = " << erfc(x) << '\n';
-	std::cout << "tgamma(" << x << ") = " << tgamma(x) << '\n';
-	std::cout << "lgamma(" << x << ") = " << lgamma(x) << '\n';
-
-	std::cout << "\nPhase 0: stub infrastructure validation - PASS\n";
-	std::cout << "TODO: Implement Taylor series/Lanczos approximation in Phase 2\n";
-
+	nrOfFailedTestCases += ReportTestResult(VerifyErrorFunction<ereal<>>(reportTestCases), "erf/erfc(ereal)", test_tag);
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;   // ignore errors
+
 #else
 
-	// Phase 0: No automated tests yet
-	// TODO Phase 2: Add REGRESSION_LEVEL_1 tests (basic error/gamma functionality)
-	// TODO Phase 2: Add REGRESSION_LEVEL_2 tests (extended range)
-	// TODO Phase 2: Add REGRESSION_LEVEL_3 tests (precision validation)
-	// TODO Phase 2: Add REGRESSION_LEVEL_4 tests (stress testing)
+#	if REGRESSION_LEVEL_1
+	test_tag = "erf/erfc";
+	nrOfFailedTestCases += ReportTestResult(VerifyErrorFunction<ereal<>>(reportTestCases), "erf/erfc(ereal)", test_tag);
+
+	test_tag = "tgamma";
+	nrOfFailedTestCases += ReportTestResult(VerifyTgamma<ereal<>>(reportTestCases), "tgamma(ereal)", test_tag);
+
+	test_tag = "lgamma";
+	nrOfFailedTestCases += ReportTestResult(VerifyLgamma<ereal<>>(reportTestCases), "lgamma(ereal)", test_tag);
+#	endif
+
+#	if REGRESSION_LEVEL_2
+	test_tag = "error/gamma fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyErrorGammaFuzz<ereal<>>(reportTestCases, 1000), "error/gamma property fuzz", test_tag);
+#	endif
+
+#	if REGRESSION_LEVEL_3
+#	endif
+
+#	if REGRESSION_LEVEL_4
+#	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
@@ -72,16 +207,8 @@ catch (char const* msg) {
 	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
 	return EXIT_FAILURE;
 }
-catch (const sw::universal::universal_arithmetic_exception& err) {
-	std::cerr << "Caught unexpected universal arithmetic exception : " << err.what() << std::endl;
-	return EXIT_FAILURE;
-}
-catch (const sw::universal::universal_internal_exception& err) {
-	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
-	return EXIT_FAILURE;
-}
-catch (const std::runtime_error& err) {
-	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+catch (const std::exception& err) {
+	std::cerr << "Caught exception: " << err.what() << std::endl;
 	return EXIT_FAILURE;
 }
 catch (...) {

--- a/elastic/ereal/math/functions/error_and_gamma.cpp
+++ b/elastic/ereal/math/functions/error_and_gamma.cpp
@@ -58,6 +58,18 @@ namespace {
 				if (reportTestCases) std::cout << "    FAIL erf+erfc != 1 at " << v << "\n"; ++nrOfFailedTestCases;
 			}
 		}
+		// special values: erf(+/-Inf) = +/-1, erfc(+/-Inf) = 0/2, NaN propagates
+		double pinf = std::numeric_limits<double>::infinity();
+		double qnan = std::numeric_limits<double>::quiet_NaN();
+		if (!close_rel(erf(Real(pinf)), Real(1.0), 1.0e-14) || !close_rel(erf(Real(-pinf)), Real(-1.0), 1.0e-14)) {
+			if (reportTestCases) std::cout << "    FAIL erf(+/-Inf) != +/-1\n"; ++nrOfFailedTestCases;
+		}
+		if (!erfc(Real(pinf)).iszero() || !close_rel(erfc(Real(-pinf)), Real(2.0), 1.0e-14)) {
+			if (reportTestCases) std::cout << "    FAIL erfc(+/-Inf) != 0/2\n"; ++nrOfFailedTestCases;
+		}
+		if (!std::isnan(double(erf(Real(qnan)))) || !std::isnan(double(erfc(Real(qnan))))) {
+			if (reportTestCases) std::cout << "    FAIL erf/erfc(NaN) not NaN\n"; ++nrOfFailedTestCases;
+		}
 		return nrOfFailedTestCases;
 	}
 
@@ -87,6 +99,17 @@ namespace {
 				if (reportTestCases) std::cout << "    FAIL gamma recurrence at " << v << "\n"; ++nrOfFailedTestCases;
 			}
 		}
+		// special values: tgamma(+Inf) = +Inf, tgamma(NaN) = NaN
+		{
+			double pinf = std::numeric_limits<double>::infinity();
+			double rinf = double(tgamma(Real(pinf)));
+			if (!std::isinf(rinf) || rinf < 0) {
+				if (reportTestCases) std::cout << "    FAIL tgamma(+Inf) != +Inf\n"; ++nrOfFailedTestCases;
+			}
+			if (!std::isnan(double(tgamma(Real(std::numeric_limits<double>::quiet_NaN()))))) {
+				if (reportTestCases) std::cout << "    FAIL tgamma(NaN) != NaN\n"; ++nrOfFailedTestCases;
+			}
+		}
 		return nrOfFailedTestCases;
 	}
 
@@ -109,6 +132,11 @@ namespace {
 			if (!close_rel(lgamma(x), Real(std::lgamma(v)), 1.0e-12)) {
 				if (reportTestCases) std::cout << "    FAIL lgamma(" << v << ") vs std\n"; ++nrOfFailedTestCases;
 			}
+		}
+		// special value: lgamma(+Inf) = +Inf
+		double linf = double(lgamma(Real(std::numeric_limits<double>::infinity())));
+		if (!std::isinf(linf) || linf < 0) {
+			if (reportTestCases) std::cout << "    FAIL lgamma(+Inf) != +Inf\n"; ++nrOfFailedTestCases;
 		}
 		return nrOfFailedTestCases;
 	}

--- a/elastic/ereal/math/functions/error_and_gamma.cpp
+++ b/elastic/ereal/math/functions/error_and_gamma.cpp
@@ -14,6 +14,7 @@
 #include <universal/utility/directives.hpp>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>

--- a/elastic/ereal/math/functions/fractional.cpp
+++ b/elastic/ereal/math/functions/fractional.cpp
@@ -254,7 +254,7 @@ namespace {
 					++nrOfFailedTestCases;
 				}
 				// |fmod(x,y)| < |y| and same sign as x (when nonzero)
-				if (std::abs(double(r)) > std::abs(dy)) {
+				if (std::abs(double(r)) >= std::abs(dy)) {
 					if (reportTestCases) std::cout << "    FAIL |fmod| >= |y| at x=" << dx << '\n';
 					++nrOfFailedTestCases;
 				}

--- a/elastic/ereal/math/functions/fractional.cpp
+++ b/elastic/ereal/math/functions/fractional.cpp
@@ -5,11 +5,14 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <cmath>
+#include <random>
 #include <universal/number/ereal/ereal.hpp>
 #include <universal/verification/test_suite.hpp>
 
-namespace sw {
-	namespace universal {
+namespace {
+	using namespace sw::universal;
 
 		// Verify fmod function
 		template<typename Real>
@@ -23,7 +26,7 @@ namespace sw {
 			Real expected = x - (n * y);
 
 			if (result != expected) {
-				if (reportTestCases) std::cerr << "FAIL: fmod(5.3, 2.0) property violation\n";
+				if (reportTestCases) std::cout << "    FAIL fmod(5.3, 2.0) property violation\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -32,11 +35,11 @@ namespace sw {
 			Real neg_result = fmod(Real(-5.3), Real(2.0));
 
 			if (!pos_result.ispos()) {
-				if (reportTestCases) std::cerr << "FAIL: fmod(5.3, 2.0) should be positive\n";
+				if (reportTestCases) std::cout << "    FAIL fmod(5.3, 2.0) should be positive\n";
 				++nrOfFailedTestCases;
 			}
 			if (!neg_result.isneg()) {
-				if (reportTestCases) std::cerr << "FAIL: fmod(-5.3, 2.0) should be negative\n";
+				if (reportTestCases) std::cout << "    FAIL fmod(-5.3, 2.0) should be negative\n";
 				++nrOfFailedTestCases;
 			}
 
@@ -55,7 +58,7 @@ namespace sw {
 				Real result = remainder(x, y);
 				Real expected(1.0);
 				if (result != expected) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(7.0, 3.0) = "
+					if (reportTestCases) std::cout << "    FAIL remainder(7.0, 3.0) = "
 						<< double(result) << ", expected 1.0\n";
 					++nrOfFailedTestCases;
 				}
@@ -69,7 +72,7 @@ namespace sw {
 				Real result = remainder(x, y);
 				Real expected(1.0);
 				if (result != expected) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(5.0, 2.0) = "
+					if (reportTestCases) std::cout << "    FAIL remainder(5.0, 2.0) = "
 						<< double(result) << ", expected 1.0 (rounds 2.5 to 2 even)\n";
 					++nrOfFailedTestCases;
 				}
@@ -83,7 +86,7 @@ namespace sw {
 				Real result = remainder(x, y);
 				Real expected(-1.0);
 				if (result != expected) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(7.0, 2.0) = "
+					if (reportTestCases) std::cout << "    FAIL remainder(7.0, 2.0) = "
 						<< double(result) << ", expected -1.0 (rounds 3.5 to 4 even)\n";
 					++nrOfFailedTestCases;
 				}
@@ -96,7 +99,7 @@ namespace sw {
 				Real result = remainder(x, y);
 				Real expected(-1.0);
 				if (result != expected) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(-7.0, 3.0) = "
+					if (reportTestCases) std::cout << "    FAIL remainder(-7.0, 3.0) = "
 						<< double(result) << ", expected -1.0\n";
 					++nrOfFailedTestCases;
 				}
@@ -109,7 +112,7 @@ namespace sw {
 				Real result = remainder(x, y);
 				Real expected(0.0);
 				if (result != expected) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(9.0, 3.0) = "
+					if (reportTestCases) std::cout << "    FAIL remainder(9.0, 3.0) = "
 						<< double(result) << ", expected 0.0\n";
 					++nrOfFailedTestCases;
 				}
@@ -124,14 +127,14 @@ namespace sw {
 				Real y_half = y / Real(2.0);
 
 				if (result != expected) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(10.0, 3.0) = "
+					if (reportTestCases) std::cout << "    FAIL remainder(10.0, 3.0) = "
 						<< double(result) << ", expected 1.0\n";
 					++nrOfFailedTestCases;
 				}
 
 				// Verify result is in range [-1.5, 1.5]
 				if (abs(result) > y_half) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(10.0, 3.0) out of range [-1.5, 1.5]\n";
+					if (reportTestCases) std::cout << "    FAIL remainder(10.0, 3.0) out of range [-1.5, 1.5]\n";
 					++nrOfFailedTestCases;
 				}
 			}
@@ -144,7 +147,7 @@ namespace sw {
 				Real result = remainder(x, y);
 				Real expected(-1.0);
 				if (result != expected) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(11.0, 4.0) = "
+					if (reportTestCases) std::cout << "    FAIL remainder(11.0, 4.0) = "
 						<< double(result) << ", expected -1.0\n";
 					++nrOfFailedTestCases;
 				}
@@ -166,14 +169,14 @@ namespace sw {
 				try {
 					Real result = remainder(x, y);
 					// If we get here, exception was not thrown
-					if (reportTestCases) std::cerr << "FAIL: remainder(5.0, 0.0) should throw exception\n";
+					if (reportTestCases) std::cout << "    FAIL remainder(5.0, 0.0) should throw exception\n";
 					++nrOfFailedTestCases;
 				}
 				catch (const ereal_divide_by_zero&) {
 					caught_exception = true;
 				}
 				catch (...) {
-					if (reportTestCases) std::cerr << "FAIL: remainder(5.0, 0.0) threw wrong exception type\n";
+					if (reportTestCases) std::cout << "    FAIL remainder(5.0, 0.0) threw wrong exception type\n";
 					++nrOfFailedTestCases;
 				}
 
@@ -190,14 +193,14 @@ namespace sw {
 				try {
 					Real result = fmod(x, y);
 					// If we get here, exception was not thrown
-					if (reportTestCases) std::cerr << "FAIL: fmod(5.0, 0.0) should throw exception\n";
+					if (reportTestCases) std::cout << "    FAIL fmod(5.0, 0.0) should throw exception\n";
 					++nrOfFailedTestCases;
 				}
 				catch (const ereal_divide_by_zero&) {
 					caught_exception = true;
 				}
 				catch (...) {
-					if (reportTestCases) std::cerr << "FAIL: fmod(5.0, 0.0) threw wrong exception type\n";
+					if (reportTestCases) std::cout << "    FAIL fmod(5.0, 0.0) threw wrong exception type\n";
 					++nrOfFailedTestCases;
 				}
 
@@ -223,15 +226,54 @@ namespace sw {
 			Real remainder_result = remainder(x, y);
 
 			if (fmod_result == remainder_result) {
-				if (reportTestCases) std::cerr << "FAIL: fmod and remainder should differ for 5.3/2.0\n";
+				if (reportTestCases) std::cout << "    FAIL fmod and remainder should differ for 5.3/2.0\n";
 				++nrOfFailedTestCases;
 			}
 
 			return nrOfFailedTestCases;
 		}
 
-	}
-}
+
+		// Property fuzzer: the fmod/remainder reduction identities and ranges over
+		// random dividend/divisor pairs (divisor bounded away from zero).
+		template<typename Real>
+		int VerifyFractionalFuzz(bool reportTestCases, unsigned nrIterations) {
+			int nrOfFailedTestCases = 0;
+			std::mt19937_64 rng(0xC1A55'1FFEULL);
+			std::uniform_real_distribution<double> xd(-1.0e3, 1.0e3);
+			std::uniform_real_distribution<double> yd(0.5, 1.0e2);
+			for (unsigned i = 0; i < nrIterations; ++i) {
+				double dx = xd(rng), dy = yd(rng) * (rng() & 1 ? 1.0 : -1.0);
+				Real x(dx), y(dy);
+				// fmod: x == trunc(x/y)*y + fmod(x,y)
+				Real r = fmod(x, y);
+				Real n = trunc(x / y);
+				double recon = double(n * y + r);
+				if (std::abs(recon - dx) > 1.0e-10 * (1.0 + std::abs(dx))) {
+					if (reportTestCases) std::cout << "    FAIL fmod reduction at x=" << dx << " y=" << dy << '\n';
+					++nrOfFailedTestCases;
+				}
+				// |fmod(x,y)| < |y| and same sign as x (when nonzero)
+				if (std::abs(double(r)) > std::abs(dy)) {
+					if (reportTestCases) std::cout << "    FAIL |fmod| >= |y| at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				if (!r.iszero() && (r.isneg() != (dx < 0.0))) {
+					if (reportTestCases) std::cout << "    FAIL fmod sign at x=" << dx << '\n';
+					++nrOfFailedTestCases;
+				}
+				// remainder: |remainder(x,y)| <= |y|/2 (within rounding)
+				Real rem = remainder(x, y);
+				if (std::abs(double(rem)) > std::abs(dy) * 0.5 + 1.0e-10 * std::abs(dy)) {
+					if (reportTestCases) std::cout << "    FAIL |remainder| > |y|/2 at x=" << dx << " y=" << dy << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
+}  // anonymous namespace
+
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0
@@ -255,7 +297,7 @@ try {
 
 	std::string test_suite  = "ereal mathlib fractional function validation";
 	std::string test_tag    = "fractional";
-	bool reportTestCases    = false;
+	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -302,6 +344,9 @@ try {
 
 	test_tag = "fmod vs remainder";
 	nrOfFailedTestCases += ReportTestResult(VerifyFmodVsRemainder<ereal<>>(reportTestCases), "fmod vs remainder", test_tag);
+
+	test_tag = "fractional fuzz";
+	nrOfFailedTestCases += ReportTestResult(VerifyFractionalFuzz<ereal<>>(reportTestCases, 1000), "fmod/remainder property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2


### PR DESCRIPTION
## Summary
Final category (5 of 5) for the `elastic/ereal/math/functions/` refactor: `fractional.cpp`, `error_and_gamma.cpp`, `ereal_math_stub_test.cpp`. **Completes the 15-file standardization.**

Relates to #944 (parent epic, Phase B). **Resolves #950.**

## Changes
- **`fractional.cpp`** -- standardized; kept the fmod/remainder/div-by-zero/fmod-vs-remainder tests; added `VerifyFractionalFuzz` (reduction identity `x==trunc(x/y)*y+fmod(x,y)`, `|fmod|<|y|`, fmod sign, `|remainder|<=|y|/2`). `modf` is **not** covered -- it is not implemented for `ereal` (only `std::modf` is used internally).
- **`error_and_gamma.cpp`** -- was a Phase-0 `MANUAL_TESTING` smoke stub; erf/erfc/tgamma/lgamma turn out to be implemented and accurate, so converted to real tests: `VerifyErrorFunction` (erf(0)==0, vs std, parity, `erf+erfc==1`), `VerifyTgamma` (`tgamma(n)==(n-1)!`, `tgamma(1/2)^2==pi`, recurrence `tgamma(x+1)==x*tgamma(x)`), `VerifyLgamma` (fixed points, `lgamma==log(tgamma)`, vs std), and a property fuzzer.
- **`ereal_math_stub_test.cpp`** -- refactored the print-only demo into `VerifyMathSmoke`, a breadth-first regression that calls every mathlib function once on an in-domain input and asserts a finite result (kept, not removed, per maintainer preference; complements the per-function files).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_math_fractional | OK | PASS | OK | PASS |
| er_math_error_and_gamma | OK | PASS | OK | PASS |
| er_math_ereal_math_stub_test | OK | PASS | OK | PASS |

## #950 complete
cat1 (#974) · cat2 (#975) · cat3 (#976) · cat4 (#977) · cat5 (this) -- all 15 files standardized to the addition.cpp framework with oracle-free property/identity coverage. The precision-lifting self-oracle (and the `log1p` precision gap surfaced in cat2) remain scoped to #954.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Converted manual smoke tests into automated regression tests integrated with the project test runner.
  * Added comprehensive verifiers for math families: classification, arithmetic, truncation, roots, exponentials/logs, trig, error/gamma, and nextafter.
  * Introduced deterministic and randomized property-based fuzzers to broaden coverage.
  * Standardized reporting and simplified exception handling; adjusted manual-testing defaults to enable automated runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/978?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->