### PR TITLE
fix(internal): correct inverted is_nonoverlapping expansion predicate (#999)

### DIFF
--- a/include/sw/universal/internal/expansion/expansion_ops.hpp
+++ b/include/sw/universal/internal/expansion/expansion_ops.hpp
@@ -950,26 +950,53 @@ inline bool is_decreasing_magnitude(const std::vector<double>& e) {
     return true;
 }
 
-// Check if adjacent components are nonoverlapping
-// (i.e., adding them with FAST-TWO-SUM produces no error)
+// Check if adjacent components are nonoverlapping.
+//
+// Nonoverlapping (Shewchuk / Priest): each component's significant bits lie
+// strictly below the previous component's least significant bit, i.e. for a
+// decreasing-magnitude expansion |e[i]| <= ulp(e[i-1])/2 == 2^(ilogb(e[i-1]) - 53)
+// for a normal double e[i-1]. (Equivalent to the verified check_priest_normal
+// gap test in verification/ereal_test_support.hpp.)
+//
+// NOTE: a prior implementation used a fast_two_sum error heuristic that was
+// inverted -- it flagged genuinely non-overlapping pairs (the small component
+// passes through fast_two_sum unchanged as the error term) as overlapping, and
+// declared exactly-combining overlapping pairs non-overlapping (issue #999).
 inline bool is_nonoverlapping(const std::vector<double>& e) {
     for (size_t i = 1; i < e.size(); ++i) {
-        double sum, err;
-        fast_two_sum(e[i-1], e[i], sum, err);
-        if (err != 0.0 && std::abs(err) > std::abs(e[i]) * 1e-10) {
-            // Allow tiny numerical noise but flag real overlaps
-            return false;
-        }
+        double prev = e[i - 1];
+        double cur  = e[i];
+        if (cur == 0.0) continue;                       // a zero component never overlaps
+        if (!std::isfinite(prev) || !std::isfinite(cur)) return false;
+        if (prev == 0.0) return false;                  // nonzero below a zero: not canonical
+        // |cur| <= ulp(prev)/2 ; ilogb(prev) is well-defined here (prev finite, nonzero)
+        if (std::abs(cur) > std::ldexp(1.0, std::ilogb(prev) - 53)) return false;
     }
     return true;
 }
 
-// Check if expansion is strongly nonoverlapping (Shewchuk's strict property)
-// This is a simplified check - full verification requires checking exponent differences
+// Check if expansion is strongly nonoverlapping (Shewchuk's strict property).
+//
+// Strongly nonoverlapping == nonoverlapping AND, for any adjacent pair whose
+// exponents are exactly one ulp apart (the smaller sits right at the previous
+// component's half-ulp boundary, ilogb(cur) == ilogb(prev) - 53), the smaller
+// component must be a power of two. A full bit of separation
+// (ilogb(cur) <= ilogb(prev) - 54) imposes no extra constraint.
 inline bool is_strongly_nonoverlapping(const std::vector<double>& e) {
-    // For now, use the same check as nonoverlapping
-    // TODO: Implement full strong nonoverlapping check using exponent comparison
-    return is_nonoverlapping(e);
+    for (size_t i = 1; i < e.size(); ++i) {
+        double prev = e[i - 1];
+        double cur  = e[i];
+        if (cur == 0.0) continue;
+        if (!std::isfinite(prev) || !std::isfinite(cur)) return false;
+        if (prev == 0.0) return false;
+        int eprev = std::ilogb(prev);
+        int ecur  = std::ilogb(cur);
+        if (ecur > eprev - 53) return false;            // overlapping
+        if (ecur == eprev - 53) {                       // adjacent: smaller must be a power of two
+            if (std::abs(cur) != std::ldexp(1.0, ecur)) return false;
+        }
+    }
+    return true;
 }
 
 } // namespace expansion_ops

