### PR TITLE
feat(bfloat16): add ldexp/frexp/scalbn/logb/ilogb exponent functions (#941)

### DIFF
--- a/include/sw/universal/number/bfloat16/math/functions/exponent.hpp
+++ b/include/sw/universal/number/bfloat16/math/functions/exponent.hpp
@@ -28,4 +28,35 @@ inline bfloat16 expm1(bfloat16 x) {
 	return bfloat16(std::expm1(double(x)));
 }
 
+// ---- exponent manipulation (issue #941) ----
+// bfloat16 delegates to the host double routines (matching the exp/log family
+// above); a bfloat16 value is exactly representable in double, so the only loss
+// is the final round of the result back to bfloat16's 8-bit significand.
+
+// Decompose x into a normalized fraction in [0.5, 1) and an integer power of two:
+// x == frexp(x, &e) * 2^e. Writes the exponent to *exp.
+inline bfloat16 frexp(bfloat16 x, int* exp) {
+	return bfloat16(std::frexp(double(x), exp));
+}
+
+// Multiply x by 2^n.
+inline bfloat16 ldexp(bfloat16 x, int n) {
+	return bfloat16(std::ldexp(double(x), n));
+}
+
+// Multiply x by FLT_RADIX^n; FLT_RADIX == 2 here, so identical to ldexp.
+inline bfloat16 scalbn(bfloat16 x, int n) {
+	return bfloat16(std::scalbn(double(x), n));
+}
+
+// Unbiased radix-2 exponent of x, as a floating-point value.
+inline bfloat16 logb(bfloat16 x) {
+	return bfloat16(std::logb(double(x)));
+}
+
+// Unbiased radix-2 exponent of x, as an int.
+inline int ilogb(bfloat16 x) {
+	return std::ilogb(double(x));
+}
+
 }} // namespace sw::universal

