### PR TITLE
fix(ereal): stop ereal regression tests from running for hours in CI

### DIFF
--- a/elastic/ereal/api/string_parsing.cpp
+++ b/elastic/ereal/api/string_parsing.cpp
@@ -287,9 +287,9 @@ int test_error_handling() {
 
 #ifndef REGRESSION_LEVEL_OVERRIDE
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()

--- a/elastic/ereal/arithmetic/addition.cpp
+++ b/elastic/ereal/arithmetic/addition.cpp
@@ -365,7 +365,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -390,19 +390,19 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition(reportTestCases), "ereal", "addition foundational");
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 1000), "ereal", "addition fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 100), "ereal", "addition fuzz x100");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 10000), "ereal", "addition fuzz x10k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 1000), "ereal", "addition fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 100000), "ereal", "addition fuzz x100k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 10000), "ereal", "addition fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 1000000), "ereal", "addition fuzz x1M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAddition_Fuzz(reportTestCases, 100000), "ereal", "addition fuzz x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/algebraic_identities.cpp
+++ b/elastic/ereal/arithmetic/algebraic_identities.cpp
@@ -230,7 +230,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -255,19 +255,19 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities(reportTestCases), "ereal", "algebraic identities foundational");
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 1000), "ereal", "algebraic identities fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 100), "ereal", "algebraic identities fuzz x100");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 10000), "ereal", "algebraic identities fuzz x10k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 1000), "ereal", "algebraic identities fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 100000), "ereal", "algebraic identities fuzz x100k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 10000), "ereal", "algebraic identities fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 1000000), "ereal", "algebraic identities fuzz x1M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealAlgebraicIdentities_Fuzz(reportTestCases, 100000), "ereal", "algebraic identities fuzz x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/division.cpp
+++ b/elastic/ereal/arithmetic/division.cpp
@@ -385,7 +385,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -410,19 +410,19 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision(reportTestCases), "ereal", "division foundational");
-	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 1000), "ereal", "division fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 100), "ereal", "division fuzz x100");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 10000), "ereal", "division fuzz x10k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 1000), "ereal", "division fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 100000), "ereal", "division fuzz x100k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 10000), "ereal", "division fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 1000000), "ereal", "division fuzz x1M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealDivision_Fuzz(reportTestCases, 100000), "ereal", "division fuzz x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/exact_value_oracle.cpp
+++ b/elastic/ereal/arithmetic/exact_value_oracle.cpp
@@ -139,7 +139,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -155,22 +155,22 @@ int main() try {
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 #if MANUAL_TESTING
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "exact value manual");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100), "ereal", "exact value manual");
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 #else
 
 #	if REGRESSION_LEVEL_1
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "exact value x1k");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100), "ereal", "exact value x100");
 #	endif
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 10000), "ereal", "exact value x10k");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "exact value x1k");
 #	endif
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100000), "ereal", "exact value x100k");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 10000), "ereal", "exact value x10k");
 #	endif
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000000), "ereal", "exact value x1M");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100000), "ereal", "exact value x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/multiplication.cpp
+++ b/elastic/ereal/arithmetic/multiplication.cpp
@@ -473,7 +473,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -498,19 +498,19 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication(reportTestCases), "ereal", "multiplication foundational");
-	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 1000), "ereal", "multiplication fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 100), "ereal", "multiplication fuzz x100");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 10000), "ereal", "multiplication fuzz x10k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 1000), "ereal", "multiplication fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 100000), "ereal", "multiplication fuzz x100k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 10000), "ereal", "multiplication fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 1000000), "ereal", "multiplication fuzz x1M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealMultiplication_Fuzz(reportTestCases, 100000), "ereal", "multiplication fuzz x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/precision_lifting.cpp
+++ b/elastic/ereal/arithmetic/precision_lifting.cpp
@@ -9,8 +9,8 @@
 // truncation; nothing is dropped, so narrow and wide compute the same value).
 //
 // REGRESSION_LEVEL convention:
