### PR TITLE
perf(ereal): tier mathlib property-fuzz by regression level (#1007)

### DIFF
--- a/elastic/ereal/math/functions/exponent.cpp
+++ b/elastic/ereal/math/functions/exponent.cpp
@@ -327,7 +327,18 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyExpLogRoundtrip<ereal<>>(reportTestCases), "log(exp(x)) roundtrip", test_tag);
 
 	test_tag = "exp/log fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyExponentFuzz<ereal<>>(reportTestCases, 100), "exp/log property fuzz", test_tag);
+	// L1 (sanity tier; run by CI's Debug-instrumented ASan/UBSan/coverage jobs) takes
+	// only a small fuzz smoke sample. The count scales up for the on-demand stress
+	// tiers L2-L4 so QA depth is preserved where runtime is not a concern (#1007).
+	unsigned expFuzzCount = 20;
+#if REGRESSION_LEVEL_4
+	expFuzzCount = 2000;
+#elif REGRESSION_LEVEL_3
+	expFuzzCount = 500;
+#elif REGRESSION_LEVEL_2
+	expFuzzCount = 100;
+#endif
+	nrOfFailedTestCases += ReportTestResult(VerifyExponentFuzz<ereal<>>(reportTestCases, expFuzzCount), "exp/log property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/hyperbolic.cpp
+++ b/elastic/ereal/math/functions/hyperbolic.cpp
@@ -414,7 +414,18 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyAtanh<ereal<>>(reportTestCases), "atanh(ereal)", test_tag);
 
 	test_tag = "hyperbolic fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyHyperbolicFuzz<ereal<>>(reportTestCases, 50), "hyperbolic property fuzz", test_tag);
+	// L1 (sanity tier; run by CI's Debug-instrumented ASan/UBSan/coverage jobs) takes
+	// only a small fuzz smoke sample. The count scales up for the on-demand stress
+	// tiers L2-L4 so QA depth is preserved where runtime is not a concern (#1007).
+	unsigned hyperbolicFuzzCount = 15;
+#if REGRESSION_LEVEL_4
+	hyperbolicFuzzCount = 2000;
+#elif REGRESSION_LEVEL_3
+	hyperbolicFuzzCount = 500;
+#elif REGRESSION_LEVEL_2
+	hyperbolicFuzzCount = 100;
+#endif
+	nrOfFailedTestCases += ReportTestResult(VerifyHyperbolicFuzz<ereal<>>(reportTestCases, hyperbolicFuzzCount), "hyperbolic property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/hypot.cpp
+++ b/elastic/ereal/math/functions/hypot.cpp
@@ -225,7 +225,18 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyHypot3D<ereal<>>(reportTestCases), "hypot(ereal, ereal, ereal)", test_tag);
 
 	test_tag = "hypot fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyHypotFuzz<ereal<>>(reportTestCases, 50), "hypot property fuzz", test_tag);
+	// L1 (sanity tier; run by CI's Debug-instrumented ASan/UBSan/coverage jobs) takes
+	// only a small fuzz smoke sample. The count scales up for the on-demand stress
+	// tiers L2-L4 so QA depth is preserved where runtime is not a concern (#1007).
+	unsigned hypotFuzzCount = 15;
+#if REGRESSION_LEVEL_4
+	hypotFuzzCount = 2000;
+#elif REGRESSION_LEVEL_3
+	hypotFuzzCount = 500;
+#elif REGRESSION_LEVEL_2
+	hypotFuzzCount = 100;
+#endif
+	nrOfFailedTestCases += ReportTestResult(VerifyHypotFuzz<ereal<>>(reportTestCases, hypotFuzzCount), "hypot property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/logarithm.cpp
+++ b/elastic/ereal/math/functions/logarithm.cpp
@@ -335,7 +335,18 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyLogExpRoundtrip<ereal<>>(reportTestCases), "exp(log(x)) roundtrip", test_tag);
 
 	test_tag = "log property fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyLogarithmFuzz<ereal<>>(reportTestCases, 50), "log property fuzz", test_tag);
+	// L1 (sanity tier; run by CI's Debug-instrumented ASan/UBSan/coverage jobs) takes
+	// only a small fuzz smoke sample. The count scales up for the on-demand stress
+	// tiers L2-L4 so QA depth is preserved where runtime is not a concern (#1007).
+	unsigned logFuzzCount = 15;
+#if REGRESSION_LEVEL_4
+	logFuzzCount = 2000;
+#elif REGRESSION_LEVEL_3
+	logFuzzCount = 500;
+#elif REGRESSION_LEVEL_2
+	logFuzzCount = 100;
+#endif
+	nrOfFailedTestCases += ReportTestResult(VerifyLogarithmFuzz<ereal<>>(reportTestCases, logFuzzCount), "log property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/pow.cpp
+++ b/elastic/ereal/math/functions/pow.cpp
@@ -413,7 +413,18 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyPowGeneralPowers<ereal<>>(reportTestCases), "pow(ereal) general", test_tag);
 
 	test_tag = "pow fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyPowFuzz<ereal<>>(reportTestCases, 50), "pow property fuzz", test_tag);
