### PR TITLE
fix(cfloat): isnormal() returns false for +-0 (IEEE / std::isnormal)

### DIFF
--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -1794,7 +1794,7 @@ public:
 	}
 	// isnormal returns true if 0 or exponent bits are not all zero or one, false otherwise
 	constexpr bool isnormal() const noexcept {
-		if (iszeroencoding()) return true; // filter out the one special case
+		if (iszeroencoding()) return false; // zero is not a normal number (matches std::isnormal / IEEE classification)
 		blockbinary<es, bt> e{};
 		exponent(e);
 		return !e.iszero() && !e.all();

--- a/static/float/cfloat/math/classify.cpp
+++ b/static/float/cfloat/math/classify.cpp
@@ -16,6 +16,31 @@ bool isdenorm(double d) {
 	return (std::fpclassify(d) == FP_SUBNORMAL);
 }
 
+// Assert IEEE / std::isnormal classification: zero, subnormal, inf and nan are
+// NOT normal; finite non-zero normals are (issue #1030 -- isnormal() used to
+// return true for +-0).
+template<typename TestType>
+int VerifyIsNormalClassification(bool reportTestCases) {
+	using namespace sw::universal;
+	int fails = 0;
+	auto check = [&](const char* name, bool got, bool expect) {
+		if (got != expect) { ++fails; if (reportTestCases) std::cout << "isnormal(" << name << ") = " << got << " expected " << expect << '\n'; }
+	};
+	TestType pzero(0);
+	TestType nzero; nzero.setbits(size_t(1) << (TestType::nbits - 1)); // -0
+	TestType one(1);
+	TestType inf; inf.setinf(false);
+	TestType nan; nan.setnan();
+	check("+0", pzero.isnormal(), false);
+	check("-0", nzero.isnormal(), false);
+	check("1.0", one.isnormal(), true);
+	check("inf", inf.isnormal(), false);
+	check("nan", nan.isnormal(), false);
+	TestType sub; sub.setbits(1);                       // smallest non-zero encoding
+	if (!sub.iszero() && sub.isdenormal()) check("subnormal", sub.isnormal(), false);
+	return fails;
+}
+
 #define MANUAL_TESTING 0
 
 int main()
@@ -125,6 +150,14 @@ try {
 		<< "isnan(1.0) = " << isnan(cone) << '\n';
 
 	std::cout << '\n';
+
+	// assertion-based isnormal classification (issue #1030)
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIsNormalClassification< cfloat<32, 8, uint32_t, true, false, false> >(reportTestCases), "cfloat<32,8>", "isnormal");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIsNormalClassification< half >(reportTestCases), "half", "isnormal");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIsNormalClassification< cfloat<8, 4, uint8_t, false, false, false> >(reportTestCases), "cfloat<8,4> noSub", "isnormal");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/static/float/cfloat/math/fractional.cpp
+++ b/static/float/cfloat/math/fractional.cpp
@@ -33,8 +33,7 @@ int VerifyCfloatFractionExponent(bool reportTestCases) {
 			nrOfFailedTests++;
 			if (reportTestCases)	ReportOneInputFunctionError("FAIL", "frexp/ldexp", a, b, c);
 		}
-		// (cfloat isnormal() also reports true for +-0, so exclude zero explicitly)
-		if (checkRange && a.isnormal() && !a.iszero()) {   // std::frexp fraction range, where representable
+		if (checkRange && a.isnormal()) {   // std::frexp fraction range, where representable (isnormal() is false for zero, #1030)
 			double fb = std::abs(double(b));
 			if (!(fb >= 0.5 && fb < 1.0)) {
 				nrOfFailedTests++;


### PR DESCRIPTION
## Summary
`cfloat<>::isnormal()` returned **true for +-0**. The zero-encoding early-out returned `true` ("filter out the one special case"), but zero is not a normal number -- `std::isnormal(0) == false`. Subnormal/inf/nan were already correct; zero was the only wrong category (issue #1030).

```cpp
// before:  if (iszeroencoding()) return true;
// after:   if (iszeroencoding()) return false;
```

## Caller sweep (the safety analysis -- no adaptation needed)
Swept every `isnormal()` consumer:
- **cfloat-internal conversion/normalization** (`cfloat_impl.hpp` 455, 512, 2128, 2189, 2276, 2338): each sits in an `else` branch *after* an earlier `iszero()` test, so zero never reaches the `isnormal()` check. **Unaffected.**
- **elreal** `block.is_normalised()`: guards with `is_zero_block()` first.
- **complex** `isnormal`: short-circuits `re == 0.0 || ...`.
- **closure_plot_png**: already excludes zero (`&& result != 0`).
- `classify.cpp` printed `isnormal(0.0)` (no assert) -> output is now correct (matches the `std::isnormal(0.0)=false` line beside it).

**No call site depends on zero-as-normal.** Verified the riskiest consumers directly: cfloat-to-cfloat and double->cfloat **conversion tests pass unchanged** on gcc + clang.

## Changes
- `include/sw/universal/number/cfloat/cfloat_impl.hpp` -- the one-line fix
- `static/float/cfloat/math/classify.cpp` -- added `VerifyIsNormalClassification` asserting +-0/inf/nan/subnormal are not normal and finite non-zero normals are (the suite was print-only)
- `static/float/cfloat/math/fractional.cpp` -- removed the #1027 `isnormal() && !iszero()` workaround now that `isnormal()` is correct for zero

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| cfloat_classify (new isnormal asserts) | PASS | PASS |
| cfloat_fractional | PASS | PASS |
| cfloat_cfloat_to_cfloat_conversion | PASS | PASS |
| cfloat_double_conversion | PASS | PASS |
| el_arith_exact_value_oracle (#1022) | PASS | PASS |

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Resolves #1030

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `isnormal()` behavior to properly classify zero encodings as not normal, aligning with IEEE-754 standard classification.

* **Tests**
  * Added comprehensive test validation for normal number classification across signed zero, normal values, subnormal values, infinity, and NaN cases.
  * Improved test code with assertion-based validation for better test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stillwater-sc/universal/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->