### PR TITLE
test(elreal): independent exact dyadic oracle for Phase 1-4 building blocks

### DIFF
--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -23,10 +23,16 @@
 namespace {
 
 // Exact value of a block as a dyadic rational (value(b) = v * 2^exp), shared
-// with the #1022 oracle. double(b.v) is exact for every elreal FpType.
+// with the #1022 oracle. double(b.v) is lossless only for an FpType with <= 53
+// significand bits; every elreal block host used here qualifies. A wider host
+// (e.g. cfloat<nbits,es,uint64_t,...> with nbits > 64) would need a wider exact
+// conversion, so we static_assert against it rather than silently mis-reference.
 template <typename FpType>
 sw::universal::dyadic exact_block(const sw::universal::block<FpType>& b) {
     using namespace sw::universal;
+    static_assert(std::numeric_limits<FpType>::digits <= 53,
+        "exact_block uses double(b.v) as the block's exact value, lossless only "
+        "for FpType with <= 53 significand bits.");
     if (b.is_zero_block()) return dyadic();
     dyadic d = dyadic::from_double(static_cast<double>(b.v));
     d.scale += b.exp;

--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -76,7 +76,10 @@ template <typename FpType>
 sw::universal::dyadic exact_value(const sw::universal::ZBCL<FpType>& z) {
     using namespace sw::universal;
     dyadic acc;
-    for (const auto& blk : z.take(16)) acc = acc + exact_block(blk);
+    // 32-block window, matching the #1022 oracle's ZBCL_EXACT_WINDOW so both
+    // files agree on the exact value of the same stream; finite test sums settle
+    // well within it.
+    for (const auto& blk : z.take(32)) acc = acc + exact_block(blk);
     return acc;
 }
 

--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -17,31 +17,48 @@
 #include <iostream>
 
 #include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
 #include <universal/verification/test_suite.hpp>
 
 namespace {
 
+// Exact value of a block as a dyadic rational (value(b) = v * 2^exp), shared
+// with the #1022 oracle. double(b.v) is exact for every elreal FpType.
 template <typename FpType>
-long double block_value(const sw::universal::block<FpType>& b) {
-    if (b.is_zero_block()) return 0.0L;
-    return static_cast<long double>(b.v) * std::ldexp(1.0L, b.exp);
+sw::universal::dyadic exact_block(const sw::universal::block<FpType>& b) {
+    using namespace sw::universal;
+    if (b.is_zero_block()) return dyadic();
+    dyadic d = dyadic::from_double(static_cast<double>(b.v));
+    d.scale += b.exp;
+    return d;
 }
 
+template <typename FpType>
+sw::universal::dyadic exact_value(const sw::universal::ZBCL<FpType>& z) {
+    using namespace sw::universal;
+    dyadic acc;
+    for (const auto& blk : z.take(16)) acc = acc + exact_block(blk);
+    return acc;
+}
+
+// Value preservation, validated against an INDEPENDENT exact dyadic oracle
+// (not long double -- see #1022). double and float are round-to-nearest, so
+// add() must reproduce the exact sum of the REPRESENTED operands bit-for-bit:
+//   exact(add(za, zb)) == exact(za) + exact(zb).
+// The reference uses the represented values exact(za)/exact(zb), not the
+// original double literals, so it is correct for the float host too (the old
+// 4-ulp band masked that distinction).
 template <typename FpType>
 int verify_value(double a, double b, const std::string& tag) {
     using namespace sw::universal;
     int nrFailures = 0;
-    auto z = add(from_native<FpType>(a), from_native<FpType>(b));
-    auto blocks = z.take(8);
-    long double got = 0.0L;
-    for (const auto& blk : blocks) got += block_value(blk);
-    long double ref = static_cast<long double>(a) + static_cast<long double>(b);
-    constexpr int p = std::numeric_limits<FpType>::digits;
-    long double scale = std::fmax(std::fabs(ref), 1.0L);
-    long double tol = scale * std::ldexp(1.0L, -p) * 4; // a few FpType-ulps
-    if (std::fabs(ref - got) > tol) {
-        std::cout << tag << " value mismatch: ref=" << ref << " got=" << got
-                  << " diff=" << std::fabs(ref - got) << " tol=" << tol << '\n';
+    auto za = from_native<FpType>(a);
+    auto zb = from_native<FpType>(b);
+    dyadic ref = exact_value(za) + exact_value(zb);
+    dyadic got = exact_value(add(za, zb));
+    if (ref != got) {
+        std::cout << tag << " value mismatch (exact dyadic): a=" << a
+                  << " b=" << b << '\n';
         ++nrFailures;
     }
     return nrFailures;

--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -22,19 +22,52 @@
 
 namespace {
 
+// Exact value of a binary float v as a dyadic, with no precision loss at any
+// significand width (shared with the #1022 oracle; see its exact_real for the
+// full rationale). p <= 53: double is exact. p > 53 (quad and up): extract the
+// full integer significand directly, 24 bits at a time, using only exact
+// power-of-two shifts / bit-exact floor / sub-2^24 chunks -- never through double.
+template <typename T>
+sw::universal::dyadic exact_real(T v) {
+    using namespace sw::universal;
+    if (v == T(0)) return dyadic();
+    if constexpr (std::numeric_limits<T>::digits <= 53) {
+        return dyadic::from_double(static_cast<double>(v));
+    } else {
+        static_assert(std::numeric_limits<T>::max_exponent
+                          > std::numeric_limits<T>::digits,
+            "exact_real wide path needs exponent range > significand width.");
+        using std::frexp; using std::ldexp; using std::floor;
+        int e = 0;
+        T m = frexp(v, &e);
+        constexpr int p = std::numeric_limits<T>::digits;
+        T scaled = ldexp(m, p);
+        bool neg = scaled < T(0);
+        if (neg) scaled = -scaled;
+        dyadic::bigint M(0);
+        const T CHUNK = ldexp(T(1), 24);
+        int shift = 0;
+        while (scaled > T(0)) {
+            T hi = floor(scaled / CHUNK);
+            T lo = scaled - hi * CHUNK;
+            dyadic::bigint chunk(static_cast<long long>(static_cast<double>(lo)));
+            chunk <<= shift;
+            M = M + chunk;
+            scaled = hi;
+            shift += 24;
+        }
+        if (neg) M = -M;
+        return dyadic(M, e - p);
+    }
+}
+
 // Exact value of a block as a dyadic rational (value(b) = v * 2^exp), shared
-// with the #1022 oracle. double(b.v) is lossless only for an FpType with <= 53
-// significand bits; every elreal block host used here qualifies. A wider host
-// (e.g. cfloat<nbits,es,uint64_t,...> with nbits > 64) would need a wider exact
-// conversion, so we static_assert against it rather than silently mis-reference.
+// with the #1022 oracle.
 template <typename FpType>
 sw::universal::dyadic exact_block(const sw::universal::block<FpType>& b) {
     using namespace sw::universal;
-    static_assert(std::numeric_limits<FpType>::digits <= 53,
-        "exact_block uses double(b.v) as the block's exact value, lossless only "
-        "for FpType with <= 53 significand bits.");
     if (b.is_zero_block()) return dyadic();
-    dyadic d = dyadic::from_double(static_cast<double>(b.v));
+    dyadic d = exact_real(b.v);
     d.scale += b.exp;
     return d;
 }

--- a/elastic/elreal/arithmetic/exact_value_oracle.cpp
+++ b/elastic/elreal/arithmetic/exact_value_oracle.cpp
@@ -14,29 +14,31 @@
 // cannot see.
 //
 // Exact value of a McCleeary block (sign,exp,bv packed into FpType `v` plus an
-// int32 `exp`) is  value(b) = v * 2^exp,  so
-//     exact(b) = from_double(double(b.v))  with its dyadic scale shifted by b.exp.
-// This is exact only when double(b.v) loses nothing, i.e. FpType has at most 53
-// significand bits. Every elreal block host exercised here qualifies (float 24,
-// double 53, half 11, bfloat16 8, cfloat<24,5> 19, cfloat<32,8> 24); a wider
-// host -- e.g. cfloat<nbits,es,uint64_t,...> with nbits > 64 -- would need a
-// wider exact conversion, and exact_block() static_asserts against it rather
-// than silently producing a wrong reference. The exact value of a ZBCL prefix
-// is the (exact) sum of its block dyadics.
+// int32 `exp`) is  value(b) = v * 2^exp, where exact_real(v) is the exact dyadic
+// of v at ANY significand width: for <= 53-bit hosts double is already exact; for
+// wider hosts (quad and up) it extracts the full integer significand directly,
+// never capping at double -- verified here at 113 bits (cfloat<128,15>). See
+// exact_real() for the two regimes and why the split is necessary (a narrow-
+// exponent wide host cannot represent its own scaled-up significand). The exact
+// value of a ZBCL prefix is the (exact) sum of its block dyadics.
 //
 // What is asserted:
-//   * block_two_sum / block_two_mult are error-free transforms, so
-//         exact(high) + exact(low) == exact(a) {+,*} exact(b)   EXACTLY,
-//     UNLESS the residual `low` is a subnormal the FpType cannot represent --
-//     the cfloat<24,5> representability floor identified in #942. We encode that
-//     exception structurally (a nonzero dyadic error is tolerated ONLY when the
-//     least-significant result block is a nonzero subnormal); a wrong high part,
-//     or a wrong NORMAL residual, still fails.
-//   * threeAdd and the lazy add() combinator reproduce the exact sum on the
-//     wide-exponent RN hosts (double, float, cfloat<32,8>), where the expansion
-//     is always representable -- asserted as exact dyadic equality. Narrow-
-//     exponent RN hosts (half, cfloat<24,5>) are validated at the EFT level
-//     above; their multi-block strict bound needs a rounding oracle (future).
+//   * block_two_sum: exact(high) + exact(low) == exact(a) + exact(b) EXACTLY,
+//     on every round-to-nearest host INCLUDING quad precision -- UNLESS the
+//     residual `low` is a subnormal the FpType cannot represent (the cfloat<24,5>
+//     #942 floor). That exception is encoded structurally (a nonzero dyadic error
+//     is tolerated ONLY when the least-significant result block is a nonzero
+//     subnormal); a wrong high part, or a wrong NORMAL residual, still fails.
+//   * block_two_mult: same, but NOT exercised at quad precision. two_prod_host
+//     computes the residual of an odd-precision product in a `double`
+//     intermediate (#942); that holds for p <= 26 but cannot represent the
+//     residual of a 113-bit product -- a genuine limitation of the multiply EFT,
+//     not of this oracle (filed separately). Exercised on the p <= 24 hosts.
+//   * threeAdd and the lazy add() combinator are twoSum-based (no two_prod), so
+//     they are exact on the RN hosts including quad -- asserted as exact dyadic
+//     equality. Narrow-exponent RN hosts (half, cfloat<24,5>) are validated at
+//     the EFT level above; their multi-block strict bound needs a rounding
+//     oracle (future).
 //
 // bfloat16 is NOT an exact-EFT host. It rounds toward zero
 // (numeric_limits<bfloat16>::round_style == round_toward_zero; the float->bf16
@@ -71,17 +73,69 @@ namespace {
 
 using namespace sw::universal;
 
-// exact value of a single block as a dyadic rational. Shares no code with the
-// block/EFT/threeAdd/add algorithms under test.
+// Exact value of a binary floating-point value v as a dyadic rational, with NO
+// precision loss at any significand width.
+//
+// Two regimes, chosen at compile time by the significand width p = digits:
+//
+//   * p <= 53: double represents v exactly, so from_double is exact and cheap.
+//     This covers float(24), double(53), half(11), bfloat16(8), cfloat<24,5>(19),
+//     cfloat<32,8>(24) -- every <= 53-bit host, including the narrow-exponent
+//     ones whose integer significand would OVERFLOW the type's own range.
+//
+//   * p > 53: too wide for double. Extract the full significand directly:
+//     v = m * 2^e (frexp); the integer significand m*2^p is peeled into the
+//     bigint 24 bits at a time using only exact operations (power-of-two shifts,
+//     bit-exact floor, sub-2^24 chunks that convert through double->int64
+//     losslessly). This needs 2^p (and the 2^24 chunk) to be representable in T,
+//     i.e. the exponent range must exceed the significand width -- which holds
+//     for every real quad/extended host (long double, cfloat<128,15>, ...); the
+//     static_assert documents the requirement. Verified here at 113 bits.
+//
+// Unqualified frexp/ldexp/floor resolve to std:: (native) or sw::universal::
+// (Universal types) by overload resolution.
+template <typename T>
+dyadic exact_real(T v) {
+    if (v == T(0)) return dyadic();
+    if constexpr (std::numeric_limits<T>::digits <= 53) {
+        return dyadic::from_double(static_cast<double>(v));
+    } else {
+        static_assert(std::numeric_limits<T>::max_exponent
+                          > std::numeric_limits<T>::digits,
+            "exact_real's wide-significand path scales the significand up to an "
+            "integer; that requires the exponent range to exceed the significand "
+            "width. A host with > 53 significand bits but a small exponent range "
+            "cannot even represent its own integer significand.");
+        using std::frexp; using std::ldexp; using std::floor;
+        int e = 0;
+        T m = frexp(v, &e);                          // v = m * 2^e, |m| in [0.5,1)
+        constexpr int p = std::numeric_limits<T>::digits;
+        T scaled = ldexp(m, p);                      // exact integer, |scaled| < 2^p
+        bool neg = scaled < T(0);
+        if (neg) scaled = -scaled;
+        dyadic::bigint M(0);
+        const T CHUNK = ldexp(T(1), 24);             // 2^24 (representable: p > 53 > 24)
+        int shift = 0;
+        while (scaled > T(0)) {
+            T hi = floor(scaled / CHUNK);            // scaled = hi*2^24 + lo (both exact)
+            T lo = scaled - hi * CHUNK;              // lo in [0, 2^24), exact integer
+            dyadic::bigint chunk(static_cast<long long>(static_cast<double>(lo)));
+            chunk <<= shift;
+            M = M + chunk;
+            scaled = hi;
+            shift += 24;
+        }
+        if (neg) M = -M;
+        return dyadic(M, e - p);
+    }
+}
+
+// exact value of a single block as a dyadic rational (value(b) = v * 2^exp).
+// Shares no code with the block/EFT/threeAdd/add algorithms under test.
 template <typename FpType>
 dyadic exact_block(const block<FpType>& b) {
-    static_assert(std::numeric_limits<FpType>::digits <= 53,
-        "exact_block uses double(b.v) as the block's exact value, which is "
-        "lossless only for FpType with <= 53 significand bits. A wider host "
-        "(e.g. cfloat<nbits,es,uint64_t,...> with nbits > 64) needs a wider "
-        "exact conversion into the dyadic oracle.");
     if (b.is_zero_block()) return dyadic();
-    dyadic d = dyadic::from_double(static_cast<double>(b.v));
+    dyadic d = exact_real(b.v);
     d.scale += b.exp;          // multiply by 2^exp exactly (value = v * 2^exp)
     return d;
 }
@@ -98,18 +152,14 @@ dyadic exact_zbcl(const ZBCL<FpType>& z) {
     return exact_blocks(z.take(32));   // finite sums settle well within 32 blocks
 }
 
-// value of a block in double. For the round-to-nearest hosts we use the dyadic
-// oracle (above); for bfloat16 we use double directly -- it carries ~45 bits of
-// headroom over bfloat16's 8-bit significand, so it is a genuinely exact oracle
-// for bfloat16 sums/products in this test range (unlike long-double-over-double,
-// which was the Phase 1-4 weakness this file removes).
+// value of a block in double, and its ulp -- used only for the bfloat16
+// truncation bound (double has ~45 bits of headroom over bfloat16's 8).
 template <typename FpType>
 double dval(const block<FpType>& b) {
     if (b.is_zero_block()) return 0.0;
     return std::ldexp(static_cast<double>(b.v), b.exp);
 }
 
-// ulp of a block at its own exponent: 2^(E(b) - (k-1)).
 template <typename FpType>
 double block_ulp(const block<FpType>& b) {
     const int E = b.is_zero_block() ? b.exp : b.exponent();
@@ -132,9 +182,7 @@ template <typename FpType>
 int check_two_sum(const block<FpType>& a, const block<FpType>& b,
                   const std::string& tag) {
     auto [high, low] = block_two_sum(a, b);          // precondition: a.exp == b.exp
-    dyadic ref = exact_block(a) + exact_block(b);
-    dyadic got = exact_block(high) + exact_block(low);
-    dyadic err = ref - got;
+    dyadic err = (exact_block(a) + exact_block(b)) - (exact_block(high) + exact_block(low));
     if (!acceptable(err, low)) {
         std::cout << tag << " two_sum value WRONG: a=" << double(a.v)
                   << " b=" << double(b.v)
@@ -150,9 +198,7 @@ template <typename FpType>
 int check_two_mult(const block<FpType>& a, const block<FpType>& b,
                    const std::string& tag) {
     auto [high, low] = block_two_mult(a, b);
-    dyadic ref = exact_block(a) * exact_block(b);
-    dyadic got = exact_block(high) + exact_block(low);
-    dyadic err = ref - got;
+    dyadic err = (exact_block(a) * exact_block(b)) - (exact_block(high) + exact_block(low));
     if (!acceptable(err, low)) {
         std::cout << tag << " two_mult value WRONG: a=" << double(a.v)
                   << " b=" << double(b.v)
@@ -163,7 +209,7 @@ int check_two_mult(const block<FpType>& a, const block<FpType>& b,
     return 0;
 }
 
-// ---- threeAdd (wide hosts): exact(out1+out2+out3) == exact(ia+ib+ic) --------
+// ---- threeAdd: exact(out1+out2+out3) == exact(ia+ib+ic) ---------------------
 template <typename FpType>
 int check_threeAdd_exact(const block<FpType>& ia, const block<FpType>& ib,
                          const block<FpType>& ic, const std::string& tag) {
@@ -178,51 +224,37 @@ int check_threeAdd_exact(const block<FpType>& ia, const block<FpType>& ib,
     return 0;
 }
 
-// ---- add() (wide hosts): exact(take(N)) == exact(za) + exact(zb) ------------
+// ---- add() : exact(take(N)) == exact(za) + exact(zb) ------------------------
 template <typename FpType>
 int check_add_exact(double a, double b, const std::string& tag) {
     auto za = from_native<FpType>(a);
     auto zb = from_native<FpType>(b);
     auto z  = add(za, zb);
-    dyadic ref = exact_zbcl(za) + exact_zbcl(zb);   // uses the represented values
-    dyadic got = exact_zbcl(z);
-    if (ref != got) {
+    if ((exact_zbcl(za) + exact_zbcl(zb)) != exact_zbcl(z)) {
         std::cout << tag << " add value WRONG: a=" << a << " b=" << b << "\n";
         return 1;
     }
     return 0;
 }
 
-// EFT sweep: runs for EVERY host (the residual block is directly inspectable, so
-// the #942 subnormal-floor exception is exact).
+// two_sum sweep: every round-to-nearest host, INCLUDING quad precision. The
+// residual block is directly inspectable, so the #942 subnormal exception is
+// exact.
 template <typename FpType>
-int sweep_eft(const std::string& tag) {
+int sweep_two_sum(const std::string& tag) {
     using B = block<FpType>;
     int fail = 0;
     constexpr int p = std::numeric_limits<FpType>::digits;
-
-    // --- two_sum, shared exp = 0 ---
-    // residual at the ulp boundary
     {
         FpType tiny = static_cast<FpType>(std::ldexp(1.0, -p));
         if (tiny != FpType{0})
             fail += check_two_sum<FpType>(B{FpType{1}, 0}, B{tiny, 0}, tag + " 1+2^-p");
     }
-    // exact cancellation
     fail += check_two_sum<FpType>(B{FpType{1.25}, 0}, B{FpType{-1.25}, 0}, tag + " 1.25-1.25");
-    // wide scale separation within one exp
     fail += check_two_sum<FpType>(B{static_cast<FpType>(1e4), 0},
                                   B{static_cast<FpType>(1.0/1024), 0}, tag + " 1e4+2^-10");
-    // nonzero shared exp must not change exactness
     fail += check_two_sum<FpType>(B{FpType{1}, 7}, B{FpType{0.25}, 7}, tag + " offset=7");
 
-    // --- two_mult ---
-    fail += check_two_mult<FpType>(B{FpType{1.5}, 0}, B{FpType{1.5}, 0}, tag + " 1.5*1.5");
-    fail += check_two_mult<FpType>(B{FpType{3}, 0}, B{FpType{0.5}, 0}, tag + " 3*0.5 exact");
-    fail += check_two_mult<FpType>(B{static_cast<FpType>(123.456), 2},
-                                   B{static_cast<FpType>(-7.875), -1}, tag + " mixed-exp");
-
-    // --- randomised EFT sweep ---
     std::mt19937_64 rng(0x1022ABCDULL);
     std::uniform_real_distribution<double> ud(-100.0, 100.0);
     for (int i = 0; i < 300; ++i) {
@@ -230,37 +262,53 @@ int sweep_eft(const std::string& tag) {
         FpType bv = static_cast<FpType>(ud(rng));
         if (av == FpType{0} || bv == FpType{0}) continue;
         fail += check_two_sum<FpType>(B{av, 0}, B{bv, 0}, tag + " rand-sum");
+    }
+    return fail;
+}
+
+// two_mult sweep: RN hosts whose two_prod_host is exact (p <= 24 here; the
+// double specialisation covers double). NOT quad: the odd-p double intermediate
+// cannot hold a 113-bit product residual (separate elreal limitation).
+template <typename FpType>
+int sweep_two_mult(const std::string& tag) {
+    using B = block<FpType>;
+    int fail = 0;
+    fail += check_two_mult<FpType>(B{FpType{1.5}, 0}, B{FpType{1.5}, 0}, tag + " 1.5*1.5");
+    fail += check_two_mult<FpType>(B{FpType{3}, 0}, B{FpType{0.5}, 0}, tag + " 3*0.5 exact");
+    fail += check_two_mult<FpType>(B{static_cast<FpType>(123.456), 2},
+                                   B{static_cast<FpType>(-7.875), -1}, tag + " mixed-exp");
+    std::mt19937_64 rng(0x4242ULL);
+    std::uniform_real_distribution<double> ud(-100.0, 100.0);
+    for (int i = 0; i < 300; ++i) {
+        FpType av = static_cast<FpType>(ud(rng));
+        FpType bv = static_cast<FpType>(ud(rng));
+        if (av == FpType{0} || bv == FpType{0}) continue;
         fail += check_two_mult<FpType>(B{av, 0}, B{bv, 0}, tag + " rand-mult");
     }
     return fail;
 }
 
-// Multi-block combinators: strict exact equality, wide-exponent hosts only.
+// threeAdd + add(): strict exact equality. twoSum-based, so exact on every RN
+// host including quad precision.
 template <typename FpType>
 int sweep_combinators_exact(const std::string& tag) {
     using B = block<FpType>;
     int fail = 0;
-
-    // threeAdd hand-picked
     fail += check_threeAdd_exact<FpType>(B{FpType{1}, 0}, B{FpType{0.25}, 0}, B{FpType{0.0625}, 0}, tag + " 3add nice");
     fail += check_threeAdd_exact<FpType>(B{static_cast<FpType>(1e6), 0}, B{FpType{1}, 0}, B{static_cast<FpType>(1.0/4096), 0}, tag + " 3add spread");
     fail += check_threeAdd_exact<FpType>(B{FpType{5}, 0}, B{FpType{-5}, 0}, B{FpType{2.5}, 0}, tag + " 3add cancel");
 
-    // add() hand-picked, incl. classic non-representable decimals (the cast
-    // values are what we reference, so equality is well-defined)
     fail += check_add_exact<FpType>(1.0, 0.25, tag + " add 1+0.25");
     fail += check_add_exact<FpType>(1e3, 1.0, tag + " add 1e3+1");
     fail += check_add_exact<FpType>(0.1, 0.2, tag + " add 0.1+0.2");
     fail += check_add_exact<FpType>(-2.5, -7.5, tag + " add -2.5-7.5");
     fail += check_add_exact<FpType>(1.0e8, 3.0e-3, tag + " add 1e8+3e-3");
 
-    // randomised
     std::mt19937_64 rng(0xC0FFEEULL);
     std::uniform_real_distribution<double> ud(-1000.0, 1000.0);
     for (int i = 0; i < 200; ++i) {
         double a = ud(rng), b = ud(rng);
         fail += check_add_exact<FpType>(a, b, tag + " add rand");
-        // threeAdd over randomised blocks (shared exp 0)
         FpType av = static_cast<FpType>(a), bv = static_cast<FpType>(b), cv = static_cast<FpType>(ud(rng));
         if (av != FpType{0} && bv != FpType{0} && cv != FpType{0})
             fail += check_threeAdd_exact<FpType>(B{av, 0}, B{bv, 0}, B{cv, 0}, tag + " 3add rand");
@@ -271,11 +319,10 @@ int sweep_combinators_exact(const std::string& tag) {
 // Truncating host (bfloat16): EFTs cannot be exact because bfloat16 rounds
 // toward zero (numeric_limits::round_style == round_toward_zero; its float->bf16
 // cast is `bits >> 16`, discarding the low bits). Knuth/Dekker EFTs require
-// round-to-nearest. We therefore PIN the behaviour with a truncation bound
-// rather than exactness: the recovered (high + low) must agree with the exact
-// product/sum to within ~1 ulp of the residual block (or 1 ulp of the high block
-// when the residual truncates away to zero). This still catches a wholesale-wrong
-// result while documenting that bfloat16 is an approximate-only elreal host.
+// round-to-nearest. We PIN the behaviour with a truncation bound rather than
+// exactness: the recovered (high + low) must agree with the exact product/sum to
+// within ~1 ulp of the residual block (or 1 ulp of the high block when the
+// residual truncates to zero). Documents that bfloat16 is approximate-only.
 template <typename FpType>
 int check_two_sum_bounded(const block<FpType>& a, const block<FpType>& b,
                           const std::string& tag) {
@@ -331,26 +378,33 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
-    using cf24 = cfloat<24, 5, std::uint16_t, true, false, false>;
-    using cf32 = cfloat<32, 8, std::uint32_t, true, false, false>;
+    using cf24  = cfloat<24, 5, std::uint16_t, true, false, false>;
+    using cf32  = cfloat<32, 8, std::uint32_t, true, false, false>;
+    using q128  = cfloat<128, 15, std::uint32_t, true, false, false>;  // IEEE-quad-width host (113-bit significand)
 
-    // EFT building blocks: exact (modulo #942 subnormal floor) on the
-    // round-to-nearest hosts. bfloat16 is EXCLUDED: it truncates toward zero,
-    // so Knuth/Dekker EFTs are not exact on it (see header note).
-    nrOfFailedTestCases += sweep_eft<float>("float");
-    nrOfFailedTestCases += sweep_eft<double>("double");
-    nrOfFailedTestCases += sweep_eft<half>("half");
-    nrOfFailedTestCases += sweep_eft<cf24>("cfloat<24,5>");
-    nrOfFailedTestCases += sweep_eft<cf32>("cfloat<32,8>");
-
-    // threeAdd + add(): strict exact equality on the wide-exponent RN hosts.
+    // two_sum: exact on every RN host -- including quad precision (cf<128,15>).
+    // The dyadic oracle extracts the full significand, so this would be
+    // impossible to certify through a double reference.
+    nrOfFailedTestCases += sweep_two_sum<float>("float");
+    nrOfFailedTestCases += sweep_two_sum<double>("double");
+    nrOfFailedTestCases += sweep_two_sum<half>("half");
+    nrOfFailedTestCases += sweep_two_sum<cf24>("cfloat<24,5>");
+    nrOfFailedTestCases += sweep_two_sum<cf32>("cfloat<32,8>");
+    nrOfFailedTestCases += sweep_two_sum<q128>("cfloat<128,15> (quad)");
+    // two_mult: exact on the p<=24 RN hosts. NOT quad -- two_prod_host's odd-p
+    // double intermediate cannot hold a 113-bit product residual (separate issue).
+    nrOfFailedTestCases += sweep_two_mult<float>("float");
+    nrOfFailedTestCases += sweep_two_mult<double>("double");
+    nrOfFailedTestCases += sweep_two_mult<half>("half");
+    nrOfFailedTestCases += sweep_two_mult<cf24>("cfloat<24,5>");
+    nrOfFailedTestCases += sweep_two_mult<cf32>("cfloat<32,8>");
+    // threeAdd + add(): twoSum-based -> exact on every RN host including quad.
     nrOfFailedTestCases += sweep_combinators_exact<float>("float");
     nrOfFailedTestCases += sweep_combinators_exact<double>("double");
     nrOfFailedTestCases += sweep_combinators_exact<cf32>("cfloat<32,8>");
-
+    nrOfFailedTestCases += sweep_combinators_exact<q128>("cfloat<128,15> (quad)");
     // bfloat16 truncates (round_toward_zero): not an exact-EFT host. Pin its
-    // approximate behaviour with a truncation bound so a regression is caught
-    // and the limitation is documented in an executable form.
+    // approximate behaviour with a truncation bound.
     nrOfFailedTestCases += sweep_eft_truncating<bfloat16>("bfloat16");
 
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/elastic/elreal/arithmetic/exact_value_oracle.cpp
+++ b/elastic/elreal/arithmetic/exact_value_oracle.cpp
@@ -57,6 +57,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <cassert>
 #include <cmath>
 #include <iostream>
 #include <random>
@@ -119,6 +120,7 @@ dyadic exact_real(T v) {
         while (scaled > T(0)) {
             T hi = floor(scaled / CHUNK);            // scaled = hi*2^24 + lo (both exact)
             T lo = scaled - hi * CHUNK;              // lo in [0, 2^24), exact integer
+            assert(lo >= T(0) && lo < CHUNK && "exact_real chunk out of [0, 2^24)");
             dyadic::bigint chunk(static_cast<long long>(static_cast<double>(lo)));
             chunk <<= shift;
             M = M + chunk;
@@ -147,9 +149,14 @@ dyadic exact_blocks(const std::vector<block<FpType>>& bs) {
     return acc;
 }
 
+// Number of ZBCL blocks forced when computing an exact value. Finite sums of the
+// test inputs settle well within this; kept identical to addition.cpp's window
+// so the two files agree on the "exact value" of the same stream.
+constexpr std::size_t ZBCL_EXACT_WINDOW = 32;
+
 template <typename FpType>
 dyadic exact_zbcl(const ZBCL<FpType>& z) {
-    return exact_blocks(z.take(32));   // finite sums settle well within 32 blocks
+    return exact_blocks(z.take(ZBCL_EXACT_WINDOW));
 }
 
 // value of a block in double, and its ulp -- used only for the bfloat16
@@ -266,9 +273,13 @@ int sweep_two_sum(const std::string& tag) {
     return fail;
 }
 
-// two_mult sweep: RN hosts whose two_prod_host is exact (p <= 24 here; the
-// double specialisation covers double). NOT quad: the odd-p double intermediate
-// cannot hold a 113-bit product residual (separate elreal limitation).
+// two_mult sweep: RN hosts whose two_prod_host is exact. The generic cfloat
+// two_prod uses a double intermediate for odd p, limiting it to p <= 26; the
+// p <= 24 hosts here are within that bound. double itself (sweep_two_mult<double>,
+// p = 53) is exact too -- intentional, not a bug: it has a dedicated two_prod
+// specialisation (error_free_ops two_prod / hardware FMA), not the double
+// intermediate. NOT quad: the odd-p double intermediate cannot hold a 113-bit
+// product residual (separate elreal limitation, issue #1024).
 template <typename FpType>
 int sweep_two_mult(const std::string& tag) {
     using B = block<FpType>;

--- a/elastic/elreal/arithmetic/exact_value_oracle.cpp
+++ b/elastic/elreal/arithmetic/exact_value_oracle.cpp
@@ -14,10 +14,15 @@
 // cannot see.
 //
 // Exact value of a McCleeary block (sign,exp,bv packed into FpType `v` plus an
-// int32 `exp`) is  value(b) = v * 2^exp,  and v is exactly representable in a
-// double for every elreal FpType (all have <= 24 significand bits), so
+// int32 `exp`) is  value(b) = v * 2^exp,  so
 //     exact(b) = from_double(double(b.v))  with its dyadic scale shifted by b.exp.
-// The exact value of a ZBCL prefix is the (exact) sum of its block dyadics.
+// This is exact only when double(b.v) loses nothing, i.e. FpType has at most 53
+// significand bits. Every elreal block host exercised here qualifies (float 24,
+// double 53, half 11, bfloat16 8, cfloat<24,5> 19, cfloat<32,8> 24); a wider
+// host -- e.g. cfloat<nbits,es,uint64_t,...> with nbits > 64 -- would need a
+// wider exact conversion, and exact_block() static_asserts against it rather
+// than silently producing a wrong reference. The exact value of a ZBCL prefix
+// is the (exact) sum of its block dyadics.
 //
 // What is asserted:
 //   * block_two_sum / block_two_mult are error-free transforms, so
@@ -70,6 +75,11 @@ using namespace sw::universal;
 // block/EFT/threeAdd/add algorithms under test.
 template <typename FpType>
 dyadic exact_block(const block<FpType>& b) {
+    static_assert(std::numeric_limits<FpType>::digits <= 53,
+        "exact_block uses double(b.v) as the block's exact value, which is "
+        "lossless only for FpType with <= 53 significand bits. A wider host "
+        "(e.g. cfloat<nbits,es,uint64_t,...> with nbits > 64) needs a wider "
+        "exact conversion into the dyadic oracle.");
     if (b.is_zero_block()) return dyadic();
     dyadic d = dyadic::from_double(static_cast<double>(b.v));
     d.scale += b.exp;          // multiply by 2^exp exactly (value = v * 2^exp)

--- a/elastic/elreal/arithmetic/exact_value_oracle.cpp
+++ b/elastic/elreal/arithmetic/exact_value_oracle.cpp
@@ -1,0 +1,352 @@
+// exact_value_oracle.cpp: independent EXACT oracle for the elreal building blocks (#1022)
+//
+// The Phase 1-4 elreal tests check value preservation against `long double`.
+// That is not an exact oracle: on x86_64 it carries only ~11 mantissa bits over
+// double (enough to catch gross errors, not to certify bit-exactness), and on
+// MSVC / most ARM / RISC-V `long double` aliases `double`, giving ZERO headroom
+// over the type under test. This file removes that dependency for the building
+// blocks, exactly as the ereal/Priest effort did (#987, dyadic_exact.hpp).
+//
+// The reference is exact dyadic-rational arithmetic (dyadic_exact.hpp, backed by
+// einteger). It shares NO code with the block / EFT / threeAdd / add algorithms,
+// so it catches a result that is structurally well-formed (0-overlap, right
+// exponents) but encodes the WRONG value -- the failure mode `long double`
+// cannot see.
+//
+// Exact value of a McCleeary block (sign,exp,bv packed into FpType `v` plus an
+// int32 `exp`) is  value(b) = v * 2^exp,  and v is exactly representable in a
+// double for every elreal FpType (all have <= 24 significand bits), so
+//     exact(b) = from_double(double(b.v))  with its dyadic scale shifted by b.exp.
+// The exact value of a ZBCL prefix is the (exact) sum of its block dyadics.
+//
+// What is asserted:
+//   * block_two_sum / block_two_mult are error-free transforms, so
+//         exact(high) + exact(low) == exact(a) {+,*} exact(b)   EXACTLY,
+//     UNLESS the residual `low` is a subnormal the FpType cannot represent --
+//     the cfloat<24,5> representability floor identified in #942. We encode that
+//     exception structurally (a nonzero dyadic error is tolerated ONLY when the
+//     least-significant result block is a nonzero subnormal); a wrong high part,
+//     or a wrong NORMAL residual, still fails.
+//   * threeAdd and the lazy add() combinator reproduce the exact sum on the
+//     wide-exponent RN hosts (double, float, cfloat<32,8>), where the expansion
+//     is always representable -- asserted as exact dyadic equality. Narrow-
+//     exponent RN hosts (half, cfloat<24,5>) are validated at the EFT level
+//     above; their multi-block strict bound needs a rounding oracle (future).
+//
+// bfloat16 is NOT an exact-EFT host. It rounds toward zero
+// (numeric_limits<bfloat16>::round_style == round_toward_zero; the float->bf16
+// cast is `bits >> 16`, which discards the low bits with no rounding). Knuth /
+// Dekker error-free transforms are exact only under round-to-nearest, so on
+// bfloat16 they leak up to ~1 residual-ulp -- an inherent property of the host,
+// like the cfloat<24,5> subnormal floor (#942) but caused by the rounding mode
+// rather than the exponent range. We therefore pin bfloat16 with a truncation
+// BOUND (sweep_eft_truncating) instead of exactness, and use double as its exact
+// reference (double has ~45 bits of headroom over bfloat16's 8-bit significand).
+// This is the latent inexactness the Phase 1-4 long-double / 128-ulp^2
+// tolerances were masking; see epic #923.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+using namespace sw::universal;
+
+// exact value of a single block as a dyadic rational. Shares no code with the
+// block/EFT/threeAdd/add algorithms under test.
+template <typename FpType>
+dyadic exact_block(const block<FpType>& b) {
+    if (b.is_zero_block()) return dyadic();
+    dyadic d = dyadic::from_double(static_cast<double>(b.v));
+    d.scale += b.exp;          // multiply by 2^exp exactly (value = v * 2^exp)
+    return d;
+}
+
+template <typename FpType>
+dyadic exact_blocks(const std::vector<block<FpType>>& bs) {
+    dyadic acc;                // 0
+    for (const auto& b : bs) acc = acc + exact_block(b);
+    return acc;
+}
+
+template <typename FpType>
+dyadic exact_zbcl(const ZBCL<FpType>& z) {
+    return exact_blocks(z.take(32));   // finite sums settle well within 32 blocks
+}
+
+// value of a block in double. For the round-to-nearest hosts we use the dyadic
+// oracle (above); for bfloat16 we use double directly -- it carries ~45 bits of
+// headroom over bfloat16's 8-bit significand, so it is a genuinely exact oracle
+// for bfloat16 sums/products in this test range (unlike long-double-over-double,
+// which was the Phase 1-4 weakness this file removes).
+template <typename FpType>
+double dval(const block<FpType>& b) {
+    if (b.is_zero_block()) return 0.0;
+    return std::ldexp(static_cast<double>(b.v), b.exp);
+}
+
+// ulp of a block at its own exponent: 2^(E(b) - (k-1)).
+template <typename FpType>
+double block_ulp(const block<FpType>& b) {
+    const int E = b.is_zero_block() ? b.exp : b.exponent();
+    return std::ldexp(1.0, E - (block<FpType>::k - 1));
+}
+
+// A nonzero dyadic error is acceptable ONLY when the least-significant result
+// block is a nonzero subnormal -- i.e. the format genuinely cannot represent the
+// residual (the #942 floor). err == 0 is always acceptable. A wrong high part
+// (least block zero, err != 0) or a wrong normal residual (least block normal,
+// err != 0) is NOT acceptable.
+template <typename FpType>
+bool acceptable(const dyadic& err, const block<FpType>& least) {
+    if (err.iszero()) return true;
+    return !least.is_zero_block() && !least.is_normalised();
+}
+
+// ---- block_two_sum: exact(high)+exact(low) == exact(a)+exact(b) -------------
+template <typename FpType>
+int check_two_sum(const block<FpType>& a, const block<FpType>& b,
+                  const std::string& tag) {
+    auto [high, low] = block_two_sum(a, b);          // precondition: a.exp == b.exp
+    dyadic ref = exact_block(a) + exact_block(b);
+    dyadic got = exact_block(high) + exact_block(low);
+    dyadic err = ref - got;
+    if (!acceptable(err, low)) {
+        std::cout << tag << " two_sum value WRONG: a=" << double(a.v)
+                  << " b=" << double(b.v)
+                  << " high=" << double(high.v) << " low=" << double(low.v)
+                  << " (low normalised=" << low.is_normalised() << ")\n";
+        return 1;
+    }
+    return 0;
+}
+
+// ---- block_two_mult: exact(high)+exact(low) == exact(a)*exact(b) ------------
+template <typename FpType>
+int check_two_mult(const block<FpType>& a, const block<FpType>& b,
+                   const std::string& tag) {
+    auto [high, low] = block_two_mult(a, b);
+    dyadic ref = exact_block(a) * exact_block(b);
+    dyadic got = exact_block(high) + exact_block(low);
+    dyadic err = ref - got;
+    if (!acceptable(err, low)) {
+        std::cout << tag << " two_mult value WRONG: a=" << double(a.v)
+                  << " b=" << double(b.v)
+                  << " high=" << double(high.v) << " low=" << double(low.v)
+                  << " (low normalised=" << low.is_normalised() << ")\n";
+        return 1;
+    }
+    return 0;
+}
+
+// ---- threeAdd (wide hosts): exact(out1+out2+out3) == exact(ia+ib+ic) --------
+template <typename FpType>
+int check_threeAdd_exact(const block<FpType>& ia, const block<FpType>& ib,
+                         const block<FpType>& ic, const std::string& tag) {
+    auto r = threeAdd(ia, ib, ic);
+    dyadic ref = exact_block(ia) + exact_block(ib) + exact_block(ic);
+    dyadic got = exact_block(r.out1) + exact_block(r.out2) + exact_block(r.out3);
+    if (ref != got) {
+        std::cout << tag << " threeAdd value WRONG: ia=" << double(ia.v)
+                  << " ib=" << double(ib.v) << " ic=" << double(ic.v) << "\n";
+        return 1;
+    }
+    return 0;
+}
+
+// ---- add() (wide hosts): exact(take(N)) == exact(za) + exact(zb) ------------
+template <typename FpType>
+int check_add_exact(double a, double b, const std::string& tag) {
+    auto za = from_native<FpType>(a);
+    auto zb = from_native<FpType>(b);
+    auto z  = add(za, zb);
+    dyadic ref = exact_zbcl(za) + exact_zbcl(zb);   // uses the represented values
+    dyadic got = exact_zbcl(z);
+    if (ref != got) {
+        std::cout << tag << " add value WRONG: a=" << a << " b=" << b << "\n";
+        return 1;
+    }
+    return 0;
+}
+
+// EFT sweep: runs for EVERY host (the residual block is directly inspectable, so
+// the #942 subnormal-floor exception is exact).
+template <typename FpType>
+int sweep_eft(const std::string& tag) {
+    using B = block<FpType>;
+    int fail = 0;
+    constexpr int p = std::numeric_limits<FpType>::digits;
+
+    // --- two_sum, shared exp = 0 ---
+    // residual at the ulp boundary
+    {
+        FpType tiny = static_cast<FpType>(std::ldexp(1.0, -p));
+        if (tiny != FpType{0})
+            fail += check_two_sum<FpType>(B{FpType{1}, 0}, B{tiny, 0}, tag + " 1+2^-p");
+    }
+    // exact cancellation
+    fail += check_two_sum<FpType>(B{FpType{1.25}, 0}, B{FpType{-1.25}, 0}, tag + " 1.25-1.25");
+    // wide scale separation within one exp
+    fail += check_two_sum<FpType>(B{static_cast<FpType>(1e4), 0},
+                                  B{static_cast<FpType>(1.0/1024), 0}, tag + " 1e4+2^-10");
+    // nonzero shared exp must not change exactness
+    fail += check_two_sum<FpType>(B{FpType{1}, 7}, B{FpType{0.25}, 7}, tag + " offset=7");
+
+    // --- two_mult ---
+    fail += check_two_mult<FpType>(B{FpType{1.5}, 0}, B{FpType{1.5}, 0}, tag + " 1.5*1.5");
+    fail += check_two_mult<FpType>(B{FpType{3}, 0}, B{FpType{0.5}, 0}, tag + " 3*0.5 exact");
+    fail += check_two_mult<FpType>(B{static_cast<FpType>(123.456), 2},
+                                   B{static_cast<FpType>(-7.875), -1}, tag + " mixed-exp");
+
+    // --- randomised EFT sweep ---
+    std::mt19937_64 rng(0x1022ABCDULL);
+    std::uniform_real_distribution<double> ud(-100.0, 100.0);
+    for (int i = 0; i < 300; ++i) {
+        FpType av = static_cast<FpType>(ud(rng));
+        FpType bv = static_cast<FpType>(ud(rng));
+        if (av == FpType{0} || bv == FpType{0}) continue;
+        fail += check_two_sum<FpType>(B{av, 0}, B{bv, 0}, tag + " rand-sum");
+        fail += check_two_mult<FpType>(B{av, 0}, B{bv, 0}, tag + " rand-mult");
+    }
+    return fail;
+}
+
+// Multi-block combinators: strict exact equality, wide-exponent hosts only.
+template <typename FpType>
+int sweep_combinators_exact(const std::string& tag) {
+    using B = block<FpType>;
+    int fail = 0;
+
+    // threeAdd hand-picked
+    fail += check_threeAdd_exact<FpType>(B{FpType{1}, 0}, B{FpType{0.25}, 0}, B{FpType{0.0625}, 0}, tag + " 3add nice");
+    fail += check_threeAdd_exact<FpType>(B{static_cast<FpType>(1e6), 0}, B{FpType{1}, 0}, B{static_cast<FpType>(1.0/4096), 0}, tag + " 3add spread");
+    fail += check_threeAdd_exact<FpType>(B{FpType{5}, 0}, B{FpType{-5}, 0}, B{FpType{2.5}, 0}, tag + " 3add cancel");
+
+    // add() hand-picked, incl. classic non-representable decimals (the cast
+    // values are what we reference, so equality is well-defined)
+    fail += check_add_exact<FpType>(1.0, 0.25, tag + " add 1+0.25");
+    fail += check_add_exact<FpType>(1e3, 1.0, tag + " add 1e3+1");
+    fail += check_add_exact<FpType>(0.1, 0.2, tag + " add 0.1+0.2");
+    fail += check_add_exact<FpType>(-2.5, -7.5, tag + " add -2.5-7.5");
+    fail += check_add_exact<FpType>(1.0e8, 3.0e-3, tag + " add 1e8+3e-3");
+
+    // randomised
+    std::mt19937_64 rng(0xC0FFEEULL);
+    std::uniform_real_distribution<double> ud(-1000.0, 1000.0);
+    for (int i = 0; i < 200; ++i) {
+        double a = ud(rng), b = ud(rng);
+        fail += check_add_exact<FpType>(a, b, tag + " add rand");
+        // threeAdd over randomised blocks (shared exp 0)
+        FpType av = static_cast<FpType>(a), bv = static_cast<FpType>(b), cv = static_cast<FpType>(ud(rng));
+        if (av != FpType{0} && bv != FpType{0} && cv != FpType{0})
+            fail += check_threeAdd_exact<FpType>(B{av, 0}, B{bv, 0}, B{cv, 0}, tag + " 3add rand");
+    }
+    return fail;
+}
+
+// Truncating host (bfloat16): EFTs cannot be exact because bfloat16 rounds
+// toward zero (numeric_limits::round_style == round_toward_zero; its float->bf16
+// cast is `bits >> 16`, discarding the low bits). Knuth/Dekker EFTs require
+// round-to-nearest. We therefore PIN the behaviour with a truncation bound
+// rather than exactness: the recovered (high + low) must agree with the exact
+// product/sum to within ~1 ulp of the residual block (or 1 ulp of the high block
+// when the residual truncates away to zero). This still catches a wholesale-wrong
+// result while documenting that bfloat16 is an approximate-only elreal host.
+template <typename FpType>
+int check_two_sum_bounded(const block<FpType>& a, const block<FpType>& b,
+                          const std::string& tag) {
+    auto [high, low] = block_two_sum(a, b);
+    double err   = std::fabs((dval(a) + dval(b)) - (dval(high) + dval(low)));
+    double bound = 2.0 * (low.is_zero_block() ? block_ulp(high) : block_ulp(low));
+    if (err > bound) {
+        std::cout << tag << " two_sum exceeds truncation bound: err=" << err
+                  << " bound=" << bound << " (a=" << double(a.v) << " b=" << double(b.v) << ")\n";
+        return 1;
+    }
+    return 0;
+}
+
+template <typename FpType>
+int check_two_mult_bounded(const block<FpType>& a, const block<FpType>& b,
+                           const std::string& tag) {
+    auto [high, low] = block_two_mult(a, b);
+    double err   = std::fabs((dval(a) * dval(b)) - (dval(high) + dval(low)));
+    double bound = 2.0 * (low.is_zero_block() ? block_ulp(high) : block_ulp(low));
+    if (err > bound) {
+        std::cout << tag << " two_mult exceeds truncation bound: err=" << err
+                  << " bound=" << bound << " (a=" << double(a.v) << " b=" << double(b.v) << ")\n";
+        return 1;
+    }
+    return 0;
+}
+
+template <typename FpType>
+int sweep_eft_truncating(const std::string& tag) {
+    using B = block<FpType>;
+    int fail = 0;
+    fail += check_two_sum_bounded<FpType>(B{FpType{1.25}, 0}, B{FpType{-1.25}, 0}, tag + " cancel");
+    fail += check_two_sum_bounded<FpType>(B{FpType{1}, 7}, B{FpType{0.25}, 7}, tag + " offset");
+    std::mt19937_64 rng(0xB16ULL);
+    std::uniform_real_distribution<double> ud(-100.0, 100.0);
+    for (int i = 0; i < 300; ++i) {
+        FpType av = static_cast<FpType>(ud(rng)), bv = static_cast<FpType>(ud(rng));
+        if (av == FpType{0} || bv == FpType{0}) continue;
+        fail += check_two_sum_bounded<FpType>(B{av, 0}, B{bv, 0}, tag + " rand-sum");
+        fail += check_two_mult_bounded<FpType>(B{av, 0}, B{bv, 0}, tag + " rand-mult");
+    }
+    return fail;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal exact dyadic-rational oracle (#1022)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    using cf24 = cfloat<24, 5, std::uint16_t, true, false, false>;
+    using cf32 = cfloat<32, 8, std::uint32_t, true, false, false>;
+
+    // EFT building blocks: exact (modulo #942 subnormal floor) on the
+    // round-to-nearest hosts. bfloat16 is EXCLUDED: it truncates toward zero,
+    // so Knuth/Dekker EFTs are not exact on it (see header note).
+    nrOfFailedTestCases += sweep_eft<float>("float");
+    nrOfFailedTestCases += sweep_eft<double>("double");
+    nrOfFailedTestCases += sweep_eft<half>("half");
+    nrOfFailedTestCases += sweep_eft<cf24>("cfloat<24,5>");
+    nrOfFailedTestCases += sweep_eft<cf32>("cfloat<32,8>");
+
+    // threeAdd + add(): strict exact equality on the wide-exponent RN hosts.
+    nrOfFailedTestCases += sweep_combinators_exact<float>("float");
+    nrOfFailedTestCases += sweep_combinators_exact<double>("double");
+    nrOfFailedTestCases += sweep_combinators_exact<cf32>("cfloat<32,8>");
+
+    // bfloat16 truncates (round_toward_zero): not an exact-EFT host. Pin its
+    // approximate behaviour with a truncation bound so a regression is caught
+    // and the limitation is documented in an executable form.
+    nrOfFailedTestCases += sweep_eft_truncating<bfloat16>("bfloat16");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
The **Phase-5 precondition** (#1022): lock down a *validated* baseline for the elreal McCleeary substrate before building more arithmetic on it. Ports the ereal/#987 exact-oracle approach (`dyadic_exact.hpp`, an einteger-backed exact dyadic-rational reference sharing no code with the algorithms under test) to elreal, removing the Phase 1-4 reliance on `long double` -- which is not an exact oracle (it aliases `double` on MSVC/ARM/RISC-V, giving **zero** headroom over the type under test).

## What the oracle asserts
`exact(block) = from_double(double(b.v)) << b.exp`; `exact(ZBCL) = sum of block dyadics`.
- **block_two_sum / block_two_mult**: `exact(high)+exact(low) == exact(a){+,*}exact(b)` bit-for-bit, tolerating a nonzero error **only** when the residual block is a nonzero subnormal (the cfloat<24,5> #942 floor). A wrong high part or a wrong *normal* residual still fails.
- **threeAdd / add()**: exact dyadic equality on the wide-exponent RN hosts.
- Randomized + adversarial sweeps (cancellation, scale separation, classic `0.1+0.2`).

**Strict-exact PASSES on all five round-to-nearest hosts**: `float`, `double`, `half`, `cfloat<24,5>` (modulo #942), `cfloat<32,8>`.

## Finding (what the loose tolerances were masking)
**bfloat16 is not an exact-EFT host.** It rounds toward zero (`numeric_limits<bfloat16>::round_style == round_toward_zero`; its float->bf16 cast is `bits >> 16`, no rounding). Knuth/Dekker EFTs are exact only under round-to-nearest, so on bfloat16 they leak up to ~1 residual-ulp. This is **intentional bfloat16 behaviour, not an elreal bug** -- it makes elreal-over-bfloat16 inherently approximate (like the cfloat<24,5> floor, but caused by the rounding mode, not the exponent range). bfloat16 is **pinned** with a truncation bound (using `double` as its exact reference -- ~45 bits headroom over bfloat16's 8) so a regression is caught and the limitation is executable. A note is posted on epic #923.

## Changes
- `elastic/elreal/arithmetic/exact_value_oracle.cpp` (new) -- the keystone independent-oracle test.
- `elastic/elreal/arithmetic/addition.cpp` -- replaced the 4-ulp long-double band with the dyadic exact check; this also corrects a latent reference bug the band hid (for the `float` host the old reference summed the original `double` literals, not the represented float-cast operands).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| el_arith_exact_value_oracle | OK | PASS | OK | PASS |
| el_arith_addition | OK | PASS | OK | PASS |
| full elreal suite (16 tests) | OK | PASS | OK | PASS |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE builds elreal)
- [ ] Promote to ready when satisfied

Resolves #1022
Relates to #923

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced approximate long-double checks with an exact dyadic-rational oracle for addition tests, improving precision and diagnostics.
  * Added a standalone exact-value verification tool to validate block-level and multi-block arithmetic across host types, with special handling for subnormal results and truncated-host behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->