### PR TITLE
perf(bfloat16): marshal exponent functions through float (PR #1015 review)

### DIFF
--- a/include/sw/universal/number/bfloat16/math/functions/exponent.hpp
+++ b/include/sw/universal/number/bfloat16/math/functions/exponent.hpp
@@ -29,34 +29,37 @@ inline bfloat16 expm1(bfloat16 x) {
 }
 
 // ---- exponent manipulation (issue #941) ----
-// bfloat16 delegates to the host double routines (matching the exp/log family
-// above); a bfloat16 value is exactly representable in double, so the only loss
-// is the final round of the result back to bfloat16's 8-bit significand.
+// These delegate to the host FLOAT routines. A bfloat16 is the high 16 bits of
+// an IEEE-754 float32 and shares its 8-bit exponent field, so bfloat16 -> float
+// is exact and covers bfloat16's entire exponent range. float is therefore the
+// natural -- and cheaper -- marshalling type for exponent manipulation (no
+// widening to double, per PR #1015 review); the only loss is the final round of
+// the result back to bfloat16's 8-bit significand.
 
 // Decompose x into a normalized fraction in [0.5, 1) and an integer power of two:
 // x == frexp(x, &e) * 2^e. Writes the exponent to *exp.
 inline bfloat16 frexp(bfloat16 x, int* exp) {
-	return bfloat16(std::frexp(double(x), exp));
+	return bfloat16(std::frexp(float(x), exp));
 }
 
 // Multiply x by 2^n.
 inline bfloat16 ldexp(bfloat16 x, int n) {
-	return bfloat16(std::ldexp(double(x), n));
+	return bfloat16(std::ldexp(float(x), n));
 }
 
 // Multiply x by FLT_RADIX^n; FLT_RADIX == 2 here, so identical to ldexp.
 inline bfloat16 scalbn(bfloat16 x, int n) {
-	return bfloat16(std::scalbn(double(x), n));
+	return bfloat16(std::scalbn(float(x), n));
 }
 
 // Unbiased radix-2 exponent of x, as a floating-point value.
 inline bfloat16 logb(bfloat16 x) {
-	return bfloat16(std::logb(double(x)));
+	return bfloat16(std::logb(float(x)));
 }
 
 // Unbiased radix-2 exponent of x, as an int.
 inline int ilogb(bfloat16 x) {
-	return std::ilogb(double(x));
+	return std::ilogb(float(x));
 }
 
 }} // namespace sw::universal

--- a/static/float/bfloat16/math/exponent.cpp
+++ b/static/float/bfloat16/math/exponent.cpp
@@ -7,6 +7,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
 #include <cmath>
+#include <climits>
+#include <limits>
 #include <universal/number/bfloat16/bfloat16.hpp>
 #include <universal/verification/test_suite.hpp>
 
@@ -82,6 +84,39 @@ namespace sw { namespace universal {
 				if (reportTestCases) std::cout << "FAIL ldexp/scalbn by 0: " << fv << '\n';
 				++nrOfFailedTestCases;
 			}
+		}
+
+		// IEEE special cases: zero, +/-inf, NaN (frexp/ldexp/scalbn preserve the
+		// class; ilogb returns the std sentinels). bfloat16 shares float's
+		// special-value encoding.
+		const float inf = std::numeric_limits<float>::infinity();
+		const float nan = std::numeric_limits<float>::quiet_NaN();
+
+		// +0 and -0: frexp -> zero with exponent 0; ldexp/scalbn -> zero
+		for (float z : { 0.0f, -0.0f }) {
+			bfloat16 x(z);
+			int e = 99;
+			if (!frexp(x, &e).iszero() || e != 0) { if (reportTestCases) std::cout << "FAIL frexp(zero)\n"; ++nrOfFailedTestCases; }
+			if (!ldexp(x, 5).iszero() || !scalbn(x, -5).iszero()) { if (reportTestCases) std::cout << "FAIL ldexp/scalbn(zero)\n"; ++nrOfFailedTestCases; }
+			if (ilogb(x) != FP_ILOGB0) { if (reportTestCases) std::cout << "FAIL ilogb(zero) != FP_ILOGB0\n"; ++nrOfFailedTestCases; }
+		}
+
+		// +/-inf: frexp/ldexp/scalbn stay infinite; ilogb == INT_MAX
+		for (float i : { inf, -inf }) {
+			bfloat16 x(i);
+			int e = 0;
+			if (!frexp(x, &e).isinf()) { if (reportTestCases) std::cout << "FAIL frexp(inf)\n"; ++nrOfFailedTestCases; }
+			if (!ldexp(x, 3).isinf() || !scalbn(x, -3).isinf()) { if (reportTestCases) std::cout << "FAIL ldexp/scalbn(inf)\n"; ++nrOfFailedTestCases; }
+			if (ilogb(x) != INT_MAX) { if (reportTestCases) std::cout << "FAIL ilogb(inf) != INT_MAX\n"; ++nrOfFailedTestCases; }
+		}
+
+		// NaN: frexp/ldexp/scalbn stay NaN; ilogb == FP_ILOGBNAN
+		{
+			bfloat16 x(nan);
+			int e = 0;
+			if (!frexp(x, &e).isnan()) { if (reportTestCases) std::cout << "FAIL frexp(nan)\n"; ++nrOfFailedTestCases; }
+			if (!ldexp(x, 2).isnan() || !scalbn(x, 2).isnan()) { if (reportTestCases) std::cout << "FAIL ldexp/scalbn(nan)\n"; ++nrOfFailedTestCases; }
+			if (ilogb(x) != FP_ILOGBNAN) { if (reportTestCases) std::cout << "FAIL ilogb(nan) != FP_ILOGBNAN\n"; ++nrOfFailedTestCases; }
 		}
 
 		return nrOfFailedTestCases;


### PR DESCRIPTION
## Summary
Follow-up addressing review feedback on #1015 (bfloat16 exponent-manipulation functions, #941; merged).

- **Maintainer (@Ravenwater):** marshal through `float` instead of `double`. A bfloat16 is the high 16 bits of an IEEE float32 and shares its 8-bit exponent field, so `bfloat16 -> float` is exact and covers bfloat16's entire exponent range -- the natural, cheaper marshalling type for exponent manipulation (no widening to double). Results are identical; only the conversion is cheaper.
- **CodeRabbit:** added IEEE special-case coverage to the test -- `+0`/`-0`, `+/-inf`, `NaN`: frexp/ldexp/scalbn preserve the value class, and ilogb returns the std sentinels (`FP_ILOGB0`, `INT_MAX`, `FP_ILOGBNAN`).

## Changes
- `include/sw/universal/number/bfloat16/math/functions/exponent.hpp` -- `double(x)` -> `float(x)` in all 5 functions.
- `static/float/bfloat16/math/exponent.cpp` -- IEEE special-case section.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| bfloat16 exponent functions (incl. special cases) | PASS | PASS |

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready: `gh pr ready`

Relates to #941

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special floating-point values (zero, infinity, NaN) in bfloat16 exponent manipulation functions.
  * Expanded test coverage for edge cases in exponent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->