### PR TITLE
feat(ereal): precision-lifting self-oracle (#954 D2)

### DIFF
--- a/elastic/ereal/arithmetic/precision_lifting.cpp
+++ b/elastic/ereal/arithmetic/precision_lifting.cpp
@@ -1,0 +1,143 @@
+// precision_lifting.cpp: self-referential precision-lifting oracle (#954, D2).
+//
+// First-principles verification with no external oracle: the widest
+// configuration ereal<19> (1007 bits) is the value-canonical ground truth for
+// any narrower one. For random narrow inputs lifted value-preservingly to
+// ereal<19>, the narrow result (also lifted) must EQUAL the operation computed
+// at wide precision -- exactly, because ereal operations are maxlimbs-
+// independent (maxlimbs is the algorithmic ceiling on inputs, not a runtime
+// truncation; nothing is dropped, so narrow and wide compute the same value).
+//
+// REGRESSION_LEVEL convention:
+//   LEVEL 1 -- config pairs (2,19) (4,19) (8,19) (16,19), fuzz x1k each.
+//   LEVEL 2 -- fuzz x10k.   LEVEL 3 -- x100k.   LEVEL 4 -- x1M.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <random>
+#include <universal/number/ereal/ereal.hpp>
+#include <universal/verification/ereal_test_support.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	template <unsigned maxlimbs>
+	ereal<maxlimbs> random_ereal(std::mt19937_64& rng, double leading_magnitude = 1e6) {
+		std::uniform_int_distribution<unsigned> n_dist(1, maxlimbs);
+		std::uniform_int_distribution<int> sign_dist(0, 1);
+		std::uniform_real_distribution<double> unit(0.5, 2.0);
+		ereal<maxlimbs> result(0.0);
+		unsigned n_limbs = n_dist(rng);
+		double mag = leading_magnitude;
+		for (unsigned i = 0; i < n_limbs; ++i) {
+			result += unit(rng) * mag * (sign_dist(rng) ? 1.0 : -1.0);
+			mag = std::ldexp(mag, -50);
+			if (mag < std::ldexp(1.0, -950)) break;
+		}
+		return result;
+	}
+
+	constexpr unsigned WIDE = 19;  // ground-truth configuration (1007 bits)
+
+	// Precision-lifting fuzz for one narrow configuration NARROW against WIDE.
+	template <unsigned NARROW>
+	int VerifyPrecisionLifting(bool reportTestCases, unsigned nrIterations) {
+		const uint64_t seed = 0xC0FFEE'A11CEULL + NARROW;
+		std::mt19937_64 rng(seed);
+		int nrOfFailedTestCases = 0;
+
+		auto agree = [&](const char* op, const ereal<NARROW>& rn, const ereal<WIDE>& rw, unsigned i) {
+			// lift the narrow result to WIDE and compare exactly (operations are
+			// maxlimbs-independent, so this must hold bit-for-bit).
+			if (widen<WIDE>(rn) != rw) {
+				if (reportTestCases) std::cout << "    FAIL " << op << " ereal<" << NARROW
+					<< "> vs ereal<19> (seed=0x" << std::hex << seed << " iter=" << std::dec << i << ")\n";
+				++nrOfFailedTestCases;
+			}
+		};
+
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			ereal<NARROW> a = random_ereal<NARROW>(rng);
+			ereal<NARROW> b = random_ereal<NARROW>(rng);
+			ereal<WIDE> aw = widen<WIDE>(a);
+			ereal<WIDE> bw = widen<WIDE>(b);
+
+			agree("a+b", a + b, aw + bw, i);
+			agree("a-b", a - b, aw - bw, i);
+			agree("a*b", a * b, aw * bw, i);
+			if (!b.iszero()) agree("a/b", a / b, aw / bw, i);
+		}
+		return nrOfFailedTestCases;
+	}
+
+	int RunAllConfigs(bool reportTestCases, unsigned nrIterations) {
+		int fails = 0;
+		fails += VerifyPrecisionLifting<2>(reportTestCases, nrIterations);
+		fails += VerifyPrecisionLifting<4>(reportTestCases, nrIterations);
+		fails += VerifyPrecisionLifting<8>(reportTestCases, nrIterations);
+		fails += VerifyPrecisionLifting<16>(reportTestCases, nrIterations);
+		return fails;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "ereal precision-lifting oracle (ereal<19> ground truth)";
+	std::string test_tag            = "precision lifting";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "precision lifting manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "precision lifting x1k");
+#	endif
+#	if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 10000), "ereal", "precision lifting x10k");
+#	endif
+#	if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100000), "ereal", "precision lifting x100k");
+#	endif
+#	if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000000), "ereal", "precision lifting x1M");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/verification/ereal_test_support.hpp
+++ b/include/sw/universal/verification/ereal_test_support.hpp
@@ -91,6 +91,7 @@ bool is_priest_normal(const ereal<maxlimbs>& v) noexcept {
 // same operation computed at wide precision.
 template<unsigned WIDE, unsigned NARROW>
 ereal<WIDE> widen(const ereal<NARROW>& v) {
+	static_assert(WIDE >= NARROW, "widen<WIDE, NARROW>: target configuration must be at least as wide as the source");
 	ereal<WIDE> w(0.0);
 	for (double limb : v.limbs()) w += limb;
 	return w;

--- a/include/sw/universal/verification/ereal_test_support.hpp
+++ b/include/sw/universal/verification/ereal_test_support.hpp
@@ -84,4 +84,16 @@ bool is_priest_normal(const ereal<maxlimbs>& v) noexcept {
 	return check_priest_normal(v.limbs()).ok();
 }
 
+// Value-preserving lift of a narrow expansion into a wider configuration, by
+// re-summing its (non-overlapping) limbs. Used by the precision-lifting oracle
+// (#954 D2): the widest configuration ereal<19> is the value-canonical ground
+// truth for any narrower one, so a narrow result lifted to wide must equal the
+// same operation computed at wide precision.
+template<unsigned WIDE, unsigned NARROW>
+ereal<WIDE> widen(const ereal<NARROW>& v) {
+	ereal<WIDE> w(0.0);
+	for (double limb : v.limbs()) w += limb;
+	return w;
+}
+
 }}  // namespace sw::universal


### PR DESCRIPTION
## Summary
Deliverable 2 of #954: a self-referential precision-lifting oracle. The widest configuration `ereal<19>` (1007 bits) is the value-canonical ground truth for any narrower one -- no external oracle.

Relates to #944 (Phase E). Relates to #954 (D2 of 4).

## Changes
- **`ereal_test_support.hpp`** -- `widen<WIDE>(ereal<NARROW>)`: value-preserving lift by re-summing the non-overlapping limbs.
- **`elastic/ereal/arithmetic/precision_lifting.cpp`** -- for config pairs (2,19), (4,19), (8,19), (16,19): generate narrow inputs, lift to `ereal<19>`, and assert `widen(a_n op b_n) == (a_w op b_w)` for `+ - * /` (LEVEL_1..4 = x1k..x1M).

## Why the comparison is exact
ereal operations are **maxlimbs-independent** -- `maxlimbs` is the algorithmic ceiling on inputs, not a runtime truncation, so a narrow result carries the same value as the wide one. A probe over 5,000 cases confirmed bit-identical narrow-vs-wide results for all four operators.

## Result
**0 failures through x100k on gcc-13 and clang-18** across all 4 config pairs -- so no arithmetic operator needs a skip-list entry. (Depends on #981 having made `*`/`/` canonical.)

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_arith_precision_lifting | OK | PASS (x1k/x10k/x100k x4 configs) | OK | PASS |

## Remaining #954
- D3: advanced generators (magnitude sweep, targeted bit patterns) + retrofit the structural oracle into the per-operator fuzzers. (D4 already landed.)

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Relates to #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression "oracle" to verify precision lifting across arithmetic operations (add, sub, mul, div) between narrower and wider configurations.
  * Added a test utility to perform value-preserving widening and exact comparisons across precisions.
  * Test harness reports failing cases with metadata and supports selectable regression intensity for automated runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->