### PR TITLE
fix(erational): correct ieee754 conversion (both directions) + add tests (#986)

### DIFF
--- a/elastic/rational/decimal/conversion/ieee754.cpp
+++ b/elastic/rational/decimal/conversion/ieee754.cpp
@@ -1,0 +1,184 @@
+// ieee754.cpp: regression tests for double/float <-> erational conversion (#986)
+//
+// erational stores an exact rational (edecimal numerator / edecimal
+// denominator). A binary float is the exact dyadic rational
+//   (-1)^s * significand * 2^(e - bias - fbits),
+// so conversion in is exact, and conversion out is the correctly-rounded
+// (round-half-to-even) nearest float. Before #986 the inbound conversion
+// dropped the exponent (collapsing every value into [1,2)) and the outbound
+// conversion ignored the sign and overflowed for large numerator/denominator;
+// there was no test covering ieee754 conversion at all.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+#include <random>
+#include <universal/number/erational/erational.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// A finite double round-trips exactly: (double)erational(d) == d. erational
+	// represents every double exactly, and the nearest-float of an exactly
+	// representable value is itself.
+	int VerifyDoubleRoundTrip(bool reportTestCases, unsigned nrIterations) {
+		std::mt19937_64 rng(0xE4A11Aull);
+		std::uniform_int_distribution<std::uint64_t> bits;
+		int nrOfFailedTestCases = 0;
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			double d;
+			std::uint64_t u = bits(rng);
+			std::memcpy(&d, &u, sizeof(d));
+			if (!std::isfinite(d)) continue;          // inf/nan are out of scope
+			double r = double(erational(d));
+			if (r != d) {
+				if (reportTestCases) std::cout << "    FAIL roundtrip d=" << d << " got " << r << '\n';
+				++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	// Hand-picked values across the whole range: integers, fractions, signs,
+	// subnormals, the extremes, and exact-but-awkward decimals.
+	int VerifySpecificConversions(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+		const double cases[] = {
+			0.0, -0.0, 1.0, 2.0, 3.0, 0.5, -4.0, 0.1, -0.1, 0.25, 1.0 / 3.0,
+			123456.789, -987.654, std::ldexp(1.0, 60), std::ldexp(1.0, -60),
+			DBL_MIN, DBL_TRUE_MIN, 2.0 * DBL_TRUE_MIN, DBL_MAX, -DBL_MAX,
+			1e-300, 1e300, -1e-300
+		};
+		for (double d : cases) {
+			double r = double(erational(d));
+			// Exact value round-trip. erational is a rational type and has no
+			// signed zero: -0.0 canonicalizes to 0 (0 == -0 mathematically), so
+			// the value compare r == d is the correct criterion (it treats
+			// +0 and -0 as equal and still distinguishes sign for non-zero).
+			if (r != d) {
+				if (reportTestCases) std::cout << "    FAIL specific d=" << d << " got " << r << '\n';
+				++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	// Arithmetic on exactly representable integer operands stays exact and
+	// round-trips through double.
+	int VerifyArithmeticRoundTrip(bool reportTestCases, unsigned nrIterations) {
+		std::mt19937_64 rng(0xA21CEull);
+		std::uniform_int_distribution<int> d(-100000, 100000);
+		int nrOfFailedTestCases = 0;
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			int a = d(rng), b = d(rng);
+			if (double(erational(a) + erational(b)) != double(a) + double(b)) {
+				if (reportTestCases) std::cout << "    FAIL add " << a << '+' << b << '\n';
+				++nrOfFailedTestCases;
+			}
+			if (double(erational(a) - erational(b)) != double(a) - double(b)) {
+				if (reportTestCases) std::cout << "    FAIL sub " << a << '-' << b << '\n';
+				++nrOfFailedTestCases;
+			}
+			if (double(erational(a) * erational(b)) != double(a) * double(b)) {
+				if (reportTestCases) std::cout << "    FAIL mul " << a << '*' << b << '\n';
+				++nrOfFailedTestCases;
+			}
+			// (a*b)/b == a exactly (exact rational division)
+			if (b != 0) {
+				long long prod = static_cast<long long>(a) * static_cast<long long>(b);
+				if (double(erational(prod) / erational(b)) != double(a)) {
+					if (reportTestCases) std::cout << "    FAIL div (" << a << '*' << b << ")/" << b << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+	// float round-trip (narrower mantissa exercises a different fbits/bias).
+	int VerifyFloatRoundTrip(bool reportTestCases, unsigned nrIterations) {
+		std::mt19937_64 rng(0xF10A7ull);
+		std::uniform_int_distribution<std::uint32_t> bits;
+		int nrOfFailedTestCases = 0;
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			float f;
+			std::uint32_t u = bits(rng);
+			std::memcpy(&f, &u, sizeof(f));
+			if (!std::isfinite(f)) continue;
+			float r = float(erational(f));
+			if (r != f) {
+				if (reportTestCases) std::cout << "    FAIL float roundtrip f=" << f << " got " << r << '\n';
+				++nrOfFailedTestCases;
+			}
+		}
+		return nrOfFailedTestCases;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "erational ieee754 conversion";
+	std::string test_tag            = "conversion";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	nrOfFailedTestCases += ReportTestResult(VerifySpecificConversions(reportTestCases), "erational", "specific values");
+
+#if MANUAL_TESTING
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleRoundTrip(reportTestCases, 2000), "erational", "double roundtrip");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleRoundTrip(reportTestCases, 2000),     "erational", "double roundtrip x2k");
+	nrOfFailedTestCases += ReportTestResult(VerifyFloatRoundTrip(reportTestCases, 2000),      "erational", "float roundtrip x2k");
+	nrOfFailedTestCases += ReportTestResult(VerifyArithmeticRoundTrip(reportTestCases, 2000), "erational", "arithmetic roundtrip x2k");
+#	endif
+#	if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleRoundTrip(reportTestCases, 20000),     "erational", "double roundtrip x20k");
+	nrOfFailedTestCases += ReportTestResult(VerifyArithmeticRoundTrip(reportTestCases, 20000), "erational", "arithmetic roundtrip x20k");
+#	endif
+#	if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleRoundTrip(reportTestCases, 100000), "erational", "double roundtrip x100k");
+#	endif
+#	if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleRoundTrip(reportTestCases, 500000), "erational", "double roundtrip x500k");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/elastic/rational/decimal/conversion/ieee754.cpp
+++ b/elastic/rational/decimal/conversion/ieee754.cpp
@@ -121,6 +121,20 @@ namespace {
 		return nrOfFailedTestCases;
 	}
 
+	// Degenerate denominators (reachable via the (n, d) ctor and other paths)
+	// must resolve to IEEE infinity/NaN in to_ieee754, not spin in the exponent
+	// search. Regression guard for the CodeRabbit critical finding on #993.
+	int VerifyDegenerateDenominator(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+		double pinf = double(erational(static_cast<std::int64_t>(1),  static_cast<std::uint64_t>(0)));
+		double ninf = double(erational(static_cast<std::int64_t>(-1), static_cast<std::uint64_t>(0)));
+		double nan0 = double(erational(static_cast<std::int64_t>(0),  static_cast<std::uint64_t>(0)));
+		if (!(std::isinf(pinf) && pinf > 0)) { if (reportTestCases) std::cout << "    FAIL 1/0 != +inf (" << pinf << ")\n"; ++nrOfFailedTestCases; }
+		if (!(std::isinf(ninf) && ninf < 0)) { if (reportTestCases) std::cout << "    FAIL -1/0 != -inf (" << ninf << ")\n"; ++nrOfFailedTestCases; }
+		if (!std::isnan(nan0))               { if (reportTestCases) std::cout << "    FAIL 0/0 != nan (" << nan0 << ")\n"; ++nrOfFailedTestCases; }
+		return nrOfFailedTestCases;
+	}
+
 }  // anonymous namespace
 
 // Regression testing guards
@@ -147,6 +161,7 @@ int main() try {
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 	nrOfFailedTestCases += ReportTestResult(VerifySpecificConversions(reportTestCases), "erational", "specific values");
+	nrOfFailedTestCases += ReportTestResult(VerifyDegenerateDenominator(reportTestCases), "erational", "degenerate denominator");
 
 #if MANUAL_TESTING
 	nrOfFailedTestCases += ReportTestResult(VerifyDoubleRoundTrip(reportTestCases, 2000), "erational", "double roundtrip");

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cstdint>
+#include <cmath>
 #include <sstream>
 #include <cassert>
 #include <iostream>
@@ -408,17 +409,58 @@ protected:
 	template<typename Real,
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
 	erational& convert_ieee754(Real rhs) noexcept {
-		// extract components, convert mantissa to fraction with denominator 2^23, adjust fraction using scale, normalize
-		uint64_t bits{ 0 };
-		uint64_t e{ 0 }, f{ 0 };
+		// A binary floating-point value is the exact dyadic rational
+		//     (-1)^s * significand * 2^(e - bias - fbits)
+		// where, for a normal value, significand = (fraction | hidden bit) and
+		// e is the biased exponent; for a subnormal value there is no hidden
+		// bit and the exponent is the minimum (e == 0 -> 1 - bias). Build the
+		// numerator/denominator exactly as significand over a power of two,
+		// then reduce. (Previously the exponent scaling was dropped entirely,
+		// so every value collapsed into [1,2) and subnormals/zero were
+		// unhandled -- issue #986.)
+		numerator = 0;
+		denominator = 1;
+		negative = false;
+		if (rhs == 0) return *this;                       // +/-0 -> 0/1
+		if (std::isinf(rhs) || std::isnan(rhs)) return *this;  // not representable; map to 0
+
+		uint64_t bits{ 0 }, e{ 0 }, f{ 0 };
 		bool s{ false };
 		extractFields(rhs, s, e, f, bits);
 		negative = s;
-		if (e == 0) { // subnormal
+
+		constexpr int bias  = ieee754_parameter<Real>::bias;
+		constexpr int fbits = ieee754_parameter<Real>::fbits;
+		uint64_t significand;
+		int exp_pow;
+		if (e == 0) { // subnormal: no hidden bit, exponent fixed at the minimum
+			significand = f;
+			exp_pow     = 1 - bias - fbits;
 		}
-		else { // normal
-			numerator = f | ieee754_parameter<Real>::hmask;
-			denominator = ieee754_parameter<Real>::hmask;
+		else {        // normal: restore the hidden bit
+			significand = f | ieee754_parameter<Real>::hmask;
+			exp_pow     = static_cast<int>(e) - bias - fbits;
+		}
+
+		// 2^k as an exact edecimal via square-and-multiply (k >= 0).
+		auto pow2 = [](int k) {
+			edecimal result(1), base(2);
+			while (k > 0) {
+				if (k & 1) result *= base;
+				base *= base;
+				k >>= 1;
+			}
+			return result;
+		};
+
+		edecimal sig(static_cast<long long>(significand));
+		if (exp_pow >= 0) {
+			numerator   = sig * pow2(exp_pow);
+			denominator = 1;
+		}
+		else {
+			numerator   = sig;
+			denominator = pow2(-exp_pow);
 		}
 		normalize();
 		return *this;

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -385,6 +385,15 @@ protected:
 	template<typename Real,
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
 	Real to_ieee754() const {
+		// A zero denominator can arise from other paths (setdenominator,
+		// erational_divide, the divide-by-zero fallback). Resolve it here in
+		// IEEE terms before the exponent search, which would otherwise spin
+		// forever (den * 2^p stays zero, so den2p_le_num is always true).
+		if (denominator.iszero()) {
+			if (numerator.iszero()) return std::numeric_limits<Real>::quiet_NaN();   // 0/0
+			return negative ? -std::numeric_limits<Real>::infinity()
+			                :  std::numeric_limits<Real>::infinity();                 // +/- n/0
+		}
 		if (numerator.iszero()) return negative ? -static_cast<Real>(0) : static_cast<Real>(0);
 
 		constexpr int bias  = ieee754_parameter<Real>::bias;
@@ -443,7 +452,10 @@ protected:
 		}
 		if (q.iszero()) return negative ? -static_cast<Real>(0) : static_cast<Real>(0);
 
-		Real mantissa = static_cast<Real>(static_cast<unsigned long long>(q));
+		// Convert the integer mantissa straight from edecimal to Real. q is in
+		// [0, 2^(fbits+1)] and thus exactly representable; going through a
+		// 64-bit integer would narrow unsafely for long double (fbits >= 63).
+		Real mantissa = static_cast<Real>(q);
 		Real value = std::ldexp(mantissa, static_cast<int>(targetExp));
 		return negative ? -value : value;
 	}
@@ -519,7 +531,7 @@ protected:
 			return result;
 		};
 
-		edecimal sig(static_cast<long long>(significand));
+		edecimal sig(significand);   // unsigned ctor: safe for wide significands (long double fbits >= 63)
 		if (exp_pow >= 0) {
 			numerator   = sig * pow2(exp_pow);
 			denominator = 1;

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -377,10 +377,76 @@ protected:
 	template<typename UnsignedInt,
 		typename = typename std::enable_if< std::is_integral<UnsignedInt>::value, UnsignedInt >::type>
 	UnsignedInt to_unsigned() const { return static_cast<UnsignedInt>(numerator / denominator); }
-	// convert to ieee-754
+	// convert to ieee-754: correctly-rounded (round-half-to-even) conversion of
+	// the exact rational numerator/denominator to the target binary float.
+	// The previous one-liner (Real(numerator)/Real(denominator)) ignored the
+	// sign and overflowed/lost precision when numerator or denominator did not
+	// fit a Real (e.g. subnormals, 0.1, 1e-300). Issue #986.
 	template<typename Real,
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
-	Real to_ieee754() const { return Real(numerator) / Real(denominator); }
+	Real to_ieee754() const {
+		if (numerator.iszero()) return negative ? -static_cast<Real>(0) : static_cast<Real>(0);
+
+		constexpr int bias  = ieee754_parameter<Real>::bias;
+		constexpr int fbits = ieee754_parameter<Real>::fbits;
+		const long minLSBexp = 1L - bias - fbits;   // exponent of the smallest subnormal's unit bit
+
+		edecimal num = numerator;     // normalize() keeps numerator/denominator positive
+		edecimal den = denominator;
+
+		// 2^k as an exact edecimal (k >= 0), via square-and-multiply.
+		auto pow2 = [](long k) {
+			edecimal r(1), b(2);
+			while (k > 0) { if (k & 1) r *= b; b *= b; k >>= 1; }
+			return r;
+		};
+		// test den * 2^p <= num without forming negative powers of two
+		auto den2p_le_num = [&](long p) -> bool {
+			if (p >= 0) { edecimal lhs = den * pow2(p);  return !(lhs > num); }
+			else        { edecimal rhs = num * pow2(-p); return !(den > rhs); }
+		};
+
+		// e2 = floor(log2(num/den)): seed from decimal digit counts (log2(10) ~ 3.3219),
+		// then correct so that den*2^e2 <= num < den*2^(e2+1).
+		long Dn = static_cast<long>(num.size());
+		long Dd = static_cast<long>(den.size());
+		long e2 = static_cast<long>(std::floor(static_cast<double>(Dn - Dd) * 3.3219280948873623));
+		while ( den2p_le_num(e2 + 1)) ++e2;
+		while (!den2p_le_num(e2))     --e2;
+
+		// exponent of the result's unit (LSB) bit, pinned to the subnormal floor
+		long targetExp = e2 - fbits;
+		if (targetExp < minLSBexp) targetExp = minLSBexp;
+		long shift = -targetExp;       // scale value by 2^shift to obtain an integer mantissa
+
+		// mantissa = round( num/den * 2^shift ), integer division with remainder
+		edecimal q, rem, divisor;
+		if (shift >= 0) {
+			edecimal scaledNum = num * pow2(shift);
+			divisor = den;
+			q   = scaledNum; q   /= divisor;
+			rem = scaledNum; rem %= divisor;
+		}
+		else {
+			divisor = den * pow2(-shift);
+			q   = num; q   /= divisor;
+			rem = num; rem %= divisor;
+		}
+		// round half to even on 2*rem vs divisor
+		edecimal twoRem = rem + rem;
+		if (twoRem > divisor) {
+			++q;
+		}
+		else if (twoRem == divisor) {
+			edecimal two(2), qmod = q; qmod %= two;   // bump only if q is odd
+			if (!qmod.iszero()) ++q;
+		}
+		if (q.iszero()) return negative ? -static_cast<Real>(0) : static_cast<Real>(0);
+
+		Real mantissa = static_cast<Real>(static_cast<unsigned long long>(q));
+		Real value = std::ldexp(mantissa, static_cast<int>(targetExp));
+		return negative ? -value : value;
+	}
 
 	template<typename SignedInt,
 		typename = typename std::enable_if< std::is_integral<SignedInt>::value, SignedInt >::type>


### PR DESCRIPTION
## Summary
`erational` produced wildly wrong results for trivial inputs because **both** of its ieee754 conversions were broken, and it had no conversion test coverage. Discovered while evaluating it as an oracle for the ereal/Priest verification effort (epic #987); see `docs/bugs/ereal-failure-mode.md`.

## Defects fixed
**Inbound (`double -> erational`).** `convert_ieee754` dropped the exponent: the normal branch set `numerator = significand`, `denominator = 2^52` with no `2^(e-bias)` scaling, and the subnormal branch was empty. So `erational(2.0)==1`, `erational(3.0)==1.5`, `erational(0.1)~=1.6`, `erational(0.0)` threw divide-by-zero, and `1+2==3` was false. Now builds the exact dyadic rational `(-1)^s * significand * 2^(e-bias-fbits)` for normal, subnormal, and zero.

**Outbound (`erational -> double`).** `to_ieee754` was `Real(numerator)/Real(denominator)` -- it ignored the sign and converted possibly-324-digit numerator/denominator to `Real` separately, overflowing/losing precision for subnormals, `0.1`, `1e-300`, etc. Now a correctly-rounded (round-half-to-even) big-rational-to-`double` conversion with sign and subnormal handling: estimate the binary exponent from decimal digit counts, correct it exactly, scale to an integer mantissa via exact `edecimal` arithmetic, round, and assemble with `ldexp`.

## Why it shipped
`erational` had **no ieee754-conversion test** (only string-parse). Added `elastic/rational/decimal/conversion/ieee754.cpp`: double + float round-trip fuzz, specific values (integers, fractions, signs, subnormals, `DBL_MIN`/`DBL_TRUE_MIN`/`DBL_MAX`, `1e+/-300`), and arithmetic round-trips.

## Verification
- All original failing cases now correct; `(1+2)==3`, `(1/3)*3==1` hold.
- Round-trip 0 failures over random full-range finite doubles (and floats), incl. subnormals/extremes.
- Existing erational api / logic / string_parse / sqrt / arithmetic tests still PASS (no regression).
- `edecimal` (the underlying big-decimal) probed sound; `normalize()` is a correct Euclid-gcd reduce.

## Notes
- `erational` is a rational type with no signed zero: `-0.0` canonicalizes to `0`.
- Built in the full CI tier via the elastic cascade; the new test is globbed into the erational conversion suite.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| erational ieee754 conversion | OK | PASS | OK | PASS |

Resolves #986. With #992 (einteger), these are the foundation fixes preceding epic #987.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IEEE‑754 conversion: sign-aware, correctly rounded (round‑half‑to‑even) conversions with better subnormal, zero, infinity and NaN handling.

* **Tests**
  * Added a comprehensive regression test suite that verifies exact round‑trip conversions for float/double, edge cases (signed zero, subnormals, extremes), arithmetic exactness on small integers, degenerate denominators, and randomized sampling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->