--- a/static/float/bfloat16/math/exponent.cpp
+++ b/static/float/bfloat16/math/exponent.cpp
@@ -1,0 +1,142 @@
+// exponent.cpp: test suite for bfloat16 exponent-manipulation functions
+//               ldexp / frexp / scalbn / logb / ilogb (issue #941)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace sw { namespace universal {
+
+	// Verify the exponent-manipulation functions by their mathematical
+	// properties (not by re-deriving the double delegation): scaling by a power
+	// of two is exact in bfloat16, so these identities must hold exactly.
+	int VerifyExponentFunctions(bool reportTestCases) {
+		int nrOfFailedTestCases = 0;
+
+		// representative finite, normal bfloat16 values (all exactly representable)
+		const float values[] = { 1.0f, 0.5f, 2.0f, 3.5f, 0.75f, 100.0f, 0.015625f, -4.0f, -0.25f };
+		const int   shifts[] = { -5, -1, 0, 1, 3, 7 };
+
+		for (float fv : values) {
+			bfloat16 x(fv);
+
+			// frexp: x == fraction * 2^e, with |fraction| in [0.5, 1)
+			int e = 0;
+			bfloat16 fraction = frexp(x, &e);
+			double fabsd = std::abs(double(fraction));
+			if (!(fabsd >= 0.5 && fabsd < 1.0)) {
+				if (reportTestCases) std::cout << "FAIL frexp fraction out of [0.5,1): " << fv << " -> " << double(fraction) << '\n';
+				++nrOfFailedTestCases;
+			}
+			if (ldexp(fraction, e) != x) {
+				if (reportTestCases) std::cout << "FAIL frexp/ldexp roundtrip: " << fv << '\n';
+				++nrOfFailedTestCases;
+			}
+
+			// ilogb / logb / frexp exponent relationship: frexp exponent == ilogb + 1
+			int il = ilogb(x);
+			if (il != e - 1) {
+				if (reportTestCases) std::cout << "FAIL ilogb vs frexp exponent: " << fv << " ilogb=" << il << " frexp_e=" << e << '\n';
+				++nrOfFailedTestCases;
+			}
+			// logb returns the unbiased exponent as a value: logb(x) == ilogb(x)
+			if (logb(x) != bfloat16(il)) {
+				if (reportTestCases) std::cout << "FAIL logb != ilogb for " << fv << '\n';
+				++nrOfFailedTestCases;
+			}
+			// 2^ilogb(x) <= |x| < 2^(ilogb(x)+1)
+			double ax = std::abs(double(x));
+			if (!(std::ldexp(1.0, il) <= ax && ax < std::ldexp(1.0, il + 1))) {
+				if (reportTestCases) std::cout << "FAIL ilogb range for " << fv << '\n';
+				++nrOfFailedTestCases;
+			}
+
+			for (int n : shifts) {
+				// scalbn == ldexp (radix 2)
+				if (scalbn(x, n) != ldexp(x, n)) {
+					if (reportTestCases) std::cout << "FAIL scalbn != ldexp: " << fv << " n=" << n << '\n';
+					++nrOfFailedTestCases;
+				}
+				// ldexp by a power of two is exact -> exact round-trip (no over/underflow in this range)
+				if (ldexp(ldexp(x, n), -n) != x) {
+					if (reportTestCases) std::cout << "FAIL ldexp roundtrip: " << fv << " n=" << n << '\n';
+					++nrOfFailedTestCases;
+				}
+				// ldexp(x, n) == x * 2^n (exact power-of-two multiply)
+				if (ldexp(x, n) != bfloat16(double(x) * std::ldexp(1.0, n))) {
+					if (reportTestCases) std::cout << "FAIL ldexp value: " << fv << " n=" << n << '\n';
+					++nrOfFailedTestCases;
+				}
+			}
+		}
+
+		// ldexp(x, 0) == x for every value
+		for (float fv : values) {
+			bfloat16 x(fv);
+			if (ldexp(x, 0) != x || scalbn(x, 0) != x) {
+				if (reportTestCases) std::cout << "FAIL ldexp/scalbn by 0: " << fv << '\n';
+				++nrOfFailedTestCases;
+			}
+		}
+
+		return nrOfFailedTestCases;
+	}
+
+}} // namespace sw::universal
+
+#define MANUAL_TESTING 0
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "bfloat16 mathlib exponent-manipulation functions";
+	std::string test_tag    = "ldexp/frexp/scalbn/logb/ilogb";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+	{
+		bfloat16 x(3.5f);
+		int e;
+		bfloat16 f = frexp(x, &e);
+		std::cout << "frexp(3.5) = " << double(f) << " * 2^" << e << '\n';
+		std::cout << "ldexp(3.5, 2) = " << double(ldexp(x, 2)) << '\n';
+		std::cout << "ilogb(3.5) = " << ilogb(x) << ", logb(3.5) = " << double(logb(x)) << '\n';
+	}
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+	nrOfFailedTestCases += ReportTestResult(VerifyExponentFunctions(reportTestCases), "bfloat16", test_tag);
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
`bfloat16` was missing the `<cmath>` exponent-manipulation family that `cfloat<>` exposes. Added **`ldexp`, `frexp`, `scalbn`, `logb`, `ilogb`** to `bfloat16/math/functions/exponent.hpp`, delegating to the host `double` routines (Option 1 in the issue) -- matching bfloat16's existing `exp`/`log`/`sin` style. A bfloat16 is exactly representable in `double`, so the only rounding is the final result back to bfloat16's 8-bit significand.

`exponent.hpp` is already included by `bfloat16/mathlib.hpp`, so the functions are available via ADL wherever the mathlib is in scope (e.g. the elreal `threeAdd` `twoSumRN` alignment path that motivated this).

## Changes
- `include/sw/universal/number/bfloat16/math/functions/exponent.hpp` -- 5 new functions.
- `static/float/bfloat16/math/exponent.cpp` -- property-based regression test.

## Test (semantic, not implementation-derived)
Scaling by a power of two is exact in bfloat16, so the test asserts exact identities: `frexp`/`ldexp` round-trip, `|fraction| in [0.5,1)`, `scalbn==ldexp`, `ilogb==frexp_exp-1`, `logb==ilogb`, and `2^ilogb(x) <= |x| < 2^(ilogb(x)+1)`. Verified it catches a broken `ldexp` (exit non-zero).

| Target | gcc | clang |
|--------|-----|-------|
| bfloat16 exponent functions | PASS | PASS |
| bfloat16 mathlib (umbrella, no conflicts) | PASS | PASS |

## Follow-up (out of scope; elreal epic #923/#940)
Drop the bfloat16 fallback TODO in `threeAdd.hpp::detail_mccleeary::ldexp_block` and add bfloat16 to the Phase 4 FpType sweep.

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready: `gh pr ready`

Resolves #941

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exponent manipulation functions for bfloat16: `frexp`, `ldexp`, `scalbn`, `logb`, and `ilogb` for enhanced mathematical operations.

* **Tests**
  * Added comprehensive test suite validating exponent manipulation functions with multiple mathematical properties and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->