### PR TITLE
fix(einteger): correct multiply carry propagation + shift canonicalization (#991)

### DIFF
--- a/elastic/einteger/arithmetic/multiplication.cpp
+++ b/elastic/einteger/arithmetic/multiplication.cpp
@@ -9,7 +9,9 @@
 #include <iomanip>
 #include <string>
 #include <cmath>
+#include <cstdint>
 #include <limits>
+#include <random>
 
 // minimum set of include files to reflect source code dependencies
 #include <universal/number/einteger/einteger.hpp>
@@ -51,6 +53,70 @@ namespace sw { namespace universal {
 		}
 		if (reportTestCases) std::cout << std::endl;
 		std::cout << "samples : " << cnt << '\n';
+		return nrOfFailedTests;
+	}
+
+	// MULTI-LIMB multiplication cross-checked against a native 64-bit reference.
+	// The legacy VerifyElasticMultiplication only ever multiplied single-limb
+	// operands (values < 2^20 are one limb for every block type), so it could
+	// not reach the limb-boundary carry path -- which is exactly where #991
+	// lived: (2^32)*(2^32) != 2^64 and ~99.99% of multi-limb products were
+	// wrong. Here operands are chosen large enough to span several limbs for
+	// uint8_t / uint16_t blocks while the product still fits in int64, so the
+	// reference is exact and the check is portable (no __int128 needed).
+	template<typename BlockType>
+	int VerifyMultiLimbMultiplication(bool reportTestCases, std::int64_t maxOperand, unsigned nrCases) {
+		using Integer = einteger<BlockType>;
+		int nrOfFailedTests = 0;
+		std::mt19937_64 rng(0xC0FFEEull);
+		std::uniform_int_distribution<std::int64_t> dist(-maxOperand, maxOperand);
+		for (unsigned i = 0; i < nrCases; ++i) {
+			std::int64_t a = dist(rng), b = dist(rng);
+			std::int64_t ref = a * b;                 // fits int64 by construction
+			Integer ia(a), ib(b), ic = ia * ib, iref(ref);
+			if (ic != iref) {
+				++nrOfFailedTests;
+				if (reportTestCases) ReportBinaryArithmeticError("FAIL", "*", ia, ib, ic, iref);
+				if (nrOfFailedTests > 20) break;
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+	// Hand-checkable power-of-two products straddling limb boundaries:
+	// (2^p)*(2^q) == 2^(p+q). Also asserts canonical storage (no trailing zero
+	// limbs) on both the shift result and the product -- the trailing-zero leak
+	// that made operator== report equal values unequal (a shift of an exact
+	// multiple of the block width skipped remove_leading_zeros).
+	template<typename BlockType>
+	int VerifyLimbBoundaryPow2(bool reportTestCases) {
+		using Integer = einteger<BlockType>;
+		constexpr unsigned B = sizeof(BlockType) * 8;
+		int nrOfFailedTests = 0;
+		for (unsigned p = 0; p <= 5 * B; ++p) {
+			for (unsigned q = 0; q <= 5 * B; q += 3) {
+				Integer a(1); a <<= static_cast<int>(p);
+				Integer b(1); b <<= static_cast<int>(q);
+				Integer prod = a * b;
+				Integer ref(1); ref <<= static_cast<int>(p + q);
+				if (prod != ref) {
+					++nrOfFailedTests;
+					if (reportTestCases) std::cout << "    FAIL (2^" << p << ")*(2^" << q << ") != 2^" << (p + q) << '\n';
+				}
+				// 2^k occupies exactly floor(k/B)+1 limbs in canonical form.
+				if (a.limbs() != p / B + 1) {
+					++nrOfFailedTests;
+					if (reportTestCases) std::cout << "    FAIL non-canonical shift 2^" << p
+						<< " has " << a.limbs() << " limbs, expected " << (p / B + 1) << '\n';
+				}
+				if (prod.limbs() != (p + q) / B + 1) {
+					++nrOfFailedTests;
+					if (reportTestCases) std::cout << "    FAIL non-canonical product 2^" << (p + q)
+						<< " has " << prod.limbs() << " limbs, expected " << ((p + q) / B + 1) << '\n';
+				}
+				if (nrOfFailedTests > 40) return nrOfFailedTests;
+			}
+		}
 		return nrOfFailedTests;
 	}
 
@@ -141,6 +207,17 @@ try {
 
 	nrOfFailedTestCases += ReportTestResult(VerifyElasticMultiplication<16, uint32_t>(reportTestCases), "einteger<uint32_t> 1word", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifyElasticMultiplication<20, uint32_t>(reportTestCases), "einteger<uint32_t> 2words", test_tag);
+
+	// Multi-limb coverage (regression guard for #991): operands span several
+	// limbs while the product still fits int64, so the native reference is exact.
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiLimbMultiplication<uint8_t> (reportTestCases, 2000000000LL, 50000), "einteger<uint8_t>  multi-limb", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiLimbMultiplication<uint16_t>(reportTestCases, 2000000000LL, 50000), "einteger<uint16_t> multi-limb", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiLimbMultiplication<uint32_t>(reportTestCases, 2000000000LL, 50000), "einteger<uint32_t> multi-limb", test_tag);
+
+	// Power-of-two products across limb boundaries + canonical-form checks.
+	nrOfFailedTestCases += ReportTestResult(VerifyLimbBoundaryPow2<uint8_t> (reportTestCases), "einteger<uint8_t>  pow2 limb-boundary", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyLimbBoundaryPow2<uint16_t>(reportTestCases), "einteger<uint16_t> pow2 limb-boundary", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyLimbBoundaryPow2<uint32_t>(reportTestCases), "einteger<uint32_t> pow2 limb-boundary", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/include/sw/universal/number/einteger/einteger_impl.hpp
+++ b/include/sw/universal/number/einteger/einteger_impl.hpp
@@ -107,7 +107,12 @@ public:
 			}
 			// adjust the shift
 			shift -= static_cast<int>(blockShift * bitsInBlock);
-			if (shift == 0) return *this;
+			// when the shift is an exact multiple of the block width there is no
+			// intra-block shift left to do; trim the speculative high limb from
+			// the push_back(0) above before returning, so the result stays
+			// canonical (the trailing path below cannot run here -- a shift of 0
+			// would form a (<< bitsInBlock) mask, which is undefined).
+			if (shift == 0) { remove_leading_zeros(); return *this; }
 		}
 		if (MSU > 0) {
 			// construct the mask for the upper bits in the block that needs to move to the higher word
@@ -312,16 +317,33 @@ public:
 		unsigned rl = rhs.limbs();
 
 		clear();
-		std::uint64_t segment(0);
+		// Schoolbook multiply with a per-row carry. block(k) reads 0 past the
+		// end and setblock(k, ...) grows storage, so reading/writing ahead of
+		// the current size is safe. The carry is reset for each outer limb and
+		// rippled into the higher limbs at the end of each row.
+		// Fixes #991: the previous version kept a single carry accumulator
+		// across all rows and flushed it only once at block(ll+rl-1), which
+		// misplaced carries at the limb boundary -- e.g. (2^32)*(2^32) did not
+		// equal 2^64, and ~99.99% of 53-bit x 53-bit products were wrong.
 		for (unsigned i = 0; i < ll; ++i) {
+			std::uint64_t carry = 0;
 			for (unsigned j = 0; j < rl; ++j) {
-				segment += static_cast<std::uint64_t>(base.block(i)) * static_cast<std::uint64_t>(rhs.block(j));
-				segment += block(i + j);
+				std::uint64_t segment = static_cast<std::uint64_t>(base.block(i)) * static_cast<std::uint64_t>(rhs.block(j))
+				                      + static_cast<std::uint64_t>(block(i + j))
+				                      + carry;
 				setblock(i + j, static_cast<bt>(segment));
-				segment >>= bitsInBlock;
+				carry = segment >> bitsInBlock;
+			}
+			for (unsigned k = i + rl; carry != 0; ++k) {
+				std::uint64_t segment = static_cast<std::uint64_t>(block(k)) + carry;
+				setblock(k, static_cast<bt>(segment));
+				carry = segment >> bitsInBlock;
 			}
 		}
-		if (segment != 0) setblock(ll + rl - 1, static_cast<bt>(segment));
+		// trim high zero limbs so equality/comparison (which short-circuit on
+		// limb count) see a canonical representation, consistent with the other
+		// mutating operators.
+		remove_leading_zeros();
 		setsign(ls ^ rs);
 		return *this;
 	}


### PR DESCRIPTION
## Summary
`einteger::operator*=` produced incorrect results for multi-limb operands -- `(2^32)*(2^32) != 2^64`, ~99.99% of random 53-bit x 53-bit products wrong. Discovered while building an exact-arithmetic oracle for the ereal/Priest verification effort (epic #987); see `docs/bugs/ereal-failure-mode.md`.

## Root cause
`operator*=` used a single `segment` carry accumulator declared outside the outer-limb loop (never reset per row) and flushed the final carry only once at `block(ll+rl-1)`. Carries generated mid-row for `i < ll-1` were misplaced. Single-limb operands (`ll==rl==1`) happened to work, which is why the existing test never caught it: every `VerifyElasticMultiplication` config multiplied only values `< 2^20`, i.e. single-limb for their block type.

A second, related defect surfaced via `operator==` (which short-circuits on limb count): `operator<<=` returned early when the shift was an exact multiple of the block width, skipping `remove_leading_zeros()` and leaving an untrimmed trailing-zero limb. Equal values (a product vs `1<<64`) then compared unequal.

## Changes
- `einteger_impl.hpp` `operator*=`: per-row carry with proper ripple into higher limbs; `remove_leading_zeros()` before return for canonical output.
- `einteger_impl.hpp` `operator<<=`: trim before the exact-block-multiple early return.
- `elastic/einteger/arithmetic/multiplication.cpp`: add multi-limb verification cross-checked against an exact int64 reference (operands multi-limb, product fits int64 -- portable, no `__int128`) and hand-checkable power-of-two products across limb boundaries with canonical-form (limb-count) assertions.

## Verification
- `(2^32)^2 == 2^64`, `(2^32+1)^2` correct.
- 1.2M random products (53-bit and 62-bit operands, signed) match `__int128`.
- New multi-limb + pow2-limb-boundary suites PASS on gcc-13 and clang-18.
- Existing einteger addition / subtraction / division / api tests still PASS (no regression).
- Independently confirmed: this fix unblocks the dyadic exact oracle, which then reports `two_sum` and `two_prod` exact in the normal regime.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| einteger multiplication | OK | PASS | OK | PASS |

Resolves #991. Part of the #986/#991 foundation fixes preceding epic #987.

## Test plan
- [ ] Fast CI (gcc + clang CI_LITE) passes
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multiplication carry propagation across limb boundaries, resolving computation errors at boundary conditions
  * Corrected left-shift operations when shifting by multiples of block width

* **Tests**
  * Added regression tests for multi-limb multiplication with randomized operands across various block types
  * Added boundary condition tests ensuring correctness at limb boundaries with power-of-two products

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->