### PR TITLE
fix(cfloat): native trunc/floor/ceil/round (correct for >53-bit significands)

### DIFF
--- a/include/sw/universal/number/cfloat/math/functions/truncate.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/truncate.hpp
@@ -8,88 +8,87 @@
 
 namespace sw { namespace universal {
 
+// These operate directly on the cfloat encoding (no round-trip through double).
+// A double-based implementation is wrong for cfloats with more than 53
+// significand bits: any integer above 2^53 loses its low bits in the conversion,
+// so e.g. floor(2^60 + 8) would not return 2^60 + 8 (issue #1026). trunc() masks
+// the fraction bits below the binary point according to the unbiased scale;
+// floor, ceil, and round are derived from trunc plus cfloat's (correctly
+// rounded) arithmetic and comparisons.
+
 // Truncate value by rounding toward zero, returning the nearest integral value that is not larger in magnitude than x
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
 cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> trunc(cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> x) {
-	return cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>(std::trunc(double(x)));
-}
-
-// Round to nearest: returns the integral value that is nearest to x, with halfway cases rounded away from zero
-template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
-cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> round(cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> x) {
-	return cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>(std::round(double(x)));
+	using Cfloat = cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>;
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+	// subnormals have magnitude < 1 (the smallest normal is well below 1 for any
+	// es), so truncation toward zero yields signed zero.
+	if (!x.isnormal()) {
+		Cfloat z; z.setzero(); if (x.sign()) z.setsign(true);
+		return z;
+	}
+	constexpr int fbits = static_cast<int>(Cfloat::fbits);
+	const int scale = x.scale();                 // unbiased exponent, floor(log2|x|)
+	if (scale >= fbits) return x;                // no fraction bits below 2^0: integral
+	if (scale < 0) {                             // |x| < 1
+		Cfloat z; z.setzero(); if (x.sign()) z.setsign(true);
+		return z;
+	}
+	// clear the fraction bits whose weight is below 2^0, i.e. indices
+	// [0 .. fbits - scale - 1]; the exponent and hidden bit are untouched, so the
+	// result stays a valid normal value equal to the truncated integer.
+	Cfloat r(x);
+	for (int i = 0; i < fbits - scale; ++i) r.setbit(static_cast<unsigned>(i), false);
+	return r;
 }
 
 // Round x downward, returning the largest integral value that is not greater than x
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
 cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> floor(cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> x) {
-	return cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>(std::floor(double(x)));
+	using Cfloat = cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>;
+	if (x.isnan() || x.isinf()) return x;
+	Cfloat t = trunc(x);
+	// negative, non-integral -> the largest integer <= x is one below trunc
+	if (x.sign() && t != x) t = t - Cfloat(1);
+	return t;
 }
 
 // Round x upward, returning the smallest integral value that is greater than x
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
 cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> ceil(cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> x) {
-	return cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>(std::ceil(double(x)));
+	using Cfloat = cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>;
+	if (x.isnan() || x.isinf()) return x;
+	Cfloat t = trunc(x);
+	// positive, non-integral -> the smallest integer >= x is one above trunc
+	if (!x.sign() && t != x) t = t + Cfloat(1);
+	return t;
 }
 
-#ifdef NOW
-by design, non compilable text;
-this is the libc algorithm for floor(double)
-
-static double huge = 1.0e300;
-
-// TBD, defined to compile, not functionally correct
-#define __HI(x) x
-#define __LO(x) x
-// algorithm for floor(double)
-double floor(double x) {
-	int i0, i1, j0;
-	unsigned i, j;
-	i0 = __HI(x);
-	i1 = __LO(x);
-	j0 = ((i0 >> 20) & 0x7ff) - 0x3ff;
-	if (j0 < 20) {
-		if (j0 < 0) { 	/* raise inexact if x != 0 */
-			if (huge + x > 0.0) {/* return 0*sign(x) if |x|<1 */
-				if (i0 >= 0) { i0 = i1 = 0; }
-				else if (((i0 & 0x7fffffff) | i1) != 0)
-				{
-					i0 = 0xbff00000; i1 = 0;
-				}
-			}
-		}
-		else {
-			i = (0x000fffff) >> j0;
-			if (((i0&i) | i1) == 0) return x; /* x is integral */
-			if (huge + x > 0.0) {	/* raise inexact flag */
-				if (i0 < 0) i0 += (0x00100000) >> j0;
-				i0 &= (~i); i1 = 0;
-			}
-		}
-	}
-	else if (j0 > 51) {
-		if (j0 == 0x400) return x + x;	/* inf or NaN */
-		else return x;		/* x is integral */
+// Round to nearest: returns the integral value that is nearest to x, with halfway cases rounded away from zero
+template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>
+cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> round(cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating> x) {
+	using Cfloat = cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSaturating>;
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+	Cfloat t = trunc(x);
+	if (t == x) return x;                        // already integral
+	// Decide whether to round away from zero WITHOUT constructing 0.5 -- some
+	// low-range cfloats cannot represent it. For |x| >= 1 (normal, scale >= 0)
+	// the discarded fraction is >= 0.5 iff its leading bit (weight 2^-1, i.e.
+	// fraction-bit index fbits-scale-1) is set; that gives ties-away-from-zero.
+	// For |x| < 1 (normal scale < 0, or subnormal), test |x| >= 0.5 via the
+	// exact 2*|x| >= 1.
+	constexpr int fbits = static_cast<int>(Cfloat::fbits);
+	bool away;
+	const int scale = x.scale();
+	if (x.isnormal() && scale >= 0) {
+		away = x.test(static_cast<unsigned>(fbits - scale - 1));
 	}
 	else {
-		i = ((unsigned)(0xffffffff)) >> (j0 - 20);
-		if ((i1&i) == 0) return x;	/* x is integral */
-		if (huge + x > 0.0) { 		/* raise inexact flag */
-			if (i0 < 0) {
-				if (j0 == 20) i0 += 1;
-				else {
-					j = i1 + (1 << (52 - j0));
-					if (j < i1) i0 += 1; 	/* got a carry */
-					i1 = j;
-				}
-			}
-			i1 &= (~i);
-		}
+		Cfloat ax = x.sign() ? -x : x;           // |x|
+		away = (ax + ax) >= Cfloat(1);           // 2|x| >= 1  <=>  |x| >= 0.5
 	}
-	__HI(x) = i0;
-	__LO(x) = i1;
-	return x;
+	if (away) t = x.sign() ? t - Cfloat(1) : t + Cfloat(1);
+	return t;
 }
-#endif //NOW
 
 }} // namespace sw::universal

--- a/static/float/cfloat/math/truncate.cpp
+++ b/static/float/cfloat/math/truncate.cpp
@@ -9,25 +9,25 @@
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/verification/cfloat_test_suite_mathlib.hpp>
 
+// Exhaustive verifier: for every encoding of a small cfloat, compare the native
+// trunc/floor/ceil/round against the representable cfloat of the std result.
+// Valid because these types have <= 53 significand bits, so float/double are an
+// exact reference. (The wide-precision case, where double is NOT exact, is
+// covered by VerifyWideTruncation below -- the regression #1026 was about.)
 template<typename TestType>
 int VerifyFloor(bool reportTestCases) {
 	using namespace sw::universal;
 	constexpr size_t nbits = TestType::nbits;
 	constexpr size_t NR_VALUES = (1ull << nbits);
 	int nrOfFailedTestCases = 0;
-
 	TestType a;
 	for (size_t i = 0; i < NR_VALUES; ++i) {
 		a.setbits(i);
+		if (a.isnan() || a.isinf()) continue;
 		TestType l1 = floor(a);
-		// generate the reference
-		float f = float(a);         // we can stay with floats as the state space NR_VALUES is always going to be small to be practical (nbits < 16)
-		float ff = std::floor(f);
-		TestType l2 = ff;
+		TestType l2 = TestType(std::floor(float(a)));
 		if (l1 != l2) {
-			if (a.isnan() || l1.isnan()) continue;
-			std::cout << to_binary(a) << " : " << a << '\n';
-			std::cout << "floor(" << f << ") = " << l2 << " vs result " << l1 << '\n';
+			std::cout << to_binary(a) << " : floor(" << float(a) << ") = " << l2 << " vs result " << l1 << '\n';
 			++nrOfFailedTestCases;
 			if (reportTestCases) ReportOneInputFunctionError("floor", "floor", a, l1, l2);
 		}
@@ -41,24 +41,94 @@ int VerifyCeil(bool reportTestCases) {
 	constexpr size_t nbits = TestType::nbits;
 	constexpr size_t NR_VALUES = (1ull << nbits);
 	int nrOfFailedTestCases = 0;
-
 	TestType a;
 	for (size_t i = 0; i < NR_VALUES; ++i) {
 		a.setbits(i);
+		if (a.isnan() || a.isinf()) continue;
 		TestType l1 = ceil(a);
-		// generate the reference
-		float f = float(a);
-		float cf = std::ceil(f);
-		TestType l2 = cf;
+		TestType l2 = TestType(std::ceil(float(a)));
 		if (l1 != l2) {
-			if (a.isnan() || l1.isnan()) continue;
-			std::cout << to_binary(a) << " : " << a << '\n';
-			std::cout << "ceil(" << f << ") = " << l2 << " vs result " << l1 << '\n';
+			std::cout << to_binary(a) << " : ceil(" << float(a) << ") = " << l2 << " vs result " << l1 << '\n';
 			++nrOfFailedTestCases;
 			if (reportTestCases) ReportOneInputFunctionError("ceil", "ceil", a, l1, l2);
 		}
 	}
 	return nrOfFailedTestCases;
+}
+
+template<typename TestType>
+int VerifyTrunc(bool reportTestCases) {
+	using namespace sw::universal;
+	constexpr size_t nbits = TestType::nbits;
+	constexpr size_t NR_VALUES = (1ull << nbits);
+	int nrOfFailedTestCases = 0;
+	TestType a;
+	for (size_t i = 0; i < NR_VALUES; ++i) {
+		a.setbits(i);
+		if (a.isnan() || a.isinf()) continue;
+		TestType l1 = trunc(a);
+		TestType l2 = TestType(std::trunc(float(a)));
+		if (l1 != l2) {
+			std::cout << to_binary(a) << " : trunc(" << float(a) << ") = " << l2 << " vs result " << l1 << '\n';
+			++nrOfFailedTestCases;
+			if (reportTestCases) ReportOneInputFunctionError("trunc", "trunc", a, l1, l2);
+		}
+	}
+	return nrOfFailedTestCases;
+}
+
+template<typename TestType>
+int VerifyRound(bool reportTestCases) {
+	using namespace sw::universal;
+	constexpr size_t nbits = TestType::nbits;
+	constexpr size_t NR_VALUES = (1ull << nbits);
+	int nrOfFailedTestCases = 0;
+	TestType a;
+	for (size_t i = 0; i < NR_VALUES; ++i) {
+		a.setbits(i);
+		if (a.isnan() || a.isinf()) continue;
+		TestType l1 = round(a);
+		TestType l2 = TestType(std::round(float(a)));  // ties away from zero, matches our round
+		if (l1 != l2) {
+			std::cout << to_binary(a) << " : round(" << float(a) << ") = " << l2 << " vs result " << l1 << '\n';
+			++nrOfFailedTestCases;
+			if (reportTestCases) ReportOneInputFunctionError("round", "round", a, l1, l2);
+		}
+	}
+	return nrOfFailedTestCases;
+}
+
+// Wide-precision verifier (issue #1026): a cfloat with > 53 significand bits has
+// integers that a double cannot represent. We build a large integer N exactly
+// (2^60 + 8, well within a 113-bit significand) plus exactly-representable
+// fractions, and check trunc/floor/ceil/round against cfloat-constructed
+// references -- NO double round-trip, which the buggy implementation relied on.
+template<typename Wide>
+int VerifyWideTruncation(bool reportTestCases) {
+	using namespace sw::universal;
+	(void)reportTestCases;
+	int fail = 0;
+	const Wide N  = Wide(1152921504606846976.0) + Wide(8);  // 2^60 + 8 (exact)
+	const Wide N1 = N + Wide(1);                             // 2^60 + 9
+	const Wide h(0.5), q(0.25), t3(0.75);
+
+	struct Case { Wide x, efloor, eceil, etrunc, eround; const char* tag; };
+	const Case cases[] = {
+		{ N,        N,   N,  N,  N,   "N" },
+		{ N + h,    N,   N1, N,  N1,  "N+0.5" },
+		{ N + q,    N,   N1, N,  N,   "N+0.25" },
+		{ N + t3,   N,   N1, N,  N1,  "N+0.75" },
+		{ -(N + h), -N1, -N, -N, -N1, "-(N+0.5)" },
+		{ -(N + q), -N1, -N, -N, -N,  "-(N+0.25)" },
+		{ -(N + t3),-N1, -N, -N, -N1, "-(N+0.75)" },
+	};
+	for (const auto& c : cases) {
+		if (floor(c.x) != c.efloor) { std::cout << "wide floor " << c.tag << " FAIL: " << floor(c.x) << " vs " << c.efloor << '\n'; ++fail; }
+		if (ceil (c.x) != c.eceil ) { std::cout << "wide ceil "  << c.tag << " FAIL: " << ceil(c.x)  << " vs " << c.eceil  << '\n'; ++fail; }
+		if (trunc(c.x) != c.etrunc) { std::cout << "wide trunc " << c.tag << " FAIL: " << trunc(c.x) << " vs " << c.etrunc << '\n'; ++fail; }
+		if (round(c.x) != c.eround) { std::cout << "wide round " << c.tag << " FAIL: " << round(c.x) << " vs " << c.eround << '\n'; ++fail; }
+	}
+	return fail;
 }
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
@@ -90,23 +160,31 @@ try {
 
 #if MANUAL_TESTING
 	// generate individual testcases to hand trace/debug
-
-	nrOfFailedTestCases = ReportTestResult(VerifyFloor< cfloat<8, 2, uint8_t> >(reportTestCases), "floor", "cfloat<8,2>");
-	nrOfFailedTestCases = ReportTestResult(VerifyCeil < cfloat<8, 2, uint8_t> >(reportTestCases), "ceil ", "cfloat<8,2>");
+	nrOfFailedTestCases += ReportTestResult(VerifyFloor< cfloat<8, 2, uint8_t> >(reportTestCases), "floor", "cfloat<8,2>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCeil < cfloat<8, 2, uint8_t> >(reportTestCases), "ceil ", "cfloat<8,2>");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;  // ignore failures in manual testing mode
 #else
 
 #if REGRESSION_LEVEL_1
-	nrOfFailedTestCases = ReportTestResult(VerifyFloor< cfloat<8, 2, uint8_t> >(reportTestCases), "floor", "cfloat<8,2>");
-	nrOfFailedTestCases = ReportTestResult(VerifyCeil < cfloat<8, 2, uint8_t> >(reportTestCases), "ceil ", "cfloat<8,2>");
+	nrOfFailedTestCases += ReportTestResult(VerifyFloor< cfloat<8, 2, uint8_t> >(reportTestCases), "floor", "cfloat<8,2>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCeil < cfloat<8, 2, uint8_t> >(reportTestCases), "ceil ", "cfloat<8,2>");
+	nrOfFailedTestCases += ReportTestResult(VerifyTrunc< cfloat<8, 2, uint8_t> >(reportTestCases), "trunc", "cfloat<8,2>");
+	nrOfFailedTestCases += ReportTestResult(VerifyRound< cfloat<8, 2, uint8_t> >(reportTestCases), "round", "cfloat<8,2>");
 
-	nrOfFailedTestCases = ReportTestResult(VerifyFloor< half >(reportTestCases), "floor", "half");
-	nrOfFailedTestCases = ReportTestResult(VerifyCeil < half >(reportTestCases), "ceil ", "half");
+	nrOfFailedTestCases += ReportTestResult(VerifyFloor< half >(reportTestCases), "floor", "half");
+	nrOfFailedTestCases += ReportTestResult(VerifyCeil < half >(reportTestCases), "ceil ", "half");
+	nrOfFailedTestCases += ReportTestResult(VerifyTrunc< half >(reportTestCases), "trunc", "half");
+	nrOfFailedTestCases += ReportTestResult(VerifyRound< half >(reportTestCases), "round", "half");
 
-	nrOfFailedTestCases = ReportTestResult(VerifyFloor< bfloat_t >(reportTestCases), "floor", "bfloat_t");
-	nrOfFailedTestCases = ReportTestResult(VerifyCeil < bfloat_t >(reportTestCases), "ceil ", "bfloat_t");
+	nrOfFailedTestCases += ReportTestResult(VerifyFloor< bfloat_t >(reportTestCases), "floor", "bfloat_t");
+	nrOfFailedTestCases += ReportTestResult(VerifyCeil < bfloat_t >(reportTestCases), "ceil ", "bfloat_t");
+	nrOfFailedTestCases += ReportTestResult(VerifyTrunc< bfloat_t >(reportTestCases), "trunc", "bfloat_t");
+	nrOfFailedTestCases += ReportTestResult(VerifyRound< bfloat_t >(reportTestCases), "round", "bfloat_t");
+
+	// issue #1026: > 53-bit significand, where the old double-based impl was wrong
+	nrOfFailedTestCases += ReportTestResult(VerifyWideTruncation< cfloat<128, 15, std::uint32_t, true, false, false> >(reportTestCases), "wide trunc/floor/ceil/round", "cfloat<128,15>");
 
 #endif
 


### PR DESCRIPTION
## Summary
`trunc`/`round`/`floor`/`ceil` for `cfloat<>` computed `std::X(double(x))`. That is wrong for cfloats with **more than 53 significand bits**: any integer above 2^53 loses its low bits in the `double` conversion, so e.g. `floor(2^60 + 8)` did not return `2^60 + 8` (#1026). Reimplemented directly on the cfloat encoding.

## The fix (`truncate.hpp`)
- **trunc** — clear the fraction bits below 2^0 per the unbiased `scale` (`scale >= fbits` → integral; subnormal or `scale < 0` → signed zero). Pure bit operation.
- **floor / ceil** — `trunc`, then `-/+ 1` for the negative/positive non-integral case.
- **round** — ties away from zero, decided from the **2^-1 fraction bit** for `|x| >= 1` and from `2|x| >= 1` for `|x| < 1`. Deliberately never constructs `0.5`, which some low-range cfloats (e.g. `cfloat<8,2>`) cannot represent -- an early version did and regressed those.

All derived ops use cfloat's own (correctly rounded) arithmetic/comparisons; no `double` round-trip.

## Test (`static/float/cfloat/math/truncate.cpp`)
- Added exhaustive **trunc** and **round** coverage (was floor/ceil only).
- Added a **wide-precision verifier** on `cfloat<128,15>`: `2^60+8` ± exact fractions, both signs, checked against **cfloat-constructed** references (no `double`).
- Fixed the result accumulation (`=` → `+=`, a latent bug that hid all but the last sub-test).

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| cfloat_truncate (exhaustive narrow + wide cfloat<128,15>) | PASS | PASS |
| cfloat_fractional (fmod, regression check) | PASS | PASS |

Exhaustive `cfloat<8,2>`/`half`/`bfloat_t` match the representable std reference; wide `cfloat<128,15>` exact.

## Notes
- Found while resolving #1024 (the elreal exact oracle hit this); the oracle worked around it by reading cfloat bits directly. With this fix that workaround is no longer strictly necessary, though it remains valid.
- Sibling issue #1027 (cfloat `frexp` returns [1,2) vs std's [0.5,1)) is separate.

## Test plan
- [x] Fast CI passes
- [x] Promote to ready when satisfied

Resolves #1026

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated truncation and rounding functions with improved edge case handling and special value support (NaN, Inf, zeros).

* **Tests**
  * Expanded test coverage for mathematical truncation and rounding functions across additional numeric types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->