### PR TITLE
fix(ereal): UBSan signed-overflow in check_priest_normal on non-finite limbs

### DIFF
--- a/elastic/ereal/arithmetic/structural_stress.cpp
+++ b/elastic/ereal/arithmetic/structural_stress.cpp
@@ -45,6 +45,10 @@ namespace {
 	                const char* context, bool reportTestCases) {
 		int fails = 0;
 		auto probe = [&](const char* op, const ereal<16>& r) {
+			// The magnitude sweep deliberately reaches 2^900; sums/products there
+			// overflow to inf/nan, which is expected, not a normal-form violation.
+			// Only assert Priest-normal form on finite (representable) results.
+			if (!std::isfinite(double(r))) return;
 			if (auto pn = check_priest_normal(r); !pn.ok()) {
 				if (reportTestCases) std::cout << "    FAIL priest-normal " << op
 					<< " [" << context << "]: " << pn.what()

--- a/include/sw/universal/verification/ereal_test_support.hpp
+++ b/include/sw/universal/verification/ereal_test_support.hpp
@@ -31,7 +31,7 @@ namespace sw { namespace universal {
 // with the limb index at which it occurs, so a fuzzer failure points directly
 // at the broken invariant.
 struct PriestNormalResult {
-	enum class Violation { None, NonDecreasing, Overlap, InteriorZero };
+	enum class Violation { None, NonDecreasing, Overlap, InteriorZero, NonFinite };
 	Violation   violation = Violation::None;
 	std::size_t index     = 0;
 
@@ -42,6 +42,7 @@ struct PriestNormalResult {
 		case Violation::NonDecreasing: return "non-decreasing magnitude |z_k| < |z_{k+1}|";
 		case Violation::Overlap:       return "overlap |z_{k+1}| > ulp(z_k)/2";
 		case Violation::InteriorZero:  return "zero component in a non-zero expansion";
+		case Violation::NonFinite:     return "non-finite (inf/nan) component";
 		}
 		return "unknown";
 	}
@@ -59,6 +60,10 @@ inline PriestNormalResult check_priest_normal(const std::vector<double>& L) noex
 	if (L.size() == 1 && L[0] == 0.0) return r;
 
 	for (std::size_t i = 0; i < L.size(); ++i) {
+		// A non-finite limb is not a valid normal-form component; flag it before
+		// the ilogb below, where std::ilogb(inf/nan) returns INT_MIN/INT_MAX and
+		// the subsequent "- 53" would be signed-integer overflow (UB).
+		if (!std::isfinite(L[i])) { r.violation = R::Violation::NonFinite; r.index = i; return r; }
 		if (L[i] == 0.0) { r.violation = R::Violation::InteriorZero; r.index = i; return r; }
 	}
 	for (std::size_t i = 0; i + 1 < L.size(); ++i) {


### PR DESCRIPTION
## Problem
UBSan on `main` fails:
```
ereal_test_support.hpp:69:60: runtime error: signed integer overflow:
  -2147483648 - 53 cannot be represented in type 'int'
  #0 check_priest_normal(...)  ereal_test_support.hpp:69
  ...  structural_stress.cpp (VerifyMagnitudeSweep)
```
`check_priest_normal` computes `std::ilogb(L[i]) - 53`. For a non-finite limb (inf/nan), `std::ilogb` returns `INT_MIN`/`INT_MAX`, so `INT_MIN - 53` is signed-integer overflow (UB). `structural_stress`'s magnitude sweep reaches `2^900`, where sums/products overflow to inf/nan and reach the predicate.

Pre-existing since #954; it surfaced now because #1001 let the sanitizer suite actually finish (it previously ran for hours and was cancelled).

## Fix
- `check_priest_normal`: detect a non-finite limb (new `Violation::NonFinite`) in the first scan, before the `ilogb` — the predicate never invokes UB regardless of input.
- `structural_stress`: skip non-finite (overflowed) results; overflow at the extreme end of the `2^-900..2^900` sweep is expected, not a normal-form violation.

## Verification
- `structural_stress` built with `-fsanitize=undefined -fno-sanitize-recover`: **0 runtime errors, PASS**.
- All `check_priest_normal` consumers (priest_normal_form, exact_value_oracle, structural_stress, addition/subtraction/multiplication/division retrofits, eft_exactness) build and PASS on gcc-13 and clang-18.

This clears the UBSan red on `main`.

## Test plan
- [ ] Fast CI passes
- [ ] Promote/merge to clear the UBSan failure

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to correctly handle arithmetic operations producing overflow/underflow edge cases (infinity/NaN values), preventing undefined behavior in validation checks and improving overall robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1003?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->