### PR TITLE
feat(ereal): Priest normal-form structural oracle (#954 D1)

### DIFF
--- a/elastic/ereal/arithmetic/priest_normal_form.cpp
+++ b/elastic/ereal/arithmetic/priest_normal_form.cpp
@@ -1,0 +1,164 @@
+// priest_normal_form.cpp: structural-oracle tests for ereal (issue #954, D1).
+//
+// Verifies the assert_priest_normal helper itself on crafted limb vectors, and
+// then asserts that every result of +, -, *, / over random multi-component
+// expansions is in Priest normal form (decreasing magnitude, non-overlapping,
+// no interior zeros). This is a first-principles check -- no external oracle.
+//
+// (Multiplication/division producing canonical, non-overlapping output depends
+// on #981, which renormalizes expansion_product.)
+//
+// REGRESSION_LEVEL convention:
+//   LEVEL 1 -- helper unit tests + structural fuzz x1k.
+//   LEVEL 2 -- structural fuzz x10k.   LEVEL 3 -- x100k.   LEVEL 4 -- x1M.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <random>
+#include <vector>
+#include <universal/number/ereal/ereal.hpp>
+#include <universal/verification/ereal_test_support.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+	using Violation = PriestNormalResult::Violation;
+
+	// =========================================================================
+	// LEVEL 1a: unit-test the structural oracle on crafted limb vectors
+	// =========================================================================
+	int VerifyPriestOracle(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+
+		auto expect = [&](const char* name, const std::vector<double>& L, Violation want) {
+			Violation got = check_priest_normal(L).violation;
+			if (got != want) {
+				if (reportTestCases) std::cout << "    FAIL " << name << ": got violation "
+					<< static_cast<int>(got) << " want " << static_cast<int>(want) << '\n';
+				++nrOfFailedTestCases;
+			}
+		};
+
+		const double e60 = std::ldexp(1.0, -60);  // well below ulp(1.0)/2 = 2^-53
+		// normal expansions
+		expect("normal 2-limb",     {1.0, e60},          Violation::None);
+		expect("normal single",     {3.14},              Violation::None);
+		expect("canonical zero",    {0.0},               Violation::None);
+		// non-decreasing magnitude
+		expect("non-decreasing",    {1.0, 2.0},          Violation::NonDecreasing);
+		// overlap: 0.5 > ulp(1.0)/2 (= 2^-53)
+		expect("overlap",           {1.0, 0.5},          Violation::Overlap);
+		// interior zero in a non-zero expansion
+		expect("interior zero",     {1.0, 0.0},          Violation::InteriorZero);
+
+		return nrOfFailedTestCases;
+	}
+
+	// Multi-component generator (same shape as the arithmetic fuzzers).
+	template <unsigned maxlimbs>
+	ereal<maxlimbs> random_ereal(std::mt19937_64& rng, double leading_magnitude = 1e6) {
+		std::uniform_int_distribution<unsigned> n_dist(1, maxlimbs);
+		std::uniform_int_distribution<int> sign_dist(0, 1);
+		std::uniform_real_distribution<double> unit(0.5, 2.0);
+		ereal<maxlimbs> result(0.0);
+		unsigned n_limbs = n_dist(rng);
+		double mag = leading_magnitude;
+		for (unsigned i = 0; i < n_limbs; ++i) {
+			result += unit(rng) * mag * (sign_dist(rng) ? 1.0 : -1.0);
+			mag = std::ldexp(mag, -50);
+			if (mag < std::ldexp(1.0, -950)) break;
+		}
+		return result;
+	}
+
+	// =========================================================================
+	// LEVEL 1b+: every operator result must be Priest-normal
+	// =========================================================================
+	int VerifyResultsArePriestNormal(bool reportTestCases, unsigned nrIterations) {
+		const uint64_t seed = 0xC0FFEE'A11CEULL;
+		std::mt19937_64 rng(seed);
+		int nrOfFailedTestCases = 0;
+
+		auto must_be_normal = [&](const char* op, const ereal<16>& r, unsigned i) {
+			PriestNormalResult pr = check_priest_normal(r);
+			if (!pr.ok()) {
+				if (reportTestCases) std::cout << "    FAIL " << op << " result not priest-normal ("
+					<< pr.what() << " at limb " << pr.index << ", seed=0x" << std::hex << seed
+					<< " iter=" << std::dec << i << ")\n";
+				++nrOfFailedTestCases;
+			}
+		};
+
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			ereal<16> a = random_ereal<16>(rng);
+			ereal<16> b = random_ereal<16>(rng);
+			must_be_normal("a+b", a + b, i);
+			must_be_normal("a-b", a - b, i);
+			must_be_normal("a*b", a * b, i);
+			if (!b.iszero()) must_be_normal("a/b", a / b, i);
+		}
+		return nrOfFailedTestCases;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "ereal Priest normal form (structural oracle)";
+	std::string test_tag            = "priest normal form";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	nrOfFailedTestCases += ReportTestResult(VerifyPriestOracle(reportTestCases), "ereal", "priest oracle manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyPriestOracle(reportTestCases), "ereal", "priest oracle helper");
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 1000), "ereal", "results priest-normal x1k");
+#	endif
+#	if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 10000), "ereal", "results priest-normal x10k");
+#	endif
+#	if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 100000), "ereal", "results priest-normal x100k");
+#	endif
+#	if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 1000000), "ereal", "results priest-normal x1M");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/verification/ereal_test_support.hpp
+++ b/include/sw/universal/verification/ereal_test_support.hpp
@@ -1,0 +1,87 @@
+#pragma once
+// ereal_test_support.hpp: first-principles structural oracle for ereal.
+//
+// assert/check Priest's normal form on an ereal expansion directly from its
+// limb vector -- no external oracle required (issue #954, Deliverable 1).
+//
+// Priest's normal form (Shewchuk's expansion arithmetic) requires, for a
+// non-zero expansion z = (z_0, z_1, ..., z_{m-1}) with |z_0| >= ... >= |z_{m-1}|:
+//   - decreasing magnitude:  |z_k|     >= |z_{k+1}|
+//   - non-overlapping:       |z_{k+1}| <= ulp(z_k) / 2
+//   - no zero components     (canonical zero is the single-limb {0.0})
+//
+// Note: there is intentionally NO "length <= maxlimbs" check. maxlimbs is the
+// algorithmic ceiling on inputs (the static_assert in ereal_impl.hpp), not a
+// cap on result length: a non-overlapping product of two N-limb expansions can
+// legitimately need more than N components when its value spans more than
+// N*53 binary exponents. (Investigated under #981.)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <cstddef>
+#include <vector>
+#include <universal/number/ereal/ereal.hpp>
+
+namespace sw { namespace universal {
+
+// Structured result of a Priest-normal-form check: the first violation found,
+// with the limb index at which it occurs, so a fuzzer failure points directly
+// at the broken invariant.
+struct PriestNormalResult {
+	enum class Violation { None, NonDecreasing, Overlap, InteriorZero };
+	Violation   violation = Violation::None;
+	std::size_t index     = 0;
+
+	constexpr bool ok() const noexcept { return violation == Violation::None; }
+	const char* what() const noexcept {
+		switch (violation) {
+		case Violation::None:          return "priest-normal";
+		case Violation::NonDecreasing: return "non-decreasing magnitude |z_k| < |z_{k+1}|";
+		case Violation::Overlap:       return "overlap |z_{k+1}| > ulp(z_k)/2";
+		case Violation::InteriorZero:  return "zero component in a non-zero expansion";
+		}
+		return "unknown";
+	}
+};
+
+// Core check on a raw limb vector. Returns the first violation (with index),
+// or { None } if the expansion is in Priest normal form. Does not throw.
+// Exposed directly so tests can feed crafted (non-normal) limb vectors that
+// ereal's own operations would never produce.
+inline PriestNormalResult check_priest_normal(const std::vector<double>& L) noexcept {
+	using R = PriestNormalResult;
+	R r;
+
+	// Canonical zero: a single 0.0 limb is normal by definition.
+	if (L.size() == 1 && L[0] == 0.0) return r;
+
+	for (std::size_t i = 0; i < L.size(); ++i) {
+		if (L[i] == 0.0) { r.violation = R::Violation::InteriorZero; r.index = i; return r; }
+	}
+	for (std::size_t i = 0; i + 1 < L.size(); ++i) {
+		const double cur  = std::abs(L[i]);
+		const double next = std::abs(L[i + 1]);
+		if (next > cur) { r.violation = R::Violation::NonDecreasing; r.index = i; return r; }
+		// ulp(z_k)/2 == 2^(ilogb(z_k) - 53) for a normal double z_k.
+		const double half_ulp = std::ldexp(1.0, std::ilogb(L[i]) - 53);
+		if (next > half_ulp) { r.violation = R::Violation::Overlap; r.index = i; return r; }
+	}
+	return r;
+}
+
+// Check Priest's normal form on an ereal expansion.
+template<unsigned maxlimbs>
+PriestNormalResult check_priest_normal(const ereal<maxlimbs>& v) noexcept {
+	return check_priest_normal(v.limbs());
+}
+
+// Convenience predicate.
+template<unsigned maxlimbs>
+bool is_priest_normal(const ereal<maxlimbs>& v) noexcept {
+	return check_priest_normal(v.limbs()).ok();
+}
+
+}}  // namespace sw::universal