-//   LEVEL 1 -- config pairs (2,19) (4,19) (8,19) (16,19), fuzz x1k each.
-//   LEVEL 2 -- fuzz x10k.   LEVEL 3 -- x100k.   LEVEL 4 -- x1M.
+//   LEVEL 1 -- config pairs (2,19) (4,19) (8,19) (16,19), fuzz x100 each.
+//   LEVEL 2 -- fuzz x1k.   LEVEL 3 -- x10k.   LEVEL 4 -- x100k.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -95,7 +95,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -111,22 +111,22 @@ int main() try {
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 #if MANUAL_TESTING
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "precision lifting manual");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100), "ereal", "precision lifting manual");
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
 #else
 
 #	if REGRESSION_LEVEL_1
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "precision lifting x1k");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100), "ereal", "precision lifting x100");
 #	endif
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 10000), "ereal", "precision lifting x10k");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000), "ereal", "precision lifting x1k");
 #	endif
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100000), "ereal", "precision lifting x100k");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 10000), "ereal", "precision lifting x10k");
 #	endif
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 1000000), "ereal", "precision lifting x1M");
+	nrOfFailedTestCases += ReportTestResult(RunAllConfigs(reportTestCases, 100000), "ereal", "precision lifting x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/priest_normal_form.cpp
+++ b/elastic/ereal/arithmetic/priest_normal_form.cpp
@@ -9,8 +9,8 @@
 // on #981, which renormalizes expansion_product.)
 //
 // REGRESSION_LEVEL convention:
-//   LEVEL 1 -- helper unit tests + structural fuzz x1k.
-//   LEVEL 2 -- structural fuzz x10k.   LEVEL 3 -- x100k.   LEVEL 4 -- x1M.
+//   LEVEL 1 -- helper unit tests + structural fuzz x100.
+//   LEVEL 2 -- structural fuzz x1k.   LEVEL 3 -- x10k.   LEVEL 4 -- x100k.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -115,7 +115,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -138,16 +138,16 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyPriestOracle(reportTestCases), "ereal", "priest oracle helper");
-	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 1000), "ereal", "results priest-normal x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 100), "ereal", "results priest-normal x100");
 #	endif
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 10000), "ereal", "results priest-normal x10k");
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 1000), "ereal", "results priest-normal x1k");
 #	endif
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 100000), "ereal", "results priest-normal x100k");
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 10000), "ereal", "results priest-normal x10k");
 #	endif
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 1000000), "ereal", "results priest-normal x1M");
+	nrOfFailedTestCases += ReportTestResult(VerifyResultsArePriestNormal(reportTestCases, 100000), "ereal", "results priest-normal x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/arithmetic/structural_stress.cpp
+++ b/elastic/ereal/arithmetic/structural_stress.cpp
@@ -184,7 +184,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif

--- a/elastic/ereal/arithmetic/subtraction.cpp
+++ b/elastic/ereal/arithmetic/subtraction.cpp
@@ -486,7 +486,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif
@@ -511,19 +511,19 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction(reportTestCases), "ereal", "subtraction foundational");
-	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 1000), "ereal", "subtraction fuzz x1k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 100), "ereal", "subtraction fuzz x100");
 #	endif
 
 #	if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 10000), "ereal", "subtraction fuzz x10k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 1000), "ereal", "subtraction fuzz x1k");
 #	endif
 
 #	if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 100000), "ereal", "subtraction fuzz x100k");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 10000), "ereal", "subtraction fuzz x10k");
 #	endif
 
 #	if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 1000000), "ereal", "subtraction fuzz x1M");
+	nrOfFailedTestCases += ReportTestResult(VerifyErealSubtraction_Fuzz(reportTestCases, 100000), "ereal", "subtraction fuzz x100k");
 #	endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/ereal/geometry/predicates.cpp
+++ b/elastic/ereal/geometry/predicates.cpp
@@ -244,9 +244,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_2 0
 #define REGRESSION_LEVEL_3 0
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()

--- a/elastic/ereal/math/constants/constant_generation.cpp
+++ b/elastic/ereal/math/constants/constant_generation.cpp
@@ -241,9 +241,9 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
-#	define REGRESSION_LEVEL_3 1
-#	define REGRESSION_LEVEL_4 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
 #endif
 
 int main()

--- a/elastic/ereal/math/constants/reference_constants.cpp
+++ b/elastic/ereal/math/constants/reference_constants.cpp
@@ -182,9 +182,9 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
-#	define REGRESSION_LEVEL_3 1
-#	define REGRESSION_LEVEL_4 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
 #endif
 
 int main()

--- a/elastic/ereal/math/functions/classify.cpp
+++ b/elastic/ereal/math/functions/classify.cpp
@@ -229,9 +229,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -281,7 +281,7 @@ try {
 
 #if REGRESSION_LEVEL_2
 	test_tag = "classify fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyClassifyFuzz<ereal<>>(reportTestCases, 1000), "classify(ereal) fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyClassifyFuzz<ereal<>>(reportTestCases, 50), "classify(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/ereal_math_stub_test.cpp
+++ b/elastic/ereal/math/functions/ereal_math_stub_test.cpp
@@ -105,9 +105,9 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
-#	define REGRESSION_LEVEL_3 1
-#	define REGRESSION_LEVEL_4 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
 #endif
 
 int main()

--- a/elastic/ereal/math/functions/error_and_gamma.cpp
+++ b/elastic/ereal/math/functions/error_and_gamma.cpp
@@ -181,9 +181,9 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
-#	define REGRESSION_LEVEL_3 1
-#	define REGRESSION_LEVEL_4 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -218,7 +218,7 @@ try {
 
 #	if REGRESSION_LEVEL_2
 	test_tag = "error/gamma fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyErrorGammaFuzz<ereal<>>(reportTestCases, 1000), "error/gamma property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyErrorGammaFuzz<ereal<>>(reportTestCases, 50), "error/gamma property fuzz", test_tag);
 #	endif
 
 #	if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/exponent.cpp