+	// L1 (sanity tier; run by CI's Debug-instrumented ASan/UBSan/coverage jobs) takes
+	// only a small fuzz smoke sample. The count scales up for the on-demand stress
+	// tiers L2-L4 so QA depth is preserved where runtime is not a concern (#1007).
+	unsigned powFuzzCount = 15;
+#if REGRESSION_LEVEL_4
+	powFuzzCount = 2000;
+#elif REGRESSION_LEVEL_3
+	powFuzzCount = 500;
+#elif REGRESSION_LEVEL_2
+	powFuzzCount = 100;
+#endif
+	nrOfFailedTestCases += ReportTestResult(VerifyPowFuzz<ereal<>>(reportTestCases, powFuzzCount), "pow property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/sqrt.cpp
+++ b/elastic/ereal/math/functions/sqrt.cpp
@@ -250,7 +250,18 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyCbrt<ereal<>>(reportTestCases), "cbrt(ereal)", test_tag);
 
 	test_tag = "sqrt fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifySqrtFuzz<ereal<>>(reportTestCases, 50), "sqrt/cbrt property fuzz", test_tag);
+	// L1 (sanity tier; run by CI's Debug-instrumented ASan/UBSan/coverage jobs) takes
+	// only a small fuzz smoke sample. The count scales up for the on-demand stress
+	// tiers L2-L4 so QA depth is preserved where runtime is not a concern (#1007).
+	unsigned sqrtFuzzCount = 15;
+#if REGRESSION_LEVEL_4
+	sqrtFuzzCount = 2000;
+#elif REGRESSION_LEVEL_3
+	sqrtFuzzCount = 500;
+#elif REGRESSION_LEVEL_2
+	sqrtFuzzCount = 100;
+#endif
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtFuzz<ereal<>>(reportTestCases, sqrtFuzzCount), "sqrt/cbrt property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/trigonometry.cpp
+++ b/elastic/ereal/math/functions/trigonometry.cpp
@@ -468,7 +468,18 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyAtan2<ereal<>>(reportTestCases), "atan2(ereal)", test_tag);
 
 	test_tag = "trig fuzz";
-	nrOfFailedTestCases += ReportTestResult(VerifyTrigonometryFuzz<ereal<>>(reportTestCases, 50), "trig property fuzz", test_tag);
+	// L1 (sanity tier; run by CI's Debug-instrumented ASan/UBSan/coverage jobs) takes
+	// only a small fuzz smoke sample. The count scales up for the on-demand stress
+	// tiers L2-L4 so QA depth is preserved where runtime is not a concern (#1007).
+	unsigned trigFuzzCount = 15;
+#if REGRESSION_LEVEL_4
+	trigFuzzCount = 2000;
+#elif REGRESSION_LEVEL_3
+	trigFuzzCount = 500;
+#elif REGRESSION_LEVEL_2
+	trigFuzzCount = 100;
+#endif
+	nrOfFailedTestCases += ReportTestResult(VerifyTrigonometryFuzz<ereal<>>(reportTestCases, trigFuzzCount), "trig property fuzz", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2


### PR DESCRIPTION
## Summary
- The ereal mathlib property-fuzz ran a heavy fixed count (x100 exponent, x50 others) **only at L1** -- the sanity tier that CI's Debug-instrumented jobs (ASan/UBSan/coverage) run. At `-O0` + instrumentation that loop is ~40x slower than the `-O3` matrix, so those jobs took ~1h+ (hyperbolic 568s, exponent 420s under coverage).
- Tier the fuzz count by regression level: **L1 keeps a small smoke sample** (exponent x20, others x15); L2/L3/L4 scale up (x100/x500/x2000) for the on-demand stress builds. The fuzz runs once, count selected by the highest enabled level.

## Root cause
The single L1-only fixed fuzz count meant the *cheapest* tier paid the *heaviest* fuzz cost, and the higher tiers did no property-fuzzing at all. PR #1004 (full-precision transcendentals) increased per-call cost, making the L1 fuzz dominate the instrumented jobs.

## Changes
- `elastic/ereal/math/functions/{exponent,hyperbolic,trigonometry,logarithm,pow,hypot,sqrt}.cpp` -- replace the L1-only fixed fuzz count with a regression-level-scaled count. Fixed-point correctness tests and the ereal<16>/<19> blocks are untouched.

## Effect (L1, -O3)
| test | before | after |
|---|---|---|
| exponent | 9.7 s | 1.7 s |
| hyperbolic | ~11 s | 3.3 s |
| trigonometry | ~7 s | 2.1 s |
| logarithm | ~7 s | 2.2 s |
| pow | ~5 s | 1.4 s |

The Debug-instrumented Coverage/ASan/UBSan jobs drop proportionally; stress-tier QA depth is preserved (and the property fuzz now actually scales at L2-L4, where it previously did not run).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| er_math_{exponent,hyperbolic,trigonometry,logarithm,pow,hypot,sqrt} | OK | PASS (L1) | OK | PASS (L1) |
| er_math_exponent (L2 tiering) | OK | PASS | - | - |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #1007

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mathematical function regression test suites to dynamically scale fuzz testing iterations based on regression tier. Lower-intensity runs execute abbreviated test samples for faster feedback, while higher-intensity tiers perform more comprehensive testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->