### PR DESCRIPTION
## Summary
Deliverable 1 of #954's first-principles verification machinery: a structural oracle that checks an `ereal` expansion is in **Priest normal form**, derived directly from the limb vector -- no external oracle.

Relates to #944 (parent epic, Phase E). Relates to #954 (D1 of 4).

## Changes
- **`include/sw/universal/verification/ereal_test_support.hpp`** -- `check_priest_normal(...)` returning a structured `PriestNormalResult { violation, index }` (so a fuzzer failure points at the exact broken invariant), plus `is_priest_normal()`. Checks **decreasing magnitude**, **non-overlapping** (`|z_{k+1}| <= ulp(z_k)/2`), and **no interior zeros**. A limb-vector overload lets tests feed crafted non-normal vectors.
- **`elastic/ereal/arithmetic/priest_normal_form.cpp`** -- unit-tests the oracle on crafted vectors (normal / non-decreasing / overlap / interior-zero), then a fuzzer asserting **every `+ - * /` result is Priest-normal** over random multi-component expansions (LEVEL_1..4 = x1k..x1M).

## Design note (corrects #954's spec)
No `length <= maxlimbs` check: #981's investigation proved `maxlimbs` is the algorithmic ceiling on **inputs**, not a cap on result length (a non-overlapping product can need >maxlimbs components for a wide-range value). So that condition is intentionally omitted.

## Dependency
Passes only because **#981** (merged) fixed `expansion_product`'s missing renormalize -- before that, `*`/`/` produced ~93% overlapping results. The oracle is exactly what surfaced #981.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_arith_priest_normal_form | OK | PASS (unit + fuzz x1k/x10k/x100k) | OK | PASS |

## Remaining #954 deliverables (follow-on PRs)
- D2: precision-lifting self-oracle (`ereal<N>` vs `ereal<19>`).
- D3: advanced generators (magnitude sweep, targeted bit patterns) + hook the oracle into the existing per-operator fuzzers.
- (D4 per-operator `Verify*_Fuzz` already landed in #945/#946/#947.)

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Relates to #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression tests for multi-component floating-point number validation.
  * Implemented verification utilities to ensure correct mathematical invariants in arithmetic operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->