+++ b/elastic/ereal/math/functions/exponent.cpp
@@ -279,9 +279,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -326,7 +326,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyExpLogRoundtrip<ereal<>>(reportTestCases), "log(exp(x)) roundtrip", test_tag);
 
 	test_tag = "exp/log fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyExponentFuzz<ereal<>>(reportTestCases, 1000), "exp/log property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyExponentFuzz<ereal<>>(reportTestCases, 100), "exp/log property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/fractional.cpp
+++ b/elastic/ereal/math/functions/fractional.cpp
@@ -286,9 +286,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -346,7 +346,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyFmodVsRemainder<ereal<>>(reportTestCases), "fmod vs remainder", test_tag);
 
 	test_tag = "fractional fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyFractionalFuzz<ereal<>>(reportTestCases, 1000), "fmod/remainder property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyFractionalFuzz<ereal<>>(reportTestCases, 50), "fmod/remainder property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/hyperbolic.cpp
+++ b/elastic/ereal/math/functions/hyperbolic.cpp
@@ -362,9 +362,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -414,7 +414,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyAtanh<ereal<>>(reportTestCases), "atanh(ereal)", test_tag);
 
 	test_tag = "hyperbolic fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyHyperbolicFuzz<ereal<>>(reportTestCases, 1000), "hyperbolic property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyHyperbolicFuzz<ereal<>>(reportTestCases, 50), "hyperbolic property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/hypot.cpp
+++ b/elastic/ereal/math/functions/hypot.cpp
@@ -189,9 +189,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -225,7 +225,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyHypot3D<ereal<>>(reportTestCases), "hypot(ereal, ereal, ereal)", test_tag);
 
 	test_tag = "hypot fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyHypotFuzz<ereal<>>(reportTestCases, 1000), "hypot property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyHypotFuzz<ereal<>>(reportTestCases, 50), "hypot property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/logarithm.cpp
+++ b/elastic/ereal/math/functions/logarithm.cpp
@@ -288,9 +288,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -335,7 +335,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyLogExpRoundtrip<ereal<>>(reportTestCases), "exp(log(x)) roundtrip", test_tag);
 
 	test_tag = "log property fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyLogarithmFuzz<ereal<>>(reportTestCases, 1000), "log property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyLogarithmFuzz<ereal<>>(reportTestCases, 50), "log property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/minmax.cpp
+++ b/elastic/ereal/math/functions/minmax.cpp
@@ -158,9 +158,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -197,7 +197,7 @@ try {
 
 #if REGRESSION_LEVEL_2
 	test_tag = "minmax fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyMinMaxFuzz<ereal<>>(reportTestCases, 1000), "minmax(ereal) fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyMinMaxFuzz<ereal<>>(reportTestCases, 50), "minmax(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/next.cpp
+++ b/elastic/ereal/math/functions/next.cpp
@@ -111,9 +111,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -160,7 +160,7 @@ try {
 
 #	if REGRESSION_LEVEL_2
 	nrOfFailedTestCases +=
-	    ReportTestResult(VerifyNextFuzz<ereal<>>(reportTestCases, 1000), "nextafter(ereal) fuzz", test_tag);
+	    ReportTestResult(VerifyNextFuzz<ereal<>>(reportTestCases, 50), "nextafter(ereal) fuzz", test_tag);
 #	endif
 
 #	if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/numerics.cpp
+++ b/elastic/ereal/math/functions/numerics.cpp
@@ -185,9 +185,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -234,7 +234,7 @@ try {
 
 #if REGRESSION_LEVEL_2
 	test_tag = "numerics fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyNumericsFuzz<ereal<>>(reportTestCases, 1000), "numerics(ereal) fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyNumericsFuzz<ereal<>>(reportTestCases, 50), "numerics(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/functions/pow.cpp
+++ b/elastic/ereal/math/functions/pow.cpp
@@ -367,9 +367,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -413,7 +413,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyPowGeneralPowers<ereal<>>(reportTestCases), "pow(ereal) general", test_tag);
 
 	test_tag = "pow fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyPowFuzz<ereal<>>(reportTestCases, 1000), "pow property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyPowFuzz<ereal<>>(reportTestCases, 50), "pow property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/sqrt.cpp
+++ b/elastic/ereal/math/functions/sqrt.cpp
@@ -213,9 +213,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -250,7 +250,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyCbrt<ereal<>>(reportTestCases), "cbrt(ereal)", test_tag);
 
 	test_tag = "sqrt fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifySqrtFuzz<ereal<>>(reportTestCases, 1000), "sqrt/cbrt property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtFuzz<ereal<>>(reportTestCases, 50), "sqrt/cbrt property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/trigonometry.cpp
+++ b/elastic/ereal/math/functions/trigonometry.cpp
@@ -412,9 +412,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -468,7 +468,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyAtan2<ereal<>>(reportTestCases), "atan2(ereal)", test_tag);
 
 	test_tag = "trig fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyTrigonometryFuzz<ereal<>>(reportTestCases, 1000), "trig property fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyTrigonometryFuzz<ereal<>>(reportTestCases, 50), "trig property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/truncate.cpp
