### PR TITLE
feat(internal): EFT primitive exactness proof (#988, #987 Layer 1)

### DIFF
--- a/docs/bugs/ereal-failure-mode.md
+++ b/docs/bugs/ereal-failure-mode.md
@@ -204,4 +204,5 @@ discovering missing properties later when a fuzzer happens to trip over them.
   Geometric Predicates," Discrete & Computational Geometry, 1997.
 - Epic #944 (ereal regression-suite refactor); issues #954 (structural oracle),
   #981 / #982 (`expansion_product` renormalization bug + fix), #955 (MPFR
-  oracle, closed wontfix -- superseded by the erational oracle in Layer 2).
+  oracle, closed wontfix -- superseded by the dyadic oracle in Layer 2;
+  `erational` was the first candidate backend but is broken, #986).

--- a/docs/bugs/ereal-failure-mode.md
+++ b/docs/bugs/ereal-failure-mode.md
@@ -1,0 +1,207 @@
+# ereal / Priest verification failure mode and remediation plan
+
+Status: remediation in progress (epic to be filed)
+Type: process + verification-coverage defect, not a single code bug
+Affected: `elastic/ereal/` test suite and `include/sw/universal/internal/expansion/`
+
+## Summary
+
+The `ereal` type implements Douglas Priest / Jonathan Shewchuk multi-component
+floating-point expansion arithmetic. During the epic #944 effort to strengthen
+its regression suite, a serious oversight surfaced: the implementation was
+built and tested as something *associated with* Priest's algorithms (the
+error-free-transformation primitives, the citations, the expansion structure)
+without being pinned to the *theorems that define them*. The most visible
+instance was that Priest normal form was not enforced anywhere until issue #954
+added a structural oracle -- which in turn revealed a real bug (#981:
+`expansion_product` never renormalized its accumulated result, producing
+overlapping multi-limb products; fixed in #982).
+
+Normal form was the symptom. The disease is structural in how verification was
+conceived, described below.
+
+## The disease: self-referential and structural-only verification
+
+Of the three oracles the epic produced, **none checks the property that
+defines why the algorithm exists** -- that an expansion carries the *exact*
+mathematical result of an operation.
+
+| Oracle | File | What it proves | What it cannot catch |
+|--------|------|----------------|----------------------|
+| Structural | `arithmetic/priest_normal_form.cpp` | result is in Priest normal form (decreasing magnitude, non-overlapping, no interior zeros) | a normalized expansion that encodes the **wrong value** |
+| Precision-lifting | `arithmetic/precision_lifting.cpp` | `ereal<N>` agrees with `ereal<19>` | a **systematic value error in the shared algorithm** -- both sides run the same code and agree with each other |
+| Projection | most fuzzers / function tests | result is close to a `double` reference within tolerance | error in the **extra precision** the expansion exists to carry (it is discarded by the projection) |
+
+Consequence: there is currently **no test that asserts `a (op) b` equals the
+exact mathematical result of `a op b`**. The precision-lifting oracle is
+self-referential -- it proves *consistency between configurations*, not
+*correctness*. The structural oracle proves *shape*, not *value*. The whole
+purpose of a Priest expansion is to carry the exact result, and that property
+is never checked exactly.
+
+### Concrete unverified precondition (live example)
+
+`two_prod` (the foundation of every expansion product) relies on `std::fma`
+being exact:
+
+```cpp
+inline void two_prod(double a, double b, double& x, double& y) {
+    volatile double vx = a * b;
+    x = vx;
+    volatile double vy = std::fma(a, b, -vx);   // assumes exact FMA
+    y = vy;
+}
+```
+
+The project's own notes record that MinGW's *software* `fma` is off by 1-2 ULP,
+which silently breaks the error-free transformation. So `two_prod` is *assumed*
+exact per platform, never proven. This is the same failure pattern at the
+primitive level: a theorem ("`x + y == a*b` exactly") treated as an assumption.
+
+## Root cause
+
+When implementing a named algorithm, its published invariants and theorems
+must be part of the *definition of done*. Here they were not: the
+implementation was written from a reading of the source, and verification was
+added afterward in whatever shape was convenient (structural checks,
+self-comparison, double projection) rather than in the shape the literature
+dictates (exact identities checked against an independent reference). An
+unaided reading of the source is exactly what produced the normal-form
+omission, so verification cannot rest on that same reading.
+
+## Remediation plan: three layers, all tied to the literature
+
+Chosen approach: **full plan, in order**, each layer as its own PR.
+
+### Layer 1 -- Primitive exactness (the error-free transformations)
+
+Prove the named theorems for the building blocks, on the actual build platform:
+
+- `two_sum` / `fast_two_sum`: `s + e == a + b` with **zero** rounding.
+- `two_prod`: `x + y == a*b` exactly.
+- Assert `fast_two_sum`'s `|a| >= |b|` precondition holds at every call site
+  (currently assumed).
+- Resolve the `std::fma` (MinGW software-FMA) correctness risk explicitly.
+
+These rest under everything else, so they are verified first.
+
+### Layer 2 -- Independent exact-value oracle (the keystone)
+
+The oracle must be exact and have **no external dependency** (this sidesteps
+exactly what closed the MPFR-oracle idea, issue #955, as wontfix). Every
+`double` is a *dyadic* rational -- `sign * mantissa * 2^exp` with integer
+mantissa and exponent -- so an exact reference needs only big-integer
+arithmetic and power-of-two scaling, never general division or gcd.
+
+**Oracle foundation: BLOCKED -- both candidate big-number types are broken.**
+The first instinct was to use the library's `erational` (adaptive rational).
+Probing it before building on it -- the discipline this whole effort is about --
+revealed `erational` is broken (#986): its `double` conversion ignores the
+exponent, so `erational(2.0)` yields `1` and `1 + 2 == 3` is false. The
+fallback was `einteger` (adaptive integer); a small probe (operands < 2^20)
+looked clean, so a dyadic-rational oracle was built on it -- but a *deeper*
+probe at full 53-bit operands found `einteger`'s multiply is also broken
+(#991): `(2^32)*(2^32) != 2^64`, ~99.99% of 53-bit products wrong, due to a
+carry-propagation defect at the limb boundary. The shallow first probe is
+itself an instance of the under-testing failure mode this effort exists to
+correct.
+
+Consequence: there is currently **no trustworthy exact big-number type in the
+library** to anchor the keystone oracle. The dyadic oracle design
+(`include/sw/universal/verification/dyadic_exact.hpp`, numerator = big integer,
+denominator = power of two) is correct and ready, but needs a sound integer
+backend. Resolution options (maintainer decision):
+
+1. **Fix `einteger` multiply (#991)** -- appears to be a contained carry bug; a
+   patch is proposed in the issue. Then `einteger` becomes the oracle backend.
+2. **`__int128`-bounded oracle** -- no library dependency; covers `two_prod`
+   fully (106-bit products) and `two_sum` for bounded exponent gaps, with
+   extreme-gap cases handled structurally. Limited range, more caveats.
+3. **Fix `erational` (#986)** and use it.
+
+Recommended: option 1 -- it is small, fixes a real shipped bug, and yields a
+general exact backend usable by the whole verification effort.
+
+The oracle:
+
+1. inputs (doubles / ereal limbs) -> exact dyadic rationals,
+2. compute `+`, `-`, `*` in exact dyadic arithmetic (exact and closed; `/` is
+   handled separately since a quotient need not be dyadic and `ereal`'s own
+   division is not claimed exact -- there the oracle checks a residual bound,
+   not bit-exact equality),
+3. convert the `ereal` result's components -> dyadic rationals and sum them,
+4. assert **bit-exact equality** for `+`, `-`, `*`.
+
+This reference shares no code with the expansion algorithms, so it can catch a
+normalized-but-wrong value -- the class of bug nothing currently catches. This
+is the artifact that directly answers "is this actually computing Priest
+arithmetic, or just something shaped like it." Whatever it finds (errors, or
+millions of clean cases) is an independent check the maintainer holds, not a
+claim to be taken on faith.
+
+### Layer 3 -- Line-by-line conformance audit
+
+Map each implemented routine to its published figure and confirm correspondence
+in writing:
+
+- `grow_expansion`, `fast_expansion_sum`, `linear_expansion_sum`,
+  `scale_expansion`, `priest_renormalize`, `expansion_product` vs the
+  Shewchuk (1997) figures and Priest's normalization.
+- Confirm the encoded normal-form predicate (`|z_{k+1}| <= ulp(z_k)/2`,
+  decreasing magnitude, no interior zeros) is **literally Priest's published
+  definition** with citation, not a paraphrase.
+
+The resulting conformance table becomes the contract for the type.
+
+## Discovery during remediation: two more broken core types
+
+Verifying the intended oracle *before* building on it (the central discipline
+of this effort) uncovered two independent, serious bugs in the library's
+exact-arithmetic types. This both validates the discipline and shows the trust
+problem is broader than `ereal`.
+
+### `einteger` multiply is broken (#991)
+
+`einteger::operator*=` mishandles carries at the limb boundary:
+`(2^32)*(2^32) != 2^64`, and ~99.99% of random 53-bit x 53-bit products are
+wrong. Single-limb and some multi-limb products are correct, so a shallow probe
+(operands < 2^20) passed and nearly led to building the oracle on it -- exactly
+the under-testing trap. Root cause: the carry accumulator is not reset per
+outer-limb iteration and the final carry is flushed once instead of rippled per
+row. Patch proposed in #991.
+
+### `erational` is broken (#986)
+
+`erational` (adaptive-precision rational) was found to be fundamentally broken:
+
+- `erational::convert_ieee754` ignores the floating-point exponent: its "normal"
+  branch sets `numerator = significand`, `denominator = 2^52` and never applies
+  the `2^(exp - bias)` scaling; its subnormal branch is an empty `{}`.
+- Result: every value collapses into `[1,2)`. `erational(2.0) -> 1`,
+  `erational(3.0) -> 1.5`, `erational(0.1) -> 1.6`, `erational(0.0) -> NaN` with
+  a thrown `divide_by_zero`, and `erational(1.0) + erational(2.0) == erational(3.0)`
+  is **false**.
+- It has no regression tests and is OFF in CI
+  (`UNIVERSAL_BUILD_NUMBER_ERATIONALS ... OFF`).
+
+This is the same failure pattern as the `ereal` issue (a type shipped without
+its defining behavior verified) and should be filed and fixed on its own track.
+It is the reason the Layer-2 oracle is built on `einteger` instead. Note: this
+finding is itself a validation of the "probe before you build on it" discipline
+this remediation is meant to instill.
+
+## Process change
+
+For any named algorithm, encode its published invariants/theorems as tests
+**first**, with the citation, as part of definition-of-done -- rather than
+discovering missing properties later when a fuzzer happens to trip over them.
+
+## References
+
+- D. M. Priest, "On Properties of Floating Point Arithmetics: Numerical
+  Stability and the Cost of Accurate Computations," PhD thesis, 1992.
+- J. R. Shewchuk, "Adaptive Precision Floating-Point Arithmetic and Fast Robust
+  Geometric Predicates," Discrete & Computational Geometry, 1997.
+- Epic #944 (ereal regression-suite refactor); issues #954 (structural oracle),
+  #981 / #982 (`expansion_product` renormalization bug + fix), #955 (MPFR
+  oracle, closed wontfix -- superseded by the erational oracle in Layer 2).

--- a/include/sw/universal/verification/dyadic_exact.hpp
+++ b/include/sw/universal/verification/dyadic_exact.hpp
@@ -1,0 +1,86 @@
+#pragma once
+// dyadic_exact.hpp: an exact dyadic-rational reference oracle (epic #987).
+//
+// Every IEEE-754 binary floating-point value is a dyadic rational: a value of
+// the form  numerator * 2^scale  with an integer numerator and an integer
+// scale. Dyadic rationals are closed under +, -, and * with NO rounding and
+// require NO division or gcd -- only big-integer arithmetic and power-of-two
+// shifts. That makes them an ideal independent oracle for expansion arithmetic
+// (Shewchuk/Priest error-free transformations and expansions): the oracle
+// shares no code path with the algorithms under test, so it can catch a result
+// that is structurally well-formed but numerically wrong.
+//
+// Backed by einteger (adaptive-precision integer, verified sound). It is
+// deliberately NOT backed by erational, whose double conversion is broken
+// (see issue #986).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <cstdint>
+#include <universal/number/einteger/einteger.hpp>
+
+namespace sw { namespace universal {
+
+// Exact dyadic rational  value == numerator * 2^scale.
+// numerator carries the sign (einteger is signed); scale is a binary exponent.
+struct dyadic {
+	using bigint = einteger<std::uint32_t>;
+
+	bigint numerator;   // signed
+	int    scale = 0;   // value = numerator * 2^scale
+
+	dyadic() : numerator(0), scale(0) {}
+	dyadic(const bigint& n, int s) : numerator(n), scale(s) {}
+
+	// Exact construction from a double. frexp gives d = m * 2^e with m in
+	// [0.5, 1); m * 2^53 is then an integer M with |M| < 2^53 (exact in a
+	// double), so d = M * 2^(e - 53). Handles normals, subnormals, and zero;
+	// inf/nan are out of scope (callers must not pass them).
+	static dyadic from_double(double d) {
+		if (d == 0.0) return dyadic();              // +0 and -0 both map to exact 0
+		int e = 0;
+		double m = std::frexp(d, &e);               // d == m * 2^e
+		long long M = static_cast<long long>(std::ldexp(m, 53));  // exact integer
+		return dyadic(bigint(M), e - 53);
+	}
+
+	bool iszero() const { return numerator.iszero(); }
+};
+
+// Bring two dyadics to a common (minimum) scale by left-shifting the numerators.
+// Left shift by k multiplies by 2^k exactly; the gap can be large (up to the
+// full double exponent span) but einteger grows as needed.
+inline void dyadic_align(const dyadic& a, const dyadic& b,
+                         dyadic::bigint& na, dyadic::bigint& nb, int& common) {
+	common = (a.scale < b.scale) ? a.scale : b.scale;
+	na = a.numerator; na <<= (a.scale - common);
+	nb = b.numerator; nb <<= (b.scale - common);
+}
+
+inline dyadic operator-(const dyadic& a) { return dyadic(-a.numerator, a.scale); }
+
+inline dyadic operator+(const dyadic& a, const dyadic& b) {
+	dyadic::bigint na, nb; int common;
+	dyadic_align(a, b, na, nb, common);
+	return dyadic(na + nb, common);
+}
+
+inline dyadic operator-(const dyadic& a, const dyadic& b) { return a + (-b); }
+
+inline dyadic operator*(const dyadic& a, const dyadic& b) {
+	// (na * 2^sa)(nb * 2^sb) == (na*nb) * 2^(sa+sb)
+	return dyadic(a.numerator * b.numerator, a.scale + b.scale);
+}
+
+// Exact equality: align to a common scale and compare numerators.
+inline bool operator==(const dyadic& a, const dyadic& b) {
+	dyadic::bigint na, nb; int common;
+	dyadic_align(a, b, na, nb, common);
+	return na == nb;
+}
+inline bool operator!=(const dyadic& a, const dyadic& b) { return !(a == b); }
+
+}}  // namespace sw::universal

--- a/internal/expansion/CMakeLists.txt
+++ b/internal/expansion/CMakeLists.txt
@@ -1,9 +1,11 @@
 file(GLOB API_SRC "./api/*.cpp")
+file(GLOB PRIMITIVES_SRC "./primitives/*.cpp")
 file(GLOB ARITHMETIC_SRC "./arithmetic/*.cpp")
 file(GLOB GROWTH_SRC "./growth/*.cpp")
 file(GLOB PERFORMANCE_SRC "./performance/*.cpp")
 
 compile_all("true" "exp_api" "Internal/multi-component/expansion/api" "${API_SRC}")
+compile_all("true" "exp_prim" "Internal/multi-component/expansion/primitives" "${PRIMITIVES_SRC}")
 compile_all("true" "exp_arith" "Internal/multi-component/expansion/arithmetic" "${ARITHMETIC_SRC}")
 compile_all("true" "exp_growth" "Internal/multi-component/expansion/growth" "${GROWTH_SRC}")
 compile_all("true" "exp_perf" "Internal/multi-component/expansion/performance" "${PERFORMANCE_SRC}")

--- a/internal/expansion/primitives/eft_exactness.cpp
+++ b/internal/expansion/primitives/eft_exactness.cpp
@@ -127,7 +127,10 @@ namespace {
 			double s, e; fast_two_sum(a, b, s, e);
 			bool exact = (dyadic::from_double(a) + dyadic::from_double(b)
 			              == dyadic::from_double(s) + dyadic::from_double(e));
-			if (exact) { if (reportTestCases) std::cout << "    NOTE fast_two_sum exact even with |a|<|b| (unexpected)\n"; }
+			if (exact) {
+				if (reportTestCases) std::cout << "    FAIL fast_two_sum stayed exact with |a|<|b| (precondition not load-bearing)\n";
+				++fails;
+			}
 		}
 		return fails;
 	}
@@ -184,7 +187,7 @@ int main() try {
 	nrOfFailedTestCases += ReportTestResult(VerifyFastTwoSum(reportTestCases, 10000), "fast_two_sum", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifyTwoProd(reportTestCases, 10000), "two_prod", test_tag);
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
-	return EXIT_SUCCESS;
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 #else
 
 #	if REGRESSION_LEVEL_1

--- a/internal/expansion/primitives/eft_exactness.cpp
+++ b/internal/expansion/primitives/eft_exactness.cpp
@@ -1,0 +1,219 @@
+// eft_exactness.cpp: prove the error-free transformations are exact (epic #987, Layer 1)
+//
+// The expansion algorithms rest on three error-free transformations (Shewchuk
+// 1997; Knuth; Dekker). Their defining theorems are exact identities:
+//
+//   two_sum(a,b)      -> (s,e):  s == fl(a+b)  and  s + e == a + b   exactly
+//   fast_two_sum(a,b) -> (s,e):  same, under the precondition |a| >= |b|
+//   two_prod(a,b)     -> (x,y):  x == fl(a*b)  and  x + y == a * b   exactly
+//
+// We verify these against an independent exact dyadic-rational oracle
+// (dyadic_exact.hpp, backed by einteger), which shares no code with the
+// transformations under test. The identities hold when the rounded result
+// stays finite (sums) and in the normal range (products): two_prod's error
+// term y is only representable when a*b neither overflows nor underflows into
+// the subnormal range, so the product fuzz stays within a normal-result band.
+//
+// Precondition audit: fast_two_sum's |a| >= |b| requirement is guaranteed at
+// its sole call site, priest_renormalize's cumulative sweep in
+// expansion_ops.hpp, where it is applied to a magnitude-sorted expansion. The
+// fuzz below only feeds |a| >= |b| pairs and additionally checks that the
+// identity breaks when the precondition is violated (so the precondition is
+// load-bearing, not incidental). two_prod uses std::fma, so VerifyTwoProd also
+// serves as a platform check that fma is correctly rounded (it is the gap that
+// would silently break every product).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cfloat>
+#include <cmath>
+#include <cstdint>
+#include <random>
+#include <universal/internal/expansion/expansion_ops.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+	using sw::universal::expansion_ops::two_sum;
+	using sw::universal::expansion_ops::fast_two_sum;
+	using sw::universal::expansion_ops::two_prod;
+
+	// random normal double with exponent in [elo, ehi], full 52-bit mantissa, random sign
+	double rdbl(std::mt19937_64& rng, int elo, int ehi) {
+		std::uniform_int_distribution<int> ed(elo, ehi);
+		std::uniform_int_distribution<std::uint64_t> md(0, (1ULL << 52) - 1);
+		std::uniform_int_distribution<int> sd(0, 1);
+		double frac = std::ldexp(static_cast<double>(md(rng)), -52);  // [0,1)
+		double v = std::ldexp(1.0 + frac, ed(rng));
+		return sd(rng) ? -v : v;
+	}
+
+	// s + e == a + b  exactly, and s == fl(a+b)
+	bool two_sum_is_exact(double a, double b) {
+		double s, e; two_sum(a, b, s, e);
+		if (s != a + b) return false;
+		return dyadic::from_double(a) + dyadic::from_double(b)
+		    == dyadic::from_double(s) + dyadic::from_double(e);
+	}
+	// x + y == a * b  exactly, and x == fl(a*b)
+	bool two_prod_is_exact(double a, double b) {
+		double x, y; two_prod(a, b, x, y);
+		if (x != a * b) return false;
+		return dyadic::from_double(a) * dyadic::from_double(b)
+		    == dyadic::from_double(x) + dyadic::from_double(y);
+	}
+
+	// Independent self-check of the oracle on exactly representable values, so a
+	// failure elsewhere is attributable to the EFT, not the reference.
+	int VerifyOracleSanity(bool reportTestCases) {
+		int fails = 0;
+		auto chk = [&](bool c, const char* w) { if (!c) { if (reportTestCases) std::cout << "    FAIL oracle " << w << '\n'; ++fails; } };
+		chk(dyadic::from_double(2.0) + dyadic::from_double(3.0) == dyadic::from_double(5.0), "2+3");
+		chk(dyadic::from_double(0.5) * dyadic::from_double(0.25) == dyadic::from_double(0.125), "0.5*0.25");
+		chk(dyadic::from_double(-4.0) + dyadic::from_double(4.0) == dyadic::from_double(0.0), "-4+4");
+		chk(dyadic::from_double(1e16) + dyadic::from_double(1.0) != dyadic::from_double(1e16), "1e16+1");
+		chk(dyadic::from_double(DBL_TRUE_MIN) * dyadic::from_double(2.0) == dyadic::from_double(2.0 * DBL_TRUE_MIN), "subnormal*2");
+		return fails;
+	}
+
+	// two_sum is exact for all finite a, b whose sum is finite (subnormals
+	// included). Structured edges + random fuzz.
+	int VerifyTwoSum(bool reportTestCases, unsigned nrIterations) {
+		int fails = 0;
+		auto probe = [&](double a, double b, const char* tag) {
+			if (!two_sum_is_exact(a, b)) { if (reportTestCases) std::cout << "    FAIL two_sum " << tag << " a=" << a << " b=" << b << '\n'; ++fails; }
+		};
+		// edges
+		probe(1.0, DBL_TRUE_MIN, "1+true_min");
+		probe(1.0, -DBL_TRUE_MIN, "1-true_min");
+		probe(DBL_MAX, -DBL_MAX, "max-max");
+		probe(1.0, 1.0, "1+1");
+		probe(1.0, std::ldexp(1.0, -53), "tie");
+		probe(0.0, -0.0, "+0-0");
+		probe(std::ldexp(1.0, 1000), std::ldexp(1.0, -1000), "huge gap");
+		probe(DBL_MIN, DBL_TRUE_MIN, "min+true_min");
+		std::mt19937_64 rng(0x7500ull);
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			double a = rdbl(rng, -1000, 1000), b = rdbl(rng, -1000, 1000);
+			if (!std::isfinite(a + b)) continue;
+			if (!two_sum_is_exact(a, b)) { if (reportTestCases) std::cout << "    FAIL two_sum fuzz a=" << a << " b=" << b << " (iter " << i << ")\n"; ++fails; }
+		}
+		return fails;
+	}
+
+	// fast_two_sum is exact under |a| >= |b|; verify on ordered pairs, and
+	// confirm the precondition is load-bearing (unordered pairs can break it).
+	int VerifyFastTwoSum(bool reportTestCases, unsigned nrIterations) {
+		int fails = 0;
+		std::mt19937_64 rng(0xFA57ull);
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			double a = rdbl(rng, -1000, 1000), b = rdbl(rng, -1000, 1000);
+			if (std::abs(a) < std::abs(b)) std::swap(a, b);   // enforce |a| >= |b|
+			if (!std::isfinite(a + b)) continue;
+			double s, e; fast_two_sum(a, b, s, e);
+			bool ok = (s == a + b) &&
+			          (dyadic::from_double(a) + dyadic::from_double(b)
+			           == dyadic::from_double(s) + dyadic::from_double(e));
+			if (!ok) { if (reportTestCases) std::cout << "    FAIL fast_two_sum a=" << a << " b=" << b << " (iter " << i << ")\n"; ++fails; }
+		}
+		// precondition is load-bearing: a known case where |a| < |b| is NOT exact
+		{
+			double a = 1.0, b = std::ldexp(1.0, 60);  // |a| < |b|
+			double s, e; fast_two_sum(a, b, s, e);
+			bool exact = (dyadic::from_double(a) + dyadic::from_double(b)
+			              == dyadic::from_double(s) + dyadic::from_double(e));
+			if (exact) { if (reportTestCases) std::cout << "    NOTE fast_two_sum exact even with |a|<|b| (unexpected)\n"; }
+		}
+		return fails;
+	}
+
+	// two_prod is exact when the product is a normal double (no overflow, no
+	// subnormal underflow of the error term).
+	int VerifyTwoProd(bool reportTestCases, unsigned nrIterations) {
+		int fails = 0;
+		auto probe = [&](double a, double b, const char* tag) {
+			if (!two_prod_is_exact(a, b)) { if (reportTestCases) std::cout << "    FAIL two_prod " << tag << " a=" << a << " b=" << b << '\n'; ++fails; }
+		};
+		probe(1.5, 1.5, "1.5*1.5");
+		probe(3.0, 7.0, "3*7");
+		probe(1.0, 1.0, "1*1");
+		probe(-2.0, 0.5, "-2*0.5");
+		probe(std::ldexp(1.0, 200), std::ldexp(1.0, -100), "pow2 spread");
+		std::mt19937_64 rng(0x9A0Dull);
+		for (unsigned i = 0; i < nrIterations; ++i) {
+			double a = rdbl(rng, -450, 450), b = rdbl(rng, -450, 450);  // product exp in [-900,900], normal
+			if (!two_prod_is_exact(a, b)) { if (reportTestCases) std::cout << "    FAIL two_prod fuzz a=" << a << " b=" << b << " (iter " << i << ")\n"; ++fails; }
+		}
+		return fails;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "error-free transformation exactness (two_sum / fast_two_sum / two_prod)";
+	std::string test_tag            = "eft exactness";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	nrOfFailedTestCases += ReportTestResult(VerifyOracleSanity(reportTestCases), "oracle", "dyadic self-check");
+
+#if MANUAL_TESTING
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoSum(reportTestCases, 10000), "two_sum", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyFastTwoSum(reportTestCases, 10000), "fast_two_sum", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoProd(reportTestCases, 10000), "two_prod", test_tag);
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoSum(reportTestCases, 50000),     "two_sum",      test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyFastTwoSum(reportTestCases, 50000), "fast_two_sum", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoProd(reportTestCases, 50000),    "two_prod",     test_tag);
+#	endif
+#	if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoSum(reportTestCases, 200000),     "two_sum x2",      test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoProd(reportTestCases, 200000),    "two_prod x2",     test_tag);
+#	endif
+#	if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoSum(reportTestCases, 1000000),  "two_sum x3",  test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoProd(reportTestCases, 1000000), "two_prod x3", test_tag);
+#	endif
+#	if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoSum(reportTestCases, 5000000),  "two_sum x4",  test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyTwoProd(reportTestCases, 5000000), "two_prod x4", test_tag);
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Layer 1 of epic #987 (prove ereal/Priest conformance). Verifies the three error-free transformations the expansion algorithms rest on satisfy their **defining exact identities**, checked against an **independent** exact dyadic-rational oracle that shares no code with the transforms under test.

```
two_sum / fast_two_sum:  s + e == a + b   exactly   (s == fl(a+b))
two_prod:                x + y == a * b   exactly   (x == fl(a*b))
```

## Why this is trustworthy
The oracle (`dyadic_exact.hpp`) represents each double as an exact `numerator * 2^scale` over `einteger` (just fixed + verified in #992) and is closed under +,-,* with no rounding. It is built bottom-up and self-checked, so a failure is attributable to the EFT, not the reference. This is the "probe before you build on it" discipline that uncovered the broken `einteger`/`erational` types (#991/#986) in the first place.

## Changes
- `internal/expansion/primitives/eft_exactness.cpp` (new): oracle self-check; structured edges (equal magnitude, opposite signs, subnormal tails, ties, signed zero, large exponent gaps); randomized fuzz L1..L4.
- `include/sw/universal/verification/dyadic_exact.hpp` (new): the einteger-backed exact dyadic-rational oracle (reused by Layer 2).
- `docs/bugs/ereal-failure-mode.md` (new): the verification failure-mode assessment + 3-layer plan.
- `internal/expansion/CMakeLists.txt`: wire the new `primitives/` test category.

## Domain notes (where the theorems hold)
- `two_sum` is exact for any finite sum (subnormals included).
- `two_prod` is exact within the normal-product band; its error term `y` is unrepresentable when `a*b` underflows into the subnormal range (a property of the EFT, documented and respected by the fuzz). It also serves as a platform check that `std::fma` is correctly rounded.
- `fast_two_sum` is fed `|a| >= |b|` (its precondition, guaranteed at its sole call site in `priest_renormalize`); the test confirms the precondition is load-bearing.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| exp_prim eft_exactness | OK | PASS | OK | PASS |

Relates to #987 (Layer 1 of 3).

## Test plan
- [x] Fast CI (gcc + clang CI_LITE) passes
- [x] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented a verification failure mode in mathematical expansion logic, recorded related issues in rational/integer arithmetic, and outlined a three-step remediation plan (primitive exactness, independent exact-value oracle, conformance audit).

* **Tests**
  * Added verification tests that use an independent exact-value oracle to validate exactness of core floating-point transformation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->