### PR TITLE
fix(ereal): renormalize expansion_product output to Priest canonical form (#981)

### DIFF
--- a/include/sw/universal/internal/expansion/expansion_ops.hpp
+++ b/include/sw/universal/internal/expansion/expansion_ops.hpp
@@ -740,6 +740,14 @@ inline std::vector<double> expansion_product(const std::vector<double>& e, const
         }
     }
 
+    // Renormalize the accumulated partial products into Priest canonical form.
+    // linear_expansion_sum keeps the running sum ordered but leaves overlapping,
+    // uncompressed components; without this final renormalize the product (and
+    // division, which is e * reciprocal) returns a non-canonical expansion that
+    // violates the non-overlapping invariant (issue #981). renormalize_expansion
+    // is exactly value-preserving.
+    result = renormalize_expansion(result);
+    if (result.empty()) result.push_back(0.0);  // canonical zero
     return result;
 }
 


### PR DESCRIPTION
## Summary
`expansion_product` accumulated partial products with `linear_expansion_sum` but **never renormalized its final result**, so ereal `*` (and `/`, which is `e * reciprocal(f)`) returned non-canonical expansions -- overlapping components and limb counts far past the value's true non-overlapping length. `+`/`-` were already correct (they renormalize). Surfaced by the #954 structural oracle.

Resolves #981. Relates to #944, #954.

## Root cause
```cpp
std::vector<double> result{0.0};
for (const auto& e_component : e)
    if (e_component != 0.0)
        result = linear_expansion_sum(result, scale_expansion(f, e_component));
return result;          // never renormalized
```

## Fix
Append a closing `renormalize_expansion(result)` (guarding the zero case). `renormalize_expansion` is the Priest canonical sweepUp/recurse/sweepDown -- exactly value-preserving -- so the value is unchanged; only the limb structure is canonicalized.

## Evidence (20,000 random ereal<16> pairs)
| op | non-overlap violations | max limbs |
|----|------------------------|-----------|
| `*` before | 18567 | 69 |
| `*` after  | **0** | 21 |
| `/` before | 18742 | 71 |
| `/` after  | **0** | 20 |

Projected value unchanged in **0 / 20000** cases. This is the mul/div analogue of #959 (which fixed non-canonical `+` output via the canonical renormalize).

## Test Results (gcc-13 + clang-18)
All pass, no regressions: `addition`, `subtraction`, `multiplication`, `division`, `algebraic_identities`, and the `exponent`/`logarithm`/`sqrt`/`pow`/`trigonometry` mathlib tests (which exercise mul/div heavily). Results are now Priest-canonical.

## Note
`maxlimbs` is the algorithmic ceiling on inputs, not a hard cap on result length -- a non-overlapping product of two 16-limb expansions can legitimately need up to ~21 components (its value spans >16*53 bits).

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expansion product calculations to return consistently normalized results and properly handle zero cases, ensuring reliability for downstream mathematical operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->