### PR TITLE
fix(ereal): parse high-precision decimals without precision loss or NaN (#1006)

### DIFF
--- a/elastic/ereal/conversion/string_parse.cpp
+++ b/elastic/ereal/conversion/string_parse.cpp
@@ -234,6 +234,57 @@ try {
 		ReportTestResult(nrOfFailedTestCases - start, "nlimbs parity", "ereal parse");
 	}
 
+	// ----- #1006: high-precision parse (no ~16-digit cliff, no NaN on long input) -----
+	{
+		int start = nrOfFailedTestCases;
+		// 1/7 = 0.142857... to 200 digits must parse to far more than double
+		// precision: check 7*v == 1 to >100 digits (was capped near 16 before #1006).
+		std::string oneSeventh = "0.";
+		for (int i = 0; i < 200; ++i) oneSeventh += "142857"[i % 6];
+		ereal<19> v;
+		if (!parse(oneSeventh, v) || v.isnan()) {
+			if (reportTestCases) std::cout << "FAIL 200-digit fractional parse failed/nan\n";
+			++nrOfFailedTestCases;
+		}
+		else {
+			double err = std::fabs(static_cast<double>(v * ereal<19>(7.0) - ereal<19>(1.0)));
+			if (!(err < 1e-100)) {
+				if (reportTestCases) std::cout << "FAIL 1/7 parse precision: 7*v-1 = " << err << " (want < 1e-100)\n";
+				++nrOfFailedTestCases;
+			}
+		}
+		// A ~440-digit string must still parse to a finite value (no NaN/crash).
+		std::string longStr = "0.";
+		for (int i = 0; i < 440; ++i) longStr += "142857"[i % 6];
+		ereal<19> w;
+		if (!parse(longStr, w) || w.isnan() || w.isinf()) {
+			if (reportTestCases) std::cout << "FAIL 440-digit parse not finite\n";
+			++nrOfFailedTestCases;
+		}
+		ReportTestResult(nrOfFailedTestCases - start, "high-precision fractional parse (#1006)", "ereal parse");
+	}
+
+	// ----- #1006: out-of-range exponents saturate to inf/zero, never NaN -----
+	{
+		int start = nrOfFailedTestCases;
+		ereal<19> over;     // 1e400 > DBL_MAX -> +inf, NOT NaN
+		if (!parse("1e400", over) || over.isnan() || !over.isinf() || std::signbit(static_cast<double>(over))) {
+			if (reportTestCases) std::cout << "FAIL 1e400 should be +inf (not NaN)\n";
+			++nrOfFailedTestCases;
+		}
+		ereal<19> negover;  // -1e400 -> -inf
+		if (!parse("-1e400", negover) || negover.isnan() || !negover.isinf() || !std::signbit(static_cast<double>(negover))) {
+			if (reportTestCases) std::cout << "FAIL -1e400 should be -inf (not NaN)\n";
+			++nrOfFailedTestCases;
+		}
+		ereal<19> under;    // 1e-400 < DBL_MIN -> 0, NOT NaN
+		if (!parse("1e-400", under) || under.isnan() || !under.iszero()) {
+			if (reportTestCases) std::cout << "FAIL 1e-400 should be zero (not NaN)\n";
+			++nrOfFailedTestCases;
+		}
+		ReportTestResult(nrOfFailedTestCases - start, "out-of-range exponent saturation (#1006)", "ereal parse");
+	}
+
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/include/sw/universal/internal/expansion/expansion_ops.hpp
+++ b/include/sw/universal/internal/expansion/expansion_ops.hpp
@@ -802,18 +802,52 @@ inline std::vector<double> expansion_reciprocal(const std::vector<double>& e, in
  * EXPANSION-QUOTIENT: Divide two expansions
  * ==========================================
  *
- * Algorithm: Compute e / f = e * (1/f)
+ * Algorithm: Compute e / f = (e * (1/f')) * 2^-k, where f = f' * 2^k with
+ * f' in [0.5, 1).
+ *
+ * Why scale the divisor to near-unit magnitude first: forming 1/f directly
+ * fails when |f| is large. For example 1/10^300 ~= 1e-300, whose second
+ * expansion component (~1e-316) is below DBL_MIN and therefore subnormal --
+ * which Shewchuk's algorithms forbid -- so the reciprocal collapses to ~1
+ * normal component (~16 correct digits). The reciprocal accuracy degrades by
+ * ~1 decimal digit per decimal order of magnitude of the divisor (issue #1006).
+ *
+ * Scaling f to f' in [0.5, 1) by an exact power of two (ldexp, lossless) keeps
+ * the Newton reciprocal operating on a near-unit, fully-normal operand whose
+ * result is also near-unit and fully representable. The product e * (1/f') is
+ * formed in normal range, and only then is the exact 2^-k applied. The quotient
+ * therefore carries full precision whenever the *result* is in normal range
+ * (e.g. parsing 0.142857... = M / 10^e); it can only lose precision when the
+ * quotient itself is near DBL_MIN, which is an inherent representational limit,
+ * not an algorithmic one.
  *
  * Input:
  *   e - numerator expansion
- *   f - denominator expansion (must be non-zero)
+ *   f - denominator expansion (must be non-zero, finite)
  *
  * Output:
  *   h - expansion representing e / f
  */
 inline std::vector<double> expansion_quotient(const std::vector<double>& e, const std::vector<double>& f, int iterations = 3) {
-    std::vector<double> reciprocal = expansion_reciprocal(f, iterations);
-    return expansion_product(e, reciprocal);
+    // Divide-by-zero / non-finite divisor: fall back to the direct reciprocal,
+    // which yields the IEEE special value (Inf/NaN) the callers expect.
+    if (f.empty() || f[0] == 0.0 || !std::isfinite(f[0])) {
+        std::vector<double> reciprocal = expansion_reciprocal(f, iterations);
+        return expansion_product(e, reciprocal);
+    }
+    // f = f' * 2^k with f' in [0.5, 1): k = ilogb(f[0]) + 1.
+    int k = std::ilogb(f[0]) + 1;
+    std::vector<double> fscaled(f.size());
+    for (std::size_t i = 0; i < f.size(); ++i) fscaled[i] = std::ldexp(f[i], -k);
+    std::vector<double> reciprocal = expansion_reciprocal(fscaled, iterations);
+    std::vector<double> quotient = expansion_product(e, reciprocal);
+    for (auto& v : quotient) v = std::ldexp(v, -k);  // exact: * 2^-k
+    // ldexp can underflow the smallest components to 0; renormalize to strip
+    // those zeros and restore Priest canonical (non-overlapping, no interior
+    // zero) form.
+    quotient = renormalize_expansion(quotient);
+    if (quotient.empty()) quotient.push_back(0.0);  // canonical zero
+    return quotient;
 }
 
 /*

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -401,9 +401,22 @@ public:
 			}
 		}
 
-		// Parse mantissa digits
+		// Parse mantissa digits.
+		//
+		// Significant digits are accumulated into `result` as an integer via
+		// Horner (result = result*10 + digit); the decimal point and any explicit
+		// exponent are applied afterward as a power of ten. Accumulation stops
+		// after MAX_SIG_DIGITS significant digits because (a) ereal<maxlimbs>
+		// cannot represent more than ~maxlimbs*16 decimal digits anyway, and
+		// (b) `result`'s leading component must stay below DBL_MAX, so the integer
+		// can hold at most ~307 digits. Past the cap, integer digits scale the
+		// exponent and fraction digits (below precision) are dropped (#1006).
 		bool found_digit = false;
 		bool saw_exponent_marker = false;
+		bool sig_started = false;   // seen the first nonzero significant digit
+		unsigned numSig = 0;        // significant digits accumulated into result
+		int dropped_integer = 0;    // integer digits dropped past the cap (scale up)
+		const unsigned MAX_SIG_DIGITS = (maxlimbs * 16u + 16u < 307u) ? (maxlimbs * 16u + 16u) : 307u;
 		ereal<maxlimbs> ten(10.0);
 
 		while (pos < str.length()) {
@@ -412,13 +425,24 @@ public:
 			if (std::isdigit(c)) {
 				found_digit = true;
 				int digit = c - '0';
+				if (digit != 0) sig_started = true;
 
-				// result = result * 10 + digit
-				result = result * ten;
-				result = result + ereal<maxlimbs>(static_cast<double>(digit));
-
-				if (decimal_point_seen) {
-					++decimal_position;
+				if (!sig_started) {
+					// Leading zero: not a significant digit. A leading zero in
+					// the fraction still shifts the scale (e.g. 0.001).
+					if (decimal_point_seen) ++decimal_position;
+				}
+				else if (numSig < MAX_SIG_DIGITS) {
+					// result = result * 10 + digit
+					result = result * ten;
+					result = result + ereal<maxlimbs>(static_cast<double>(digit));
+					++numSig;
+					if (decimal_point_seen) ++decimal_position;
+				}
+				else {
+					// Past the precision cap: an integer digit scales the value
+					// by ten; a fraction digit is below precision and dropped.
+					if (!decimal_point_seen) ++dropped_integer;
 				}
 			}
 			else if (c == '.' && !decimal_point_seen) {
@@ -468,21 +492,55 @@ public:
 		// valid decimal literal.
 		if (pos != str.length()) return false;
 
-		// Apply decimal point adjustment
+		// Net power of ten = explicit exponent - fraction digits + dropped
+		// integer digits (digits past the cap that were not stored in result).
 		if (decimal_point_seen) {
 			exponent -= decimal_position;
 		}
+		exponent += dropped_integer;
 
-		// Apply exponent using pown(10, exp) for integer powers
-		// pown uses repeated squaring and maintains full precision
-		if (exponent != 0) {
-			ereal<maxlimbs> power_of_ten = pown(ten, exponent);
-			result = result * power_of_ten;
+		// Apply the power-of-ten scale.
+		//
+		// A negative exponent is applied by DIVIDING by the normal-range 10^e,
+		// NOT by multiplying by 10^-e. The latter is a subnormal-range value that
+		// cannot hold more than ~1 normal component, which would cap the result
+		// near 16 digits regardless of maxlimbs (#1006). expansion_quotient scales
+		// the divisor to near-unit magnitude, so the (normal-range) quotient keeps
+		// full precision. 10^e overflows DBL_MAX for e > 308, so |exponent| is
+		// applied in chunks of at most 10^308; for an out-of-range value the chain
+		// saturates to inf (overflow) or 0 (underflow) rather than producing NaN.
+		if (!result.iszero()) {
+			if (exponent > 0) {
+				int e = exponent;
+				while (e > 0 && !result.isinf() && !result.isnan()) {
+					int step = (e > 308) ? 308 : e;
+					result = result * pown(ten, step);
+					e -= step;
+				}
+				// A product that overflows DBL_MAX leaves a NaN error term; the
+				// input was a valid finite decimal, so saturate to +inf (the sign
+				// is applied below).
+				if (result.isnan()) result.setinf(false);
+			}
+			else if (exponent < 0) {
+				int e = -exponent;
+				while (e > 308 && !result.iszero()) { result = result / pown(ten, 308); e -= 308; }
+				if (e > 0 && !result.iszero()) result = result / pown(ten, e);
+			}
 		}
 
 		// Apply sign
 		if (negative) {
 			result = -result;
+		}
+
+		// Limit to the type's component budget. Components past maxlimbs lie below
+		// ereal<maxlimbs>'s representable precision and would be subnormal, which
+		// violates the normal-double invariant that Shewchuk's two_sum/two_product
+		// require. The expansion is in canonical decreasing-magnitude order, so the
+		// leading maxlimbs components carry the full representable value (#1006).
+		if (result._limb.size() > maxlimbs) {
+			result._limb.resize(maxlimbs);
 		}
 
 		// Success - assign to *this


### PR DESCRIPTION
## Summary
`ereal::parse()` built the mantissa as a giant integer `M` and multiplied by `10^(-e)`, which had two failures:
- **NaN** for inputs needing `|exponent| >= 309`: `10^e` (and `M` for >308-digit integers) exceed DBL_MAX, so the leading component became `inf` and the EFT error term `NaN`.
- **Precision decayed ~1 digit per power of ten**: `10^(-e)` is subnormal-range (`1/10^300 ~ 1e-300`, 2nd component `~1e-316` < DBL_MIN), so it can hold only ~1 normal component — capping results near 16 digits regardless of `maxlimbs`.

## Root primitive fix (`expansion_quotient`)
Scale the divisor to near-unit magnitude by an exact power of two (`ldexp`) before the Newton reciprocal, form `e * (1/f')` in normal range, then apply the exact `2^-k`; renormalize to strip any components that underflowed to zero. The reciprocal now runs on a normal, near-unit operand, so **division keeps full precision whenever the quotient is in normal range** (benefits all ereal division of large/small-magnitude operands, not just parse).

## `parse()` changes
- Apply a negative exponent by **dividing** by the normal-range `10^e` (full precision) instead of multiplying by the subnormal `10^-e`.
- Cap significant digits at `MAX_SIG_DIGITS (<= 307)` so `M` stays below DBL_MAX (dropped integer digits scale the exponent; sub-precision fraction digits dropped; leading zeros skipped).
- Apply `|exponent|` in chunks of `<= 10^308` so out-of-range values **saturate to inf/0, never NaN**.
- Cap the result to `maxlimbs` components (leading canonical-order ones carry the value; the rest would be subnormal, violating the EFT invariant).

## Results (verified, gcc+clang at L1)
| input | before | after |
|---|---|---|
| `0.1428...` (200 digits), 7*v==1 | ~16 digits | **>200 digits** |
| 300-digit fraction | ~24 digits | **~300 digits** |
| 440-digit fraction | **NaN** | finite, ~306 digits (ereal<19> max) |
| `1e400` | **NaN** | `+inf` |
| `1e-400` | **NaN** | `0` |

## Changes
- `include/sw/universal/internal/expansion/expansion_ops.hpp` — `expansion_quotient` scaled-divisor reciprocal + renormalize.
- `include/sw/universal/number/ereal/ereal_impl.hpp` — `parse()` rewrite (divide-not-multiply, digit cap, chunked exponent, limb cap).
- `elastic/ereal/conversion/string_parse.cpp` — new high-precision + saturation regression cases.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| er_conv_string_parse (incl. new #1006 cases) | PASS | PASS |
| full ereal suite (41 tests: arithmetic/conversion/logic/math/api) | PASS | PASS |

## Test plan
- [x] Fast CI passes
- [x] Promote to ready when satisfied: `gh pr ready`

Resolves #1006

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision and accuracy in decimal-string parsing for high-precision numbers.
  * Fixed overflow behavior to correctly saturate extreme exponents to infinity instead of NaN.
  * Enhanced division algorithm stability through safer numerical computation methods.
  * Better handling of precision limits and boundary conditions in numeric parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->