### PR TITLE
feat(ereal): audit api/ -- classify demos vs tests, refactor + ASCII (#953)

### DIFF
--- a/elastic/ereal/api/README.md
+++ b/elastic/ereal/api/README.md
@@ -1,0 +1,44 @@
+# elastic/ereal/api/
+
+This directory mixes two kinds of programs (audited in issue #953). The
+distinction matters for CI: a regression test's exit code is meaningful, a
+demo's is not (a demo "passes" if it compiles and runs without crashing).
+
+## Regression tests (framework-based; exit code is meaningful)
+
+These assert specific numerical/behavioral properties, count failures, and
+return `EXIT_FAILURE` on mismatch. They follow the standard test-suite
+reporting convention (`ReportTestSuiteHeader` / `ReportTestSuiteResults`).
+
+| File | Exercises |
+|------|-----------|
+| `adaptive_simple.cpp` | adaptive-precision growth, basic invariants |
+| `adaptive_threshold.cpp` | maxlimbs/threshold behavior |
+| `constexpr.cpp` | constexpr construction + `static_assert` checks |
+| `ostream_formatting.cpp` | `operator<<` formatting properties |
+| `phase2.cpp` | truncate / numerics / fractional comprehensive checks |
+| `phase3.cpp` | sqrt / cbrt / hypot root-function checks |
+| `progressive_precision.cpp` | precision scaling vs maxlimbs (WIP; marked WILL_FAIL in CMake) |
+| `string_parsing.cpp` | `parse()` / `operator>>` over many literal forms |
+
+## Demos (informational; not assertion-driven)
+
+These walk through usage patterns and print results for human inspection.
+They intentionally do NOT follow the assertion framework; pass/fail is just
+"compiled and ran". Left as-is by design.
+
+| File | Demonstrates |
+|------|--------------|
+| `accurate_summation.cpp` | accurate summation of many terms |
+| `adaptive_check.cpp` | quick adaptive-precision sanity printout |
+| `catastrophic_cancellation.cpp` | ereal vs double under cancellation |
+| `dot_product.cpp` | exact/accurate dot products |
+| `test_negation.cpp` | negation usage walkthrough |
+
+## Excluded
+
+- `api.cpp` -- the canonical API walkthrough; excluded from the #953 audit per
+  the parent epic (#944).
+
+All files in this directory are ASCII-only (no Unicode), per the project's
+console-portability rule.

--- a/elastic/ereal/api/accurate_summation.cpp
+++ b/elastic/ereal/api/accurate_summation.cpp
@@ -118,7 +118,7 @@ try {
 	// Test 3: Sum many tiny values into large accumulator
 	// ===================================================================
 
-	std::cout << "Test 3: 1e20 + sum(1000 × 1e10)\n";
+	std::cout << "Test 3: 1e20 + sum(1000 x 1e10)\n";
 	std::cout << "--------------------------------\n\n";
 
 	{
@@ -144,7 +144,7 @@ try {
 	// Test 4: Worst case for Kahan (requires multiple compensations)
 	// ===================================================================
 
-	std::cout << "Test 4: [1e30, 1, -1e30, 1, ...] × 500 (Kahan worst case)\n";
+	std::cout << "Test 4: [1e30, 1, -1e30, 1, ...] x 500 (Kahan worst case)\n";
 	std::cout << "-----------------------------------------------------------\n\n";
 
 	{

--- a/elastic/ereal/api/adaptive_simple.cpp
+++ b/elastic/ereal/api/adaptive_simple.cpp
@@ -53,30 +53,30 @@ try {
 	// Verify thresholds scale properly
 	std::cout << "\nThreshold Validation:\n";
 	if (threshold_e19 < threshold_e16) {
-		std::cout << "✓ PASS: ereal<19> has tighter threshold than ereal<16>\n";
+		std::cout << "[ok] PASS: ereal<19> has tighter threshold than ereal<16>\n";
 	} else {
-		std::cerr << "✗ FAIL: Threshold scaling incorrect\n";
+		std::cerr << "[x] FAIL: Threshold scaling incorrect\n";
 		++nrOfFailedTestCases;
 	}
 
 	if (threshold_e16 < threshold_e12) {
-		std::cout << "✓ PASS: ereal<16> has tighter threshold than ereal<12>\n";
+		std::cout << "[ok] PASS: ereal<16> has tighter threshold than ereal<12>\n";
 	} else {
-		std::cerr << "✗ FAIL: Threshold scaling incorrect\n";
+		std::cerr << "[x] FAIL: Threshold scaling incorrect\n";
 		++nrOfFailedTestCases;
 	}
 
 	if (threshold_e12 < threshold_e8) {
-		std::cout << "✓ PASS: ereal<12> has tighter threshold than ereal<8>\n";
+		std::cout << "[ok] PASS: ereal<12> has tighter threshold than ereal<8>\n";
 	} else {
-		std::cerr << "✗ FAIL: Threshold scaling incorrect\n";
+		std::cerr << "[x] FAIL: Threshold scaling incorrect\n";
 		++nrOfFailedTestCases;
 	}
 
 	if (threshold_e16 < threshold_d) {
-		std::cout << "✓ PASS: ereal<16> has tighter threshold than double\n";
+		std::cout << "[ok] PASS: ereal<16> has tighter threshold than double\n";
 	} else {
-		std::cerr << "✗ FAIL: ereal<16> threshold should be tighter than double\n";
+		std::cerr << "[x] FAIL: ereal<16> threshold should be tighter than double\n";
 		++nrOfFailedTestCases;
 	}
 
@@ -85,9 +85,9 @@ try {
 	Real16 one(1.0);
 	Real16 one_copy(1.0);
 	if (check_exact_value(one, one_copy)) {
-		std::cout << "✓ PASS: Exact values correctly identified as equal\n";
+		std::cout << "[ok] PASS: Exact values correctly identified as equal\n";
 	} else {
-		std::cerr << "✗ FAIL: Exact values not recognized as equal\n";
+		std::cerr << "[x] FAIL: Exact values not recognized as equal\n";
 		++nrOfFailedTestCases;
 	}
 
@@ -96,17 +96,17 @@ try {
 	Real16 x(1.0);
 	Real16 y(1.0 + 1e-20); // very close
 	if (check_relative_error(x, y)) {
-		std::cout << "✓ PASS: Very close values pass threshold check\n";
+		std::cout << "[ok] PASS: Very close values pass threshold check\n";
 	} else {
-		std::cerr << "✗ FAIL: Close values should pass threshold\n";
+		std::cerr << "[x] FAIL: Close values should pass threshold\n";
 		++nrOfFailedTestCases;
 	}
 
 	Real16 z(100.0); // far from x
 	if (!check_relative_error(x, z)) {
-		std::cout << "✓ PASS: Distant values correctly rejected\n";
+		std::cout << "[ok] PASS: Distant values correctly rejected\n";
 	} else {
-		std::cerr << "✗ FAIL: Distant values should be rejected\n";
+		std::cerr << "[x] FAIL: Distant values should be rejected\n";
 		++nrOfFailedTestCases;
 	}
 

--- a/elastic/ereal/api/adaptive_threshold.cpp
+++ b/elastic/ereal/api/adaptive_threshold.cpp
@@ -118,10 +118,10 @@ try {
 
 		using Real = ereal<16>;
 		Real x(1.5);
-		Real lhs = x * x;  // x²
+		Real lhs = x * x;  // x^2
 		Real rhs = x * x;  // should be identical
 
-		int failures = verify_identity("x² == x²", lhs, rhs, 0.0, false);
+		int failures = verify_identity("x^2 == x^2", lhs, rhs, 0.0, false);
 		if (failures != 0) {
 			std::cerr << "FAIL: identity check failed for identical expressions\n";
 			++nrOfFailedTestCases;

--- a/elastic/ereal/api/catastrophic_cancellation.cpp
+++ b/elastic/ereal/api/catastrophic_cancellation.cpp
@@ -14,13 +14,13 @@
  * Problem: (large + small) - large should equal small, but in fixed
  * precision arithmetic, the small value is often completely lost.
  *
- * Example: (10²⁰ + 1) - 10²⁰
+ * Example: (10^2^0 + 1) - 10^2^0
  *   - In double precision: Result is 0 (wrong!)
  *   - With ereal: Result is 1 (correct!)
  *
  * This happens because:
- * 1. 10²⁰ + 1 rounds to 10²⁰ (loses the +1)
- * 2. 10²⁰ - 10²⁰ = 0
+ * 1. 10^2^0 + 1 rounds to 10^2^0 (loses the +1)
+ * 2. 10^2^0 - 10^2^0 = 0
  * 3. The small component is catastrophically lost
  */
 

--- a/elastic/ereal/api/catastrophic_cancellation.cpp
+++ b/elastic/ereal/api/catastrophic_cancellation.cpp
@@ -14,13 +14,13 @@
  * Problem: (large + small) - large should equal small, but in fixed
  * precision arithmetic, the small value is often completely lost.
  *
- * Example: (10^2^0 + 1) - 10^2^0
+ * Example: (10^20 + 1) - 10^20
  *   - In double precision: Result is 0 (wrong!)
  *   - With ereal: Result is 1 (correct!)
  *
  * This happens because:
- * 1. 10^2^0 + 1 rounds to 10^2^0 (loses the +1)
- * 2. 10^2^0 - 10^2^0 = 0
+ * 1. 10^20 + 1 rounds to 10^20 (loses the +1)
+ * 2. 10^20 - 10^20 = 0
  * 3. The small component is catastrophically lost
  */
 

--- a/elastic/ereal/api/dot_product.cpp
+++ b/elastic/ereal/api/dot_product.cpp
@@ -12,7 +12,7 @@
 /*
  * ACCURATE DOT PRODUCTS: The foundation of linear algebra
  *
- * Dot product: a·b = Σ(aᵢ × bᵢ)
+ * Dot product: a*b = Sum(ai x bi)
  *
  * Problems with fixed precision:
  * 1. Products can vary widely in magnitude
@@ -80,12 +80,12 @@ try {
 		ereal<16> edot1 = dot_product_naive<ereal<16>>(a1, b1);
 		ereal<16> edot2 = dot_product_naive<ereal<16>>(a2, b2);
 
-		std::cout << "Expected: (-1e16 × 1) + (1e16 × 1) + (1 × 1) = 1\n\n";
+		std::cout << "Expected: (-1e16 x 1) + (1e16 x 1) + (1 x 1) = 1\n\n";
 
-		std::cout << "Order 1: [-1e16, 1e16, 1]·[1, 1, 1]\n";
+		std::cout << "Order 1: [-1e16, 1e16, 1]*[1, 1, 1]\n";
 		std::cout << "  Accumulation: ((-1e16 + 1e16) + 1) = (0 + 1) = 1\n\n";
 
-		std::cout << "Order 2: [1, -1e16, 1e16]·[1, 1, 1]\n";
+		std::cout << "Order 2: [1, -1e16, 1e16]*[1, 1, 1]\n";
 		std::cout << "  Accumulation: ((1 + (-1e16)) + 1e16) = (-1e16 + 1e16) = 0 (WRONG!)\n";
 		std::cout << "  Problem: The '1' is lost when added to -1e16\n\n";
 
@@ -113,9 +113,9 @@ try {
 		std::vector<double> a = { 1.0e10, 1.0, 1.0e10, 1.0 };
 		std::vector<double> b = { 1.0, 1.0e10, -1.0, 1.0e10 };
 
-		// Expected: 1e10×1 + 1×1e10 + 1e10×(-1) + 1×1e10
+		// Expected: 1e10x1 + 1x1e10 + 1e10x(-1) + 1x1e10
 		//         = 1e10 + 1e10 - 1e10 + 1e10 = 2e10
-		// BUT: 1×1e10 terms should cancel perfectly!
+		// BUT: 1x1e10 terms should cancel perfectly!
 		// Result should be dominated by the small cross terms
 
 		double dot_double = dot_product_naive<double>(a, b);
@@ -140,22 +140,22 @@ try {
 
 	{
 		// Ill-conditioned: alternating huge terms with sub-ULP residuals
-		// High condition number: κ = (||a|| × ||b||) / |a·b| >> 1
+		// High condition number: k = (||a|| x ||b||) / |a*b| >> 1
 		//
 		// Pattern: 20 pairs of (BIG, -BIG) in vector a where BIG = 1e16
 		//          Relative perturbations eps = 1e-16 create sub-ULP residuals
 		//
 		// Key insight:
 		//   - ULP at 1e16 is ~2.0 (2^53 spacing)
-		//   - Products: BIG × (1 + i×eps) = 1e16 + i  (where i = 0..19)
+		//   - Products: BIG x (1 + ixeps) = 1e16 + i  (where i = 0..19)
 		//   - The residual "i" is sub-ULP and OBLITERATED in double precision!
 		//   - After cancellation: (1e16 + i) - 1e16 = i is LOST in double
 		//   - ereal preserves every component exactly
 		//
 		// This creates:
-		//   - Intermediate sums swinging ±1e16 (catastrophic cancellation)
+		//   - Intermediate sums swinging +/-1e16 (catastrophic cancellation)
 		//   - Final result = 190 (sum 0+1+2+...+19) - microscopic vs intermediate values
-		//   - Condition number κ ≈ 1e16 / 190 ≈ 5e13 (catastrophically ill-conditioned!)
+		//   - Condition number k ~= 1e16 / 190 ~= 5e13 (catastrophically ill-conditioned!)
 		//   - Double precision obliterates the sub-ULP residuals
 		//   - ereal preserves all components exactly
 
@@ -166,7 +166,7 @@ try {
 		std::vector<double> a(2 * n_pairs);
 		std::vector<double> b(2 * n_pairs);
 
-		// Construct alternating ±BIG with sub-ULP perturbations
+		// Construct alternating +/-BIG with sub-ULP perturbations
 		for (size_t i = 0; i < n_pairs; ++i) {
 			a[2*i]     =  BIG;
 			a[2*i + 1] = -BIG;
@@ -174,11 +174,11 @@ try {
 			b[2*i + 1] =  1.0;
 		}
 
-		// Expected: Σᵢ(BIG × (1 + i×eps)) + Σᵢ(-BIG × 1)
-		//         = Σᵢ(BIG + BIG×i×eps - BIG)
-		//         = Σᵢ(BIG × i × eps)
-		//         = BIG × eps × (0 + 1 + 2 + ... + 19)
-		//         = 1e16 × 1e-16 × 190
+		// Expected: Sumi(BIG x (1 + ixeps)) + Sumi(-BIG x 1)
+		//         = Sumi(BIG + BIGxixeps - BIG)
+		//         = Sumi(BIG x i x eps)
+		//         = BIG x eps x (0 + 1 + 2 + ... + 19)
+		//         = 1e16 x 1e-16 x 190
 		//         = 190
 		double expected = BIG * eps * (n_pairs * (n_pairs - 1) / 2);
 
@@ -187,17 +187,17 @@ try {
 
 		std::cout << "Sub-ULP catastrophic cancellation:\n";
 		std::cout << "  Vector length: " << a.size() << " elements\n";
-		std::cout << "  BIG = " << std::scientific << BIG << " (ULP at BIG ≈ 2.0)\n";
+		std::cout << "  BIG = " << std::scientific << BIG << " (ULP at BIG ~= 2.0)\n";
 		std::cout << "  eps = " << eps << " (relative perturbation)\n";
 		std::cout << std::defaultfloat;
 		std::cout << "  Pattern: a = [BIG, -BIG, BIG, -BIG, ...] (20 pairs)\n";
-		std::cout << "           b = [1+0ε, 1, 1+1ε, 1, 1+2ε, 1, ...] (i = 0..19)\n\n";
+		std::cout << "           b = [1+0eps, 1, 1+1eps, 1, 1+2eps, 1, ...] (i = 0..19)\n\n";
 
-		std::cout << "  Products: BIG × (1 + i×eps) = 1e16 + i (integer i is sub-ULP!)\n";
+		std::cout << "  Products: BIG x (1 + ixeps) = 1e16 + i (integer i is sub-ULP!)\n";
 		std::cout << "  After cancellation: (1e16 + i) - 1e16 = i (OBLITERATED in double)\n";
-		std::cout << "  Intermediate sums swing: ±1e16\n";
+		std::cout << "  Intermediate sums swing: +/-1e16\n";
 		std::cout << "  Expected final result:   " << expected << " (0+1+2+...+19 = 190)\n";
-		std::cout << "  Condition number κ:      ~" << std::scientific << (2.0 * BIG) / expected
+		std::cout << "  Condition number k:      ~" << std::scientific << (2.0 * BIG) / expected
 		          << " (catastrophically ill-conditioned!)\n\n";
 		std::cout << std::defaultfloat;
 
@@ -246,14 +246,14 @@ try {
 		std::vector<double> a(1000, 1.0e-5);
 		std::vector<double> b(1000, 1.0e-5);
 
-		// Expected: 1000 × (1e-5 × 1e-5) = 1000 × 1e-10 = 1e-7
+		// Expected: 1000 x (1e-5 x 1e-5) = 1000 x 1e-10 = 1e-7
 
 		double dot_double = dot_product_naive<double>(a, b);
 		ereal<16> dot_ereal = dot_product_naive<ereal<16>>(a, b);
 
 		double expected = 1.0e-7;
 
-		std::cout << "1000 terms of (1e-5 × 1e-5):\n";
+		std::cout << "1000 terms of (1e-5 x 1e-5):\n";
 		std::cout << "Expected: " << std::scientific << expected << "\n\n";
 		std::cout << std::defaultfloat;
 
@@ -289,7 +289,7 @@ try {
 
 	std::cout << "Applications:\n";
 	std::cout << "  - Matrix-vector multiplication\n";
-	std::cout << "  - Vector norms (||v|| = √(v·v))\n";
+	std::cout << "  - Vector norms (||v|| = sqrt(v*v))\n";
 	std::cout << "  - Projections and orthogonalization\n";
 	std::cout << "  - Inner product spaces\n";
 	std::cout << "  - Iterative solvers (conjugate gradient, GMRES, etc.)\n\n";

--- a/elastic/ereal/api/phase2.cpp
+++ b/elastic/ereal/api/phase2.cpp
@@ -2,15 +2,17 @@
 #include <universal/number/ereal/ereal.hpp>
 #include <iostream>
 #include <iomanip>
+#include <universal/verification/test_suite.hpp>
 
-int main() {
+int main()
+try {
     using namespace sw::universal;
 
-    std::cout << "==========================================\n";
-    std::cout << "Phase 2 ereal mathlib comprehensive test\n";
-    std::cout << "==========================================\n\n";
+    std::string test_suite = "ereal Phase 2 mathlib comprehensive test (truncate/numerics/fractional)";
+    bool reportTestCases   = true;
+    int  totalFailures     = 0;
 
-    int totalFailures = 0;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
 
     // Test trunc
     {
@@ -118,16 +120,14 @@ int main() {
         if (!pass) totalFailures++;
     }
 
-    std::cout << "==========================================\n";
-    std::cout << "Phase 2 Comprehensive Test Summary\n";
-    std::cout << "==========================================\n";
-    std::cout << "Total failures: " << totalFailures << "\n";
-    std::cout << "Overall result: " << (totalFailures == 0 ? "PASS" : "FAIL") << "\n\n";
-
-    std::cout << "Phase 2 functions implemented:\n";
-    std::cout << "  ✓ truncate: trunc(), round() - using floor/ceil\n";
-    std::cout << "  ✓ numerics: frexp(), ldexp() - exponent manipulation\n";
-    std::cout << "  ✓ fractional: fmod(), remainder() - using division\n";
-
-    return (totalFailures > 0 ? 1 : 0);
+    ReportTestSuiteResults(test_suite, totalFailures);
+    return (totalFailures > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}
+catch (...) {
+    std::cerr << "Caught unknown exception" << std::endl;
+    return EXIT_FAILURE;
 }

--- a/elastic/ereal/api/phase3.cpp
+++ b/elastic/ereal/api/phase3.cpp
@@ -3,17 +3,18 @@
 #include <iostream>
 #include <iomanip>
 #include <cmath>
+#include <universal/verification/test_suite.hpp>
 
-int main() {
+int main()
+try {
     using namespace sw::universal;
 
-    std::cout << std::setprecision(17);
-    std::cout << "==========================================\n";
-    std::cout << "Phase 3 ereal mathlib comprehensive test\n";
-    std::cout << "Root functions: sqrt, cbrt, hypot\n";
-    std::cout << "==========================================\n\n";
+    std::string test_suite = "ereal Phase 3 mathlib comprehensive test (sqrt/cbrt/hypot)";
+    bool reportTestCases   = true;
+    int  totalFailures     = 0;
 
-    int totalFailures = 0;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+    std::cout << std::setprecision(17);
 
     // Test sqrt - exact values
     {
@@ -76,8 +77,8 @@ int main() {
 
         std::cout << "   cbrt(8.0) = " << double(result1) << " (expected 2.0)\n";
         std::cout << "   cbrt(27.0) = " << double(result2) << " (expected 3.0)\n";
-        std::cout << "   cbrt(8.0) ≈ 2.0: " << (pass1 ? "PASS" : "FAIL") << "\n";
-        std::cout << "   cbrt(27.0) ≈ 3.0: " << (pass2 ? "PASS" : "FAIL") << "\n";
+        std::cout << "   cbrt(8.0) ~= 2.0: " << (pass1 ? "PASS" : "FAIL") << "\n";
+        std::cout << "   cbrt(27.0) ~= 3.0: " << (pass2 ? "PASS" : "FAIL") << "\n";
         std::cout << "   Result: " << (pass ? "PASS" : "FAIL") << "\n\n";
         if (!pass) totalFailures++;
     }
@@ -178,27 +179,14 @@ int main() {
         if (!pass) totalFailures++;
     }
 
-    std::cout << "==========================================\n";
-    std::cout << "Phase 3 Comprehensive Test Summary\n";
-    std::cout << "==========================================\n";
-    std::cout << "Total failures: " << totalFailures << "\n";
-    std::cout << "Overall result: " << (totalFailures == 0 ? "PASS" : "FAIL") << "\n\n";
-
-    std::cout << "Phase 3 functions implemented:\n";
-    std::cout << "  ✓ sqrt() - Newton-Raphson: x' = (x + a/x) / 2\n";
-    std::cout << "  ✓ cbrt() - Range reduction + Newton-Raphson\n";
-    std::cout << "  ✓ hypot() - 2D and 3D using sqrt with expansion arithmetic\n\n";
-
-    std::cout << "Implementation details:\n";
-    std::cout << "  • Adaptive iteration count: 3 + log2(maxlimbs + 1)\n";
-    std::cout << "  • Quadratic convergence (doubles precision per iteration)\n";
-    std::cout << "  • For ereal<8>: ~13 iterations, achieving ~1e-127 precision\n";
-    std::cout << "  • cbrt uses Phase 2 frexp/ldexp for range reduction\n";
-    std::cout << "  • hypot naturally prevents overflow via expansion arithmetic\n\n";
-
-    std::cout << "Note: ereal's operator<< is a stub (prints 'TBD'),\n";
-    std::cout << "      so we convert to double for display. The actual\n";
-    std::cout << "      precision is much higher (~1e-127 errors observed).\n";
-
-    return (totalFailures > 0 ? 1 : 0);
+    ReportTestSuiteResults(test_suite, totalFailures);
+    return (totalFailures > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}
+catch (...) {
+    std::cerr << "Caught unknown exception" << std::endl;
+    return EXIT_FAILURE;
 }

--- a/elastic/ereal/api/progressive_precision.cpp
+++ b/elastic/ereal/api/progressive_precision.cpp
@@ -24,9 +24,9 @@
 // print(f"sin(0.5)  = {mp.sin(0.5)}")
 // print(f"cos(0.3)  = {mp.cos(0.3)}")
 // print(f"tan(0.4)  = {mp.tan(0.4)}")
-// print(f"atan(1.0) = {mp.atan(1.0)}")  # π/4
-// print(f"asin(0.5) = {mp.asin(0.5)}")  # π/6
-// print(f"acos(0.5) = {mp.acos(0.5)}")  # π/3
+// print(f"atan(1.0) = {mp.atan(1.0)}")  # pi/4
+// print(f"asin(0.5) = {mp.asin(0.5)}")  # pi/6
+// print(f"acos(0.5) = {mp.acos(0.5)}")  # pi/3
 //
 // # Exponential
 // print(f"exp(1.0)  = {mp.exp(1.0)}")   # e
@@ -51,10 +51,10 @@
 // -------------------
 // Each limb provides ~53 bits = ~15.95 decimal digits
 // ereal<4>  : ~64 digits
-// ereal<8>  : ~128 digits → expect ≥ 30.0 decimal digits (allowing margin)
-// ereal<12> : ~192 digits → expect ≥ 45.0 decimal digits
-// ereal<16> : ~256 digits → expect ≥ 60.0 decimal digits
-// ereal<19> : ~304 digits → expect ≥ 72.0 decimal digits (maxlimbs=19 is Shewchuk's limit)
+// ereal<8>  : ~128 digits -> expect >= 30.0 decimal digits (allowing margin)
+// ereal<12> : ~192 digits -> expect >= 45.0 decimal digits
+// ereal<16> : ~256 digits -> expect >= 60.0 decimal digits
+// ereal<19> : ~304 digits -> expect >= 72.0 decimal digits (maxlimbs=19 is Shewchuk's limit)
 //
 
 #include <universal/utility/directives.hpp>
@@ -203,7 +203,7 @@ void print_result(const TestResult& result) {
 		std::cout << "  " << MAXLIMBS_LABELS[i] << " : "
 		          << std::fixed << std::setprecision(1) << std::setw(5) << result.digits[i]
 		          << " digits  [" << (result.passed[i] ? "PASS" : "FAIL")
-		          << ": ≥" << std::setw(4) << PRECISION_THRESHOLDS[i] << " expected]";
+		          << ": >=" << std::setw(4) << PRECISION_THRESHOLDS[i] << " expected]";
 
 		if (!result.passed[i]) {
 			std::cout << " *** PRECISION LOSS DETECTED ***";
@@ -221,11 +221,11 @@ try {
 	std::cout << "Progressive Precision Validation - ereal mathlib\n";
 	std::cout << "=================================================\n";
 	std::cout << "\nDemonstrating that precision scales with maxlimbs:\n";
-	std::cout << "  ereal<4>  : ~64 bits  → expect ≥15.0 decimal digits\n";
-	std::cout << "  ereal<8>  : ~128 bits → expect ≥30.0 decimal digits\n";
-	std::cout << "  ereal<12> : ~192 bits → expect ≥45.0 decimal digits\n";
-	std::cout << "  ereal<16> : ~256 bits → expect ≥60.0 decimal digits\n";
-	std::cout << "  ereal<19> : ~304 bits → expect ≥72.0 decimal digits\n";
+	std::cout << "  ereal<4>  : ~64 bits  -> expect >=15.0 decimal digits\n";
+	std::cout << "  ereal<8>  : ~128 bits -> expect >=30.0 decimal digits\n";
+	std::cout << "  ereal<12> : ~192 bits -> expect >=45.0 decimal digits\n";
+	std::cout << "  ereal<16> : ~256 bits -> expect >=60.0 decimal digits\n";
+	std::cout << "  ereal<19> : ~304 bits -> expect >=72.0 decimal digits\n";
 
 	std::vector<TestResult> results;
 
@@ -263,28 +263,28 @@ try {
 		results.push_back(result);
 	}
 
-	// atan(1.0) = π/4
+	// atan(1.0) = pi/4
 	{
 		std::string ref = "0.7853981633974483096156608458198757210492923498437764552437361480769541015715522496570087063355292669955370216084252";
-		auto result = test_function_progressive("atan(1.0) [π/4]", "1.0", ref,
+		auto result = test_function_progressive("atan(1.0) [pi/4]", "1.0", ref,
 			[](auto x) { return atan(x); });
 		print_result(result);
 		results.push_back(result);
 	}
 
-	// asin(0.5) = π/6
+	// asin(0.5) = pi/6
 	{
 		std::string ref = "0.5235987755982988730771072305465838140328615665625176368291574320513027343810348330856695354450976446636856806947501";
-		auto result = test_function_progressive("asin(0.5) [π/6]", "0.5", ref,
+		auto result = test_function_progressive("asin(0.5) [pi/6]", "0.5", ref,
 			[](auto x) { return asin(x); });
 		print_result(result);
 		results.push_back(result);
 	}
 
-	// acos(0.5) = π/3
+	// acos(0.5) = pi/3
 	{
 		std::string ref = "1.0471975511965977461542144610931676280657231331250352736583148641026054687620696661713390708901952893273713613895003";
-		auto result = test_function_progressive("acos(0.5) [π/3]", "0.5", ref,
+		auto result = test_function_progressive("acos(0.5) [pi/3]", "0.5", ref,
 			[](auto x) { return acos(x); });
 		print_result(result);
 		results.push_back(result);
@@ -473,9 +473,9 @@ try {
 		std::cout << MAXLIMBS_LABELS[i] << " : "
 		          << passed_by_level[i] << "/" << total_by_level[i] << " passed";
 		if (passed_by_level[i] == total_by_level[i]) {
-			std::cout << " ✓\n";
+			std::cout << " [ok]\n";
 		} else {
-			std::cout << " ✗ FAILURES DETECTED\n";
+			std::cout << " [x] FAILURES DETECTED\n";
 		}
 	}
 

--- a/elastic/ereal/api/string_parsing.cpp
+++ b/elastic/ereal/api/string_parsing.cpp
@@ -204,15 +204,15 @@ int test_high_precision() {
 
 	std::cout << "\nTesting high-precision parsing:\n";
 
-	// 100-digit π
+	// 100-digit pi
 	{
 		std::string pi_100 = "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679";
 		ereal<> pi(pi_100);
-		double expected = 3.141592653589793238462643;  // First ~25 digits of π
+		double expected = 3.141592653589793238462643;  // First ~25 digits of pi
 		double comp_double = double(pi);
 		double rel_err = relative_error(pi, expected);
 
-		std::cout << "  parse(100-digit π):\n";
+		std::cout << "  parse(100-digit pi):\n";
 		std::cout << "    computed  = " << std::setprecision(20) << comp_double << "\n";
 		std::cout << "    expected  = " << expected << "\n";
 		std::cout << "    rel_err   = " << std::scientific << rel_err << "\n";


### PR DESCRIPTION
## Summary
Phase D of the ereal test-suite refactor (#944): audited the 13 files under `elastic/ereal/api/` (excluding `api.cpp` per the epic), classified each as demo vs regression test, refactored the non-compliant regression tests, and made the directory ASCII-clean.

Resolves #953. Relates to #944.

## Classification (see new `api/README.md`)
- **Regression tests refactored to the framework:** `phase2.cpp` (truncate/numerics/fractional), `phase3.cpp` (sqrt/cbrt/hypot) -- both already counted failures + returned a meaningful exit code but lacked `ReportTestSuiteHeader`/`ReportTestSuiteResults`; now wrapped in the framework with try/catch + `EXIT_FAILURE`/`EXIT_SUCCESS`.
- **Already framework-compliant (left as-is):** adaptive_simple, adaptive_threshold, constexpr, ostream_formatting, progressive_precision, string_parsing.
- **Demos (left as-is by design):** accurate_summation, adaptive_check, catastrophic_cancellation, dot_product, test_negation.

## ASCII hygiene
Stripped non-ASCII from all 9 affected files (`x ^2 ^3 ^0 +/- * sqrt ~= i eps k Sum -> >= pi [ok] [x]`) per the project's ASCII-only rule.

## Docs
Added `api/README.md` documenting which files are tests vs demos and why.

## Test Results
All 13 build and run on **gcc-13 and clang-18**. `progressive_precision` exits 1 **by design** (marked `WILL_FAIL` in CMake, pending the precision-scaling work tracked under #954); all others exit 0.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API directory README describing programs, their classification (regression tests vs demos), and how CI should treat them.

* **Style**
  * Standardized console and in-file text across demos/tests by replacing Unicode math symbols with ASCII alternatives for better compatibility and readability.

* **Refactor**
  * Migrated several test harnesses to a unified test-suite reporting flow with standardized headers, result reporting, and exception-safe main execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->