--- a/internal/expansion/api/expansion_ops.cpp
+++ b/internal/expansion/api/expansion_ops.cpp
@@ -373,6 +373,33 @@ namespace sw { namespace universal {
 			if (std::abs(est - 1.0) > 1.0e-14) ++nrOfFailedTests;
 		}
 
+		// Test is_nonoverlapping (issue #999: the predicate used to be inverted).
+		// Non-overlapping means |e[i]| <= ulp(e[i-1])/2 == 2^(ilogb(e[i-1]) - 53).
+		{
+			// genuinely non-overlapping: small component well below the ulp boundary
+			if (!is_nonoverlapping({ 2.0, std::ldexp(1.0, -60) })) ++nrOfFailedTests;
+			// heavily overlapping: 0.5 is far above ulp(1.0)/2
+			if ( is_nonoverlapping({ 1.0, 0.5 })) ++nrOfFailedTests;
+			// exactly at the half-ulp boundary is allowed (non-overlapping)
+			if (!is_nonoverlapping({ 1.0, std::ldexp(1.0, -53) })) ++nrOfFailedTests;
+			// one bit above the boundary overlaps
+			if ( is_nonoverlapping({ 1.0, std::ldexp(1.0, -52) })) ++nrOfFailedTests;
+			// multi-component canonical expansion is non-overlapping
+			if (!is_nonoverlapping({ 1.0, std::ldexp(1.0, -60), std::ldexp(1.0, -120) })) ++nrOfFailedTests;
+			// a single component (and empty) is trivially non-overlapping
+			if (!is_nonoverlapping({ 3.0 })) ++nrOfFailedTests;
+			if (!is_nonoverlapping({})) ++nrOfFailedTests;
+			// negative components: magnitudes obey the same gap rule
+			if (!is_nonoverlapping({ -8.0, std::ldexp(1.0, -55) })) ++nrOfFailedTests;
+		}
+
+		// Test is_strongly_nonoverlapping (Shewchuk's strict property).
+		{
+			if (!is_strongly_nonoverlapping({ 1.0, std::ldexp(1.0, -53) })) ++nrOfFailedTests; // power-of-two at boundary
+			if (!is_strongly_nonoverlapping({ 1.0, std::ldexp(1.0, -60) })) ++nrOfFailedTests; // well separated
+			if ( is_strongly_nonoverlapping({ 1.0, 0.5 })) ++nrOfFailedTests;                  // overlapping
+		}
+
 		return nrOfFailedTests;
 	}
 


### PR DESCRIPTION
## Summary
`expansion_ops::is_nonoverlapping` had its overlap test **backwards**:
- a genuinely non-overlapping pair `{2.0, 2^-60}` was reported **overlapping** (wrong), and
- a heavily overlapping pair `{1.0, 0.5}` was reported **non-overlapping** (wrong).

Root cause: the `fast_two_sum` error heuristic. For a non-overlapping `(a,b)`, `fast_two_sum` returns `err == b` (the small component passes through), and the guard `|err| > |e[i]|*1e-10` then flagged an overlap — the opposite of the truth; an overlapping pair combines exactly (`err == 0`) and was declared non-overlapping.

## Fix
Reimplement both predicates with the Shewchuk/Priest exponent-gap test (the same one the verified `check_priest_normal` oracle uses):
- **`is_nonoverlapping`**: `|e[i]| <= ulp(e[i-1])/2 == 2^(ilogb(e[i-1]) - 53)`, with finite/zero guards.
- **`is_strongly_nonoverlapping`** (was an unused stub forwarding to the broken predicate): Shewchuk's strict rule — non-overlapping, with an adjacent pair (ilogb gap of exactly 53) allowed only when the smaller component is a power of two. For canonical decreasing expansions this coincides with non-overlapping (expected: Priest-canonical expansions are strongly non-overlapping).

## Changes
- `include/sw/universal/internal/expansion/expansion_ops.hpp` — both predicates reimplemented with the gap test.
- `internal/expansion/api/expansion_ops.cpp` — regression cases in `test_invariants` (issue's crafted vectors, half-ulp boundary, multi-component, single/empty, negative magnitudes). These fail against the old inverted predicate.

## Impact
No production call sites — add/multiply use `linear_expansion_sum`/`renormalize_expansion`, not this predicate. Blast radius is the public predicate itself and any test relying on it.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| exp_api_expansion_ops (incl. new #999 cases) | PASS | PASS |

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #999

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Replaced heuristic-based overlap detection with precise exponent/ULP-based validation for expansion properties
  * Strengthened strict non-overlapping checks with enhanced mathematical constraint enforcement
  * Improved zero component handling and finiteness validation

* **Tests**
  * Added comprehensive test coverage for expansion verification functions, including boundary and overlap scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->