### PR TITLE
ci(cmake): gate ccache save to main + set max-size to stop PR-run eviction (#1009)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,6 +73,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: ${{ matrix.artifact }}
+          max-size: "1G"
+          # Save the ccache only on pushes to main: PR/branch runs restore the warm
+          # main cache but do not create new ones. Without this every PR run saved a
+          # fresh cache and a CI burst evicted the warm caches under GitHub's 10GB
+          # limit, dropping the hit rate to ~1% and turning ~1-min cached builds into
+          # ~9-min cold rebuilds (#1009).
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set ccache compiler launcher
         run: |
@@ -238,6 +245,13 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: ${{ matrix.artifact }}
+          max-size: "1G"
+          # Save the ccache only on pushes to main: PR/branch runs restore the warm
+          # main cache but do not create new ones. Without this every PR run saved a
+          # fresh cache and a CI burst evicted the warm caches under GitHub's 10GB
+          # limit, dropping the hit rate to ~1% and turning ~1-min cached builds into
+          # ~9-min cold rebuilds (#1009).
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set ccache compiler launcher
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- The cmake CI build time regressed from ~1 min to ~9-16 min/job. Root cause is **ccache eviction**, not code: the `[fast]` **Build** step went 55s -> 566s while **Test** stayed flat (~20s), and the ccache hit rate dropped to **~1%** (6/510) cold vs ~99% warm.
- Both ccache blocks used `key: ${{ matrix.artifact }}` with **no save-gating and no max-size**, so every PR/branch run saved a fresh (~500MB) cache. Under GitHub's **10GB per-repo cache limit** (LRU), a CI burst evicts the warm `main` caches; later runs restore a near-empty cache and pay full cold-compile cost.

## Changes (`.github/workflows/cmake.yml`, both ccache blocks)
- `save: ${{ github.ref == 'refs/heads/main' }}` -- only `main` pushes save; PR/branch runs **restore** the warm main cache but no longer create new ones (eliminates the eviction storm).
- `max-size: "1G"` -- a full build's objects fit without ccache-internal eviction (affordable now that few caches exist).

## Validation
- YAML validated (`yaml.safe_load`); `save`/`max-size` are supported `hendrikmuhs/ccache-action@v1.2.22` inputs.
- Workflow changes can't run locally; the real proof is the cache behavior on CI: after this lands on `main` and the cache warms, PR-run hit rates should return to ~99% and build times to ~1 min. Worth watching the first few post-merge runs.

## Notes
- Coverage/ASan/UBSan don't use ccache and are inherently slow (Debug `-O0` + instrumentation) -- out of scope (see #1007).
- Diagnosis detail in #1009.

## Test plan
- [ ] Fast CI passes
- [ ] After merge to main, confirm ccache hit rate recovers on subsequent PR runs
- [ ] Promote to ready when satisfied

Resolves #1009

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI caching now only saves cache artifacts when runs are on the main branch, preventing cache writes from PRs/other branches while preserving warm-main cache restores for consistent, faster builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->