+++ b/elastic/ereal/math/functions/truncate.cpp
@@ -207,9 +207,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -254,7 +254,7 @@ try {
 
 #if REGRESSION_LEVEL_2
 	test_tag = "truncate fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyTruncateFuzz<ereal<>>(reportTestCases, 1000), "truncate(ereal) fuzz", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyTruncateFuzz<ereal<>>(reportTestCases, 50), "truncate(ereal) fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_3

--- a/elastic/ereal/math/maxlimbs_threshold.cpp
+++ b/elastic/ereal/math/maxlimbs_threshold.cpp
@@ -138,9 +138,9 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
-#	define REGRESSION_LEVEL_3 1
-#	define REGRESSION_LEVEL_4 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
 #endif
 
 int main()

--- a/elastic/rational/decimal/conversion/ieee754.cpp
+++ b/elastic/rational/decimal/conversion/ieee754.cpp
@@ -145,7 +145,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif

--- a/internal/expansion/primitives/eft_exactness.cpp
+++ b/internal/expansion/primitives/eft_exactness.cpp
@@ -165,7 +165,7 @@ namespace {
 #	undef REGRESSION_LEVEL_3
 #	undef REGRESSION_LEVEL_4
 #	define REGRESSION_LEVEL_1 1
-#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_2 0
 #	define REGRESSION_LEVEL_3 0
 #	define REGRESSION_LEVEL_4 0
 #endif


### PR DESCRIPTION
## Problem
Sanitizer and Coverage CI were running for **hours** (some jobs 3+ h, piling up). They build with `-DUNIVERSAL_BUILD_CI=ON` and **no `REGRESSION_LEVEL` override**, so each test uses its in-file default regression block.

## Root cause (two compounding bugs)
1. **20 ereal test files set `REGRESSION_LEVEL_3=1` and `_4=1` in their default block** (copy-paste), so a plain/CI build ran the full L1..L4 stress workload, including 1024-bit-plus high-precision transcendental evaluations. `exponent.cpp` alone took **6308 s (1.75 h)** in a normal build.
2. The fuzz/iteration counts (x1k/x10k/x100k/x1M) and L2 high-precision blocks were calibrated for cheap fixed-size types. ereal ops are far more expensive per operation (Newton reciprocal, series transcendentals, `O(m^2)` renormalize), so even the default level was minutes per test (division 341 s, precision_lifting 228 s, logarithm 126 s, ...).

## Fix
- Set default `REGRESSION_LEVEL_3=0, _4=0` across the 20 affected files (the intended "level-1 sanity by default" convention; L3/L4 remain available via `-DUNIVERSAL_BUILD_REGRESSION_LEVEL_3/4=ON`).
- Set default `L2=0` for the expensive multi-component tests (`elastic/ereal/**`, `eft_exactness`, `erational ieee754`): routine/CI builds run L1 sanity only; L2+ stays opt-in.
- Cut the heavy fuzz counts 10x in the arithmetic/oracle tests and the math-function L1 fuzz to 50, with labels updated to match.

## Result (normal build, default level)
| test | before | after |
|------|--------|-------|
| er_math_exponent | 6308 s | 7.7 s |
| er_arith_division | 341 s | 0.45 s |
| er_arith_precision_lifting | 228 s | 0.30 s |
| er_math_logarithm | 126 s | 6.9 s |
| er_arith_exact_value_oracle | 80 s | 0.12 s |

All ereal math/arithmetic/oracle tests + eft_exactness + erational conversion now run in single-digit seconds and PASS on gcc-13 and clang-18. Deeper fuzz/precision still runs in explicit regression-level builds.

## Out of scope (pre-existing, flagged separately)
`elastic/ereal/api/progressive_precision.cpp` (no regression guards, ~121 s, currently fails its precision-scaling assertion on a plain build) is a pre-existing issue, not touched here.

## Test plan
- [ ] Fast CI passes
- [ ] Confirm Sanitizer/Coverage complete in normal time once this lands

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Updated default regression test level configuration across multiple test modules to streamline test execution scope.
  - Adjusted test fixture iteration counts across mathematical function and arithmetic operation tests to optimize testing performance while maintaining validation coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->