### PR TITLE
style: ASCII-only source/build files + warning cleanup

### DIFF
--- a/.claude/hooks/build-safety.sh
+++ b/.claude/hooks/build-safety.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# build-safety.sh — PreToolUse hook for Bash commands
+# build-safety.sh -- PreToolUse hook for Bash commands
 # Prevents concurrent builds and excessive parallelism.
 #
 # Reads tool input from stdin (JSON with .tool_input.command field).

--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# notify.sh — Notification hook for Claude Code
+# notify.sh -- Notification hook for Claude Code
 # Sends a notification when Claude needs attention.
 # Works across SSH sessions, local terminals, and desktop environments.
 #
 # Sends:
 #   1. OSC 9 escape (iTerm2, Windows Terminal, many modern terminals)
-#   2. Terminal bell (\a) — triggers SSH client bell
+#   2. Terminal bell (\a) -- triggers SSH client bell
 #   3. notify-send (if desktop session available)
 
 # Drain hook input from stdin; this hook does not currently use the payload.

--- a/.github/workflows/ascii-guard.yml
+++ b/.github/workflows/ascii-guard.yml
@@ -20,6 +20,8 @@ jobs:
   check-ascii:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Scan source and build files for non-ASCII bytes
         run: ./tools/scripts/check-ascii.sh

--- a/.github/workflows/ascii-guard.yml
+++ b/.github/workflows/ascii-guard.yml
@@ -1,0 +1,25 @@
+name: ASCII Guard
+
+# Enforce the ASCII-only rule for source and build files.
+# Unicode characters (box-drawing, smart quotes, math symbols, em-dashes,
+# superscripts, etc.) do not render correctly on Windows consoles and can
+# break tooling. All C/C++ source, CMake, and build/automation scripts must
+# contain only 7-bit ASCII bytes. Documentation (*.md) and binary assets are
+# exempt. See CLAUDE.md 'No Unicode Characters' and tools/scripts/check-ascii.sh.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-ascii:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan source and build files for non-ASCII bytes
+        run: ./tools/scripts/check-ascii.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,13 +229,28 @@ target_link_libraries(${PROJECT_NAME} universal::universal)
 
 ### No Unicode Characters
 
-All code, comments, and string literals must use **ASCII-only** characters. Unicode special characters (arrows, math symbols, superscripts, em-dashes, etc.) do not render correctly on Windows consoles.
+All source and build files must contain **ASCII-only** (7-bit) bytes. This is a
+hard rule, not just a style preference: Unicode special characters (box-drawing,
+arrows, math symbols, superscripts, smart quotes, em-dashes, etc.) do not render
+correctly on Windows consoles and can break tooling.
+
+Scope of the rule (enforced in CI):
+- C/C++ source: `*.hpp *.cpp *.h *.c *.cc *.cxx *.hxx *.inc *.cpp_`
+- Build/CMake: `CMakeLists.txt *.cmake Dockerfile*`
+- Scripts: `*.sh *.bash *.py *.mjs *.js`
+- Exempt: documentation (`*.md`) and binary assets (images, PDFs, spreadsheets)
 
 Use ASCII equivalents:
 - `~=` not `≈`, `!=` not `≠`, `<=` not `≤`, `>=` not `≥`
-- `->` not `→`, `--` not `—`, `*` not `·`
-- `^2` not `²`, `pi` not `π`, `+/-` not `±`
-- Regular hyphen-minus `-` not Unicode minus `−`
+- `->` not `→`, `<-` not `←`, `--` not `—`, `*` not `·`/`×`
+- `^2` not `²`, `pi` not `π`, `+/-` not `±`, `sqrt` not `√`, `inf` not `∞`
+- `-` not `+`/`|` box-drawing; use `-` `|` `+` `=` for ASCII tables/diagrams
+- Regular hyphen-minus `-` not Unicode minus `−` (and watch for raw Latin-1
+  bytes like `0xBF` from a mangled paste)
+
+Enforcement: `tools/scripts/check-ascii.sh` scans the tracked tree (run it
+locally before committing) and the `ASCII Guard` GitHub Actions workflow fails
+any PR that introduces non-ASCII bytes in an in-scope file.
 
 ### C++ Standard
 

--- a/applications/accuracy/geometry/vertex_enumeration.py
+++ b/applications/accuracy/geometry/vertex_enumeration.py
@@ -7,13 +7,13 @@ def enumerate_vertices(A, b):
     
     Parameters:
     A : numpy.ndarray
-        Matrix of hyperplane coefficients (m constraints × n dimensions)
+        Matrix of hyperplane coefficients (m constraints * n dimensions)
     b : numpy.ndarray
         Vector of hyperplane constants (m constraints)
         
     Returns:
     numpy.ndarray
-        Array of vertices (k vertices × n dimensions)
+        Array of vertices (k vertices * n dimensions)
     """
     m, n = A.shape  # m constraints, n dimensions
     vertices = []
@@ -49,7 +49,7 @@ def get_bounding_box(vertices):
     
     Parameters:
     vertices : numpy.ndarray
-        Array of vertices (k vertices × n dimensions)
+        Array of vertices (k vertices * n dimensions)
         
     Returns:
     tuple

--- a/applications/accuracy/mathematics/harmonic_series.cpp
+++ b/applications/accuracy/mathematics/harmonic_series.cpp
@@ -1,4 +1,4 @@
-﻿// harmonic_series.cpp: experiments with mixed-precision representations of the Harmonic Series
+// harmonic_series.cpp: experiments with mixed-precision representations of the Harmonic Series
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/accuracy/mathematics/numeric_constants.cpp
+++ b/applications/accuracy/mathematics/numeric_constants.cpp
@@ -1,4 +1,4 @@
-﻿// numeric_constants.cpp: experiments with mixed-precision representations of important numerical constants
+// numeric_constants.cpp: experiments with mixed-precision representations of important numerical constants
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/accuracy/mathematics/rump_equation.cpp
+++ b/applications/accuracy/mathematics/rump_equation.cpp
@@ -163,7 +163,7 @@ try {
  * one off constant computation from "Handbook of Floating-Point Arithmetic":
      f(a,b) = 333.75*b^6 + a^2*(11*a^2*b^2 - b^6 - 121*b^4 - 2) + 5.5*b^8 + a/(2*b)
      for a=77617.0, b=33096.0
-The exact result is -54767 / 66192 which starts with −0.8273960599...
+The exact result is -54767 / 66192 which starts with -0.8273960599...
 Using pow vs repeated mutiplication for the power expressions usually yields the same answer, but not always
 Running on x86 fp types we get (picking some interesting MPFR results)
 Type        | Rep Mult    | Pow Func

--- a/applications/accuracy/ode/first_order_ode.cpp
+++ b/applications/accuracy/ode/first_order_ode.cpp
@@ -21,7 +21,7 @@ so that the equation is of the first order and no higher-order
 derivatives exist. The differential equation in first-order can 
 also be written as;
 
-               y’ = f(x,y)   or
+               y' = f(x,y)   or
         (d/dx) y  = f(x,y)
 
 The differential equation is generally used to express a relation 
@@ -32,7 +32,7 @@ domain if we know the functions and some of the derivatives.
 First Order Linear Differential Equation
 
 If the function f is a linear expression in y, then the first-order 
-differential equation y’ = f(x, y) is a linear equation. That is, 
+differential equation y' = f(x, y) is a linear equation. That is, 
 the equation is linear and the function f takes the form
 
           f(x,y) = p(x)y + q(x)
@@ -44,9 +44,9 @@ Differential equations that are not linear are called
 nonlinear equations.
 
 Consider the first-order differential equation 
-               y’ = f(x,y),  
+               y' = f(x,y),  
 is a linear equation and it can be written in the form
-               y’ + a(x)y = f(x)
+               y' + a(x)y = f(x)
 where a(x) and f(x) are continuous functions of x
 
 The alternate method to represent the first-order linear equation 

--- a/applications/accuracy/pde/laplace.cpp
+++ b/applications/accuracy/pde/laplace.cpp
@@ -63,10 +63,10 @@ If I were starting the experiment, I'd try solving
 Laplace's equation on a square. Boundary condition 
 f(x,y) = 1 on some part of the square like the left half 
            of the bottom border (to be asymmetrical), 
-f(x,y) = 0 elsewhere on the border or maybe put a –1 value 
+f(x,y) = 0 elsewhere on the border or maybe put a -1 value 
            somewhere (it wastes the sign bit of a posit 
 		   if all the values are nonnegative), 
-∇²f = 0 on the interior. Try the oldest and simplest 
+grad^2f = 0 on the interior. Try the oldest and simplest 
 method of relaxation, even though better iterative methods 
 are known, with a very coarse grid and very low precision posits. 
 Like, a 4-by-4 grid of points and 4-bit posits with es = 2. 

--- a/applications/accuracy/science/physics_constants.cpp
+++ b/applications/accuracy/science/physics_constants.cpp
@@ -53,13 +53,13 @@ The seven definitions above are rewritten below with the derived units (joule, c
 in terms of the seven base units; second, metre, kilogram, ampere, kelvin, mole, and candela, according to the 9th SI Brochure. 
 In the list that follows, the symbol sr stands for the dimensionless unit steradian.
 
-DeltanuCs = Deltanu(133Cs)hfs = 9192631770 s-1
-c = 299792458 m*s-1
-h = 6.62607015*10-34 kg*m2*s-1
-e = 1.602176634*10-19 A*s
-k = 1.380649*10-23 kg*m2*K-1*s-2
-NA = 6.02214076*1023 mol-1
-Kcd = 683 cd*sr*s3*kg-1*m-2
+DeltanuCs = Deltanu(133Cs)hfs = 9192631770 s^-1
+c = 299792458 m*s^-1
+h = 6.62607015*10^-34 kg*m^2*s^-1
+e = 1.602176634*10^-19 A*s
+k = 1.380649*10^-23 kg*m^2*K^-1*s^-2
+NA = 6.02214076*10^23 mol^-1
+Kcd = 683 cd*sr*s^3*kg^-1*m^-2
 As part of the redefinition, the international prototype kilogram was retired and definitions of the kilogram, 
 the ampere, and the kelvin were replaced. The definition of the mole was revised. These changes have the effect 
 of redefining the SI base units, though the definitions of the SI derived units in terms of the base units remain the same.

--- a/applications/accuracy/science/physics_constants.cpp
+++ b/applications/accuracy/science/physics_constants.cpp
@@ -1,4 +1,4 @@
-﻿// physics_constants.cpp: experiments with posit representations of important constants in physics 
+// physics_constants.cpp: experiments with posit representations of important constants in physics 
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -15,7 +15,7 @@
 /*
 The 2019 redefinition of the SI base units came into force on 20 May 2019,[1][2] the 144th anniversary 
 of the Metre Convention. In the redefinition, four of the seven SI base units 
-           – the kilogram, ampere, kelvin, and mole –
+           - the kilogram, ampere, kelvin, and mole -
 were redefined by setting exact numerical values for 
    - the Planck constant (h), 
    - the elementary electric charge (e), 
@@ -36,30 +36,30 @@ were redefined by setting exact numerical values for
  speed of light, the BIPM's Consultative Committee for Units (CCU) recommended and the BIPM proposed that 
  four further constants of nature should be defined to have exact values. These are:
 
-The Planck constant h is exactly 6.62607015×10^−34 joule-second (J⋅s).
-The elementary charge e is exactly 1.602176634×10^−19 coulomb (C).
-The Boltzmann constant k is exactly 1.380649×10^−23 joule per kelvin (J⋅K−1).
-The Avogadro constant NA is exactly 6.02214076×10^23 reciprocal mole (mol−1).
+The Planck constant h is exactly 6.62607015*10^-34 joule-second (J*s).
+The elementary charge e is exactly 1.602176634*10^-19 coulomb (C).
+The Boltzmann constant k is exactly 1.380649*10^-23 joule per kelvin (J*K-1).
+The Avogadro constant NA is exactly 6.02214076*10^23 reciprocal mole (mol-1).
 
 These constants are described in the 2006 version of the SI manual but in that version, the latter three 
 are defined as "constants to be obtained by experiment" rather than as "defining constants". The redefinition 
 retains unchanged the numerical values associated with the following constants of nature:
 
-The speed of light c is exactly 299792458 metres per second (m⋅s−1);
-The ground state hyperfine structure transition frequency of the caesium-133 atom ΔνCs is exactly 9192631770 hertz (Hz);
-The luminous efficacy Kcd of monochromatic radiation of frequency 540×1012 Hz (540 THz) – a frequency 
-of green-colored light at approximately the peak sensitivity of the human eye – is exactly 683 lumens per watt (lm⋅W−1).
+The speed of light c is exactly 299792458 metres per second (m*s-1);
+The ground state hyperfine structure transition frequency of the caesium-133 atom DeltanuCs is exactly 9192631770 hertz (Hz);
+The luminous efficacy Kcd of monochromatic radiation of frequency 540*1012 Hz (540 THz) - a frequency 
+of green-colored light at approximately the peak sensitivity of the human eye - is exactly 683 lumens per watt (lm*W-1).
 The seven definitions above are rewritten below with the derived units (joule, coulomb, hertz, lumen, and watt) expressed 
 in terms of the seven base units; second, metre, kilogram, ampere, kelvin, mole, and candela, according to the 9th SI Brochure. 
 In the list that follows, the symbol sr stands for the dimensionless unit steradian.
 
-ΔνCs = Δν(133Cs)hfs = 9192631770 s−1
-c = 299792458 m⋅s−1
-h = 6.62607015×10−34 kg⋅m2⋅s−1
-e = 1.602176634×10−19 A⋅s
-k = 1.380649×10−23 kg⋅m2⋅K−1⋅s−2
-NA = 6.02214076×1023 mol−1
-Kcd = 683 cd⋅sr⋅s3⋅kg−1⋅m−2
+DeltanuCs = Deltanu(133Cs)hfs = 9192631770 s-1
+c = 299792458 m*s-1
+h = 6.62607015*10-34 kg*m2*s-1
+e = 1.602176634*10-19 A*s
+k = 1.380649*10-23 kg*m2*K-1*s-2
+NA = 6.02214076*1023 mol-1
+Kcd = 683 cd*sr*s3*kg-1*m-2
 As part of the redefinition, the international prototype kilogram was retired and definitions of the kilogram, 
 the ampere, and the kelvin were replaced. The definition of the mole was revised. These changes have the effect 
 of redefining the SI base units, though the definitions of the SI derived units in terms of the base units remain the same.
@@ -159,10 +159,10 @@ try {
 
 	report_compiler();
 
-	long double h = 6.62607015e-34;  // (J⋅s)
+	long double h = 6.62607015e-34;  // (J*s)
 	long double e = 1.602176634e-19; // (C)
-	long double k = 1.380649e-23;    // (J⋅K−1)
-	long double NA = 6.02214076e23;  // (mol−1)
+	long double k = 1.380649e-23;    // (J*K-1)
+	long double NA = 6.02214076e23;  // (mol-1)
 
 
 	std::cout << "The Planck constant h is exactly 6.62607015*10^-34 joule - second.\n";

--- a/applications/approximation/taylor/taylor_series.cpp
+++ b/applications/approximation/taylor/taylor_series.cpp
@@ -1,4 +1,4 @@
-﻿//  taylor_series.cpp: experiments with number systems approximating the Reals approximating functions
+//  taylor_series.cpp: experiments with number systems approximating the Reals approximating functions
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 //

--- a/applications/mixed-precision/attention/attention.cpp
+++ b/applications/mixed-precision/attention/attention.cpp
@@ -103,7 +103,7 @@ public:
 		}
 		stats.input_loads += d_k;
 
-		// Step 1: QK^T — dot(q, k_cache[t]) for each cached token
+		// Step 1: QK^T -- dot(q, k_cache[t]) for each cached token
 		std::vector<AccumType> scores(T);
 		AccumType scale = static_cast<AccumType>(1.0 / std::sqrt(static_cast<double>(d_k)));
 		for (size_t t = 0; t < T; ++t) {

--- a/applications/performance/chaos/time_precision_lyapunov.cpp
+++ b/applications/performance/chaos/time_precision_lyapunov.cpp
@@ -23,7 +23,7 @@ Corresponding author: wpf@mail.iap.ac.cn
 
 Abstract
  The relation among reliable computation time, Tc, float-point precision, K, and the
-Lyapunov exponent, λ, is obtained as Tc= (lnB/λ)K+C, where B is the base of the float-point
+Lyapunov exponent, lambda, is obtained as Tc= (lnB/lambda)K+C, where B is the base of the float-point
 system and C is a constant dependent only on the chaotic equation. The equation shows good
 agreement with numerical experimental results, especially the scale factors.
 

--- a/applications/performance/ir/luir.cpp
+++ b/applications/performance/ir/luir.cpp
@@ -629,7 +629,7 @@ pattern is 0.10.111111111....1111
 0101
 p.setbits(0x5fff)
 pattern is 0.01.00000..0000
-theodore omtzigt5:49 PM
+theodore omtzigt5:49 PM
 top nibble is 0010 = 2
 p.setbits(0x2000)
 

--- a/applications/performance/weather/error_growth_atmospheric_model.cpp
+++ b/applications/performance/weather/error_growth_atmospheric_model.cpp
@@ -25,7 +25,7 @@ Corresponding author: wpf@mail.iap.ac.cn
 
 Abstract
  The relation among reliable computation time, Tc, float-point precision, K, and the
-Lyapunov exponent, λ, is obtained as Tc= (lnB/λ)K+C, where B is the base of the float-point
+Lyapunov exponent, lambda, is obtained as Tc= (lnB/lambda)K+C, where B is the base of the float-point
 system and C is a constant dependent only on the chaotic equation. The equation shows good
 agreement with numerical experimental results, especially the scale factors.
 

--- a/applications/precision/constants/numeric_constants.cpp
+++ b/applications/precision/constants/numeric_constants.cpp
@@ -168,7 +168,7 @@ try {
 
 Legend
 ------
-  ULP           Unit in the Last Place — the step size at the constant's value
+  ULP           Unit in the Last Place -- the step size at the constant's value
   Value         The constant as represented by the number system (shown in double)
   Relative Error  |oracle - represented| / |oracle|, computed in qd_cascade precision
 

--- a/applications/precision/floating-point/catastrophic_cancellation.cpp
+++ b/applications/precision/floating-point/catastrophic_cancellation.cpp
@@ -1,4 +1,4 @@
-﻿// catastrophic_cancellation.cpp: examples of catastrophic cancellation
+// catastrophic_cancellation.cpp: examples of catastrophic cancellation
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/contract_expand.cpp
+++ b/applications/precision/floating-point/contract_expand.cpp
@@ -1,4 +1,4 @@
-﻿// contract_expand.cpp: evaluation of contractions and expansions of posit number systems
+// contract_expand.cpp: evaluation of contractions and expansions of posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/exponentiation.cpp
+++ b/applications/precision/floating-point/exponentiation.cpp
@@ -1,4 +1,4 @@
-﻿// exponentiation.cpp: evaluation of exponentiation of posit number systems
+// exponentiation.cpp: evaluation of exponentiation of posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/integer_cover.cpp
+++ b/applications/precision/floating-point/integer_cover.cpp
@@ -1,4 +1,4 @@
-﻿// integer_cover.cpp: measuring the covering of the integers with a posit
+// integer_cover.cpp: measuring the covering of the integers with a posit
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/kahan_sum.cpp
+++ b/applications/precision/floating-point/kahan_sum.cpp
@@ -1,4 +1,4 @@
-﻿// kahan_sum.cpp: Kahan summation evaluation of posit number systems
+// kahan_sum.cpp: Kahan summation evaluation of posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/linear_cover.cpp
+++ b/applications/precision/floating-point/linear_cover.cpp
@@ -1,4 +1,4 @@
-﻿// linear_cover.cpp: covering a linear range with a posit
+// linear_cover.cpp: covering a linear range with a posit
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/oneMinusCosDivSin.cpp
+++ b/applications/precision/floating-point/oneMinusCosDivSin.cpp
@@ -1,4 +1,4 @@
-﻿// oneMinusCosDivSin.cpp: experiments with accuracy and precision 
+// oneMinusCosDivSin.cpp: experiments with accuracy and precision 
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -18,7 +18,7 @@ simply their availability.
 
 Absolute error is
 
-				 |computed value – correct value|.
+				 |computed value - correct value|.
 
 It is most appropriate when describing results with a number format that
 represents uniformly-spaced values (integer and fixed-point format).
@@ -40,10 +40,10 @@ magnitude. It has another shortcoming: If we know x to some relative error,
 then we know 1/x to a different relative error. For example, say the strength
 of a lens is supposed to be 5 diopters but we instead have one with strength
 4 diopters. A diopter is the inverse of the focal length in meters. The traditional
-relative error is then |5 – 4| / 5 = 0.2, that is, off by 20%. But if we measure
+relative error is then |5 - 4| / 5 = 0.2, that is, off by 20%. But if we measure
 the lens strength by focal length, then the correct strength is 1/5 diopters = 0.2 meter
 but instead we have a lens with strength 1/4 diopters = 0.25 meter. The traditional
-relative error is |0.2 – 0.25| / 0.2 = 0.25, that is, off by 25%.
+relative error is |0.2 - 0.25| / 0.2 = 0.25, that is, off by 25%.
 
 A better definition for number systems that cover a wide range of magnitudes is
 to take the absolute value of the logarithm of the ratio of the correct and
@@ -56,10 +56,10 @@ Relative error =
  where we require that the correct value is finite and nonzero, and the computed
  value has the same sign as the correct value. Relative error is otherwise treated
  as undefined. Peter Lindstrom notes that the natural logarithm is the right one to use,
- because the relative error of 1 + 𝜀 is close to 𝜀 when the correct value is 1,
+ because the relative error of 1 + eps is close to eps when the correct value is 1,
  which agrees with our intuition and also closely matches the traditional definition
  of relative error. Now, however, if we use our lens example, the relative error
- is |ln(5/4)| = |ln(4/5)| ≈ 0.223 and it doesn’t matter which way we measure the
+ is |ln(5/4)| = |ln(4/5)| ~= 0.223 and it doesn't matter which way we measure the
  strength of the lens.
 
 Now that we have a sound measure of error, we can use that to define accuracy:

--- a/applications/precision/floating-point/precision.cpp
+++ b/applications/precision/floating-point/precision.cpp
@@ -1,4 +1,4 @@
-﻿// precision.cpp: experiments with accuracy and precision in posit number systems
+// precision.cpp: experiments with accuracy and precision in posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -16,7 +16,7 @@ simply their availability.
 
 Absolute error is
 
-				 |computed value – correct value|.
+				 |computed value - correct value|.
 
 It is most appropriate when describing results with a number format that
 represents uniformly-spaced values (integer and fixed-point format).
@@ -38,10 +38,10 @@ magnitude. It has another shortcoming: If we know x to some relative error,
 then we know 1/x to a different relative error. For example, say the strength
 of a lens is supposed to be 5 diopters but we instead have one with strength
 4 diopters. A diopter is the inverse of the focal length in meters. The traditional
-relative error is then |5 – 4| / 5 = 0.2, that is, off by 20%. But if we measure
+relative error is then |5 - 4| / 5 = 0.2, that is, off by 20%. But if we measure
 the lens strength by focal length, then the correct strength is 1/5 diopters = 0.2 meter
 but instead we have a lens with strength 1/4 diopters = 0.25 meter. The traditional
-relative error is |0.2 – 0.25| / 0.2 = 0.25, that is, off by 25%.
+relative error is |0.2 - 0.25| / 0.2 = 0.25, that is, off by 25%.
 
 A better definition for number systems that cover a wide range of magnitudes is
 to take the absolute value of the logarithm of the ratio of the correct and
@@ -54,10 +54,10 @@ Relative error =
  where we require that the correct value is finite and nonzero, and the computed
  value has the same sign as the correct value. Relative error is otherwise treated
  as undefined. Peter Lindstrom notes that the natural logarithm is the right one to use,
- because the relative error of 1 + 𝜀 is close to 𝜀 when the correct value is 1,
+ because the relative error of 1 + eps is close to eps when the correct value is 1,
  which agrees with our intuition and also closely matches the traditional definition
  of relative error. Now, however, if we use our lens example, the relative error
- is |ln(5/4)| = |ln(4/5)| ≈ 0.223 and it doesn’t matter which way we measure the
+ is |ln(5/4)| = |ln(4/5)| ~= 0.223 and it doesn't matter which way we measure the
  strength of the lens.
 
 Now that we have a sound measure of error, we can use that to define accuracy:

--- a/applications/precision/floating-point/printing.cpp
+++ b/applications/precision/floating-point/printing.cpp
@@ -1,4 +1,4 @@
-﻿// printing.cpp: experiments with printing floating-point numbers
+// printing.cpp: experiments with printing floating-point numbers
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/rounding_error_addition.cpp
+++ b/applications/precision/floating-point/rounding_error_addition.cpp
@@ -1,4 +1,4 @@
-﻿// rounding_error_addition.cpp: rounding error comparision for addition
+// rounding_error_addition.cpp: rounding error comparision for addition
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/rounding_error_multiplication.cpp
+++ b/applications/precision/floating-point/rounding_error_multiplication.cpp
@@ -1,4 +1,4 @@
-﻿// rounding_error_multiplication.cpp: evaluation of rounding errors of multiplication in the posit number systems 
+// rounding_error_multiplication.cpp: evaluation of rounding errors of multiplication in the posit number systems 
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/sterbenz_lemma.cpp
+++ b/applications/precision/floating-point/sterbenz_lemma.cpp
@@ -1,4 +1,4 @@
-﻿// sterbenz_lemma.cpp: Demonstration of Sterbenz Lemma
+// sterbenz_lemma.cpp: Demonstration of Sterbenz Lemma
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/sum_of_integers.cpp
+++ b/applications/precision/floating-point/sum_of_integers.cpp
@@ -1,4 +1,4 @@
-﻿// sum_of_integers.cpp: evaluation of a sequence of additions in the posit number systems
+// sum_of_integers.cpp: evaluation of a sequence of additions in the posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/thin_triangle.cpp
+++ b/applications/precision/floating-point/thin_triangle.cpp
@@ -1,4 +1,4 @@
-﻿// goldberg_thin_triangle.cpp: example program showing the Goldberg thin triangle example
+// goldberg_thin_triangle.cpp: example program showing the Goldberg thin triangle example
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -19,11 +19,11 @@
 
 Introduction:
 
-Goldberg’s long thin triangle
+Goldberg's long thin triangle
 Kahan presented this problem in or prior to 1986 and the Goldberg paper (from 1991) was inspired from attended a conference by Kahan.
 
 
-Compute the area A of a thin triangle using the classic form of Heron’s equation.
+Compute the area A of a thin triangle using the classic form of Heron's equation.
 
                  ^
 	   b = c   /   \  c = 7/2 + 3*ulp(a)
@@ -32,23 +32,23 @@ Compute the area A of a thin triangle using the classic form of Heron’s equati
 			     a
 
 s = (a+b+c) / 2
-A = SQRT(s(s−a)(s−b)(s−c))
+A = SQRT(s(s-a)(s-b)(s-c))
 
 The lengths are set to:
 a=7
 b=c= 0.5(a+3*ulp(a))   ulp is "unit in last position"
 
-exact  = 1000000001001111111001110×2−31
-posit  = 1000000001001111111001111×2−31
-IEEE   = 1001010000101001011111110×2−31
+exact  = 1000000001001111111001110*2-31
+posit  = 1000000001001111111001111*2-31
+IEEE   = 1001010000101001011111110*2-31
 
 
 This is an example of loss of significance due to catastrophic cancellation
 
 For both posits & IEEE we have the upper 3 bits set for all three inputs with exponent of b and c smaller by 1. 
-For IEEE’s b and c values the bottom two bits are set. 
+For IEEE's b and c values the bottom two bits are set. 
 However posits values in this range have two more bits available, so the same numeric value has the bottom two clear. 
-Let’s look what happens when we start to compute s. First we perform a+b:
+Let's look what happens when we start to compute s. First we perform a+b:
 
            IEEE                                 POSITS
 
@@ -62,7 +62,7 @@ round:    1010.10000000000000000001            1010.10000000000000000000110
 The upper bits cause a carry (both increase exp by one) and that trailing bit of b means we need one more bit (now 25) to represent exactly. 
 IEEE has to round to 24 bits and the posits version still has one zero bit at the bottom. 
 
-Let’s complete the computation of s.
+Let's complete the computation of s.
 
 
 t1=t0+c:  1010.10000000000000000001            1010.10000000000000000000110
@@ -79,9 +79,9 @@ s:        7.000000954                          7.000000715
 This time we still need 25 bits to be exact since t0 had to adjust the exp and IEEE must round again. 
 Posits are still good with the padding bits we gave them. 
 The multiply by half introduces no error for either. 
-Also shown is the decimal values of each to 10 digits and the binary32 relative error is a tiny  3.40598×10−8.
+Also shown is the decimal values of each to 10 digits and the binary32 relative error is a tiny  3.40598*10-8.
 
-Now for the (s−a) and (s−b) terms:
+Now for the (s-a) and (s-b) terms:
 
 s-a:      111.000000000000000000010            111.000000000000000000001100
          -111.000000000000000000000           -111.000000000000000000000000
@@ -94,12 +94,12 @@ s-b:      111.000000000000000000010            111.000000000000000000001100
            11.100000000000000000001             11.100000000000000000000000
 
 
-Again posits don’t have any rounding error. The binary32 (s−b) has a tiny relative error of 6.81196×10−8 
-and the performed (s−a) subtraction was exact, but the total relative error is a massive 0.3333¯¯¯. 
+Again posits don't have any rounding error. The binary32 (s-b) has a tiny relative error of 6.81196*10-8 
+and the performed (s-a) subtraction was exact, but the total relative error is a massive 0.3333---. 
 The tiny error in s was magnified by a subtraction of a nearby number. 
 This is an example of catastrophic cancellation or loss of significance. 
 
-John D. Cook’s version of a common rule of thumb:
+John D. Cook's version of a common rule of thumb:
     Cardinal rule of floating point arithmetic:
        If x and y agree to n bits, then you can lose up to n bits of precision computing x-y.
 
@@ -145,20 +145,20 @@ Scalar HeronFormulaNaive(const Scalar& a, const Scalar& b, const Scalar& c, bool
 }
 
 /*
-“Miscalculating Area and Angles of a Needle-like Triangle”, W. Kahan, 2014
-The Boldo paper4 details Kahan’s solution (for double input) which is an example of using option two. 
-This is going to be left as a black box for now and it cost about one more issue vs. Heron’s (godbolt):
+"Miscalculating Area and Angles of a Needle-like Triangle", W. Kahan, 2014
+The Boldo paper4 details Kahan's solution (for double input) which is an example of using option two. 
+This is going to be left as a black box for now and it cost about one more issue vs. Heron's (godbolt):
 
 This list of requirements simply are: sorted largest first, valid triangle (including degenerates to line). 
-Taking the original set of inputs and using Kahan’s method with 32-bit operations gives:
+Taking the original set of inputs and using Kahan's method with 32-bit operations gives:
 
-exact   = 1.000000001001111111001110111110×2−7   ≈0.007831550660
-posit   = 1.000000001001111111001110110000×2−7   ≈0.007831550553
-IEEE    = 1.000000001001111111010000000000×2−7   ≈0.007831551135
+exact   = 1.000000001001111111001110111110*2-7   ~=0.007831550660
+posit   = 1.000000001001111111001110110000*2-7   ~=0.007831550553
+IEEE    = 1.000000001001111111010000000000*2-7   ~=0.007831551135
 
-An interesting question is then: Does the error bound of Kahan’s method hold for posits? Well we’ll have to de-black-box it at some point I guess. 
-An aside here: the complexity of Kahan’s method as shown is about the same as Heron’s (godbolt). 
-The real cost is the ordering requirement in the cases where it’s not known nor otherwise required.
+An interesting question is then: Does the error bound of Kahan's method hold for posits? Well we'll have to de-black-box it at some point I guess. 
+An aside here: the complexity of Kahan's method as shown is about the same as Heron's (godbolt). 
+The real cost is the ordering requirement in the cases where it's not known nor otherwise required.
 */
 template<typename Scalar>
 Scalar HeronFormulaKahanRewrite(const Scalar& a, const Scalar& b, const Scalar& c, bool verbose = false) {
@@ -211,7 +211,7 @@ then rounded to the nearest posit. The compiler sets up the sparse lower-triangu
 
 | 1         | | t1 |   | a |
 |           | |    |   |   |
-| b  -1     |•| t2 | = | 0 |
+| b  -1     |*| t2 | = | 0 |
 |           | |    |   |   |
 |     c  -1 | | t3 |   | 0 |
 */

--- a/applications/precision/floating-point/two_sum.cpp
+++ b/applications/precision/floating-point/two_sum.cpp
@@ -1,4 +1,4 @@
-﻿// two_sum.cpp: TwoSum evaluation of posit number systems
+// two_sum.cpp: TwoSum evaluation of posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/underflow.cpp
+++ b/applications/precision/floating-point/underflow.cpp
@@ -1,4 +1,4 @@
-﻿// underflow.cpp: experiments with underfow in posit number systems
+// underflow.cpp: experiments with underfow in posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/floating-point/underflow.cpp
+++ b/applications/precision/floating-point/underflow.cpp
@@ -1,4 +1,4 @@
-// underflow.cpp: experiments with underfow in posit number systems
+// underflow.cpp: experiments with underflow in posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/applications/precision/math/sincospi.cpp
+++ b/applications/precision/math/sincospi.cpp
@@ -19,8 +19,8 @@ the handling of floating-point flags (see fenv.h) is not required, nor do we nee
 most of the time, so I will omit these.
 
 The basic algorithmic structure is straightforward. As very large arguments are always even integers, 
-and therefore thus multiples of 2π, their sine and cosine values are well-known. Other arguments are 
-folded into range [-¼,+¼] while recording quadrant information. Polynomial minimax approximations 
+and therefore thus multiples of 2pi, their sine and cosine values are well-known. Other arguments are 
+folded into range [-1/4,+1/4] while recording quadrant information. Polynomial minimax approximations 
 are used to compute sine and cosine on the primary approximation interval. Finally, quadrant data 
 is used to map the preliminary results to the final result by cyclical exchange of results and sign change.
 
@@ -49,8 +49,8 @@ not the case, the code may experience significant slow-down due to generally slo
 #include <math.h>
 #include <stdint.h>
 
-/* Writes result sine result sin(πa) to the location pointed to by sp
-   Writes result cosine result cos(πa) to the location pointed to by cp
+/* Writes result sine result sin(pia) to the location pointed to by sp
+   Writes result cosine result cos(pia) to the location pointed to by cp
 
    In extensive testing, no errors > 0.97 ulp were found in either the sine
    or cosine results, suggesting the results returned are faithfully rounded.
@@ -104,8 +104,8 @@ void my_sincospi (double a, double *sp, double *cp)
     *cp = c;
 }
 
-/* Writes result sine result sin(πa) to the location pointed to by sp
-   Writes result cosine result cos(πa) to the location pointed to by cp
+/* Writes result sine result sin(pia) to the location pointed to by sp
+   Writes result cosine result cos(pia) to the location pointed to by cp
 
    In exhaustive testing, the maximum error in sine results was 0.96677 ulp,
    the maximum error in cosine results was 0.96563 ulp, meaning results are
@@ -155,7 +155,7 @@ void my_sincospif (float a, float *sp, float *cp)
 To the extent that you expressly depend on IEEE 754 semantics, 
 how do you get around the fact that the C standard does not require 
 implementations' floating-point representations or arithmetic to 
-comply with IEEE 754 (at all)? – John Bollinger Mar 14 '17 at 18:42 
+comply with IEEE 754 (at all)? - John Bollinger Mar 14 '17 at 18:42 
 
 @JohnBollinger I don't. If a tool chain offers sufficient control 
 of floating-point formats and transformations in accordance with 
@@ -163,19 +163,19 @@ IEEE-754 rules, then this code works correctly with respect to
 IEEE-754 (best I could test it). Conversely, if a tool chain 
 generally does not conform to IEEE-754, there should be no 
 expectation (nor do I see a necessity) for this code to comply 
-with all requirements of IEEE-754 either. – njuffa Mar 14 '17 at 18:55
+with all requirements of IEEE-754 either. - njuffa Mar 14 '17 at 18:55
 
-Out of curiosity, why do you use hex floats and decimal doubles? – rici Mar 14 '17 at 19:39
+Out of curiosity, why do you use hex floats and decimal doubles? - rici Mar 14 '17 at 19:39
 
 In the last step of the calculation of the sine, instead of computing 
-s = s * t; r = r * s; s = fma (t, π, r); which amounts to computing s = π*t + t^3, 
+s = s * t; r = r * s; s = fma (t, pi, r); which amounts to computing s = pi*t + t^3, 
 a multiplication by t can be factored out so that a fma and a 
-further multiplication suffice: s = fma (r, s,  3.1415926535897931e+0); s = s * t. – Matías Giovannini May 25 '18 at 15:19
+further multiplication suffice: s = fma (r, s,  3.1415926535897931e+0); s = s * t. - Matias Giovannini May 25 '18 at 15:19
 
-@MatíasGiovannini This re-ordering causes maximum ulp error to increase 
+@MatiasGiovannini This re-ordering causes maximum ulp error to increase 
 (anecdotally to ~ 1.5 ulp), so the implementation is no longer faithfully 
 rounded (which was a design goal of mine). This may be acceptable in 
-some contexts. – njuffa May 25 '18 at 15:57
+some contexts. - njuffa May 25 '18 at 15:57
 */
 
 // conditional compilation

--- a/applications/precision/math/stirlings_approximation.cpp
+++ b/applications/precision/math/stirlings_approximation.cpp
@@ -221,38 +221,38 @@ scale of 60! is 272
 
   The actual problem: order *= 10 develops a systematic bias
 
-  The order variable is multiplied by 10.0 at every step. Here's the key fact: 10^k is exactly representable in double only for k ≤ 22 (because 10^k = 5^k ×
-   2^k and 5^23 exceeds 53 bits). Starting at k=23, each order *= 10 rounds, and the rounding always goes the same direction — down:
+  The order variable is multiplied by 10.0 at every step. Here's the key fact: 10^k is exactly representable in double only for k <= 22 (because 10^k = 5^k *
+   2^k and 5^23 exceeds 53 bits). Starting at k=23, each order *= 10 rounds, and the rounding always goes the same direction -- down:
 
   order < true 10^k:  15 times  (systematic negative bias)
   order > true 10^k:   0 times
   order = true 10^k:  33 times
 
   This is the critical difference from random rounding errors that would tend to cancel out. The order multiplier develops a monotonically accumulating
-  negative bias because 10.0 in binary is 1.01 × 2³ — when you multiply a slightly-too-small value by this, the rounding tends to stay on the low side.
+  negative bias because 10.0 in binary is 1.01 * 2^3 -- when you multiply a slightly-too-small value by this, the rounding tends to stay on the low side.
 
   The consequence: every term from digit 23 onward is biased low
 
-  Every digits[k] * order for k ≥ 23 is systematically smaller than the true digits[k] × 10^k. The trace shows it concretely for 40!:
+  Every digits[k] * order for k >= 23 is systematically smaller than the true digits[k] * 10^k. The trace shows it concretely for 40!:
 
-  step 38: digit=2 × 10^38  got 1.999...96e+38  should be 2e+38
-  step 40: digit=8 × 10^40  got 7.999...83e+40  should be 8.000...02e+40
-  step 43: digit=1 × 10^43  got 9.999...89e+42  should be 1e+43
-  step 44: digit=9 × 10^44  got 8.999...84e+44  should be 9e+44
+  step 38: digit=2 * 10^38  got 1.999...96e+38  should be 2e+38
+  step 40: digit=8 * 10^40  got 7.999...83e+40  should be 8.000...02e+40
+  step 43: digit=1 * 10^43  got 9.999...89e+42  should be 1e+43
+  step 44: digit=9 * 10^44  got 8.999...84e+44  should be 9e+44
 
   Paradoxically, this cumulative negative bias in the terms produces a result that ends up +1 ULP high (0x...98ff vs correct 0x...98fe) because of how the
-  biased-low terms interact with the addition rounding. The error direction flips — the biased low terms cause the accumulator's rounding to overshoot.
+  biased-low terms interact with the addition rounding. The error direction flips -- the biased low terms cause the accumulator's rounding to overshoot.
 
   Why Horner doesn't have this problem
 
-  Horner's method (d = d * 10 + digit) doesn't maintain a separate power-of-ten variable. Each step transforms the accumulated best answer — it multiplies
+  Horner's method (d = d * 10 + digit) doesn't maintain a separate power-of-ten variable. Each step transforms the accumulated best answer -- it multiplies
   the current approximation by 10, then adds the next digit. The errors from each multiplication are relative to the value itself and tend to be more
   balanced (no systematic bias from maintaining a separate geometric sequence).
 
   Why long double is the real fix
 
   Even Horner in double can be off by 1 ULP for very large numbers (50! for example). The definitive fix is using long double (80-bit, 64-bit significand)
-  as the intermediate, where 10^k is exact for k ≤ 27, and the extra 11 bits of precision prevent the Horner rounding errors from accumulating enough to
+  as the intermediate, where 10^k is exact for k <= 27, and the extra 11 bits of precision prevent the Horner rounding errors from accumulating enough to
   cross a ULP boundary when cast back to double. In testing, this produces correctly-rounded doubles for all factorials up to 170!.
 
  */

--- a/applications/precision/numeric/quadratic_ereal.cpp
+++ b/applications/precision/numeric/quadratic_ereal.cpp
@@ -14,26 +14,26 @@
 /*
  * THE QUADRATIC FORMULA CATASTROPHIC CANCELLATION PROBLEM
  *
- * For ax² + bx + c = 0, the standard formula is:
- *     x = (-b ± √(b² - 4ac)) / 2a
+ * For ax^2 + bx + c = 0, the standard formula is:
+ *     x = (-b +/- sqrt(b^2 - 4ac)) / 2a
  *
- * Problem: When b² >> 4ac, we compute √(b² - 4ac) ≈ |b|, leading to:
- *     x₊ = (-b + √(b² - 4ac)) / 2a  ← catastrophic cancellation!
+ * Problem: When b^2 >> 4ac, we compute sqrt(b^2 - 4ac) ~= |b|, leading to:
+ *     x+ = (-b + sqrt(b^2 - 4ac)) / 2a  <- catastrophic cancellation!
  *
- * Example: x² - 10⁸x + 1 = 0
- *   True roots: x₁ ≈ 10⁸, x₂ ≈ 10⁻⁸
+ * Example: x^2 - 10^8x + 1 = 0
+ *   True roots: x1 ~= 10^8, x2 ~= 10^-8
  *   With double precision:
- *     b² = 10¹⁶ (exact)
+ *     b^2 = 10^16 (exact)
  *     4ac = 4 (exact)
- *     b² - 4ac = 10¹⁶ - 4 = 10¹⁶ (precision lost!)
- *     √(b² - 4ac) ≈ 10⁸ (appears exact, but small component lost)
- *     x₊ = (-10⁸ + 10⁸) / 2 = 0 / 2 = 0  ← WRONG! Should be 10⁻⁸
+ *     b^2 - 4ac = 10^16 - 4 = 10^16 (precision lost!)
+ *     sqrt(b^2 - 4ac) ~= 10^8 (appears exact, but small component lost)
+ *     x+ = (-10^8 + 10^8) / 2 = 0 / 2 = 0  <- WRONG! Should be 10^-8
  *
  * SOLUTIONS:
  *
  * 1. Stable Reformulation (Citardauq Formula):
  *    Compute one root with good formula, use Vieta's relation for other:
- *      x₁·x₂ = c/a  →  x₂ = c/(a·x₁)
+ *      x1*x2 = c/a  ->  x2 = c/(a*x1)
  *
  * 2. Adaptive Precision (ereal):
  *    Use the simple formula with adaptive precision arithmetic!
@@ -120,7 +120,7 @@ namespace sw { namespace universal {
 			x1 = (-b + sqrt_disc) / (two * a);
 		}
 
-		// Use Vieta's formula: x₁·x₂ = c/a  →  x₂ = c/(a·x₁)
+		// Use Vieta's formula: x1*x2 = c/a  ->  x2 = c/(a*x1)
 		Real x2 = c / (a * x1);
 
 		return { x1, x2 };
@@ -145,8 +145,8 @@ namespace sw { namespace universal {
 	                  const Real& a, const Real& b, const Real& c,
 	                  const Real& x1, const Real& x2) {
 		// Vieta's formulas:
-		// x₁ + x₂ = -b/a
-		// x₁·x₂ = c/a
+		// x1 + x2 = -b/a
+		// x1*x2 = c/a
 
 		Real sum = x1 + x2;
 		Real product = x1 * x2;
@@ -157,10 +157,10 @@ namespace sw { namespace universal {
 		double product_error = std::abs(double(product) - double(expected_product)) / std::abs(double(expected_product));
 
 		std::cout << "  " << std::setw(20) << std::left << method << " Vieta's check:\n";
-		std::cout << "    x₁ + x₂ = " << std::setw(20) << double(sum)
+		std::cout << "    x1 + x2 = " << std::setw(20) << double(sum)
 		          << " (expected: " << double(expected_sum) << ", rel error: "
 		          << std::setprecision(2) << std::scientific << sum_error << ")\n";
-		std::cout << "    x₁·x₂   = " << std::setw(20) << double(product)
+		std::cout << "    x1*x2   = " << std::setw(20) << double(product)
 		          << " (expected: " << double(expected_product) << ", rel error: "
 		          << product_error << ")\n";
 		std::cout << std::defaultfloat;
@@ -173,9 +173,9 @@ namespace sw { namespace universal {
 	void run_test_case(const QuadraticTest& test) {
 		std::cout << "========================================================\n";
 		std::cout << "Test: " << test.description << "\n";
-		std::cout << "Equation: " << test.a << "x² + " << test.b << "x + " << test.c << " = 0\n";
-		std::cout << "True roots: x₁ = " << std::setprecision(17) << test.true_x1
-		          << ", x₂ = " << test.true_x2 << "\n";
+		std::cout << "Equation: " << test.a << "x^2 + " << test.b << "x + " << test.c << " = 0\n";
+		std::cout << "True roots: x1 = " << std::setprecision(17) << test.true_x1
+		          << ", x2 = " << test.true_x2 << "\n";
 		std::cout << "========================================================\n\n";
 
 		// Test 1: Double precision (naive)
@@ -186,9 +186,9 @@ namespace sw { namespace universal {
 			double error_x1 = std::abs(x1 - test.true_x1) / std::abs(test.true_x1);
 			double error_x2 = std::abs(x2 - test.true_x2) / std::abs(test.true_x2);
 
-			std::cout << "  x₁ = " << std::setw(20) << x1 << " (rel error: "
+			std::cout << "  x1 = " << std::setw(20) << x1 << " (rel error: "
 			          << std::setprecision(2) << std::scientific << error_x1 << ")\n";
-			std::cout << "  x₂ = " << std::setw(20) << x2 << " (rel error: "
+			std::cout << "  x2 = " << std::setw(20) << x2 << " (rel error: "
 			          << error_x2 << ")\n";
 			std::cout << std::defaultfloat;
 
@@ -204,9 +204,9 @@ namespace sw { namespace universal {
 			double error_x1 = std::abs(x1 - test.true_x1) / std::abs(test.true_x1);
 			double error_x2 = std::abs(x2 - test.true_x2) / std::abs(test.true_x2);
 
-			std::cout << "  x₁ = " << std::setw(20) << std::setprecision(17) << x1
+			std::cout << "  x1 = " << std::setw(20) << std::setprecision(17) << x1
 			          << " (rel error: " << std::setprecision(2) << std::scientific << error_x1 << ")\n";
-			std::cout << "  x₂ = " << std::setw(20) << std::setprecision(17) << x2
+			std::cout << "  x2 = " << std::setw(20) << std::setprecision(17) << x2
 			          << " (rel error: " << error_x2 << ")\n";
 			std::cout << std::defaultfloat;
 
@@ -227,11 +227,11 @@ namespace sw { namespace universal {
 			double error_x1 = std::abs(x1_val - test.true_x1) / std::abs(test.true_x1);
 			double error_x2 = std::abs(x2_val - test.true_x2) / std::abs(test.true_x2);
 
-			std::cout << "  x₁ = " << std::setw(20) << std::setprecision(17) << x1_val
+			std::cout << "  x1 = " << std::setw(20) << std::setprecision(17) << x1_val
 			          << " (rel error: " << std::setprecision(2) << std::scientific << error_x1 << ")\n";
-			std::cout << "  x₂ = " << std::setw(20) << std::setprecision(17) << x2_val
+			std::cout << "  x2 = " << std::setw(20) << std::setprecision(17) << x2_val
 			          << " (rel error: " << error_x2 << ")\n";
-			std::cout << "  x₁ components: " << x1.limbs().size() << ", x₂ components: " << x2.limbs().size() << "\n";
+			std::cout << "  x1 components: " << x1.limbs().size() << ", x2 components: " << x2.limbs().size() << "\n";
 			std::cout << std::defaultfloat;
 
 			verify_vieta("ereal (naive)", a, b, c, x1, x2);
@@ -266,33 +266,33 @@ try {
 		// Test 1: Mild cancellation
 		{
 			1.0, 1000.0, 1.0,
-			"Mild cancellation (b² moderately larger than 4ac)",
-			-999.999001,  // x₁ (larger root in magnitude)
-			-0.001000001  // x₂ (smaller root)
+			"Mild cancellation (b^2 moderately larger than 4ac)",
+			-999.999001,  // x1 (larger root in magnitude)
+			-0.001000001  // x2 (smaller root)
 		},
 
 		// Test 2: Severe cancellation
 		{
 			1.0, 1.0e8, 1.0,
-			"Severe cancellation (b² >> 4ac)",
-			-100000000.0,     // x₁
-			-1.0e-8           // x₂ (very small - lost in double precision)
+			"Severe cancellation (b^2 >> 4ac)",
+			-100000000.0,     // x1
+			-1.0e-8           // x2 (very small - lost in double precision)
 		},
 
 		// Test 3: Extreme cancellation
 		{
 			1.0, 1.0e15, 1.0,
 			"Extreme cancellation (at double precision limit)",
-			-1.0e15,          // x₁
-			-1.0e-15          // x₂ (catastrophically lost in double)
+			-1.0e15,          // x1
+			-1.0e-15          // x2 (catastrophically lost in double)
 		},
 
 		// Test 4: Near-equal roots (challenging for any method)
 		{
 			1.0, 10000.0, 9999.0,
-			"Near-equal roots (b² - 4ac is small)",
-			-9999.00010000,  // x₁ (larger root in magnitude)
-			-0.99990000      // x₂ (smaller root)
+			"Near-equal roots (b^2 - 4ac is small)",
+			-9999.00010000,  // x1 (larger root in magnitude)
+			-0.99990000      // x2 (smaller root)
 		}
 	};
 

--- a/applications/precision/numeric/solvetest.cpp
+++ b/applications/precision/numeric/solvetest.cpp
@@ -258,17 +258,17 @@ try {
     
     // std::cout << v*(v.transpose()) << std::endl;  // <------ BUG HERE
     
-    std::fixed – Fixed Floating-point notation : 
+    std::fixed - Fixed Floating-point notation : 
     It writes floating-point values in fixed-point notation. 
     The value is represented with exactly as many digits in the decimal part as 
     specified by the precision field (precision) and with no exponent part.
 
-    std::scientific – Scientific floating-point notation : 
+    std::scientific - Scientific floating-point notation : 
     It writes floating-point values in Scientific-point notation. 
     The value is represented always with only one digit before the decimal point, 
     followed by the decimal point and as many decimal digits as the precision field (precision). 
     Finally, this notation always includes an exponential part consisting on the 
-    letter “e” followed by an optional sign and three exponential digits.
+    letter "e" followed by an optional sign and three exponential digits.
 
     */ 
 

--- a/benchmark/energy/hw_counters/rapl_measurement.cpp
+++ b/benchmark/energy/hw_counters/rapl_measurement.cpp
@@ -254,7 +254,7 @@ try {
     std::cout << "2. Cost models estimate MARGINAL per-operation energy (picojoules)\n";
     std::cout << "3. Use cost models for: comparing precisions, algorithm design decisions\n";
     std::cout << "4. Use RAPL for: measuring actual system energy, validating optimizations\n";
-    std::cout << "5. Memory access dominates: 1 DRAM read ≈ 400 FP32 FMAs in energy\n";
+    std::cout << "5. Memory access dominates: 1 DRAM read ~= 400 FP32 FMAs in energy\n";
 
     return EXIT_SUCCESS;
 }

--- a/benchmark/energy/instrumented/instrumented_energy.cpp
+++ b/benchmark/energy/instrumented/instrumented_energy.cpp
@@ -182,7 +182,7 @@ void demonstrateMatvec() {
         double energy_pj = calculateEnergy(stats, model, BitWidth::bits_32);
 
         std::cout << "  Operations: " << stats.add << " adds, " << stats.mul << " muls\n";
-        std::cout << "  Expected: " << (N * N) << " adds, " << (N * N) << " muls (O(n²))\n";
+        std::cout << "  Expected: " << (N * N) << " adds, " << (N * N) << " muls (O(n^2))\n";
         std::cout << "  Energy: " << std::fixed << std::setprecision(2)
                   << (energy_pj / 1000.0) << " nJ\n\n";
     }
@@ -265,11 +265,11 @@ void demonstratePolynomialEval() {
     std::cout << "Polynomial Evaluation (Horner's Method)\n";
     std::cout << "========================================\n\n";
 
-    // Evaluate p(x) = 1 + 2x + 3x² + 4x³ + 5x⁴ + 6x⁵
+    // Evaluate p(x) = 1 + 2x + 3x^2 + 4x^3 + 5x^4 + 6x^5
     std::vector<float> coeffs_f = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
     float x_val = 0.5f;
 
-    std::cout << "Polynomial: 1 + 2x + 3x² + 4x³ + 5x⁴ + 6x⁵\n";
+    std::cout << "Polynomial: 1 + 2x + 3x^2 + 4x^3 + 5x^4 + 6x^5\n";
     std::cout << "Evaluating at x = " << x_val << "\n\n";
 
     // --- Float ---

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,4 +1,4 @@
-# Universal Numbers Library — development image for Docker Hub.
+# Universal Numbers Library -- development image for Docker Hub.
 #
 # Provides a ready-to-use C++ development environment with the Universal
 # library installed, compilers, cmake, and command-line inspection tools.
@@ -18,7 +18,7 @@
 #   EOF
 #   g++ -std=c++20 -o hello hello.cpp && ./hello
 
-# ── Stage 1: build command-line tools ───────────────────────────────
+# -- Stage 1: build command-line tools -------------------------------
 FROM ubuntu:24.04 AS builder
 
 RUN apt-get update \
@@ -38,7 +38,7 @@ RUN cmake -S /tmp/universal-src -B /tmp/universal-build -G Ninja \
  && cmake --install /tmp/universal-build --prefix /usr/local \
  && rm -rf /tmp/universal-src /tmp/universal-build
 
-# ── Stage 2: minimal runtime image ─────────────────────────────────
+# -- Stage 2: minimal runtime image ---------------------------------
 FROM ubuntu:24.04
 
 # Install only what's needed: compiler for user code, cmake for builds.

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -23,12 +23,12 @@ const SITE = join(DOCS, 'site');       // Starlight-native pages
 const OUT = join(import.meta.dirname, 'src', 'content', 'docs');
 const BASE = '/universal';  // Astro base path
 
-// ── Source maps ────────────────────────────────────────────────────
+// -- Source maps ----------------------------------------------------
 
 /** Map from source path (relative to docs/) -> destination path (relative to content/docs/).
  *  These files get frontmatter prepended and links rewritten. */
 const FILE_MAP = {
-  // ── Number Systems ──────────────────────────────────────────────
+  // -- Number Systems ----------------------------------------------
   'number-systems/README.md': 'number-systems/index.md',
   'number-systems/integer.md': 'number-systems/integer.md',
   'number-systems/fixpnt.md': 'number-systems/fixpnt.md',
@@ -65,13 +65,13 @@ const FILE_MAP = {
   'number-systems/qd_cascade.md': 'number-systems/qd-cascade.md',
   'number-systems/complex.md': 'number-systems/complex.md',
 
-  // ── ucalc ──────────────────────────────────────────────────────
+  // -- ucalc ------------------------------------------------------
   'ucalc/README.md': 'ucalc/index.md',
   'ucalc/examples.md': 'ucalc/examples.md',
   'ucalc/step-by-step.md': 'ucalc/step-by-step.md',
   'ucalc/mcp-server.md': 'ucalc/mcp-server.md',
 
-  // ── Tutorials ───────────────────────────────────────────────────
+  // -- Tutorials ---------------------------------------------------
   'command-line-tools.md': 'getting-started/command-line-tools.md',
   'tutorials/type-parameterization.md': 'tutorials/type-parameterization.md',
   'tutorials/posit-refinement.md': 'tutorials/posit-refinement.md',
@@ -80,20 +80,20 @@ const FILE_MAP = {
   'tutorials/multi-component.md': 'tutorials/multi-component.md',
   'tutorials/ucalc-repl.md': 'tutorials/ucalc-repl.md',
 
-  // ── Mixed Precision ────────────────────────────────────────────
+  // -- Mixed Precision --------------------------------------------
   'mixed-precision-methodology.md': 'mixed-precision/methodology.md',
   'mixed-precision-sdk.md': 'mixed-precision/sdk.md',
   'mixed-precision-utilities.md': 'mixed-precision/utilities.md',
   'block-formats.md': 'mixed-precision/block-formats.md',
 
-  // ── Algorithmic Details ────────────────────────────────────────
+  // -- Algorithmic Details ----------------------------------------
   // (the section landing page comes from docs/site/algorithmic-details/index.md
   // via SITE_FILES below; the README.md in docs/algorithmic-details/ is for
   // GitHub directory view only.)
   'algorithmic-details/lns-log-add-sub.md': 'algorithmic-details/lns-log-add-sub.md',
   'algorithmic-details/multi-component-arithmetic.md': 'algorithmic-details/multi-component-arithmetic.md',
 
-  // ── Design ─────────────────────────────────────────────────────
+  // -- Design -----------------------------------------------------
   'multi-limb-arithmetic.md': 'design/multi-limb.md',
   'floatcascade-design.md': 'design/floatcascade.md',
   'design/error-propagation-design.md': 'design/error-propagation.md',
@@ -102,16 +102,16 @@ const FILE_MAP = {
   'decimal_conversion.md': 'design/decimal-conversion.md',
   'ereal_limb_limit_derivation.md': 'design/ereal_limb_limit.md',
 
-  // ── Build & Install ────────────────────────────────────────────
+  // -- Build & Install --------------------------------------------
   'cross-compilation.md': 'build/cross-compilation.md',
   'code-formatting.md': 'build/code-formatting.md',
   'troubleshooting.md': 'build/troubleshooting.md',
   'linux-packages.md': 'build/linux-packages.md',
 
-  // ── Exact Arithmetic ──────────────────────────────────────────
+  // -- Exact Arithmetic ------------------------------------------
   'the-kulisch-super-accumulator.md': 'exact-arithmetic/kulisch-super-accumulator.md',
 
-  // ── Contributing ───────────────────────────────────────────────
+  // -- Contributing -----------------------------------------------
   'RELEASE_PROCESS.md': 'contributing/release-process.md',
 };
 
@@ -142,7 +142,7 @@ const SITE_FILES = {
   'resources/presentations.md':     'resources/presentations.md',
 };
 
-// ── Link rewriting ─────────────────────────────────────────────────
+// -- Link rewriting -------------------------------------------------
 
 /**
  * Build a lookup from source .md path (relative to docs/) -> Starlight clean URL slug.
@@ -239,7 +239,7 @@ function copySiteFile(srcPath, destRelative) {
   cpSync(srcPath, destPath);
 }
 
-// ── Main ──────────────────────────────────────────────────────────
+// -- Main ----------------------------------------------------------
 
 // Clear stale Astro data store cache
 const astroCache = join(import.meta.dirname, 'node_modules', '.astro');

--- a/docs/design/error_tracker_sketch.hpp
+++ b/docs/design/error_tracker_sketch.hpp
@@ -452,7 +452,7 @@ public:
         double exact = shadow_ + rhs.shadow_;
 
         // Error in LNS addition depends on the ratio of operands
-        // When a ≈ -b, we have catastrophic cancellation
+        // When a ~= -b, we have catastrophic cancellation
         double ratio = shadow_ / rhs.shadow_;
         double cancellation_factor = 1.0;
         if (ratio < 0 && std::abs(1.0 + ratio) < 0.1) {

--- a/docs/session-notes/mixed-precision-status.txt
+++ b/docs/session-notes/mixed-precision-status.txt
@@ -1,21 +1,21 @@
-● Done. Energy cost models committed and pushed (e25687f9).
+* Done. Energy cost models committed and pushed (e25687f9).
 
   Summary of implementation:
-  ┌───────────────────────────────────────────────────────────┬───────────────────────────────────────┐
-  │                           File                            │              Description              │
-  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────┤
-  │ include/sw/universal/energy/energy.hpp                    │ Main interface, EnergyEstimator class │
-  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────┤
-  │ include/sw/universal/energy/cost_models/energy_model.hpp  │ Base types and enums                  │
-  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────┤
-  │ include/sw/universal/energy/cost_models/generic_45nm.hpp  │ Baseline Horowitz data                │
-  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────┤
-  │ include/sw/universal/energy/cost_models/intel_skylake.hpp │ 14nm desktop/server                   │
-  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────┤
-  │ include/sw/universal/energy/cost_models/arm_cortex_a.hpp  │ 7nm mobile (A76 + A55)                │
-  ├───────────────────────────────────────────────────────────┼───────────────────────────────────────┤
-  │ benchmark/energy/models/energy_models.cpp                 │ Test and demo                         │
-  └───────────────────────────────────────────────────────────┴───────────────────────────────────────┘
+  +-----------------------------------------------------------+---------------------------------------+
+  |                           File                            |              Description              |
+  +-----------------------------------------------------------+---------------------------------------+
+  | include/sw/universal/energy/energy.hpp                    | Main interface, EnergyEstimator class |
+  +-----------------------------------------------------------+---------------------------------------+
+  | include/sw/universal/energy/cost_models/energy_model.hpp  | Base types and enums                  |
+  +-----------------------------------------------------------+---------------------------------------+
+  | include/sw/universal/energy/cost_models/generic_45nm.hpp  | Baseline Horowitz data                |
+  +-----------------------------------------------------------+---------------------------------------+
+  | include/sw/universal/energy/cost_models/intel_skylake.hpp | 14nm desktop/server                   |
+  +-----------------------------------------------------------+---------------------------------------+
+  | include/sw/universal/energy/cost_models/arm_cortex_a.hpp  | 7nm mobile (A76 + A55)                |
+  +-----------------------------------------------------------+---------------------------------------+
+  | benchmark/energy/models/energy_models.cpp                 | Test and demo                         |
+  +-----------------------------------------------------------+---------------------------------------+
   Key results from the benchmark:
 
   32-bit FP FMA energy (pJ):
@@ -30,11 +30,11 @@
     8-bit vs 64-bit:  26.5x savings
 
   This addresses the P1 item from the roadmap. Next steps would be:
-  - P1.2: Extend occurrence.hpp → occurrence_with_energy.hpp
+  - P1.2: Extend occurrence.hpp -> occurrence_with_energy.hpp
   - P2.3: RAPL integration for actual energy measurement
 
 
-● RAPL can be accessed without external library dependencies. Here are the options:
+* RAPL can be accessed without external library dependencies. Here are the options:
 
   Option 1: Powercap sysfs (Recommended - Zero Dependencies)
 
@@ -42,7 +42,7 @@
   // Example: /sys/class/powercap/intel-rapl/intel-rapl:0/energy_uj
 
   Requirements:
-  - Linux kernel ≥3.13 (standard on any modern system)
+  - Linux kernel >=3.13 (standard on any modern system)
   - Read permission on /sys/class/powercap/ (usually available to all users)
   - No external libraries - just standard C++ file I/O
 
@@ -53,7 +53,7 @@
 
   Requirements:
   - Linux kernel headers (<linux/perf_event.h>)
-  - perf_event_paranoid sysctl ≤2 (or CAP_PERFMON)
+  - perf_event_paranoid sysctl <=2 (or CAP_PERFMON)
   - No external libraries
 
   Option 3: Direct MSR (No Dependencies, but Root)
@@ -80,20 +80,20 @@
   };
 
   Trade-offs:
-  ┌────────────────┬──────────────┬────────────────┬───────────────────┐
-  │     Method     │ Dependencies │  Permissions   │     Platforms     │
-  ├────────────────┼──────────────┼────────────────┼───────────────────┤
-  │ Powercap sysfs │ None         │ Usually user   │ Linux + Intel/AMD │
-  ├────────────────┼──────────────┼────────────────┼───────────────────┤
-  │ perf_event     │ None         │ sysctl setting │ Linux + Intel/AMD │
-  ├────────────────┼──────────────┼────────────────┼───────────────────┤
-  │ MSR direct     │ None         │ Root           │ Linux + Intel     │
-  ├────────────────┼──────────────┼────────────────┼───────────────────┤
-  │ PAPI library   │ libpapi      │ User           │ Cross-platform    │
-  └────────────────┴──────────────┴────────────────┴───────────────────┘
+  +----------------+--------------+----------------+-------------------+
+  |     Method     | Dependencies |  Permissions   |     Platforms     |
+  +----------------+--------------+----------------+-------------------+
+  | Powercap sysfs | None         | Usually user   | Linux + Intel/AMD |
+  +----------------+--------------+----------------+-------------------+
+  | perf_event     | None         | sysctl setting | Linux + Intel/AMD |
+  +----------------+--------------+----------------+-------------------+
+  | MSR direct     | None         | Root           | Linux + Intel     |
+  +----------------+--------------+----------------+-------------------+
+  | PAPI library   | libpapi      | User           | Cross-platform    |
+  +----------------+--------------+----------------+-------------------+
 
 
-● All RAPL components are implemented and tested. Summary of changes:
+* All RAPL components are implemented and tested. Summary of changes:
 
   Files created:
   - include/sw/universal/energy/hw_counters/rapl.hpp - RAPL reader with Linux powercap sysfs implementation and platform stubs
@@ -152,55 +152,55 @@ Instructions how to run the energy tests, and a report on the energy module.
 
 ```test
   Components
-  ┌────────────────────┬──────────────────────────────┬─────────────────────────────────────────────────────┐
-  │     Component      │             File             │                       Purpose                       │
-  ├────────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────┤
-  │ Energy Cost Models │ energy/cost_models/*.hpp     │ Per-operation energy estimates (pJ) by architecture │
-  ├────────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────┤
-  │ Energy Estimator   │ energy/energy.hpp            │ Accumulate energy for sequences of operations       │
-  ├────────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────┤
-  │ Occurrence Energy  │ energy/occurrence_energy.hpp │ Integrate operation counting with energy estimation │
-  ├────────────────────┼──────────────────────────────┼─────────────────────────────────────────────────────┤
-  │ RAPL Reader        │ energy/hw_counters/rapl.hpp  │ Hardware energy measurement (Linux/Intel/AMD)       │
-  └────────────────────┴──────────────────────────────┴─────────────────────────────────────────────────────┘
+  +--------------------+------------------------------+-----------------------------------------------------+
+  |     Component      |             File             |                       Purpose                       |
+  +--------------------+------------------------------+-----------------------------------------------------+
+  | Energy Cost Models | energy/cost_models/*.hpp     | Per-operation energy estimates (pJ) by architecture |
+  +--------------------+------------------------------+-----------------------------------------------------+
+  | Energy Estimator   | energy/energy.hpp            | Accumulate energy for sequences of operations       |
+  +--------------------+------------------------------+-----------------------------------------------------+
+  | Occurrence Energy  | energy/occurrence_energy.hpp | Integrate operation counting with energy estimation |
+  +--------------------+------------------------------+-----------------------------------------------------+
+  | RAPL Reader        | energy/hw_counters/rapl.hpp  | Hardware energy measurement (Linux/Intel/AMD)       |
+  +--------------------+------------------------------+-----------------------------------------------------+
   Supported Architectures
-  ┌────────────────┬─────────┬──────────────────────────────────────────┐
-  │     Model      │ Process │                 Use Case                 │
-  ├────────────────┼─────────┼──────────────────────────────────────────┤
-  │ Generic 45nm   │ 45nm    │ Baseline reference (Horowitz ISSCC 2014) │
-  ├────────────────┼─────────┼──────────────────────────────────────────┤
-  │ Intel Skylake  │ 14nm    │ Desktop/server x86-64                    │
-  ├────────────────┼─────────┼──────────────────────────────────────────┤
-  │ ARM Cortex-A76 │ 7nm     │ Mobile high-performance (big cores)      │
-  ├────────────────┼─────────┼──────────────────────────────────────────┤
-  │ ARM Cortex-A55 │ 7nm     │ Mobile efficiency (LITTLE cores)         │
-  └────────────────┴─────────┴──────────────────────────────────────────┘
+  +----------------+---------+------------------------------------------+
+  |     Model      | Process |                 Use Case                 |
+  +----------------+---------+------------------------------------------+
+  | Generic 45nm   | 45nm    | Baseline reference (Horowitz ISSCC 2014) |
+  +----------------+---------+------------------------------------------+
+  | Intel Skylake  | 14nm    | Desktop/server x86-64                    |
+  +----------------+---------+------------------------------------------+
+  | ARM Cortex-A76 | 7nm     | Mobile high-performance (big cores)      |
+  +----------------+---------+------------------------------------------+
+  | ARM Cortex-A55 | 7nm     | Mobile efficiency (LITTLE cores)         |
+  +----------------+---------+------------------------------------------+
   Energy Scaling by Precision (Intel Skylake, FMA operation)
-  ┌───────────┬─────────────┬─────────────────┬─────────────────┐
-  │ Precision │ Energy (pJ) │ Savings vs FP32 │ Savings vs FP64 │
-  ├───────────┼─────────────┼─────────────────┼─────────────────┤
-  │ 8-bit     │ 0.20        │ 7.5x            │ 26.5x           │
-  ├───────────┼─────────────┼─────────────────┼─────────────────┤
-  │ 16-bit    │ 0.47        │ 3.2x            │ 11.3x           │
-  ├───────────┼─────────────┼─────────────────┼─────────────────┤
-  │ 32-bit    │ 1.50        │ 1.0x            │ 3.5x            │
-  ├───────────┼─────────────┼─────────────────┼─────────────────┤
-  │ 64-bit    │ 5.30        │ 0.28x           │ 1.0x            │
-  └───────────┴─────────────┴─────────────────┴─────────────────┘
+  +-----------+-------------+-----------------+-----------------+
+  | Precision | Energy (pJ) | Savings vs FP32 | Savings vs FP64 |
+  +-----------+-------------+-----------------+-----------------+
+  | 8-bit     | 0.20        | 7.5x            | 26.5x           |
+  +-----------+-------------+-----------------+-----------------+
+  | 16-bit    | 0.47        | 3.2x            | 11.3x           |
+  +-----------+-------------+-----------------+-----------------+
+  | 32-bit    | 1.50        | 1.0x            | 3.5x            |
+  +-----------+-------------+-----------------+-----------------+
+  | 64-bit    | 5.30        | 0.28x           | 1.0x            |
+  +-----------+-------------+-----------------+-----------------+
   Memory Hierarchy Energy (Intel Skylake)
-  ┌──────────┬─────────────┬──────────────────────┐
-  │  Level   │ Energy (pJ) │ Relative to Register │
-  ├──────────┼─────────────┼──────────────────────┤
-  │ Register │ 0.33        │ 1x                   │
-  ├──────────┼─────────────┼──────────────────────┤
-  │ L1 Cache │ 3.3         │ 10x                  │
-  ├──────────┼─────────────┼──────────────────────┤
-  │ L2 Cache │ 17          │ 51x                  │
-  ├──────────┼─────────────┼──────────────────────┤
-  │ L3 Cache │ 66          │ 200x                 │
-  ├──────────┼─────────────┼──────────────────────┤
-  │ DRAM     │ 650         │ 1970x                │
-  └──────────┴─────────────┴──────────────────────┘
+  +----------+-------------+----------------------+
+  |  Level   | Energy (pJ) | Relative to Register |
+  +----------+-------------+----------------------+
+  | Register | 0.33        | 1x                   |
+  +----------+-------------+----------------------+
+  | L1 Cache | 3.3         | 10x                  |
+  +----------+-------------+----------------------+
+  | L2 Cache | 17          | 51x                  |
+  +----------+-------------+----------------------+
+  | L3 Cache | 66          | 200x                 |
+  +----------+-------------+----------------------+
+  | DRAM     | 650         | 1970x                |
+  +----------+-------------+----------------------+
 ```
 
 ## Usage Example
@@ -241,13 +241,13 @@ compute AND memory bandwidth.
 
 ```text
   Summary: Two Different Energy Questions
-  ┌─────────────────────────────────────────────────┬─────────────┬──────────────────┬───────────────────────────────────────┐
-  │                    Question                     │    Tool     │      Units       │               Use Case                │
-  ├─────────────────────────────────────────────────┼─────────────┼──────────────────┼───────────────────────────────────────┤
-  │ "How much total energy did my program use?"     │ RAPL        │ microjoules (uJ) │ Power budgeting, battery life         │
-  ├─────────────────────────────────────────────────┼─────────────┼──────────────────┼───────────────────────────────────────┤
-  │ "How much more energy does FP64 use than FP16?" │ Cost Models │ ratios (3.5x)    │ Algorithm design, precision selection │
-  └─────────────────────────────────────────────────┴─────────────┴──────────────────┴───────────────────────────────────────┘
+  +-------------------------------------------------+-------------+------------------+---------------------------------------+
+  |                    Question                     |    Tool     |      Units       |               Use Case                |
+  +-------------------------------------------------+-------------+------------------+---------------------------------------+
+  | "How much total energy did my program use?"     | RAPL        | microjoules (uJ) | Power budgeting, battery life         |
+  +-------------------------------------------------+-------------+------------------+---------------------------------------+
+  | "How much more energy does FP64 use than FP16?" | Cost Models | ratios (3.5x)    | Algorithm design, precision selection |
+  +-------------------------------------------------+-------------+------------------+---------------------------------------+
 ```
 
 The cost models answer: "If I switch from FP32 to FP16, what fraction of compute energy do I save?"
@@ -260,7 +260,7 @@ They're based on the physical reality that:
 The absolute values (picojoules) come from published silicon measurements, but the ratios are what matter for algorithm design decisions.
 
 
-● The current todo list (for the RAPL implementation) is complete:
+* The current todo list (for the RAPL implementation) is complete:
 
   - Create RAPL reader header with Linux guards
   - Add platform stubs for MacOS/Windows
@@ -270,47 +270,47 @@ The absolute values (picojoules) come from published silicon measurements, but t
 
   For the broader Mixed-Precision SDK roadmap (from docs/papers/implementation-roadmap.md), here's what remains:
 
-  Phase 1: Energy Cost Infrastructure - COMPLETE ✓
+  Phase 1: Energy Cost Infrastructure - COMPLETE OK
 
   - Energy cost tables (generic_45nm, intel_skylake, arm_cortex_a)
   - occurrence_energy.hpp integration
   - RAPL hardware measurement
 
   Phase 2: Analysis Tools - NOT STARTED
-  ┌──────┬────────────────────────────────────────────────────────────┬─────────┐
-  │ Item │                        Description                         │ Status  │
-  ├──────┼────────────────────────────────────────────────────────────┼─────────┤
-  │ P2.1 │ Range analyzer - track min/max/overflow per variable       │ Pending │
-  ├──────┼────────────────────────────────────────────────────────────┼─────────┤
-  │ P2.2 │ Type advisor - recommend precision based on range analysis │ Pending │
-  ├──────┼────────────────────────────────────────────────────────────┼─────────┤
-  │ P2.3 │ Memory access profiler - count L1/L2/L3/DRAM accesses      │ Pending │
-  └──────┴────────────────────────────────────────────────────────────┴─────────┘
+  +------+------------------------------------------------------------+---------+
+  | Item |                        Description                         | Status  |
+  +------+------------------------------------------------------------+---------+
+  | P2.1 | Range analyzer - track min/max/overflow per variable       | Pending |
+  +------+------------------------------------------------------------+---------+
+  | P2.2 | Type advisor - recommend precision based on range analysis | Pending |
+  +------+------------------------------------------------------------+---------+
+  | P2.3 | Memory access profiler - count L1/L2/L3/DRAM accesses      | Pending |
+  +------+------------------------------------------------------------+---------+
   Phase 3: Optimization Tools - NOT STARTED
-  ┌──────┬───────────────────────────────────────────────────────────┬─────────┐
-  │ Item │                        Description                        │ Status  │
-  ├──────┼───────────────────────────────────────────────────────────┼─────────┤
-  │ P3.1 │ Algorithm profiler - combine occurrence + energy + range  │ Pending │
-  ├──────┼───────────────────────────────────────────────────────────┼─────────┤
-  │ P3.2 │ Pareto explorer - find accuracy/energy trade-off frontier │ Pending │
-  ├──────┼───────────────────────────────────────────────────────────┼─────────┤
-  │ P3.3 │ Mixed-precision code generator                            │ Pending │
-  └──────┴───────────────────────────────────────────────────────────┴─────────┘
+  +------+-----------------------------------------------------------+---------+
+  | Item |                        Description                        | Status  |
+  +------+-----------------------------------------------------------+---------+
+  | P3.1 | Algorithm profiler - combine occurrence + energy + range  | Pending |
+  +------+-----------------------------------------------------------+---------+
+  | P3.2 | Pareto explorer - find accuracy/energy trade-off frontier | Pending |
+  +------+-----------------------------------------------------------+---------+
+  | P3.3 | Mixed-precision code generator                            | Pending |
+  +------+-----------------------------------------------------------+---------+
   Would you like to continue with Phase 2, or is there something else you'd like to work on?
 
 ## Phase 2 Complete
 
 ```text
   Phase 2 Summary - Analysis Tools
-  ┌──────────────────────┬──────────────────────────────────────────────────┬──────────┐
-  │         Task         │                       File                       │  Status  │
-  ├──────────────────────┼──────────────────────────────────────────────────┼──────────┤
-  │ P2.1 Range Analyzer  │ include/sw/universal/utility/range_analyzer.hpp  │ Complete │
-  ├──────────────────────┼──────────────────────────────────────────────────┼──────────┤
-  │ P2.2 Type Advisor    │ include/sw/universal/utility/type_advisor.hpp    │ Complete │
-  ├──────────────────────┼──────────────────────────────────────────────────┼──────────┤
-  │ P2.3 Memory Profiler │ include/sw/universal/utility/memory_profiler.hpp │ Complete │
-  └──────────────────────┴──────────────────────────────────────────────────┴──────────┘
+  +----------------------+--------------------------------------------------+----------+
+  |         Task         |                       File                       |  Status  |
+  +----------------------+--------------------------------------------------+----------+
+  | P2.1 Range Analyzer  | include/sw/universal/utility/range_analyzer.hpp  | Complete |
+  +----------------------+--------------------------------------------------+----------+
+  | P2.2 Type Advisor    | include/sw/universal/utility/type_advisor.hpp    | Complete |
+  +----------------------+--------------------------------------------------+----------+
+  | P2.3 Memory Profiler | include/sw/universal/utility/memory_profiler.hpp | Complete |
+  +----------------------+--------------------------------------------------+----------+
 ```
 
 Commits Made
@@ -337,58 +337,58 @@ Memory Profiler - Estimates cache/DRAM energy:
   - Shows that FP16 vs FP32 can give 8x memory energy savings
 
   Next Steps (Phase 3)
-  ┌──────┬───────────────────────────────────────────────────────────┐
-  │ Task │                        Description                        │
-  ├──────┼───────────────────────────────────────────────────────────┤
-  │ P3.1 │ Algorithm profiler - combine occurrence + energy + range  │
-  ├──────┼───────────────────────────────────────────────────────────┤
-  │ P3.2 │ Pareto explorer - find accuracy/energy trade-off frontier │
-  ├──────┼───────────────────────────────────────────────────────────┤
-  │ P3.3 │ Mixed-precision code generator                            │
-  └──────┴───────────────────────────────────────────────────────────┘
+  +------+-----------------------------------------------------------+
+  | Task |                        Description                        |
+  +------+-----------------------------------------------------------+
+  | P3.1 | Algorithm profiler - combine occurrence + energy + range  |
+  +------+-----------------------------------------------------------+
+  | P3.2 | Pareto explorer - find accuracy/energy trade-off frontier |
+  +------+-----------------------------------------------------------+
+  | P3.3 | Mixed-precision code generator                            |
+  +------+-----------------------------------------------------------+
   Would you like to continue with Phase 3?
 
 ## 
-● Phase 3 is complete. Here's a summary of all phases implemented:
+* Phase 3 is complete. Here's a summary of all phases implemented:
 
   Complete Mixed-Precision SDK Implementation
 
-  Phase 1: Energy Cost Infrastructure ✓
-  ┌──────────────────────────────────────┬─────────────────────────────┐
-  │                 File                 │           Purpose           │
-  ├──────────────────────────────────────┼─────────────────────────────┤
-  │ energy/cost_models/energy_model.hpp  │ Base energy model interface │
-  ├──────────────────────────────────────┼─────────────────────────────┤
-  │ energy/cost_models/generic_45nm.hpp  │ Generic 45nm baseline       │
-  ├──────────────────────────────────────┼─────────────────────────────┤
-  │ energy/cost_models/intel_skylake.hpp │ Intel Skylake 14nm          │
-  ├──────────────────────────────────────┼─────────────────────────────┤
-  │ energy/cost_models/arm_cortex_a.hpp  │ ARM Cortex-A76/A55 7nm      │
-  ├──────────────────────────────────────┼─────────────────────────────┤
-  │ energy/occurrence_energy.hpp         │ Operation counting + energy │
-  ├──────────────────────────────────────┼─────────────────────────────┤
-  │ energy/hw_counters/rapl.hpp          │ RAPL hardware measurement   │
-  └──────────────────────────────────────┴─────────────────────────────┘
-  Phase 2: Analysis Tools ✓
-  ┌─────────────────────────────┬───────────────────────────────────────┐
-  │            File             │                Purpose                │
-  ├─────────────────────────────┼───────────────────────────────────────┤
-  │ utility/range_analyzer.hpp  │ Track value ranges per variable       │
-  ├─────────────────────────────┼───────────────────────────────────────┤
-  │ utility/type_advisor.hpp    │ Recommend types based on requirements │
-  ├─────────────────────────────┼───────────────────────────────────────┤
-  │ utility/memory_profiler.hpp │ Model cache/DRAM energy               │
-  └─────────────────────────────┴───────────────────────────────────────┘
-  Phase 3: Optimization Tools ✓
-  ┌────────────────────────────────────────┬────────────────────────────────────┐
-  │                  File                  │              Purpose               │
-  ├────────────────────────────────────────┼────────────────────────────────────┤
-  │ utility/algorithm_profiler.hpp         │ Unified algorithm analysis         │
-  ├────────────────────────────────────────┼────────────────────────────────────┤
-  │ utility/pareto_explorer.hpp            │ Accuracy/energy trade-off frontier │
-  ├────────────────────────────────────────┼────────────────────────────────────┤
-  │ utility/precision_config_generator.hpp │ Generate config headers            │
-  └────────────────────────────────────────┴────────────────────────────────────┘
+  Phase 1: Energy Cost Infrastructure OK
+  +--------------------------------------+-----------------------------+
+  |                 File                 |           Purpose           |
+  +--------------------------------------+-----------------------------+
+  | energy/cost_models/energy_model.hpp  | Base energy model interface |
+  +--------------------------------------+-----------------------------+
+  | energy/cost_models/generic_45nm.hpp  | Generic 45nm baseline       |
+  +--------------------------------------+-----------------------------+
+  | energy/cost_models/intel_skylake.hpp | Intel Skylake 14nm          |
+  +--------------------------------------+-----------------------------+
+  | energy/cost_models/arm_cortex_a.hpp  | ARM Cortex-A76/A55 7nm      |
+  +--------------------------------------+-----------------------------+
+  | energy/occurrence_energy.hpp         | Operation counting + energy |
+  +--------------------------------------+-----------------------------+
+  | energy/hw_counters/rapl.hpp          | RAPL hardware measurement   |
+  +--------------------------------------+-----------------------------+
+  Phase 2: Analysis Tools OK
+  +-----------------------------+---------------------------------------+
+  |            File             |                Purpose                |
+  +-----------------------------+---------------------------------------+
+  | utility/range_analyzer.hpp  | Track value ranges per variable       |
+  +-----------------------------+---------------------------------------+
+  | utility/type_advisor.hpp    | Recommend types based on requirements |
+  +-----------------------------+---------------------------------------+
+  | utility/memory_profiler.hpp | Model cache/DRAM energy               |
+  +-----------------------------+---------------------------------------+
+  Phase 3: Optimization Tools OK
+  +----------------------------------------+------------------------------------+
+  |                  File                  |              Purpose               |
+  +----------------------------------------+------------------------------------+
+  | utility/algorithm_profiler.hpp         | Unified algorithm analysis         |
+  +----------------------------------------+------------------------------------+
+  | utility/pareto_explorer.hpp            | Accuracy/energy trade-off frontier |
+  +----------------------------------------+------------------------------------+
+  | utility/precision_config_generator.hpp | Generate config headers            |
+  +----------------------------------------+------------------------------------+
   Commits
 
   e4985609 Add RAPL hardware energy measurement via Linux powercap sysfs
@@ -501,35 +501,35 @@ Sample Output
 ## Mixed-Precision SDK Follow-up Roadmap
 
   Immediate Follow-ups (from SDK session)
-  ┌─────┬───────────────────────────┬────────────────────────────────────────────────────────┬────────────┐
-  │  #  │           Task            │                      Description                       │ Complexity │
-  ├─────┼───────────────────────────┼────────────────────────────────────────────────────────┼────────────┤
-  │ 1   │ occurrence Integration    │ Connect instrumented number types to energy estimation │ Medium     │
-  ├─────┼───────────────────────────┼────────────────────────────────────────────────────────┼────────────┤
-  │ 2   │ AMD Zen Model             │ Add AMD Zen 3/4 architecture energy costs              │ Low        │
-  ├─────┼───────────────────────────┼────────────────────────────────────────────────────────┼────────────┤
-  │ 3   │ Apple M-series Model      │ Add Apple M1/M2/M3 energy costs                        │ Low        │
-  ├─────┼───────────────────────────┼────────────────────────────────────────────────────────┼────────────┤
-  │ 4   │ Pareto + Memory Bandwidth │ Add memory bandwidth as 3rd optimization dimension     │ Medium     │
-  └─────┴───────────────────────────┴────────────────────────────────────────────────────────┴────────────┘
+  +-----+---------------------------+--------------------------------------------------------+------------+
+  |  #  |           Task            |                      Description                       | Complexity |
+  +-----+---------------------------+--------------------------------------------------------+------------+
+  | 1   | occurrence Integration    | Connect instrumented number types to energy estimation | Medium     |
+  +-----+---------------------------+--------------------------------------------------------+------------+
+  | 2   | AMD Zen Model             | Add AMD Zen 3/4 architecture energy costs              | Low        |
+  +-----+---------------------------+--------------------------------------------------------+------------+
+  | 3   | Apple M-series Model      | Add Apple M1/M2/M3 energy costs                        | Low        |
+  +-----+---------------------------+--------------------------------------------------------+------------+
+  | 4   | Pareto + Memory Bandwidth | Add memory bandwidth as 3rd optimization dimension     | Medium     |
+  +-----+---------------------------+--------------------------------------------------------+------------+
   Future Enhancements
-  ┌─────┬─────────────────────────────┬──────────────────────────────────────────────────────────────┬────────────┐
-  │  #  │            Task             │                         Description                          │ Complexity │
-  ├─────┼─────────────────────────────┼──────────────────────────────────────────────────────────────┼────────────┤
-  │ 5   │ Autotuning                  │ Automatically select precision per kernel based on profiling │ High       │
-  ├─────┼─────────────────────────────┼──────────────────────────────────────────────────────────────┼────────────┤
-  │ 6   │ Profile-guided Optimization │ Use RAPL measurements to refine energy models                │ Medium     │
-  ├─────┼─────────────────────────────┼──────────────────────────────────────────────────────────────┼────────────┤
-  │ 7   │ Mixed-precision BLAS        │ Apply recommendations to sw::universal::blas                 │ High       │
-  └─────┴─────────────────────────────┴──────────────────────────────────────────────────────────────┴────────────┘
+  +-----+-----------------------------+--------------------------------------------------------------+------------+
+  |  #  |            Task             |                         Description                          | Complexity |
+  +-----+-----------------------------+--------------------------------------------------------------+------------+
+  | 5   | Autotuning                  | Automatically select precision per kernel based on profiling | High       |
+  +-----+-----------------------------+--------------------------------------------------------------+------------+
+  | 6   | Profile-guided Optimization | Use RAPL measurements to refine energy models                | Medium     |
+  +-----+-----------------------------+--------------------------------------------------------------+------------+
+  | 7   | Mixed-precision BLAS        | Apply recommendations to sw::universal::blas                 | High       |
+  +-----+-----------------------------+--------------------------------------------------------------+------------+
   Position Paper Support (from gap analysis)
-  ┌─────┬───────────────────────────┬────────────────────────────────────────────────────────────┬──────────┐
-  │  #  │           Task            │                        Description                         │ Priority │
-  ├─────┼───────────────────────────┼────────────────────────────────────────────────────────────┼──────────┤
-  │ 8   │ Methodology Documentation │ Precision selection guidelines, error propagation patterns │ High     │
-  ├─────┼───────────────────────────┼────────────────────────────────────────────────────────────┼──────────┤
-  │ 9   │ Embodied AI Examples      │ Robotics pipeline (perception → planning → control)        │ Critical │
-  └─────┴───────────────────────────┴────────────────────────────────────────────────────────────┴──────────┘
+  +-----+---------------------------+------------------------------------------------------------+----------+
+  |  #  |           Task            |                        Description                         | Priority |
+  +-----+---------------------------+------------------------------------------------------------+----------+
+  | 8   | Methodology Documentation | Precision selection guidelines, error propagation patterns | High     |
+  +-----+---------------------------+------------------------------------------------------------+----------+
+  | 9   | Embodied AI Examples      | Robotics pipeline (perception -> planning -> control)        | Critical |
+  +-----+---------------------------+------------------------------------------------------------+----------+
   ---
   Current infrastructure:
   - occurrence.hpp - Basic operation counting (load, store, add, sub, mul, div, rem, sqrt)
@@ -538,7 +538,7 @@ Sample Output
 
   Which area would you like to start with?
 
-● I've completed three follow-up tasks from the SDK session. Here's a summary:
+* I've completed three follow-up tasks from the SDK session. Here's a summary:
 
   Completed Work
 
@@ -568,33 +568,33 @@ Sample Output
   62250e60 Document Mixed-Precision SDK implementation session
 
   Remaining Tasks
-  ┌──────────────────────────────────────────────┬──────────┐
-  │                     Task                     │ Priority │
-  ├──────────────────────────────────────────────┼──────────┤
-  │ Extend Pareto explorer with memory bandwidth │ Medium   │
-  ├──────────────────────────────────────────────┼──────────┤
-  │ Autotuning for precision selection           │ High     │
-  ├──────────────────────────────────────────────┼──────────┤
-  │ Profile-guided optimization using RAPL       │ Medium   │
-  ├──────────────────────────────────────────────┼──────────┤
-  │ Mixed-precision BLAS integration             │ High     │
-  ├──────────────────────────────────────────────┼──────────┤
-  │ Methodology documentation                    │ Medium   │
-  ├──────────────────────────────────────────────┼──────────┤
-  │ Embodied AI examples                         │ Critical │
-  └──────────────────────────────────────────────┴──────────┘
+  +----------------------------------------------+----------+
+  |                     Task                     | Priority |
+  +----------------------------------------------+----------+
+  | Extend Pareto explorer with memory bandwidth | Medium   |
+  +----------------------------------------------+----------+
+  | Autotuning for precision selection           | High     |
+  +----------------------------------------------+----------+
+  | Profile-guided optimization using RAPL       | Medium   |
+  +----------------------------------------------+----------+
+  | Mixed-precision BLAS integration             | High     |
+  +----------------------------------------------+----------+
+  | Methodology documentation                    | Medium   |
+  +----------------------------------------------+----------+
+  | Embodied AI examples                         | Critical |
+  +----------------------------------------------+----------+
   Would you like to continue with any of the remaining tasks?
 
 
-● All tasks are now complete. Let me update the todo list.
+* All tasks are now complete. Let me update the todo list.
 
-● All SDK follow-up tasks are now complete. Here's a summary of what was accomplished:
+* All SDK follow-up tasks are now complete. Here's a summary of what was accomplished:
 
   Completed SDK Follow-up Tasks
 
   1. Pareto Explorer with Memory Bandwidth (completed)
 
-  - Added 3D Pareto frontier: accuracy × energy × bandwidth
+  - Added 3D Pareto frontier: accuracy * energy * bandwidth
   - Added AlgorithmCharacteristics struct for algorithm profiling
   - Added roofline analysis and bandwidth-aware recommendations
 

--- a/education/interactive/expansion_algebra/expansion_algebra_tutorial.cpp
+++ b/education/interactive/expansion_algebra/expansion_algebra_tutorial.cpp
@@ -603,7 +603,7 @@ void lesson7_scaling() {
 
     std::cout << "\nLet's compute pi using different precisions:\n";
 
-    // Use Machin's formula: π/4 = 4*arctan(1/5) - arctan(1/239)
+    // Use Machin's formula: pi/4 = 4*arctan(1/5) - arctan(1/239)
     // (We'd need actual implementations of arctan, so we'll show the concept)
 
     std::cout << std::setprecision(17);
@@ -701,7 +701,7 @@ void lesson8_applications() {
     std::cout << "\nIterative refinement improves solution accuracy:\n";
     std::cout << "  1. Solve Ax = b in standard precision\n";
     std::cout << "  2. Compute residual r = b - Ax in extended precision\n";
-    std::cout << "  3. Solve correction equation: A·delta = r\n";
+    std::cout << "  3. Solve correction equation: A*delta = r\n";
     std::cout << "  4. Update: x := x + delta\n";
     std::cout << "  5. Repeat until convergence\n";
 

--- a/education/internal/multi_limb_performance.cpp
+++ b/education/internal/multi_limb_performance.cpp
@@ -51,8 +51,8 @@ void benchmark_arithmetic(const std::string& description, size_t iterations = 10
     auto add_duration = std::chrono::duration_cast<std::chrono::microseconds>(mid - start);
     auto mul_duration = std::chrono::duration_cast<std::chrono::microseconds>(end - mid);
 
-    std::cout << "  Addition (" << iterations << " ops): " << add_duration.count() << " μs\n";
-    std::cout << "  Multiplication (" << iterations/10 << " ops): " << mul_duration.count() << " μs\n";
+    std::cout << "  Addition (" << iterations << " ops): " << add_duration.count() << " us\n";
+    std::cout << "  Multiplication (" << iterations/10 << " ops): " << mul_duration.count() << " us\n";
     std::cout << "  Add throughput: " << (iterations * 1000000.0 / add_duration.count()) << " ops/sec\n";
     std::cout << "  Mul throughput: " << ((iterations/10) * 1000000.0 / mul_duration.count()) << " ops/sec\n";
     std::cout << std::endl;
@@ -155,8 +155,8 @@ int main() {
         auto time64 = std::chrono::duration_cast<std::chrono::microseconds>(end - mid);
 
         std::cout << "Array processing (1000 iterations on " << array_size << " elements):\n";
-        std::cout << "32-bit blocks: " << time32.count() << " μs\n";
-        std::cout << "64-bit blocks: " << time64.count() << " μs\n";
+        std::cout << "32-bit blocks: " << time32.count() << " us\n";
+        std::cout << "64-bit blocks: " << time64.count() << " us\n";
         std::cout << "Ratio (32/64): " << (double)time32.count() / time64.count() << "\n";
 
         // Prevent optimization
@@ -199,10 +199,10 @@ int main() {
     //    auto twos_time = std::chrono::duration_cast<std::chrono::microseconds>(end - mid);
 
     //    std::cout << "Shift operations (" << sig_iterations << " iterations):\n";
-    //    std::cout << "Ones encoding: " << ones_time.count() << " μs\n";
-    //    std::cout << "Twos encoding: " << twos_time.count() << " μs\n";
+    //    std::cout << "Ones encoding: " << ones_time.count() << " us\n";
+    //    std::cout << "Twos encoding: " << twos_time.count() << " us\n";
     //    std::cout << "Performance difference: " << std::abs((double)ones_time.count() - twos_time.count())
-    //              << " μs (" << (100.0 * std::abs((double)ones_time.count() - twos_time.count()) /
+    //              << " us (" << (100.0 * std::abs((double)ones_time.count() - twos_time.count()) /
     //                          std::min(ones_time.count(), twos_time.count())) << "%)\n";
     //    std::cout << std::endl;
     //}

--- a/education/number/posit/ulp.cpp
+++ b/education/number/posit/ulp.cpp
@@ -87,23 +87,23 @@ try {
 
 	/*
 		Example 2
-		The following example in Java approximates π as a floating point value by finding the two double values bracketing π:
+		The following example in Java approximates pi as a floating point value by finding the two double values bracketing pi:
 
-		p0 < π < p1
-		// π with 20 decimal digits
-		BigDecimal π = new BigDecimal("3.14159265358979323846");
+		p0 < pi < p1
+		// pi with 20 decimal digits
+		BigDecimal pi = new BigDecimal("3.14159265358979323846");
 
 		// truncate to a double floating point
-		double p0 = π.doubleValue();
+		double p0 = pi.doubleValue();
 		// -> 3.141592653589793  (hex: 0x1.921fb54442d18p1)
 
-		// p0 is smaller than π, so find next number representable as double
+		// p0 is smaller than pi, so find next number representable as double
 		double p1 = Math.nextUp(p0);
 		// -> 3.1415926535897936 (hex: 0x1.921fb54442d19p1)
-		Then ULP(π) is determined as
+		Then ULP(pi) is determined as
 
-		ULP(π) = p1 - p0
-		// ulp(π) is the difference between p1 and p0
+		ULP(pi) = p1 - p0
+		// ulp(pi) is the difference between p1 and p0
 		BigDecimal ulp = new BigDecimal(p1).subtract(new BigDecimal(p0));
 		// -> 4.44089209850062616169452667236328125E-16
 		// (this is precisely 2**(-51))

--- a/elastic/ereal/arithmetic/addition.cpp
+++ b/elastic/ereal/arithmetic/addition.cpp
@@ -183,7 +183,8 @@ namespace {
 			ereal<16> a(1.0);
 			ereal<16> n(qnan);
 			if (!std::isnan(double(a + n))) {
-				if (reportTestCases) std::cout << "    FAIL\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL\n";
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -248,7 +249,8 @@ namespace {
 			ereal<16> p(pinf);
 			ereal<16> n(ninf);
 			if (!std::isnan(double(p + n))) {
-				if (reportTestCases) std::cout << "    FAIL\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL\n";
+				++nrOfFailedTestCases;
 			}
 		}
 

--- a/elastic/ereal/arithmetic/multiplication.cpp
+++ b/elastic/ereal/arithmetic/multiplication.cpp
@@ -244,10 +244,12 @@ namespace {
 			ereal<16> a(2.0);
 			ereal<16> n(qnan);
 			if (!std::isnan(double(a * n))) {
-				if (reportTestCases) std::cout << "    FAIL a * NaN\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL a * NaN\n";
+				++nrOfFailedTestCases;
 			}
 			if (!std::isnan(double(n * a))) {
-				if (reportTestCases) std::cout << "    FAIL NaN * a\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL NaN * a\n";
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -260,15 +262,18 @@ namespace {
 			ereal<16> neg(ninf);
 			double r1 = double(two * pos);     // +Inf
 			if (!std::isinf(r1) || r1 < 0) {
-				if (reportTestCases) std::cout << "    FAIL 2 * +Inf got " << r1 << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL 2 * +Inf got " << r1 << '\n';
+				++nrOfFailedTestCases;
 			}
 			double r2 = double(negtwo * pos);  // -Inf
 			if (!std::isinf(r2) || r2 > 0) {
-				if (reportTestCases) std::cout << "    FAIL -2 * +Inf got " << r2 << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL -2 * +Inf got " << r2 << '\n';
+				++nrOfFailedTestCases;
 			}
 			double r3 = double(two * neg);     // -Inf
 			if (!std::isinf(r3) || r3 > 0) {
-				if (reportTestCases) std::cout << "    FAIL 2 * -Inf got " << r3 << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL 2 * -Inf got " << r3 << '\n';
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -279,15 +284,18 @@ namespace {
 			ereal<16> neg(ninf);
 			double r1 = double(pos * pos);  // +Inf
 			if (!std::isinf(r1) || r1 < 0) {
-				if (reportTestCases) std::cout << "    FAIL +Inf * +Inf got " << r1 << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL +Inf * +Inf got " << r1 << '\n';
+				++nrOfFailedTestCases;
 			}
 			double r2 = double(pos * neg);  // -Inf
 			if (!std::isinf(r2) || r2 > 0) {
-				if (reportTestCases) std::cout << "    FAIL +Inf * -Inf got " << r2 << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL +Inf * -Inf got " << r2 << '\n';
+				++nrOfFailedTestCases;
 			}
 			double r3 = double(neg * neg);  // +Inf
 			if (!std::isinf(r3) || r3 < 0) {
-				if (reportTestCases) std::cout << "    FAIL -Inf * -Inf got " << r3 << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL -Inf * -Inf got " << r3 << '\n';
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -297,10 +305,12 @@ namespace {
 			ereal<16> inf(pinf);
 			ereal<16> zero(0.0);
 			if (!std::isnan(double(inf * zero))) {
-				if (reportTestCases) std::cout << "    FAIL Inf * 0\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL Inf * 0\n";
+				++nrOfFailedTestCases;
 			}
 			if (!std::isnan(double(zero * inf))) {
-				if (reportTestCases) std::cout << "    FAIL 0 * Inf\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL 0 * Inf\n";
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -312,7 +322,8 @@ namespace {
 			ereal<16> n(-0.0);
 			double r = double(a * n);
 			if (r != 0.0 || !std::signbit(r)) {
-				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n';
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -323,7 +334,8 @@ namespace {
 			ereal<16> q(0.0);
 			double r = double(p * q);
 			if (r != 0.0 || std::signbit(r)) {
-				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n';
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -334,11 +346,13 @@ namespace {
 			ereal<16> n(-0.0);
 			double r1 = double(p * n);
 			if (r1 != 0.0 || !std::signbit(r1)) {
-				if (reportTestCases) std::cout << "    FAIL +0 * -0 signbit=" << std::signbit(r1) << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL +0 * -0 signbit=" << std::signbit(r1) << '\n';
+				++nrOfFailedTestCases;
 			}
 			double r2 = double(n * p);
 			if (r2 != 0.0 || !std::signbit(r2)) {
-				if (reportTestCases) std::cout << "    FAIL -0 * +0 signbit=" << std::signbit(r2) << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL -0 * +0 signbit=" << std::signbit(r2) << '\n';
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -349,7 +363,8 @@ namespace {
 			ereal<16> m(-0.0);
 			double r = double(n * m);
 			if (r != 0.0 || std::signbit(r)) {
-				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n'; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL signbit=" << std::signbit(r) << '\n';
+				++nrOfFailedTestCases;
 			}
 		}
 

--- a/elastic/ereal/arithmetic/subtraction.cpp
+++ b/elastic/ereal/arithmetic/subtraction.cpp
@@ -236,10 +236,12 @@ namespace {
 			ereal<16> a(1.0);
 			ereal<16> n(qnan);
 			if (!std::isnan(double(a - n))) {
-				if (reportTestCases) std::cout << "    FAIL a - NaN\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL a - NaN\n";
+				++nrOfFailedTestCases;
 			}
 			if (!std::isnan(double(n - a))) {
-				if (reportTestCases) std::cout << "    FAIL NaN - a\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL NaN - a\n";
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -283,7 +285,8 @@ namespace {
 			ereal<16> a(pinf);
 			ereal<16> b(pinf);
 			if (!std::isnan(double(a - b))) {
-				if (reportTestCases) std::cout << "    FAIL\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL\n";
+				++nrOfFailedTestCases;
 			}
 		}
 
@@ -293,7 +296,8 @@ namespace {
 			ereal<16> a(ninf);
 			ereal<16> b(ninf);
 			if (!std::isnan(double(a - b))) {
-				if (reportTestCases) std::cout << "    FAIL\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL\n";
+				++nrOfFailedTestCases;
 			}
 		}
 

--- a/elastic/ereal/math/functions/error_and_gamma.cpp
+++ b/elastic/ereal/math/functions/error_and_gamma.cpp
@@ -38,38 +38,46 @@ namespace {
 
 		// erf(0) == 0, erfc(0) == 1
 		if (!erf(Real(0.0)).iszero()) {
-			if (reportTestCases) std::cout << "    FAIL erf(0) != 0\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL erf(0) != 0\n";
+			++nrOfFailedTestCases;
 		}
 		if (!close_rel(erfc(Real(0.0)), Real(1.0), 1.0e-14)) {
-			if (reportTestCases) std::cout << "    FAIL erfc(0) != 1\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL erfc(0) != 1\n";
+			++nrOfFailedTestCases;
 		}
 		// erf matches the std::erf reference for representative points
 		for (double v : {0.5, 1.0, 2.0}) {
 			if (!close_rel(erf(Real(v)), Real(std::erf(v)), 1.0e-13)) {
-				if (reportTestCases) std::cout << "    FAIL erf(" << v << ") mismatch\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL erf(" << v << ") mismatch\n";
+				++nrOfFailedTestCases;
 			}
 		}
 		// parity: erf(-x) == -erf(x); complement: erf(x)+erfc(x) == 1
 		for (double v : {0.3, 1.0, 2.5}) {
 			Real x(v);
 			if (!close_rel(erf(-x), -erf(x), 1.0e-14)) {
-				if (reportTestCases) std::cout << "    FAIL erf parity at " << v << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL erf parity at " << v << "\n";
+				++nrOfFailedTestCases;
 			}
 			if (!close_rel(erf(x) + erfc(x), Real(1.0), 1.0e-14)) {
-				if (reportTestCases) std::cout << "    FAIL erf+erfc != 1 at " << v << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL erf+erfc != 1 at " << v << "\n";
+				++nrOfFailedTestCases;
 			}
 		}
 		// special values: erf(+/-Inf) = +/-1, erfc(+/-Inf) = 0/2, NaN propagates
 		double pinf = std::numeric_limits<double>::infinity();
 		double qnan = std::numeric_limits<double>::quiet_NaN();
 		if (!close_rel(erf(Real(pinf)), Real(1.0), 1.0e-14) || !close_rel(erf(Real(-pinf)), Real(-1.0), 1.0e-14)) {
-			if (reportTestCases) std::cout << "    FAIL erf(+/-Inf) != +/-1\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL erf(+/-Inf) != +/-1\n";
+			++nrOfFailedTestCases;
 		}
 		if (!erfc(Real(pinf)).iszero() || !close_rel(erfc(Real(-pinf)), Real(2.0), 1.0e-14)) {
-			if (reportTestCases) std::cout << "    FAIL erfc(+/-Inf) != 0/2\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL erfc(+/-Inf) != 0/2\n";
+			++nrOfFailedTestCases;
 		}
 		if (!std::isnan(double(erf(Real(qnan)))) || !std::isnan(double(erfc(Real(qnan))))) {
-			if (reportTestCases) std::cout << "    FAIL erf/erfc(NaN) not NaN\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL erf/erfc(NaN) not NaN\n";
+			++nrOfFailedTestCases;
 		}
 		return nrOfFailedTestCases;
 	}
@@ -85,19 +93,22 @@ namespace {
 		for (int n = 1; n <= 7; ++n) {
 			if (n > 1) fact *= (n - 1);
 			if (!close_rel(tgamma(Real(double(n))), Real(fact), 1.0e-13)) {
-				if (reportTestCases) std::cout << "    FAIL tgamma(" << n << ") != " << fact << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL tgamma(" << n << ") != " << fact << "\n";
+				++nrOfFailedTestCases;
 			}
 		}
 		// tgamma(1/2)^2 == pi
 		Real g = tgamma(Real(0.5));
 		if (!close_rel(g * g, Real(std::acos(-1.0)), 1.0e-13)) {
-			if (reportTestCases) std::cout << "    FAIL tgamma(1/2)^2 != pi\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL tgamma(1/2)^2 != pi\n";
+			++nrOfFailedTestCases;
 		}
 		// recurrence: tgamma(x+1) == x*tgamma(x)
 		for (double v : {1.5, 2.7, 4.2}) {
 			Real x(v);
 			if (!close_rel(tgamma(x + Real(1.0)), x * tgamma(x), 1.0e-13)) {
-				if (reportTestCases) std::cout << "    FAIL gamma recurrence at " << v << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL gamma recurrence at " << v << "\n";
+				++nrOfFailedTestCases;
 			}
 		}
 		// special values: tgamma(+Inf) = +Inf, tgamma(NaN) = NaN
@@ -105,10 +116,12 @@ namespace {
 			double pinf = std::numeric_limits<double>::infinity();
 			double rinf = double(tgamma(Real(pinf)));
 			if (!std::isinf(rinf) || rinf < 0) {
-				if (reportTestCases) std::cout << "    FAIL tgamma(+Inf) != +Inf\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL tgamma(+Inf) != +Inf\n";
+				++nrOfFailedTestCases;
 			}
 			if (!std::isnan(double(tgamma(Real(std::numeric_limits<double>::quiet_NaN()))))) {
-				if (reportTestCases) std::cout << "    FAIL tgamma(NaN) != NaN\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL tgamma(NaN) != NaN\n";
+				++nrOfFailedTestCases;
 			}
 		}
 		return nrOfFailedTestCases;
@@ -121,23 +134,27 @@ namespace {
 
 		// lgamma(1) == 0 and lgamma(2) == 0
 		if (!lgamma(Real(1.0)).iszero() || !lgamma(Real(2.0)).iszero()) {
-			if (reportTestCases) std::cout << "    FAIL lgamma(1) or lgamma(2) != 0\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL lgamma(1) or lgamma(2) != 0\n";
+			++nrOfFailedTestCases;
 		}
 		// lgamma(x) == log(tgamma(x)) for x where tgamma is moderate
 		for (double v : {1.5, 3.0, 5.0}) {
 			Real x(v);
 			if (!close_rel(lgamma(x), log(tgamma(x)), 1.0e-12)) {
-				if (reportTestCases) std::cout << "    FAIL lgamma != log(tgamma) at " << v << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL lgamma != log(tgamma) at " << v << "\n";
+				++nrOfFailedTestCases;
 			}
 			// agreement with the std::lgamma reference
 			if (!close_rel(lgamma(x), Real(std::lgamma(v)), 1.0e-12)) {
-				if (reportTestCases) std::cout << "    FAIL lgamma(" << v << ") vs std\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL lgamma(" << v << ") vs std\n";
+				++nrOfFailedTestCases;
 			}
 		}
 		// special value: lgamma(+Inf) = +Inf
 		double linf = double(lgamma(Real(std::numeric_limits<double>::infinity())));
 		if (!std::isinf(linf) || linf < 0) {
-			if (reportTestCases) std::cout << "    FAIL lgamma(+Inf) != +Inf\n"; ++nrOfFailedTestCases;
+			if (reportTestCases) std::cout << "    FAIL lgamma(+Inf) != +Inf\n";
+			++nrOfFailedTestCases;
 		}
 		return nrOfFailedTestCases;
 	}
@@ -154,18 +171,22 @@ namespace {
 			double e = edist(rng);
 			Real x(e);
 			if (!close_rel(erf(-x), -erf(x), 1.0e-13)) {
-				if (reportTestCases) std::cout << "    FAIL erf parity at " << e << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL erf parity at " << e << "\n";
+				++nrOfFailedTestCases;
 			}
 			if (!close_rel(erf(x) + erfc(x), Real(1.0), 1.0e-13)) {
-				if (reportTestCases) std::cout << "    FAIL erf+erfc != 1 at " << e << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL erf+erfc != 1 at " << e << "\n";
+				++nrOfFailedTestCases;
 			}
 			if (!(erf(x) < erf(x + Real(0.5)))) {   // erf strictly increasing
-				if (reportTestCases) std::cout << "    FAIL erf monotonic at " << e << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL erf monotonic at " << e << "\n";
+				++nrOfFailedTestCases;
 			}
 			double g = gdist(rng);
 			Real y(g);
 			if (!close_rel(tgamma(y + Real(1.0)), y * tgamma(y), 1.0e-12)) {
-				if (reportTestCases) std::cout << "    FAIL gamma recurrence at " << g << "\n"; ++nrOfFailedTestCases;
+				if (reportTestCases) std::cout << "    FAIL gamma recurrence at " << g << "\n";
+				++nrOfFailedTestCases;
 			}
 		}
 		return nrOfFailedTestCases;

--- a/include/sqrt-algorithms-for-precise-representations.txt
+++ b/include/sqrt-algorithms-for-precise-representations.txt
@@ -9,16 +9,16 @@ John
 
 MitchAlsup
 
-On Wednesday, May 24, 2023 at 9:22:07 AM UTC-5 johngustafson wrote:
+On Wednesday, May 24, 2023 at 9:22:07 AM UTC-5 johngustafson wrote:
 If you want to do a 64-bit posit square root, you will need one more iteration of Newton-Raphson, and you will need to use more than 64-bit fixed-point precision for that last iteration.
 
 IEEE 754 HW FMUL units that did Goldschmidt FDIV and SQRT instructions require 57-bits to obtains a 53-bit accurately rounded fraction which then fits in a 52-bit (with hidden bit) container.
 
-Goldschmidt is an algorithm related to Newton-Raphson except while NR has two dependent multiplies per step, Goldschmidt has two independent multiplies per step. Goldschmidt also converges by doubling the accurate bits every step. Newton-Raphson has the property of self correction whereas Goldschmidt does not. So, once enough bits have been obtained, the last step is a Newton-Raphson Multiply-Subtract, and from this ½ step one can determine the rounding to be applied {0, +1, +2}
+Goldschmidt is an algorithm related to Newton-Raphson except while NR has two dependent multiplies per step, Goldschmidt has two independent multiplies per step. Goldschmidt also converges by doubling the accurate bits every step. Newton-Raphson has the property of self correction whereas Goldschmidt does not. So, once enough bits have been obtained, the last step is a Newton-Raphson Multiply-Subtract, and from this 1/2 step one can determine the rounding to be applied {0, +1, +2}
 
-Given that Goldschmidt with a ½ step of NR gives IEEE accurate FDIVs and SWRTs, but here the multiplier is 57×57 instead of 53×53. I suspect the Posit version will require at least those same 4-more bits of precision.
+Given that Goldschmidt with a 1/2 step of NR gives IEEE accurate FDIVs and SWRTs, but here the multiplier is 57*57 instead of 53*53. I suspect the Posit version will require at least those same 4-more bits of precision.
 
-However, if you are computing a SQRT that sits right at the edge of a regime where the lesser rounding ends up in regime=k {with e=max} and the greater rounding ends up in regime k+1 {e = min}, that you will need even more bits than above by almost exactly the number of bits in the exponent posit<size,{1,2,3}>. But note:: regime k+1 may have greater fraction size when the number represented is in [0..¼] or lesser fraction size [4..infinity] So you may end  up needing those bits for regime k or regime k+1.
+However, if you are computing a SQRT that sits right at the edge of a regime where the lesser rounding ends up in regime=k {with e=max} and the greater rounding ends up in regime k+1 {e = min}, that you will need even more bits than above by almost exactly the number of bits in the exponent posit<size,{1,2,3}>. But note:: regime k+1 may have greater fraction size when the number represented is in [0..1/4] or lesser fraction size [4..infinity] So you may end  up needing those bits for regime k or regime k+1.
 
 johngustafson
 
@@ -28,14 +28,14 @@ The next step is to decode the scaling factor from the regime and exponent, and 
 
 Three iterations of Newton-Raphson using the starting piecewise linear function in SoftPosit should provide about 70 correct bits, more than enough to round correctly to 60 bits. Correct rounding is usually accomplished using the Tuckerman test or "Tuckerman rounding" in the case where the rounding lands on the tie point between two representable values. It requires two multiplies and comparison tests. The SoftPosit method uses the technique developed by John Hauser for SoftFloat, that keeps the errors all positive or all negative after each Newton-Raphson iteration, and then you only need one multiply and comparison to break the tie.
 
-It is not necessary to have 4 more bits than what you're going to round to… but the more bits you have, the less chance that you land on a tie case and have to invoke the Tuckerman test, so that improves speed. While Cerlane wrote almost all of SoftPosit, I did supply the square root routines for her library, and I'm pretty sure that for the 32-bit posits I got 31 bits of accuracy after two Newton-Raphson iterations, just 3 bits more than the 28 bits needed in general. And it works.
+It is not necessary to have 4 more bits than what you're going to round to... but the more bits you have, the less chance that you land on a tie case and have to invoke the Tuckerman test, so that improves speed. While Cerlane wrote almost all of SoftPosit, I did supply the square root routines for her library, and I'm pretty sure that for the 32-bit posits I got 31 bits of accuracy after two Newton-Raphson iterations, just 3 bits more than the 28 bits needed in general. And it works.
 
 John
 
 
 MitchAlsup
 
-On Wednesday, May 24, 2023 at 2:03:13 PM UTC-5 johngustafson wrote:
+On Wednesday, May 24, 2023 at 2:03:13 PM UTC-5 johngustafson wrote:
 The first step in any posit square root routine is to return NaR if the MSB is a 1 (which takes care of all negative inputs and NaR input), and then return 0 if the input is 0.
 
 The next step is to decode the scaling factor from the regime and exponent, and do argument reduction either to [1, 2) or [2, 4), producing the scale factor of the square root while you're at it. I do not see how you can land on the edge of a regime. Mitch, can you provide an example where this happens, ideally in low precision so it's easier to read? 
@@ -44,20 +44,20 @@ IEEE HW takes the LoB of the exponent which tells whether the domain is [1..2) o
 
 Three iterations of Newton-Raphson using the starting piecewise linear function in SoftPosit should provide about 70 correct bits, more than enough to round correctly to 60 bits.
 
-That may be true for FDIV and SQRT but it is not true for other functions which can be calculated with Newton-Raphson. The Muller book indicates that one "in general" needs 2×n+3 bits to correctly round things like Ln() or exp(). But it is true that one needs only 4-bits beyond the fraction LoB for "faithful" rounding. Matula patents mention using 6-bits in the fraction (SP) transcendentals ATI (now AMD) GPUs.
+That may be true for FDIV and SQRT but it is not true for other functions which can be calculated with Newton-Raphson. The Muller book indicates that one "in general" needs 2*n+3 bits to correctly round things like Ln() or exp(). But it is true that one needs only 4-bits beyond the fraction LoB for "faithful" rounding. Matula patents mention using 6-bits in the fraction (SP) transcendentals ATI (now AMD) GPUs.
  
 Correct rounding is usually accomplished using the Tuckerman test or "Tuckerman rounding" in the case where the rounding lands on the tie point between two representable values. It requires two multiplies and comparison tests.
 
-This is the ½ Newton-Raphson iteration I spoke of before. (Funny, I never heard of it being called the Tuckerman test. I will put that in my reference list.}
+This is the 1/2 Newton-Raphson iteration I spoke of before. (Funny, I never heard of it being called the Tuckerman test. I will put that in my reference list.}
  
 The SoftPosit method uses the technique developed by John Hauser for SoftFloat, that keeps the errors all positive or all negative after each Newton-Raphson iteration, and then you only need one multiply and comparison to break the tie.
 
 Keeping all the errors in a known direction is mandatory for making FDIV and SQRT work with Goldschmidt iteration scheme. In fact the Goldschmidt  tables I mention are organized such that the result of the even iterations have positive error and odd iterations negative. This enables convergence from a known direction and simplifies rounding.
  
 
-It is not necessary to have 4 more bits than what you're going to round to… but the more bits you have, the less chance that you land on a tie case and have to invoke the Tuckerman test, so that improves speed.
+It is not necessary to have 4 more bits than what you're going to round to... but the more bits you have, the less chance that you land on a tie case and have to invoke the Tuckerman test, so that improves speed.
 
-Any HW implementation would simply place the Tuckerman test and correction as the last step before round and normalize. And this is the primary reason FDIV is 17 cycles instead of 13 (FMAC-based 57×57 multiplier tree with 11-bit IN and 9-bit OUT tables). I had a design in 1992 where we would broadcast FDIV results in cycle 13 and then perform the test and correction and rebroadcast the result if rounding changed the result; rounding did change the result about 3 times in every 128 calculations, so we got statistical performance of 13.35 cycles FDIV.
+Any HW implementation would simply place the Tuckerman test and correction as the last step before round and normalize. And this is the primary reason FDIV is 17 cycles instead of 13 (FMAC-based 57*57 multiplier tree with 11-bit IN and 9-bit OUT tables). I had a design in 1992 where we would broadcast FDIV results in cycle 13 and then perform the test and correction and rebroadcast the result if rounding changed the result; rounding did change the result about 3 times in every 128 calculations, so we got statistical performance of 13.35 cycles FDIV.
  
 While Cerlane wrote almost all of SoftPosit, I did supply the square root routines for her library, and I'm pretty sure that for the 32-bit posits I got 31 bits of accuracy after two Newton-Raphson iterations, just 3 bits more than the 28 bits needed in general. And it works.
 

--- a/include/sw/math/constants/double_constants.hpp
+++ b/include/sw/math/constants/double_constants.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // double_constants.hpp: definition of math constants in double precision
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.

--- a/include/sw/math/constants/float_constants.hpp
+++ b/include/sw/math/constants/float_constants.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // float_constants.hpp: definition of math constants in float precision
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.

--- a/include/sw/math/constants/longdouble_constants.hpp
+++ b/include/sw/math/constants/longdouble_constants.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // longdouble_constants.hpp: definition of math constants in long double precision
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.

--- a/include/sw/math/functions/bessel.hpp
+++ b/include/sw/math/functions/bessel.hpp
@@ -86,7 +86,7 @@ T bessel_j1(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
 }
 
 
-// Modified Bessel function I_0(x) — series expansion
+// Modified Bessel function I_0(x) -- series expansion
 template<typename T>
 T bessel_i0(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
 	using std::abs;
@@ -103,7 +103,7 @@ T bessel_i0(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
     return sum;
 }
 
-// Modified Bessel function I_1(x) — series expansion
+// Modified Bessel function I_1(x) -- series expansion
 template<typename T>
 T bessel_i1(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
     using std::abs;
@@ -120,7 +120,7 @@ T bessel_i1(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
     return sum;
 }
 
-// Modified Bessel function K_0(x) — asymptotic approximation
+// Modified Bessel function K_0(x) -- asymptotic approximation
 template<typename T>
 T bessel_k0(T x) {
     using std::log, std::sqrt, std::exp;
@@ -136,7 +136,7 @@ T bessel_k0(T x) {
         // Series expansion for small x
         T y = x / T(2);
         //T y2 = y * y;
-        series = -log(y) * bessel_i0(x) + T(0.5772156649);  // Euler-Mascheroni γ
+        series = -log(y) * bessel_i0(x) + T(0.5772156649);  // Euler-Mascheroni gamma
     } else {
         // Asymptotic decay
         series = sqrt(T(3.14159265358979323846) / (T(2) * x)) * exp(-x);
@@ -145,7 +145,7 @@ T bessel_k0(T x) {
     return series;
 }
 
-// Modified Bessel function K_1(x) — asymptotic approximation
+// Modified Bessel function K_1(x) -- asymptotic approximation
 template<typename T>
 T bessel_k1(T x) {
     using std::log, std::sqrt, std::exp;
@@ -165,7 +165,7 @@ T bessel_k1(T x) {
     return series;
 }
 
-// Bessel function Y_0(x) — series expansion
+// Bessel function Y_0(x) -- series expansion
 template<typename T>
 T bessel_y0(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
 	using std::abs, std::pow, std::log;
@@ -184,7 +184,7 @@ T bessel_y0(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
     return (T(2) / T(3.14159265358979323846)) * (log(x / T(2)) + gamma) * bessel_j0<T>(x) - sum;
 }
 
-// Bessel function Y_1(x) — series expansion
+// Bessel function Y_1(x) -- series expansion
 template<typename T>
 T bessel_y1(T x, unsigned int max_terms = 50, T tolerance = T(1e-12)) {
 	using std::abs, std::pow, std::log;

--- a/include/sw/universal/adapters/adapt_integer_and_posit.hpp
+++ b/include/sw/universal/adapters/adapt_integer_and_posit.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // adapt_integer_and_posit.hpp: adapter functions to convert integer<size> type and posit<nbits,es> types
 //
 // Copyright (C) 2017-2022 Stillwater Supercomputing, Inc.

--- a/include/sw/universal/internal/blockdecimal/blockdecimal.hpp
+++ b/include/sw/universal/internal/blockdecimal/blockdecimal.hpp
@@ -527,7 +527,7 @@ public:
 	StorageType& bits() { return _block; }
 
 private:
-	bool _negative;        // sign-magnitude sign bit (NOT initialized by default — triviality)
+	bool _negative;        // sign-magnitude sign bit (NOT initialized by default -- triviality)
 	StorageType _block;    // unsigned magnitude
 
 	/////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/internal/blocktriple/blocktriple.hpp
+++ b/include/sw/universal/internal/blocktriple/blocktriple.hpp
@@ -1143,7 +1143,7 @@ public:
 					}
 				}
 				else {
-					// scientific: d.dddddde±EEE
+					// scientific: d.dddddde+/-EEE
 					if (totalDigits > 0)
 						s += static_cast<char>('0' + digits[0]);
 					else
@@ -1199,7 +1199,7 @@ private:
 		return result;
 	}
 
-	// Format exponent as ±NNN (handles arbitrarily large exponents)
+	// Format exponent as +/-NNN (handles arbitrarily large exponents)
 	static void append_exponent(std::string& str, long long e) {
 		str += (e < 0 ? '-' : '+');
 		e = (e < 0) ? -e : e;

--- a/include/sw/universal/internal/expansion/expansion_ops.hpp
+++ b/include/sw/universal/internal/expansion/expansion_ops.hpp
@@ -526,7 +526,8 @@ namespace detail_priest {
 } // namespace detail_priest
 
 inline std::vector<double> renormalize_expansion(const std::vector<double>& e) {
-    if (e.size() <= 1) return e; // Single-component input is trivially canonical.
+    if (e.empty()) return {};
+    if (e.size() == 1) return std::vector<double>{ e[0] }; // Single-component input is trivially canonical.
     std::vector<double> result = detail_priest::priest_renormalize(e);
     // Strip trailing zeros (matches the historical contract of this function).
     while (!result.empty() && result.back() == 0.0) {

--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -595,7 +595,7 @@ namespace expansion_ops {
     // Phase 1: Compression - bottom-up accumulation using quick_two_sum
     // Phase 2: Conditional refinement - carry propagation with zero detection
     //
-    // This ensures the non-overlapping property: |component[i+1]| ≤ ulp(component[i])/2
+    // This ensures the non-overlapping property: |component[i+1]| <= ulp(component[i])/2
     // Fixes precision loss in iterative algorithms (e.g., pow() improved from 77-92 bits to 200+ bits)
 
     // Generic version for arbitrary N
@@ -718,19 +718,19 @@ namespace expansion_ops {
      * ----------------
      * The bug manifests most severely in the identity test: (a+b)-a = b
      *
-     * For qd_cascade (8→4 compression):
+     * For qd_cascade (8->4 compression):
      *   - Naive sum: result[3] + result[4] + result[5] + result[6] + result[7]
      *   - Loses cumulative rounding errors across 4 additions
      *   - Test FAILED: recovered b had wrong sign and magnitude in component[3]
      *   - Error: -1.5e-51 instead of 5e-52 (212-bit precision destroyed)
      *
-     * For td_cascade (6→3 compression):
+     * For td_cascade (6->3 compression):
      *   - Naive sum: result[2] + result[3] + result[4] + result[5]
      *   - Loses cumulative rounding errors across 3 additions
      *   - Test PASSES but only because renormalize() afterward salvages precision
      *   - Still incorrect in principle - relies on post-processing to fix errors
      *
-     * For dd_cascade (4→2 compression):
+     * For dd_cascade (4->2 compression):
      *   - Naive sum: result[1] + result[2] + result[3]
      *   - Loses cumulative rounding errors across 2 additions
      *   - Test PASSES but same caveat as td_cascade
@@ -753,7 +753,7 @@ namespace expansion_ops {
      */
 
     // Compress 4-component cascade to 2 components following proven QD algorithm
-    // Used by dd_cascade for (2+2)→2 compression after addition/subtraction
+    // Used by dd_cascade for (2+2)->2 compression after addition/subtraction
     constexpr inline floatcascade<2> compress_4to2(const floatcascade<4>& e) {
         double r0 = e[0];
         double r1 = e[1];
@@ -790,7 +790,7 @@ namespace expansion_ops {
     }
 
     // Compress 6-component cascade to 3 components following proven QD algorithm
-    // Used by td_cascade for (3+3)→3 compression after addition/subtraction
+    // Used by td_cascade for (3+3)->3 compression after addition/subtraction
     constexpr inline floatcascade<3> compress_6to3(const floatcascade<6>& e) {
         double r0 = e[0];
         double r1 = e[1];
@@ -850,7 +850,7 @@ namespace expansion_ops {
     }
 
     // Compress 8-component cascade to 4 components following proven QD algorithm
-    // Used by qd_cascade for (4+4)→4 compression after addition/subtraction
+    // Used by qd_cascade for (4+4)->4 compression after addition/subtraction
     // This implements the same algorithm as sw::universal::renorm(a0,a1,a2,a3,a4,...,a7)
     // Based on: Hida, Li, Bailey "Library for Double-Double and Quad-Double Arithmetic"
     constexpr inline floatcascade<4> compress_8to4(const floatcascade<8>& e) {
@@ -977,7 +977,7 @@ namespace expansion_ops {
     // accurate_multiplication() algorithm (qd_impl.hpp lines 619-675).
     template<size_t N>
     floatcascade<N> multiply_cascades(const floatcascade<N>& a, const floatcascade<N>& b) {
-        // Generate N×N products (partial products matrix)
+        // Generate N*N products (partial products matrix)
         std::array<double, N * N> products;
         std::array<double, N * N> errors;
 

--- a/include/sw/universal/internal/floatcascade/floatcascade_td.txt
+++ b/include/sw/universal/internal/floatcascade/floatcascade_td.txt
@@ -93,7 +93,7 @@ public:
             if (i > 0) os << ", ";
             os << fc.e[i];
         }
-        os << "] ≈ " << fc.to_double();
+        os << "] ~= " << fc.to_double();
         return os;
     }
 };

--- a/include/sw/universal/internal/value/value.hpp
+++ b/include/sw/universal/internal/value/value.hpp
@@ -394,7 +394,7 @@ public:
 
 	// Get the mantissa with hidden bit for Grisu-style decimal conversion
 	// Returns: bitblock with hidden bit at position fbits, fraction bits below
-	// The actual value is: mantissa × 2^(scale - fbits)
+	// The actual value is: mantissa * 2^(scale - fbits)
 	bitblock<fhbits> mantissa() const {
 		bitblock<fhbits> m;
 		if (_zero || _inf || _nan) return m;
@@ -410,7 +410,7 @@ public:
 	}
 
 	// Get the effective binary exponent for the mantissa representation
-	// The value = mantissa × 2^mantissa_exponent()
+	// The value = mantissa * 2^mantissa_exponent()
 	int mantissa_exponent() const {
 		return _scale - static_cast<int>(fbits);
 	}

--- a/include/sw/universal/internal/variablecascade/priest_adaptive_design.txt
+++ b/include/sw/universal/internal/variablecascade/priest_adaptive_design.txt
@@ -258,7 +258,7 @@ public:
             if (i > 0) os << ", ";
             os << data[i];
         }
-        os << ") ≈ " << p.cascade.to_double();
+        os << ") ~= " << p.cascade.to_double();
         return os;
     }
     

--- a/include/sw/universal/mixedprecision/carry_analysis.hpp
+++ b/include/sw/universal/mixedprecision/carry_analysis.hpp
@@ -19,7 +19,7 @@
 // Typically reduces total bits by 10-30%.
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021, Section 5.4.
+//            PhD thesis, Universite de Perpignan, 2021, Section 5.4.
 
 #include <universal/mixedprecision/expression_graph.hpp>
 #include <universal/mixedprecision/pop_solver.hpp>

--- a/include/sw/universal/mixedprecision/codegen.hpp
+++ b/include/sw/universal/mixedprecision/codegen.hpp
@@ -11,7 +11,7 @@
 // PrecisionConfigGenerator::generateConfigHeader().
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021.
+//            PhD thesis, Universite de Perpignan, 2021.
 
 #include <universal/mixedprecision/expression_graph.hpp>
 #include <universal/utility/type_advisor.hpp>

--- a/include/sw/universal/mixedprecision/expression_graph.hpp
+++ b/include/sw/universal/mixedprecision/expression_graph.hpp
@@ -18,7 +18,7 @@
 // the case where some nodes have requirements from multiple output consumers.
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021, Chapters 4-5.
+//            PhD thesis, Universite de Perpignan, 2021, Chapters 4-5.
 
 #include <vector>
 #include <string>

--- a/include/sw/universal/mixedprecision/pop.hpp
+++ b/include/sw/universal/mixedprecision/pop.hpp
@@ -43,7 +43,7 @@
 //   g.report(std::cout, advisor);
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021.
+//            PhD thesis, Universite de Perpignan, 2021.
 
 // Phase 1: Transfer functions and UFP
 #include <universal/mixedprecision/ufp.hpp>

--- a/include/sw/universal/mixedprecision/pop_solver.hpp
+++ b/include/sw/universal/mixedprecision/pop_solver.hpp
@@ -17,7 +17,7 @@
 // total cost while meeting all accuracy requirements.
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021, Chapter 5.
+//            PhD thesis, Universite de Perpignan, 2021, Chapter 5.
 
 #include <universal/mixedprecision/expression_graph.hpp>
 

--- a/include/sw/universal/mixedprecision/simplex.hpp
+++ b/include/sw/universal/mixedprecision/simplex.hpp
@@ -18,7 +18,7 @@
 // For larger problems, link against GLPK or HiGHS.
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021, Chapter 5.
+//            PhD thesis, Universite de Perpignan, 2021, Chapter 5.
 
 #include <vector>
 #include <cmath>

--- a/include/sw/universal/mixedprecision/transfer.hpp
+++ b/include/sw/universal/mixedprecision/transfer.hpp
@@ -19,7 +19,7 @@
 // The lsb (least significant bit) position is: lsb = ufp - nsb + 1
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021, Chapter 4.
+//            PhD thesis, Universite de Perpignan, 2021, Chapter 4.
 
 #include <algorithm>
 

--- a/include/sw/universal/mixedprecision/ufp.hpp
+++ b/include/sw/universal/mixedprecision/ufp.hpp
@@ -14,7 +14,7 @@
 // which is the exponent of the most significant bit.
 //
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021.
+//            PhD thesis, Universite de Perpignan, 2021.
 
 #include <cstdint>
 #include <cmath>

--- a/include/sw/universal/native/deprecated/nonconstexpr754.hpp
+++ b/include/sw/universal/native/deprecated/nonconstexpr754.hpp
@@ -117,7 +117,7 @@ inline std::string to_triple(float number, bool nibbleMarker = false) {
 	// the exponent value used in the arithmetic is the exponent shifted by a bias 
 	// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
 	// (i.e. for 2^(e - 127) to be one, e must be 127). 
-	// Exponents range from ¿126 to +127 because exponents of ¿127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+	// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
 	if (decoder.parts.exponent == 0) {
 		s << "exp=0,";
 	}

--- a/include/sw/universal/native/ieee754_float.hpp
+++ b/include/sw/universal/native/ieee754_float.hpp
@@ -102,7 +102,7 @@ inline std::string to_triple(float number, bool nibbleMarker = false) {
 	// the exponent value used in the arithmetic is the exponent shifted by a bias 
 	// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
 	// (i.e. for 2^(e - 127) to be one, e must be 127). 
-	// Exponents range from ¿126 to +127 because exponents of ¿127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+	// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
 	if (decoder.parts.exponent == 0) {
 		s << "exp=0,";
 	}

--- a/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
@@ -111,8 +111,8 @@ namespace sw { namespace universal {
 		// exponent 
 		// the exponent value used in the arithmetic is the exponent shifted by a bias 
 		// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
-		// (i.e. for 2^(e ¿ 127) to be one, e must be 127). 
-		// Exponents range from ¿126 to +127 because exponents of ¿127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+		// (i.e. for 2^(e - 127) to be one, e must be 127). 
+		// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
 		if (decoder.parts.exponent == 0) {
 			s << "exp=0,";
 		}

--- a/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
@@ -110,9 +110,9 @@ namespace sw { namespace universal {
 
 		// exponent 
 		// the exponent value used in the arithmetic is the exponent shifted by a bias 
-		// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
-		// (i.e. for 2^(e - 127) to be one, e must be 127). 
-		// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+		// for the extended-precision long double case, an exponent value of 16383 represents the actual zero 
+		// (i.e. for 2^(e - 16383) to be one, e must be 16383). 
+		// Exponents range from -16382 to +16383 because exponents of -16383 (all 0s) and +16384 (all 1s) are reserved for special numbers.
 		if (decoder.parts.exponent == 0) {
 			s << "exp=0,";
 		}

--- a/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
@@ -117,7 +117,7 @@ inline std::string to_binary(long double number, bool bNibbleMarker = false) {
 	s << '.';
 
 #if defined(UNIVERSAL_ARCH_POWER) || (defined(UNIVERSAL_ARCH_ARM) && __LDBL_MANT_DIG__ == 113)
-	// POWER: IEEE 754 binary128 — 112 fraction bits (48 upper + 64 lower)
+	// POWER: IEEE 754 binary128 -- 112 fraction bits (48 upper + 64 lower)
 	// No explicit integer bit (implicit leading 1 for normals)
 	{
 		uint64_t mask = (uint64_t(1) << 47);
@@ -136,7 +136,7 @@ inline std::string to_binary(long double number, bool bNibbleMarker = false) {
 		}
 	}
 #else
-	// x86: 80-bit extended — bit63 is the explicit integer bit, then 63 fraction bits
+	// x86: 80-bit extended -- bit63 is the explicit integer bit, then 63 fraction bits
 	uint64_t mask = (uint64_t(1) << 62);
 	s << (decoder.parts.bit63 ? '1' : '0');
 	for (int i = 62; i >= 0; --i) {
@@ -161,8 +161,8 @@ inline std::string to_triple(long double number) {
 	// exponent 
 	// the exponent value used in the arithmetic is the exponent shifted by a bias 
 	// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
-	// (i.e. for 2^(e ¿ 127) to be one, e must be 127). 
-	// Exponents range from ¿126 to +127 because exponents of ¿127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+	// (i.e. for 2^(e - 127) to be one, e must be 127). 
+	// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
 	if (decoder.parts.exponent == 0) {
 		s << "exp=0,";
 	}

--- a/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
@@ -160,9 +160,9 @@ inline std::string to_triple(long double number) {
 
 	// exponent 
 	// the exponent value used in the arithmetic is the exponent shifted by a bias 
-	// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
-	// (i.e. for 2^(e - 127) to be one, e must be 127). 
-	// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+	// for the extended-precision long double case, an exponent value of 16383 represents the actual zero 
+	// (i.e. for 2^(e - 16383) to be one, e must be 16383). 
+	// Exponents range from -16382 to +16383 because exponents of -16383 (all 0s) and +16384 (all 1s) are reserved for special numbers.
 	if (decoder.parts.exponent == 0) {
 		s << "exp=0,";
 	}

--- a/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
@@ -130,8 +130,8 @@ inline std::string to_triple_(long double number) {
 	// exponent 
 	// the exponent value used in the arithmetic is the exponent shifted by a bias 
 	// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
-	// (i.e. for 2^(e ¿ 127) to be one, e must be 127). 
-	// Exponents range from ¿126 to +127 because exponents of ¿127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+	// (i.e. for 2^(e - 127) to be one, e must be 127). 
+	// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
 	if (decoder.parts.exponent == 0) {
 		s << "exp=0,";
 	}

--- a/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
@@ -129,9 +129,9 @@ inline std::string to_triple_(long double number) {
 
 	// exponent 
 	// the exponent value used in the arithmetic is the exponent shifted by a bias 
-	// for the IEEE 754 binary32 case, an exponent value of 127 represents the actual zero 
-	// (i.e. for 2^(e - 127) to be one, e must be 127). 
-	// Exponents range from -126 to +127 because exponents of -127 (all 0s) and +128 (all 1s) are reserved for special numbers.
+	// for the extended-precision long double case, an exponent value of 16383 represents the actual zero 
+	// (i.e. for 2^(e - 16383) to be one, e must be 16383). 
+	// Exponents range from -16382 to +16383 because exponents of -16383 (all 0s) and +16384 (all 1s) are reserved for special numbers.
 	if (decoder.parts.exponent == 0) {
 		s << "exp=0,";
 	}

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -912,7 +912,7 @@ public:
 				setnan(); // 0/0 = NaN
 			}
 			else {
-				setinf(resultSign); // x/0 = ±inf
+				setinf(resultSign); // x/0 = +/-inf
 			}
 			return *this;
 		}

--- a/include/sw/universal/number/bfloat16/math/constants/constants.hpp
+++ b/include/sw/universal/number/bfloat16/math/constants/constants.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // constants.hpp: definition of math constants in bfloat16 precision
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.

--- a/include/sw/universal/number/bfloat16/math/functions/hypot.hpp
+++ b/include/sw/universal/number/bfloat16/math/functions/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/bfloat16/math/functions/hypot.hpp
+++ b/include/sw/universal/number/bfloat16/math/functions/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -3790,7 +3790,7 @@ void ReportCfloatClassParameters() {
 template<unsigned nnbits, unsigned nes, typename nbt, bool nsub, bool nsup, bool nsat>
 constexpr inline bool operator==(const cfloat<nnbits,nes,nbt,nsub,nsup,nsat>& lhs, const cfloat<nnbits,nes,nbt,nsub,nsup,nsat>& rhs) {
 	if (lhs.isnan() || rhs.isnan()) return false;
-	if (lhs.iszero() && rhs.iszero()) return true; // +0 == -0 per IEEE-754 §5.11
+	if (lhs.iszero() && rhs.iszero()) return true; // +0 == -0 per IEEE-754 sec5.11
 	for (unsigned i = 0; i < lhs.nrBlocks; ++i) {
 		if (lhs._block[i] != rhs._block[i]) {
 			return false;

--- a/include/sw/universal/number/cfloat/fdp.hpp
+++ b/include/sw/universal/number/cfloat/fdp.hpp
@@ -102,7 +102,7 @@ quire_resolve(const quire<cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, 
 	bt_val.setsign(q.sign());
 	bt_val.setscale(s);
 
-	// Copy bits: blocktriple bit (bt_radix - k) ← accumulator bit (msb_pos - k)
+	// Copy bits: blocktriple bit (bt_radix - k) <- accumulator bit (msb_pos - k)
 	// k=0 is the MSB (hidden bit), k increases downward
 	for (unsigned k = 0; k < bfbits; ++k) {
 		int bt_bit = bt_radix - static_cast<int>(k);

--- a/include/sw/universal/number/cfloat/math/constants/constants.hpp
+++ b/include/sw/universal/number/cfloat/math/constants/constants.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // constants.hpp: definition of base math constants in long double precision for cfloats
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.

--- a/include/sw/universal/number/cfloat/math/functions/hypot.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/cfloat/math/functions/hypot.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/dbns/fdp.hpp
+++ b/include/sw/universal/number/dbns/fdp.hpp
@@ -42,7 +42,7 @@ quire_mul(const dbns<nbits, fbbits, bt, xtra...>& lhs,
 	// The double bridge requires that dbns values fit within binary64 range.
 	// dbns value = 2^(-a) * 3^b. The second-base exponent b has sbbits bits,
 	// so max b = 2^sbbits - 1. Product max 3^b component: log2(3^(2*max_b))
-	// = 2 * max_b * log2(3) ≈ 2 * max_b * 1.585 must be <= 1023.
+	// = 2 * max_b * log2(3) ~= 2 * max_b * 1.585 must be <= 1023.
 	constexpr unsigned sbbits = nbits - fbbits - 1u;
 	constexpr unsigned max_b = (1u << sbbits) - 1u;
 	static_assert(static_cast<unsigned>(2.0 * max_b * 1.585) <= 1023u,
@@ -57,7 +57,7 @@ quire_mul(const dbns<nbits, fbbits, bt, xtra...>& lhs,
 		return product;
 	}
 
-	// Convert to double and multiply — safe because static_assert above
+	// Convert to double and multiply -- safe because static_assert above
 	// guarantees the value range fits within binary64
 	double lhs_d = double(lhs);
 	double rhs_d = double(rhs);

--- a/include/sw/universal/number/dd/math/constants/dd_constants.hpp
+++ b/include/sw/universal/number/dd/math/constants/dd_constants.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // dd_constants.hpp: definition of math constants in double-double precision
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.

--- a/include/sw/universal/number/dd_cascade/dd_cascade_impl.hpp
+++ b/include/sw/universal/number/dd_cascade/dd_cascade_impl.hpp
@@ -44,8 +44,8 @@ inline bool parse(const std::string&, dd_cascade&);
 // - Compatible API with classic dd (high(), low() accessors)
 //
 // Features ported from classic dd via floatcascade base class:
-// - ✓ Full to_string() with formatting support (via floatcascade)
-// - ✓ Robust parse() for decimal strings (via floatcascade)
+// - OK Full to_string() with formatting support (via floatcascade)
+// - OK Robust parse() for decimal strings (via floatcascade)
 //
 // TODO: Port remaining features from classic dd:
 // - Advanced mathematical functions (sqrt, exp, log, trig)

--- a/include/sw/universal/number/erational/math/hypot.hpp
+++ b/include/sw/universal/number/erational/math/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/erational/math/hypot.hpp
+++ b/include/sw/universal/number/erational/math/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/ereal/ereal_impl.hpp
+++ b/include/sw/universal/number/ereal/ereal_impl.hpp
@@ -327,11 +327,11 @@ public:
 		clear();
 		// Maximum positive value: DBL_MAX plus additional components following 2^-53 scaling
 		_limb[0] = 1.7976931348623157e+308;  // DBL_MAX = 2^1024 - 2^971
-		if (maxlimbs >= 2) _limb.push_back(9.9792015476735972e+291);  // ≈ 2^971
-		if (maxlimbs >= 3) _limb.push_back(5.5395696628011126e+275);  // ≈ 2^918
-		if (maxlimbs >= 4) _limb.push_back(3.0750789988826854e+259);  // ≈ 2^865
+		if (maxlimbs >= 2) _limb.push_back(9.9792015476735972e+291);  // ~= 2^971
+		if (maxlimbs >= 3) _limb.push_back(5.5395696628011126e+275);  // ~= 2^918
+		if (maxlimbs >= 4) _limb.push_back(3.0750789988826854e+259);  // ~= 2^865
 		// For maxlimbs > 4, additional components would need to be computed
-		// Each component follows: limb[i] ≈ limb[i-1] × 2^-53
+		// Each component follows: limb[i] ~= limb[i-1] * 2^-53
 		return *this;
 	}
 

--- a/include/sw/universal/number/ereal/geometry/predicates.hpp
+++ b/include/sw/universal/number/ereal/geometry/predicates.hpp
@@ -108,10 +108,10 @@ namespace sw { namespace universal {
 	// Assumes a, b, c are in counterclockwise order
 	//
 	// Computes determinant:
-	// | ax  ay  ax²+ay²  1 |
-	// | bx  by  bx²+by²  1 |
-	// | cx  cy  cx²+cy²  1 |
-	// | dx  dy  dx²+dy²  1 |
+	// | ax  ay  ax^2+ay^2  1 |
+	// | bx  by  bx^2+by^2  1 |
+	// | cx  cy  cx^2+cy^2  1 |
+	// | dx  dy  dx^2+dy^2  1 |
 	//
 	// Note: More complex predicate requiring higher precision.
 	// ereal adapts precision automatically to maintain accuracy.
@@ -156,14 +156,14 @@ namespace sw { namespace universal {
 	// Assumes a, b, c, d have positive orientation
 	//
 	// Computes determinant:
-	// | ax  ay  az  ax²+ay²+az²  1 |
-	// | bx  by  bz  bx²+by²+bz²  1 |
-	// | cx  cy  cz  cx²+cy²+cz²  1 |
-	// | dx  dy  dz  dx²+dy²+dz²  1 |
-	// | ex  ey  ez  ex²+ey²+ez²  1 |
+	// | ax  ay  az  ax^2+ay^2+az^2  1 |
+	// | bx  by  bz  bx^2+by^2+bz^2  1 |
+	// | cx  cy  cz  cx^2+cy^2+cz^2  1 |
+	// | dx  dy  dz  dx^2+dy^2+dz^2  1 |
+	// | ex  ey  ez  ex^2+ey^2+ez^2  1 |
 	//
 	// Note: Most demanding geometric predicate - requires highest precision.
-	// ereal adapts precision automatically. Use maxlimbs ≥ 16 for reliability.
+	// ereal adapts precision automatically. Use maxlimbs >= 16 for reliability.
 	template<unsigned maxlimbs>
 	inline ereal<maxlimbs> insphere(
 		const Point3D<ereal<maxlimbs>>& a,

--- a/include/sw/universal/number/ereal/math/functions/cbrt.hpp
+++ b/include/sw/universal/number/ereal/math/functions/cbrt.hpp
@@ -11,7 +11,7 @@ namespace sw { namespace universal {
 	// cbrt: cube root function
 	// Phase 3: Full adaptive-precision implementation with range reduction
 	//   Strategy: Use frexp/ldexp for range reduction, then Newton-Raphson
-	//   Algorithm: (1) Extract sign, (2) Use frexp to get r × 2^e,
+	//   Algorithm: (1) Extract sign, (2) Use frexp to get r * 2^e,
 	//             (3) Adjust exponent divisible by 3, (4) Newton iteration on r,
 	//             (5) Scale result by 2^(e/3), (6) Restore sign
 	template<unsigned maxlimbs>
@@ -24,7 +24,7 @@ namespace sw { namespace universal {
 		bool negative = a.isneg();
 		ereal<maxlimbs> abs_a = negative ? -a : a;
 
-		// Use frexp to get: abs_a = r × 2^e where 0.5 ≤ r < 1
+		// Use frexp to get: abs_a = r * 2^e where 0.5 <= r < 1
 		int e;
 		ereal<maxlimbs> r = frexp(abs_a, &e);
 
@@ -35,7 +35,7 @@ namespace sw { namespace universal {
 			r = ldexp(r, -1);  // r = r / 2
 		}
 
-		// At this point: 0.125 ≤ r < 1.0 and e is divisible by 3
+		// At this point: 0.125 <= r < 1.0 and e is divisible by 3
 		// Initial approximation for cbrt(r) from high component
 		const auto& r_limbs = r.limbs();
 		ereal<maxlimbs> x = std::cbrt(r_limbs[0]);
@@ -43,7 +43,7 @@ namespace sw { namespace universal {
 		// Determine iterations for adaptive precision
 		int iterations = 3 + static_cast<int>(std::log2(maxlimbs + 1));
 
-		// Newton-Raphson for cbrt: x' = (2x + r/x²) / 3
+		// Newton-Raphson for cbrt: x' = (2x + r/x^2) / 3
 		// This converges to cbrt(r)
 		for (int i = 0; i < iterations; ++i) {
 			ereal<maxlimbs> x_squared = x * x;

--- a/include/sw/universal/number/ereal/math/functions/exponent.hpp
+++ b/include/sw/universal/number/ereal/math/functions/exponent.hpp
@@ -19,18 +19,18 @@ namespace sw { namespace universal {
 	// ALGORITHM OVERVIEW:
 	// ------------------
 	// The Taylor series for exp converges as:
-	//   exp(x) = 1 + x + x²/2! + x³/3! + x⁴/4! + ... = Σ xⁿ/n!
+	//   exp(x) = 1 + x + x^2/2! + x^3/3! + x^4/4! + ... = Sum x^n/n!
 	//
-	// Convergence rate is O(xⁿ/n!), so we need |x| << 1 for efficiency.
+	// Convergence rate is O(x^n/n!), so we need |x| << 1 for efficiency.
 	//
 	// RANGE REDUCTION STRATEGY:
 	// -------------------------
-	// 1. Reduce x → x/2^k until |x/2^k| ≤ 0.5
+	// 1. Reduce x -> x/2^k until |x/2^k| <= 0.5
 	// 2. Compute exp(x/2^k) using Taylor series (converges in ~20 terms)
 	// 3. Reconstruct: exp(x) = [exp(x/2^k)]^(2^k) using repeated squaring
 	//
-	// For |x| ≤ 0.5: Taylor series gives ~53 bits per 20 terms
-	// Total cost: ~20 terms + k squarings, where k ≈ log₂(|x|+1)
+	// For |x| <= 0.5: Taylor series gives ~53 bits per 20 terms
+	// Total cost: ~20 terms + k squarings, where k ~= log2(|x|+1)
 	//
 	// REFERENCES:
 	// -----------
@@ -74,19 +74,19 @@ namespace sw { namespace universal {
 			reduced_x = reduced_x * half;
 			++reduction_count;
 		}
-		// Now |reduced_x| ≤ 0.5, Taylor series converges rapidly
+		// Now |reduced_x| <= 0.5, Taylor series converges rapidly
 
 		// ============================================================================
 		// STEP 3: Taylor series for exp(reduced_x)
 		// ============================================================================
-		// Taylor series: exp(x) = 1 + x + x²/2! + x³/3! + x⁴/4! + ...
-		//              = Σ(n=0 to ∞) xⁿ/n!
+		// Taylor series: exp(x) = 1 + x + x^2/2! + x^3/3! + x^4/4! + ...
+		//              = Sum(n=0 to inf) x^n/n!
 		//
-		// For |x| ≤ 0.5: After n terms, error ≈ |x|^(n+1)/(n+1)!
-		// Example: |x| = 0.5, n = 20 gives error ≈ 2^(-69), sufficient for 20+ decimal digits
+		// For |x| <= 0.5: After n terms, error ~= |x|^(n+1)/(n+1)!
+		// Example: |x| = 0.5, n = 20 gives error ~= 2^(-69), sufficient for 20+ decimal digits
 		//
 		Real result(1.0);
-		Real term = reduced_x;  // First term: x¹/1!
+		Real term = reduced_x;  // First term: x^1/1!
 
 		// Adaptive convergence threshold
 		int precision_digits = static_cast<int>(53.0 * maxlimbs / 3.322);
@@ -144,7 +144,7 @@ namespace sw { namespace universal {
 
 	// expm1: compute e^x - 1 accurately for small x
 	// Phase 4a: implement using Taylor series (avoids cancellation for small x)
-	// For small x: expm1(x) = x + x²/2! + x³/3! + x⁴/4! + ...
+	// For small x: expm1(x) = x + x^2/2! + x^3/3! + x^4/4! + ...
 	template<unsigned maxlimbs>
 	inline ereal<maxlimbs> expm1(const ereal<maxlimbs>& x) {
 		using Real = ereal<maxlimbs>;
@@ -155,7 +155,7 @@ namespace sw { namespace universal {
 		Real neg_threshold(-0.1);
 
 		if (x < threshold && x > neg_threshold) {
-			// Taylor series: expm1(x) = x + x²/2! + x³/3! + ...
+			// Taylor series: expm1(x) = x + x^2/2! + x^3/3! + ...
 			Real result = x;
 			Real term = x;
 

--- a/include/sw/universal/number/ereal/math/functions/hyperbolic.hpp
+++ b/include/sw/universal/number/ereal/math/functions/hyperbolic.hpp
@@ -124,14 +124,14 @@ namespace sw { namespace universal {
 	// asinh: inverse hyperbolic sine - REFERENCE IMPLEMENTATION
 	//
 	// This implementation demonstrates best practices for adaptive-precision asinh:
-	// 1. Uses standard mathematical identity: asinh(x) = log(x + sqrt(x² + 1))
+	// 1. Uses standard mathematical identity: asinh(x) = log(x + sqrt(x^2 + 1))
 	// 2. Relies on reference log() and sqrt() implementations for full precision
 	// 3. Pure ereal arithmetic throughout
 	//
 	// ALGORITHM:
 	// ----------
 	// Direct computation using the logarithm:
-	//   asinh(x) = log(x + sqrt(x² + 1))
+	//   asinh(x) = log(x + sqrt(x^2 + 1))
 	//
 	// REFERENCES:
 	// -----------
@@ -149,7 +149,7 @@ namespace sw { namespace universal {
 		// Special case
 		if (x.iszero()) return Real(0.0);
 
-		// asinh(x) = log(x + sqrt(x² + 1))
+		// asinh(x) = log(x + sqrt(x^2 + 1))
 		Real x_squared = x * x;
 		Real one(1.0);
 		Real sqrt_term = sqrt(x_squared + one);
@@ -160,14 +160,14 @@ namespace sw { namespace universal {
 	// acosh: inverse hyperbolic cosine - REFERENCE IMPLEMENTATION
 	//
 	// This implementation demonstrates best practices for adaptive-precision acosh:
-	// 1. Uses standard mathematical identity: acosh(x) = log(x + sqrt(x² - 1))
+	// 1. Uses standard mathematical identity: acosh(x) = log(x + sqrt(x^2 - 1))
 	// 2. Proper domain checking (x >= 1)
 	// 3. Relies on reference log() and sqrt() implementations for full precision
 	//
 	// ALGORITHM:
 	// ----------
 	// Direct computation using the logarithm:
-	//   acosh(x) = log(x + sqrt(x² - 1)) for x >= 1
+	//   acosh(x) = log(x + sqrt(x^2 - 1)) for x >= 1
 	//
 	// REFERENCES:
 	// -----------
@@ -191,7 +191,7 @@ namespace sw { namespace universal {
 		// Special case: acosh(1) = 0
 		if (x == one) return Real(0.0);
 
-		// acosh(x) = log(x + sqrt(x² - 1))
+		// acosh(x) = log(x + sqrt(x^2 - 1))
 		Real x_squared = x * x;
 		Real sqrt_term = sqrt(x_squared - one);
 

--- a/include/sw/universal/number/ereal/math/functions/logarithm.hpp
+++ b/include/sw/universal/number/ereal/math/functions/logarithm.hpp
@@ -19,19 +19,19 @@ namespace sw { namespace universal {
 	// ALGORITHM OVERVIEW:
 	// ------------------
 	// The logarithm uses range reduction to avoid slow convergence:
-	//   log(x) = log(m · 2^e) = log(m) + e·ln(2)
+	//   log(x) = log(m * 2^e) = log(m) + e*ln(2)
 	//
-	// Where frexp() gives: x = m · 2^e with 0.5 ≤ m < 1
+	// Where frexp() gives: x = m * 2^e with 0.5 <= m < 1
 	//
 	// SERIES SELECTION:
 	// -----------------
-	// For the mantissa m ∈ [0.5, 1), we use the artanh-based series:
-	//   u = (m-1)/(m+1)  →  m = (1+u)/(1-u)
-	//   log(m) = log((1+u)/(1-u)) = 2·artanh(u) = 2(u + u³/3 + u⁵/5 + u⁷/7 + ...)
+	// For the mantissa m in [0.5, 1), we use the artanh-based series:
+	//   u = (m-1)/(m+1)  ->  m = (1+u)/(1-u)
+	//   log(m) = log((1+u)/(1-u)) = 2*artanh(u) = 2(u + u^3/3 + u^5/5 + u^7/7 + ...)
 	//
 	// This converges much faster than the naive log(1+z) series because:
-	//   - For m ∈ [0.5, 1), we have u ∈ [-1/3, 0)
-	//   - Series error ≈ u^(2n+1) drops rapidly since |u| ≤ 1/3
+	//   - For m in [0.5, 1), we have u in [-1/3, 0)
+	//   - Series error ~= u^(2n+1) drops rapidly since |u| <= 1/3
 	//   - Achieves ~53 bits in ~10 terms (vs. ~50 terms for log(1+z))
 	//
 	// REFERENCES:
@@ -55,7 +55,7 @@ namespace sw { namespace universal {
 		// STEP 1: Handle special cases
 		// ============================================================================
 		if (x.iszero()) {
-			// log(0) = -∞ (return large negative value)
+			// log(0) = -inf (return large negative value)
 			return Real(-1.0e308);
 		}
 		if (x.isneg()) {
@@ -67,8 +67,8 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 2: Range reduction using frexp
 		// ============================================================================
-		// Extract: x = mantissa · 2^exponent where 0.5 ≤ mantissa < 1
-		// Then: log(x) = log(mantissa) + exponent·ln(2)
+		// Extract: x = mantissa * 2^exponent where 0.5 <= mantissa < 1
+		// Then: log(x) = log(mantissa) + exponent*ln(2)
 		//
 		int exponent;
 		Real mantissa = frexp(x, &exponent);
@@ -80,17 +80,17 @@ namespace sw { namespace universal {
 		// STEP 3: Compute log(mantissa) using artanh-based series
 		// ============================================================================
 		// Transform: m = (1+u)/(1-u), solve for u: u = (m-1)/(m+1)
-		// Then: log(m) = log((1+u)/(1-u)) = 2·artanh(u)
-		//              = 2(u + u³/3 + u⁵/5 + u⁷/7 + ...)
+		// Then: log(m) = log((1+u)/(1-u)) = 2*artanh(u)
+		//              = 2(u + u^3/3 + u^5/5 + u^7/7 + ...)
 		//
-		// For m ∈ [0.5, 1): u ∈ [-1/3, 0), so |u| ≤ 1/3
-		// Convergence: error after n terms ≈ (1/3)^(2n+1)/(2n+1)
-		// Example: n=10 gives error ≈ 10^(-6), n=20 gives error ≈ 10^(-11)
+		// For m in [0.5, 1): u in [-1/3, 0), so |u| <= 1/3
+		// Convergence: error after n terms ~= (1/3)^(2n+1)/(2n+1)
+		// Example: n=10 gives error ~= 10^(-6), n=20 gives error ~= 10^(-11)
 		//
 		Real one(1.0);
 		Real u = (mantissa - one) / (mantissa + one);
 
-		// Series: log(m) = 2·Σ(n=0 to ∞) u^(2n+1)/(2n+1)
+		// Series: log(m) = 2*Sum(n=0 to inf) u^(2n+1)/(2n+1)
 		Real u_squared = u * u;
 		Real term = u;
 		Real result = term;
@@ -125,7 +125,7 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 4: Add exponent contribution
 		// ============================================================================
-		// log(x) = log(m) + e·ln(2)
+		// log(x) = log(m) + e*ln(2)
 		if (exponent != 0) {
 			Real exp_term = Real(static_cast<double>(exponent)) * ln2;
 			result = result + exp_term;
@@ -152,7 +152,7 @@ namespace sw { namespace universal {
 
 	// log1p: compute log(1 + x) accurately for small x
 	// Phase 4a: implement using Taylor series (avoids cancellation for small x)
-	// For small x: log(1+x) = x - x²/2 + x³/3 - x⁴/4 + ...
+	// For small x: log(1+x) = x - x^2/2 + x^3/3 - x^4/4 + ...
 	template<unsigned maxlimbs>
 	inline ereal<maxlimbs> log1p(const ereal<maxlimbs>& x) {
 		using Real = ereal<maxlimbs>;
@@ -163,7 +163,7 @@ namespace sw { namespace universal {
 		Real neg_threshold(-0.1);
 
 		if (x < threshold && x > neg_threshold) {
-			// Taylor series: log(1+x) = x - x²/2 + x³/3 - x⁴/4 + ...
+			// Taylor series: log(1+x) = x - x^2/2 + x^3/3 - x^4/4 + ...
 			Real result = x;
 			Real term = x;
 			Real neg_x = -x;

--- a/include/sw/universal/number/ereal/math/functions/trigonometry.hpp
+++ b/include/sw/universal/number/ereal/math/functions/trigonometry.hpp
@@ -11,22 +11,22 @@ namespace sw { namespace universal {
 	// sin: sine function - REFERENCE IMPLEMENTATION
 	//
 	// This implementation demonstrates best practices for adaptive-precision sine:
-	// 1. High-precision π constant (100+ digits, OEIS A000796)
+	// 1. High-precision pi constant (100+ digits, OEIS A000796)
 	// 2. Pure ereal angle reduction (no double contamination)
 	// 3. Adaptive convergence based on working precision
-	// 4. Efficient Taylor series: sin(x) = x - x³/3! + x⁵/5! - x⁷/7! + ...
+	// 4. Efficient Taylor series: sin(x) = x - x^3/3! + x^5/5! - x^7/7! + ...
 	//
 	// ALGORITHM OVERVIEW:
 	// ------------------
 	// The Taylor series for sin converges as:
-	//   sin(x) = x - x³/3! + x⁵/5! - x⁷/7! + ... = Σ (-1)^n x^(2n+1)/(2n+1)!
+	//   sin(x) = x - x^3/3! + x^5/5! - x^7/7! + ... = Sum (-1)^n x^(2n+1)/(2n+1)!
 	//
-	// Convergence rate is O(x^(2n+1)/(2n+1)!), which is excellent for |x| < π.
+	// Convergence rate is O(x^(2n+1)/(2n+1)!), which is excellent for |x| < pi.
 	//
 	// ANGLE REDUCTION:
 	// ----------------
-	// Reduce x to [-π, π] using modulo 2π:
-	//   sin(x) = sin(x mod 2π)
+	// Reduce x to [-pi, pi] using modulo 2pi:
+	//   sin(x) = sin(x mod 2pi)
 	//
 	// REFERENCES:
 	// -----------
@@ -48,9 +48,9 @@ namespace sw { namespace universal {
 		if (x.iszero()) return Real(0.0);
 
 		// ============================================================================
-		// STEP 2: High-precision π constant
+		// STEP 2: High-precision pi constant
 		// ============================================================================
-		// π to 200 digits (OEIS A000796)
+		// pi to 200 digits (OEIS A000796)
 		Real pi;
 		pi = ereal_pi<maxlimbs>();  // full ereal precision (#1002)
 
@@ -58,13 +58,13 @@ namespace sw { namespace universal {
 		Real two_pi = pi * two;
 
 		// ============================================================================
-		// STEP 3: Angle reduction - reduce to [-π, π]
+		// STEP 3: Angle reduction - reduce to [-pi, pi]
 		// ============================================================================
 		Real reduced_x = x;
 		Real x_abs = abs(x);
 
 		if (x_abs > two_pi) {
-			// Compute number of periods: n = floor(x / 2π)
+			// Compute number of periods: n = floor(x / 2pi)
 			// Must avoid double contamination in division
 			Real periods_real = x_abs / two_pi;
 
@@ -81,11 +81,11 @@ namespace sw { namespace universal {
 				periods = floor(periods_real);
 			}
 
-			// Reduce: x - 2π·n
+			// Reduce: x - 2pi*n
 			reduced_x = x - two_pi * periods;
 		}
 
-		// Further reduce to [-π, π]
+		// Further reduce to [-pi, pi]
 		if (reduced_x > pi) reduced_x = reduced_x - two_pi;
 		Real neg_pi = -pi;
 		if (reduced_x < neg_pi) reduced_x = reduced_x + two_pi;
@@ -93,8 +93,8 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 4: Taylor series with adaptive convergence
 		// ============================================================================
-		// sin(x) = x - x³/3! + x⁵/5! - x⁷/7! + ...
-		// Compute incrementally: term_n = -term_{n-1} · x² / ((2n)(2n+1))
+		// sin(x) = x - x^3/3! + x^5/5! - x^7/7! + ...
+		// Compute incrementally: term_n = -term_{n-1} * x^2 / ((2n)(2n+1))
 		//
 		Real x_squared = reduced_x * reduced_x;
 		Real term = reduced_x;
@@ -110,7 +110,7 @@ namespace sw { namespace universal {
 		}
 
 		for (int n = 1; n < max_iterations; ++n) {
-			// Next term: term_n = -term_{n-1} · x² / ((2n)(2n+1))
+			// Next term: term_n = -term_{n-1} * x^2 / ((2n)(2n+1))
 			// Critical: Must avoid double contamination
 			Real denominator_part1 = Real(static_cast<double>(2 * n));
 			Real denominator_part2 = Real(static_cast<double>(2 * n + 1));
@@ -130,22 +130,22 @@ namespace sw { namespace universal {
 	// cos: cosine function - REFERENCE IMPLEMENTATION
 	//
 	// This implementation demonstrates best practices for adaptive-precision cosine:
-	// 1. High-precision π constant (100+ digits, OEIS A000796)
+	// 1. High-precision pi constant (100+ digits, OEIS A000796)
 	// 2. Pure ereal angle reduction (no double contamination)
 	// 3. Adaptive convergence based on working precision
-	// 4. Efficient Taylor series: cos(x) = 1 - x²/2! + x⁴/4! - x⁶/6! + ...
+	// 4. Efficient Taylor series: cos(x) = 1 - x^2/2! + x^4/4! - x^6/6! + ...
 	//
 	// ALGORITHM OVERVIEW:
 	// ------------------
 	// The Taylor series for cos converges as:
-	//   cos(x) = 1 - x²/2! + x⁴/4! - x⁶/6! + ... = Σ (-1)^n x^(2n)/(2n)!
+	//   cos(x) = 1 - x^2/2! + x^4/4! - x^6/6! + ... = Sum (-1)^n x^(2n)/(2n)!
 	//
-	// Convergence rate is O(x^(2n)/(2n)!), which is excellent for |x| < π.
+	// Convergence rate is O(x^(2n)/(2n)!), which is excellent for |x| < pi.
 	//
 	// ANGLE REDUCTION:
 	// ----------------
-	// Reduce x to [-π, π] using modulo 2π:
-	//   cos(x) = cos(x mod 2π)
+	// Reduce x to [-pi, pi] using modulo 2pi:
+	//   cos(x) = cos(x mod 2pi)
 	//
 	// REFERENCES:
 	// -----------
@@ -167,9 +167,9 @@ namespace sw { namespace universal {
 		if (x.iszero()) return Real(1.0);
 
 		// ============================================================================
-		// STEP 2: High-precision π constant
+		// STEP 2: High-precision pi constant
 		// ============================================================================
-		// π to 200 digits (OEIS A000796)
+		// pi to 200 digits (OEIS A000796)
 		Real pi;
 		pi = ereal_pi<maxlimbs>();  // full ereal precision (#1002)
 
@@ -177,13 +177,13 @@ namespace sw { namespace universal {
 		Real two_pi = pi * two;
 
 		// ============================================================================
-		// STEP 3: Angle reduction - reduce to [-π, π]
+		// STEP 3: Angle reduction - reduce to [-pi, pi]
 		// ============================================================================
 		Real reduced_x = x;
 		Real x_abs = abs(x);
 
 		if (x_abs > two_pi) {
-			// Compute number of periods: n = floor(x / 2π)
+			// Compute number of periods: n = floor(x / 2pi)
 			// Must avoid double contamination in division
 			Real periods_real = x_abs / two_pi;
 
@@ -200,11 +200,11 @@ namespace sw { namespace universal {
 				periods = floor(periods_real);
 			}
 
-			// Reduce: x - 2π·n
+			// Reduce: x - 2pi*n
 			reduced_x = x - two_pi * periods;
 		}
 
-		// Further reduce to [-π, π]
+		// Further reduce to [-pi, pi]
 		if (reduced_x > pi) reduced_x = reduced_x - two_pi;
 		Real neg_pi = -pi;
 		if (reduced_x < neg_pi) reduced_x = reduced_x + two_pi;
@@ -212,8 +212,8 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 4: Taylor series with adaptive convergence
 		// ============================================================================
-		// cos(x) = 1 - x²/2! + x⁴/4! - x⁶/6! + ...
-		// Compute incrementally: term_n = -term_{n-1} · x² / ((2n-1)(2n))
+		// cos(x) = 1 - x^2/2! + x^4/4! - x^6/6! + ...
+		// Compute incrementally: term_n = -term_{n-1} * x^2 / ((2n-1)(2n))
 		//
 		Real x_squared = reduced_x * reduced_x;
 		Real term(1.0);
@@ -229,7 +229,7 @@ namespace sw { namespace universal {
 		}
 
 		for (int n = 1; n < max_iterations; ++n) {
-			// Next term: term_n = -term_{n-1} · x² / ((2n-1)(2n))
+			// Next term: term_n = -term_{n-1} * x^2 / ((2n-1)(2n))
 			// Critical: Must avoid double contamination
 			Real denominator_part1 = Real(static_cast<double>(2 * n - 1));
 			Real denominator_part2 = Real(static_cast<double>(2 * n));
@@ -260,7 +260,7 @@ namespace sw { namespace universal {
 		Real sin_x = sin(x);
 		Real cos_x = cos(x);
 
-		// Check for division by zero (cos(x) = 0 at π/2, 3π/2, etc.)
+		// Check for division by zero (cos(x) = 0 at pi/2, 3pi/2, etc.)
 		if (cos_x.iszero()) {
 			return Real(std::numeric_limits<double>::quiet_NaN());
 		}
@@ -271,15 +271,15 @@ namespace sw { namespace universal {
 	// asin: arcsine function - REFERENCE IMPLEMENTATION
 	//
 	// This implementation demonstrates best practices for adaptive-precision arcsine:
-	// 1. High-precision π/2 constant (100+ digits)
+	// 1. High-precision pi/2 constant (100+ digits)
 	// 2. Pure ereal arithmetic (no double contamination)
 	// 3. Adaptive convergence based on working precision
 	// 4. Argument reduction for |x| near 1
 	//
 	// ALGORITHM OVERVIEW:
 	// ------------------
-	// For |x| ≤ 0.8: Taylor series asin(x) = x + (1/2)x³/3 + (1·3/2·4)x⁵/5 + ...
-	// For |x| > 0.8: Use asin(x) = sign(x) * (π/2 - asin(sqrt(1-x²)))
+	// For |x| <= 0.8: Taylor series asin(x) = x + (1/2)x^3/3 + (1*3/2*4)x^5/5 + ...
+	// For |x| > 0.8: Use asin(x) = sign(x) * (pi/2 - asin(sqrt(1-x^2)))
 	//
 	// REFERENCES:
 	// -----------
@@ -305,7 +305,7 @@ namespace sw { namespace universal {
 
 		if (x.iszero()) return Real(0.0);
 
-		// High-precision π/2 constant (100+ digits)
+		// High-precision pi/2 constant (100+ digits)
 		Real pi_2;
 		pi_2 = ereal_pi_2<maxlimbs>();  // full ereal precision (#1002)
 
@@ -315,7 +315,7 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 2: Argument reduction for |x| > 0.8
 		// ============================================================================
-		// For |x| > 0.8, use asin(x) = sign(x) * (π/2 - asin(sqrt(1-x²)))
+		// For |x| > 0.8, use asin(x) = sign(x) * (pi/2 - asin(sqrt(1-x^2)))
 		Real threshold(0.8);
 		if (abs_x > threshold) {
 			Real sqrt_arg = sqrt(one - abs_x * abs_x);
@@ -326,10 +326,10 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 3: Taylor series with adaptive convergence
 		// ============================================================================
-		// asin(x) = x + (1/2)x³/3 + (1·3/2·4)x⁵/5 + (1·3·5/2·4·6)x⁷/7 + ...
+		// asin(x) = x + (1/2)x^3/3 + (1*3/2*4)x^5/5 + (1*3*5/2*4*6)x^7/7 + ...
 		//
 		// General term: [(2n-1)!!/(2n)!!] * x^(2n+1)/(2n+1)
-		// Term recursion: term_n = term_{n-1} * x² * (2n-1)² / [2n(2n+1)]
+		// Term recursion: term_n = term_{n-1} * x^2 * (2n-1)^2 / [2n(2n+1)]
 		//
 		Real x_squared = x * x;
 		Real term = x;
@@ -345,14 +345,14 @@ namespace sw { namespace universal {
 		}
 
 		for (int n = 1; n < max_iterations; ++n) {
-			// Correct recursion: term_n = term_{n-1} * x² * (2n-1)² / [2n(2n+1)]
+			// Correct recursion: term_n = term_{n-1} * x^2 * (2n-1)^2 / [2n(2n+1)]
 			// BUG FIX: Previous version was missing the squared numerator!
 			// Critical: Must avoid double contamination
 			Real factor_2n_minus_1 = Real(static_cast<double>(2 * n - 1));
 			Real factor_2n = Real(static_cast<double>(2 * n));
 			Real factor_2n_plus_1 = Real(static_cast<double>(2 * n + 1));
 
-			// Note the squared numerator: (2n-1)²
+			// Note the squared numerator: (2n-1)^2
 			term = term * x_squared * factor_2n_minus_1 * factor_2n_minus_1 / (factor_2n * factor_2n_plus_1);
 			result = result + term;
 
@@ -367,8 +367,8 @@ namespace sw { namespace universal {
 	// acos: arccosine function - REFERENCE IMPLEMENTATION
 	//
 	// This implementation demonstrates best practices for adaptive-precision arccosine:
-	// 1. High-precision π/2 constant (100+ digits)
-	// 2. Uses acos(x) = π/2 - asin(x) identity
+	// 1. High-precision pi/2 constant (100+ digits)
+	// 2. Uses acos(x) = pi/2 - asin(x) identity
 	//
 	// REFERENCES:
 	// -----------
@@ -377,24 +377,24 @@ namespace sw { namespace universal {
 	//
 	// HISTORY:
 	// --------
-	// 2025-01: Refactored to use high-precision π/2 constant
+	// 2025-01: Refactored to use high-precision pi/2 constant
 	//
 	template<unsigned maxlimbs>
 	inline ereal<maxlimbs> acos(const ereal<maxlimbs>& x) {
 		using Real = ereal<maxlimbs>;
 
-		// Domain check: |x| must be ≤ 1
+		// Domain check: |x| must be <= 1
 		Real abs_x = abs(x);
 		Real one(1.0);
 		if (abs_x > one) {
 			return Real(std::numeric_limits<double>::quiet_NaN());
 		}
 
-		// High-precision π/2 constant (100+ digits)
+		// High-precision pi/2 constant (100+ digits)
 		Real pi_2;
 		pi_2 = ereal_pi_2<maxlimbs>();  // full ereal precision (#1002)
 
-		// acos(x) = π/2 - asin(x)
+		// acos(x) = pi/2 - asin(x)
 		return pi_2 - asin(x);
 	}
 
@@ -410,21 +410,21 @@ namespace sw { namespace universal {
 	// ALGORITHM OVERVIEW:
 	// ------------------
 	// The Taylor series for atan converges as:
-	//   atan(x) = x - x³/3 + x⁵/5 - x⁷/7 + ...  for |x| ≤ 1
+	//   atan(x) = x - x^3/3 + x^5/5 - x^7/7 + ...  for |x| <= 1
 	//
-	// Convergence rate is O(x²ⁿ), so we need |x| << 1 for efficiency.
+	// Convergence rate is O(x^2n), so we need |x| << 1 for efficiency.
 	//
 	// ARGUMENT REDUCTION STRATEGY:
 	// ----------------------------
-	// 1. For |x| > 1: Use atan(x) = sign(x)·π/2 - atan(1/x)
+	// 1. For |x| > 1: Use atan(x) = sign(x)*pi/2 - atan(1/x)
 	// 2. For |x| near 1: Use atan(x) = atan(c) + atan((x-c)/(1+cx)) where c is precomputed
-	// 3. For 0.5 < |x| ≤ tan(π/12): Reduce using addition formula
-	// 4. For |x| ≤ 0.5: Use Taylor series directly (converges in ~10-20 terms)
+	// 3. For 0.5 < |x| <= tan(pi/12): Reduce using addition formula
+	// 4. For |x| <= 0.5: Use Taylor series directly (converges in ~10-20 terms)
 	//
 	// SPECIAL VALUES:
 	// ---------------
 	// For x = 1, we use Machin's formula (1706):
-	//   π/4 = 4·atan(1/5) - atan(1/239)
+	//   pi/4 = 4*atan(1/5) - atan(1/239)
 	// This converges in ~100 terms to 100 digits, vs. 10^7 terms for Leibniz series!
 	//
 	// REFERENCES:
@@ -455,16 +455,16 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 2: Special value - atan(1) using Machin's formula
 		// ============================================================================
-		// Machin (1706): π/4 = 4·atan(1/5) - atan(1/239)
-		// This is ~1000x faster than the Leibniz series for π/4 = 1 - 1/3 + 1/5 - ...
+		// Machin (1706): pi/4 = 4*atan(1/5) - atan(1/239)
+		// This is ~1000x faster than the Leibniz series for pi/4 = 1 - 1/3 + 1/5 - ...
 		if (abs_x == one) {
 			Real five(5.0);
 			Real two_three_nine(239.0);
 			Real four(4.0);
 
-			Real term1 = four * atan(one / five);      // 4·atan(1/5)
+			Real term1 = four * atan(one / five);      // 4*atan(1/5)
 			Real term2 = atan(one / two_three_nine);    // atan(1/239)
-			Real result = term1 - term2;                // π/4
+			Real result = term1 - term2;                // pi/4
 
 			return negative ? -result : result;
 		}
@@ -472,10 +472,10 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 3: Argument reduction for |x| > 1
 		// ============================================================================
-		// Use identity: atan(x) = π/2 - atan(1/x) for x > 0
+		// Use identity: atan(x) = pi/2 - atan(1/x) for x > 0
 		// This reduces |argument| from >1 to <1
 		if (abs_x > one) {
-			// High-precision π/2 constant (100+ digits)
+			// High-precision pi/2 constant (100+ digits)
 			Real pi_2;
 			pi_2 = ereal_pi_2<maxlimbs>();  // full ereal precision (#1002)
 
@@ -486,7 +486,7 @@ namespace sw { namespace universal {
 		}
 
 		// ============================================================================
-		// STEP 4: Argument reduction for 0.5 < |x| ≤ 1
+		// STEP 4: Argument reduction for 0.5 < |x| <= 1
 		// ============================================================================
 		// Use addition formula: atan(x) = atan(1/2) + atan((x - 1/2)/(1 + x/2))
 		// This reduces argument from [0.5, 1] to [-0.2, 0.4], improving convergence ~3x
@@ -515,11 +515,11 @@ namespace sw { namespace universal {
 		// ============================================================================
 		// STEP 5: Taylor series for small argument
 		// ============================================================================
-		// Taylor series: atan(x) = Σ((-1)ⁿ x^(2n+1))/(2n+1) for |x| ≤ 1
-		//              = x - x³/3 + x⁵/5 - x⁷/7 + x⁹/9 - ...
+		// Taylor series: atan(x) = Sum((-1)^n x^(2n+1))/(2n+1) for |x| <= 1
+		//              = x - x^3/3 + x^5/5 - x^7/7 + x^9/9 - ...
 		//
-		// For |x| < 0.5: Converges with relative error ε after n ≈ -log(ε)/(2·log(|x|)) terms
-		// Example: |x| = 0.4, ε = 10⁻¹⁰⁰ requires n ≈ 55 terms
+		// For |x| < 0.5: Converges with relative error eps after n ~= -log(eps)/(2*log(|x|)) terms
+		// Example: |x| = 0.4, eps = 10^-100 requires n ~= 55 terms
 		//
 		Real x_squared = reduced_x * reduced_x;
 		Real term = reduced_x;           // First term: x
@@ -527,10 +527,10 @@ namespace sw { namespace universal {
 
 		// Adaptive convergence: Stop when |term| < ulp(result)
 		// This ensures we've reached the precision limit of the representation
-		// For ereal<>: ~127 decimal digits, so we need ~53·maxlimbs binary digits precision
+		// For ereal<>: ~127 decimal digits, so we need ~53*maxlimbs binary digits precision
 		//
 		// Estimate working precision in bits: 53 * maxlimbs
-		// Convert to decimal: bits / log₂(10) ≈ bits / 3.322
+		// Convert to decimal: bits / log2(10) ~= bits / 3.322
 		//
 		// IMPORTANT: For double-precision comparison, we use a threshold that works
 		// with the double() conversion. A more sophisticated approach would compute
@@ -548,7 +548,7 @@ namespace sw { namespace universal {
 		}
 
 		for (int n = 1; n < max_iterations; ++n) {
-			// Compute next term: term = term·(-x²)
+			// Compute next term: term = term*(-x^2)
 			term = term * (-x_squared);
 
 			// Denominator: For small n (< 10^15), double has exact integer representation
@@ -603,12 +603,12 @@ namespace sw { namespace universal {
 		}
 
 		if (x.iszero()) {
-			// x = 0, result is ±π/2
+			// x = 0, result is +/-pi/2
 			return y.isneg() ? -pi_2 : pi_2;
 		}
 
 		if (y.iszero()) {
-			// y = 0, result is 0 or ±π
+			// y = 0, result is 0 or +/-pi
 			if (x.isneg()) return pi;
 			return Real(0.0);
 		}

--- a/include/sw/universal/number/ereal/numeric_limits.hpp
+++ b/include/sw/universal/number/ereal/numeric_limits.hpp
@@ -49,7 +49,7 @@ public:
 	// For conservative estimate, use maxLimbs * double::digits
 	static constexpr int  digits                   = maxLimbs * std::numeric_limits<double>::digits;
 	// digits10: number of decimal digits that can be represented without change
-	// log10(2^digits) = digits * log10(2) ≈ digits * 0.30103
+	// log10(2^digits) = digits * log10(2) ~= digits * 0.30103
 	static constexpr int  digits10                 = static_cast<int>(digits * 0.30103);
 	// max_digits10: decimal digits needed to differentiate all values
 	static constexpr int  max_digits10             = digits10 + 2;

--- a/include/sw/universal/number/fixpnt/fdp.hpp
+++ b/include/sw/universal/number/fixpnt/fdp.hpp
@@ -29,7 +29,7 @@ namespace sw { namespace universal {
 // For fixpnt<nbits, rbits, arithmetic, bt>:
 //   - Full product is blockbinary<2*nbits, bt, Signed> (2's complement)
 //   - Product has 2*rbits fractional bits
-//   - We extract: sign, magnitude, MSB position → blocktriple
+//   - We extract: sign, magnitude, MSB position -> blocktriple
 //
 // Returns a blocktriple<2*nbits-2, REP, bt> representing the unrounded product.
 // The REP tag with fbits=2*nbits-2 gives bfbits=2*nbits, radix=2*nbits-2,
@@ -128,7 +128,7 @@ quire_resolve(const quire<fixpnt<nbits, rbits, arithmetic, bt>, capacity, LimbTy
 		// The fixpnt radix point is at bit position rbits.
 		// Quire accumulator bit i represents 2^(i - rp) = 2^(i - 2*rbits).
 		// fixpnt bit j represents 2^(j - rbits).
-		// So quire bit i maps to fixpnt bit j where: i - 2*rbits = j - rbits → j = i - rbits.
+		// So quire bit i maps to fixpnt bit j where: i - 2*rbits = j - rbits -> j = i - rbits.
 
 		// Extract nbits from the quire starting at the MSB
 		// The MSB of the fixpnt result is at bit (nbits-2) for positive values

--- a/include/sw/universal/number/fixpnt/math/hypot.hpp
+++ b/include/sw/universal/number/fixpnt/math/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/fixpnt/math/hypot.hpp
+++ b/include/sw/universal/number/fixpnt/math/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/lns/fdp.hpp
+++ b/include/sw/universal/number/lns/fdp.hpp
@@ -104,7 +104,7 @@ quire_mul(const lns<nbits, rbits, bt, xtra...>& lhs,
 		if (frac < 0.0) { frac += 1.0; int_part -= 1.0; }
 		scale = static_cast<int>(int_part);
 
-		// significand = 2^frac, always in [1.0, 2.0) — never overflows
+		// significand = 2^frac, always in [1.0, 2.0) -- never overflows
 		significand = std::pow(2.0, frac);
 	}
 

--- a/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
+++ b/include/sw/universal/number/lns/lns_addsub_algorithms.hpp
@@ -489,19 +489,19 @@ struct PolynomialAddSub {
 // tables and transcendentals.
 //
 //   M. G. Arnold, T. A. Bailey, J. R. Cowles and M. D. Winkel, ``Arithmetic
-//   Co-transformations in the Real and Complex Logarithmic Number Systems,”
+//   Co-transformations in the Real and Complex Logarithmic Number Systems,"
 //   IEEE Transactions on Computers, vol. 47, no. 7, pp. 777-786, July 1998.
 //
 //   M. Arnold, T. Bailey, J. Cowles and J. Cupal, ``Initializing RAM-based
-//   Logarithmic Processors,” Journal of VLSI Signal Processing, vol. 4,
+//   Logarithmic Processors," Journal of VLSI Signal Processing, vol. 4,
 //   no. 2-3, pp. 243-252, May 1992.
 //
 //   M. Arnold, T. Bailey, J. Cowles and J. Cupal, ``Error Analysis of the
-//   Kmetz/Maenner Algorithm,” Journal of VLSI Signal Processing, vol. 33,
+//   Kmetz/Maenner Algorithm," Journal of VLSI Signal Processing, vol. 33,
 //   pp. 37-53, Oct. 2002.
 //
 //   P. D. Vouzis, C. Collange and M. G. Arnold, ``A Novel Cotransformation
-//   for LNS Subtraction,” Journal of VLSI Signal Processing, vol. 59, no. 1,
+//   for LNS Subtraction," Journal of VLSI Signal Processing, vol. 59, no. 1,
 //   pp. 29-40, Jan. 2010.
 //
 //   Arnold, M. G. and Walter, C. D. (2001). "Unrestricted faithful rounding is

--- a/include/sw/universal/number/lns/math/hypot.hpp
+++ b/include/sw/universal/number/lns/math/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/lns/math/hypot.hpp
+++ b/include/sw/universal/number/lns/math/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/posit/math/hypot.hpp
+++ b/include/sw/universal/number/posit/math/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/posit/math/hypot.hpp
+++ b/include/sw/universal/number/posit/math/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/posit1/ReadMe.txt
+++ b/include/sw/universal/number/posit1/ReadMe.txt
@@ -1,4 +1,4 @@
-﻿========================================================================
+========================================================================
     Posit Project Overview
 ========================================================================
 
@@ -29,9 +29,9 @@ We seek x, the value represented by p. The green text indicates what would happe
 (* Check for exception values: *)
 If Bits(2..n, p) == 0, (* Check for a string of all zeros after the first bit. *)
   If Bits(1..1, p) == 0, (* If the first bit is also zero, then x is zero. *)
-    x ← 0;
+    x <- 0;
   Else, (* The first bit must be one, indicating x is unsigned infinity. *)
-    x ← ±∞;
+    x <- +/-inf;
   End If;
   End; (* Can cut out early. *)
 End If;
@@ -39,48 +39,48 @@ End If;
 The example sequence fails the exception value tests, so continue.
 
 (* Process sign bit: *)
-If Bits(1..1, p) == 1, sign ← –1; p ← –p; (* 2's complement negate p. *)
-  Else sign ← 1;
+If Bits(1..1, p) == 1, sign <- -1; p <- -p; (* 2's complement negate p. *)
+  Else sign <- 1;
 End If;
 
 The first bit is a 1, so sign = -1 and p gets negated. Flip all the bits and add 1:
 0011 0111 0011 1011 1011 1101 1110 1111
 
 (* Process regime bits. The second bit, r, determines the sign of the regime. *)
-r ← Bits(2..2, p)
-Bits(1..1, p) ← r (* Duplicate first regime bit into sign bit so the "FindFirst..." instructions work. *)
+r <- Bits(2..2, p)
+Bits(1..1, p) <- r (* Duplicate first regime bit into sign bit so the "FindFirst..." instructions work. *)
 If r == 0, (* regime value is negative *)
   k = FindFirstOne(p);
-  shift ← –(2^es) × (k – 2); (* Actually a shift of k-2 by a shift by es, so this is fast. *)
+  shift <- -(2^es) * (k - 2); (* Actually a shift of k-2 by a shift by es, so this is fast. *)
 Else (* regime value is zero or positive *)
   k = FindFirstZero(p);
-  shift ← (2^es) × (k – 3);
+  shift <- (2^es) * (k - 3);
 End If;
 
 The example 001... has r = 0 so the regime value is negative. The first 1 occurs in bit 3, 
-so the regime represents –1 and contributes a shift of –(2^es) = –8. This leaves k pointing to bit 3. 
+so the regime represents -1 and contributes a shift of -(2^es) = -8. This leaves k pointing to bit 3. 
 The exponent will be in the next es bits after bit 3, which will fine-tune the shift roughed out by the regime bits.
 
 (* Add the exponent bits, as an unsigned integer, to the shift. *)
-shift ← shift + Bits(k+1..k+es, p);
+shift <- shift + Bits(k+1..k+es, p);
 
 The three exponent bits in the example are the underlined ones: 0011 0111 0011 1011 1011 1101 1110 1111. 
-As an unsigned binary integer, 101 means decimal 5, so the shift is –8 + 5 = –3.
+As an unsigned binary integer, 101 means decimal 5, so the shift is -8 + 5 = -3.
 
 (* The remaining bits are the fraction, with a hidden bit of 1, so we're done. It looks like a regular float: *)
-x ← sign × 2^shift × 1.Bits(k+es+1..n) 
+x <- sign * 2^shift * 1.Bits(k+es+1..n) 
 End
 
 The fraction bits in the example are underlined: 0011 0111 0011 1011 1011 1101 1110 1111. That fraction, 
 plus the hidden bit 1, is 121355759/(2^26), or exactly 1.80834172666072845458984375. 
-Scale this by 2^(shift) = 2^(–3) = 1/8, and the sign, to get –0.22604271583259105682373046875. 
+Scale this by 2^(shift) = 2^(-3) = 1/8, and the sign, to get -0.22604271583259105682373046875. 
 Notice that there are three more bits in the fraction than there are in an IEEE 32-bit float, 
 giving almost a full decimal more accuracy.
 
 I didn't actually run the above pseudocode so it may contain a typo or two, but it is closely based on the 
 Mathematica code for decoding a posit and that has been debugged and in use for months. 
 It is possible to decode the bit string _without_ doing 2's complement negation if the sign bit is zero 
-(the hidden bit for negative posits represents –2, not 1!), which according to Isaac Yonemoto leads to 
+(the hidden bit for negative posits represents -2, not 1!), which according to Isaac Yonemoto leads to 
 simpler hardware... but it creates a more cryptic pseudocode explanation, so I used the 2's complement negation here.
 
 /////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/posit1/math/hypot.hpp
+++ b/include/sw/universal/number/posit1/math/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/posit1/math/hypot.hpp
+++ b/include/sw/universal/number/posit1/math/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/posit1/specialized/posit_16_2.hpp
+++ b/include/sw/universal/number/posit1/specialized/posit_16_2.hpp
@@ -717,8 +717,8 @@ private:
 	// remaining = 0<remaining_bits>0..0
 	//
 	// The regime numerical meaning is as follows: If m is the number of
-	// identical bits in the regime, if the bits are 0s, then k = −m;
-	// if they are 1s, then k = m − 1.
+	// identical bits in the regime, if the bits are 0s, then k = -m;
+	// if they are 1s, then k = m - 1.
 	void decode_regime(const uint16_t bits, int8_t& m, uint16_t& remaining) const noexcept {
 		remaining = (bits << 2) & 0xFFFFu;  // sign and first regime bit
 		if (bits & 0x4000u) {  // positive regimes

--- a/include/sw/universal/number/posit1/specialized/posit_8_2.hpp
+++ b/include/sw/universal/number/posit1/specialized/posit_8_2.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // posit_8_2.hpp: specialized 8-bit posit using fast implementation specialized for posit<8,2>
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
@@ -790,8 +790,8 @@ private:
 	// remaining = 0<remaining_bits>0..0
 	//
 	// The regime numerical meaning is as follows: If m is the number of
-	// identical bits in the regime, if the bits are 0s, then k = −m;
-	// if they are 1s, then k = m − 1.
+	// identical bits in the regime, if the bits are 0s, then k = -m;
+	// if they are 1s, then k = m - 1.
 	void decode_regime(uint8_t bits, int8_t& m, uint8_t& remaining) const noexcept {
 		remaining = (bits << 2) & 0xFFu; // remove sign and first regime bit
 		if (bits & 0x40u) {  // positive regimes

--- a/include/sw/universal/number/positional/math/minmax.hpp
+++ b/include/sw/universal/number/positional/math/minmax.hpp
@@ -8,14 +8,14 @@
 
 namespace sw { namespace universal {
 
-// minimum of two values — direct comparison, no double conversion
+// minimum of two values -- direct comparison, no double conversion
 template<unsigned ndigits, unsigned radix>
 positional<ndigits, radix>
 min(positional<ndigits, radix> x, positional<ndigits, radix> y) {
 	return (x < y) ? x : y;
 }
 
-// maximum of two values — direct comparison, no double conversion
+// maximum of two values -- direct comparison, no double conversion
 template<unsigned ndigits, unsigned radix>
 positional<ndigits, radix>
 max(positional<ndigits, radix> x, positional<ndigits, radix> y) {

--- a/include/sw/universal/number/posito/ReadMe.txt
+++ b/include/sw/universal/number/posito/ReadMe.txt
@@ -1,4 +1,4 @@
-﻿========================================================================
+========================================================================
     Posit Project Overview
 ========================================================================
 
@@ -29,9 +29,9 @@ We seek x, the value represented by p. The green text indicates what would happe
 (* Check for exception values: *)
 If Bits(2..n, p) == 0, (* Check for a string of all zeros after the first bit. *)
   If Bits(1..1, p) == 0, (* If the first bit is also zero, then x is zero. *)
-    x ← 0;
+    x <- 0;
   Else, (* The first bit must be one, indicating x is unsigned infinity. *)
-    x ← ±∞;
+    x <- +/-inf;
   End If;
   End; (* Can cut out early. *)
 End If;
@@ -39,48 +39,48 @@ End If;
 The example sequence fails the exception value tests, so continue.
 
 (* Process sign bit: *)
-If Bits(1..1, p) == 1, sign ← –1; p ← –p; (* 2's complement negate p. *)
-  Else sign ← 1;
+If Bits(1..1, p) == 1, sign <- -1; p <- -p; (* 2's complement negate p. *)
+  Else sign <- 1;
 End If;
 
 The first bit is a 1, so sign = -1 and p gets negated. Flip all the bits and add 1:
 0011 0111 0011 1011 1011 1101 1110 1111
 
 (* Process regime bits. The second bit, r, determines the sign of the regime. *)
-r ← Bits(2..2, p)
-Bits(1..1, p) ← r (* Duplicate first regime bit into sign bit so the "FindFirst..." instructions work. *)
+r <- Bits(2..2, p)
+Bits(1..1, p) <- r (* Duplicate first regime bit into sign bit so the "FindFirst..." instructions work. *)
 If r == 0, (* regime value is negative *)
   k = FindFirstOne(p);
-  shift ← –(2^es) × (k – 2); (* Actually a shift of k-2 by a shift by es, so this is fast. *)
+  shift <- -(2^es) * (k - 2); (* Actually a shift of k-2 by a shift by es, so this is fast. *)
 Else (* regime value is zero or positive *)
   k = FindFirstZero(p);
-  shift ← (2^es) × (k – 3);
+  shift <- (2^es) * (k - 3);
 End If;
 
 The example 001... has r = 0 so the regime value is negative. The first 1 occurs in bit 3, 
-so the regime represents –1 and contributes a shift of –(2^es) = –8. This leaves k pointing to bit 3. 
+so the regime represents -1 and contributes a shift of -(2^es) = -8. This leaves k pointing to bit 3. 
 The exponent will be in the next es bits after bit 3, which will fine-tune the shift roughed out by the regime bits.
 
 (* Add the exponent bits, as an unsigned integer, to the shift. *)
-shift ← shift + Bits(k+1..k+es, p);
+shift <- shift + Bits(k+1..k+es, p);
 
 The three exponent bits in the example are the underlined ones: 0011 0111 0011 1011 1011 1101 1110 1111. 
-As an unsigned binary integer, 101 means decimal 5, so the shift is –8 + 5 = –3.
+As an unsigned binary integer, 101 means decimal 5, so the shift is -8 + 5 = -3.
 
 (* The remaining bits are the fraction, with a hidden bit of 1, so we're done. It looks like a regular float: *)
-x ← sign × 2^shift × 1.Bits(k+es+1..n) 
+x <- sign * 2^shift * 1.Bits(k+es+1..n) 
 End
 
 The fraction bits in the example are underlined: 0011 0111 0011 1011 1011 1101 1110 1111. That fraction, 
 plus the hidden bit 1, is 121355759/(2^26), or exactly 1.80834172666072845458984375. 
-Scale this by 2^(shift) = 2^(–3) = 1/8, and the sign, to get –0.22604271583259105682373046875. 
+Scale this by 2^(shift) = 2^(-3) = 1/8, and the sign, to get -0.22604271583259105682373046875. 
 Notice that there are three more bits in the fraction than there are in an IEEE 32-bit float, 
 giving almost a full decimal more accuracy.
 
 I didn't actually run the above pseudocode so it may contain a typo or two, but it is closely based on the 
 Mathematica code for decoding a posit and that has been debugged and in use for months. 
 It is possible to decode the bit string _without_ doing 2's complement negation if the sign bit is zero 
-(the hidden bit for negative posits represents –2, not 1!), which according to Isaac Yonemoto leads to 
+(the hidden bit for negative posits represents -2, not 1!), which according to Isaac Yonemoto leads to 
 simpler hardware... but it creates a more cryptic pseudocode explanation, so I used the 2's complement negation here.
 
 /////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/posito/math/hypot.hpp
+++ b/include/sw/universal/number/posito/math/hypot.hpp
@@ -26,7 +26,7 @@ If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
 if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-inf, hypot returns +inf even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/posito/math/hypot.hpp
+++ b/include/sw/universal/number/posito/math/hypot.hpp
@@ -25,8 +25,8 @@ Errors are reported as specified in math_errhandling.
 If the implementation supports IEEE floating-point arithmetic (IEC 60559),
 
 hypot(x, y), hypot(y, x), and hypot(x, -y) are equivalent
-if one of the arguments is ±0, hypot is equivalent to fabs called with the non-zero argument
-if one of the arguments is ±8, hypot returns +8 even if the other argument is NaN
+if one of the arguments is +/-0, hypot is equivalent to fabs called with the non-zero argument
+if one of the arguments is +/-8, hypot returns +8 even if the other argument is NaN
 otherwise, if any of the arguments is NaN, NaN is returned
 
 Notes

--- a/include/sw/universal/number/qd/math/constants/qd_constants.hpp
+++ b/include/sw/universal/number/qd/math/constants/qd_constants.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 // qd_constants.hpp: definition of math constants in quad-double precision
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.

--- a/include/sw/universal/number/support/decimal_converter.hpp
+++ b/include/sw/universal/number/support/decimal_converter.hpp
@@ -50,7 +50,7 @@ namespace internal {
 /// <summary>
 /// extract_mantissa_from_value: convert value<fbits> fraction to decimal
 /// value<> stores: (sign, scale, fraction_without_hidden_bit)
-/// The value is: (-1)^sign × 1.fraction × 2^scale
+/// The value is: (-1)^sign * 1.fraction * 2^scale
 /// We need to create a decimal representing the significand: 1.fraction = 1 + fraction
 /// as an integer: (2^fbits + fraction_bits)
 /// </summary>
@@ -121,7 +121,7 @@ inline std::string to_decimal_string(const internal::value<fbits>& v,
 	// Extract mantissa (represents the significand as an integer: 2^fbits + fraction_bits)
 	support::decimal mantissa = extract_mantissa_from_value(v);
 
-	// The value is: mantissa × 2^(scale - fbits)
+	// The value is: mantissa * 2^(scale - fbits)
 	// Since mantissa represents (2^fbits + fraction), we need to account for that
 	int adjusted_scale = v.scale() - static_cast<int>(fbits);
 

--- a/include/sw/universal/number/support/dragon.hpp
+++ b/include/sw/universal/number/support/dragon.hpp
@@ -13,13 +13,13 @@
 // that round to the original binary value, generating digits while staying within bounds.
 //
 // Algorithm:
-//   Given: v = f × 2^e (where f is the significand, e is the exponent)
-//   Find: The shortest decimal d₁d₂...dₙ × 10^k that rounds back to v
+//   Given: v = f * 2^e (where f is the significand, e is the exponent)
+//   Find: The shortest decimal d1d2...dn * 10^k that rounds back to v
 //
-//   Method: Maintain three values (r, s, m⁺, m⁻) representing:
+//   Method: Maintain three values (r, s, m^+, m^-) representing:
 //     - r/s: The scaled value we're converting
-//     - m⁺/s, m⁻/s: The upper and lower bounds of the rounding interval
-//   Generate digits while r/s is within the interval (r-m⁻)/s to (r+m⁺)/s
+//     - m^+/s, m^-/s: The upper and lower bounds of the rounding interval
+//   Generate digits while r/s is within the interval (r-m^-)/s to (r+m^+)/s
 
 #include <string>
 #include <sstream>
@@ -110,8 +110,8 @@ inline void divide_by_power_of_10(support::decimal& d, int exp) {
 /// The algorithm maintains:
 ///   r = numerator of the scaled value
 ///   s = denominator of the scaled value
-///   mp = upper bound margin (m⁺)
-///   mm = lower bound margin (m⁻)
+///   mp = upper bound margin (m^+)
+///   mm = lower bound margin (m^-)
 ///
 /// The value v = r/s, and valid decimal representations lie in the interval:
 ///   (r - mm)/s  to  (r + mp)/s
@@ -121,7 +121,7 @@ inline void divide_by_power_of_10(support::decimal& d, int exp) {
 ///
 /// Parameters:
 ///   f: mantissa as decimal integer
-///   e: binary exponent (value = f × 2^e)
+///   e: binary exponent (value = f * 2^e)
 ///   fbits: number of fraction bits in original binary representation
 ///   is_even: IEEE round-to-even flag
 ///   ctx: formatting context
@@ -129,7 +129,7 @@ inline void divide_by_power_of_10(support::decimal& d, int exp) {
 /// </summary>
 inline std::string dragon4(const support::decimal& f, int e, int fbits, bool is_even,
                            const dragon_context& ctx, int& decimal_exponent) {
-	// f × 2^e is the value to convert
+	// f * 2^e is the value to convert
 	// We need to scale it to the form r/s where we can generate decimal digits
 
 	//std::cerr << "dragon4: f=" << f << " e=" << e << " fbits=" << fbits << "\n";
@@ -138,37 +138,37 @@ inline std::string dragon4(const support::decimal& f, int e, int fbits, bool is_
 	support::decimal s;      // Denominator (will be scaled)
 	s.setdigit(1);
 
-	support::decimal mp;     // Upper margin m⁺
+	support::decimal mp;     // Upper margin m^+
 	mp.setdigit(1);
 
-	support::decimal mm;     // Lower margin m⁻
+	support::decimal mm;     // Lower margin m^-
 	mm.setdigit(1);
 
 	// Scale r, s, mp, mm based on the exponent e
 	// Goal: Get r/s into a range where we can extract decimal digits
 
 	if (e >= 0) {
-		// Value = f × 2^e = (f × 2^e) / 1
+		// Value = f * 2^e = (f * 2^e) / 1
 		multiply_by_power_of_2(r, e);
 		// mp and mm are already 1 (representing the ULP at this scale)
 	} else {
-		// Value = f × 2^e = f / 2^(-e)
+		// Value = f * 2^e = f / 2^(-e)
 		// Scale s by 2^(-e)
 		multiply_by_power_of_2(s, -e);
 	}
 
 	// Estimate the decimal exponent k such that 10^k <= v < 10^(k+1)
-	// Using log10(2) ≈ 0.30103
-	// The value is f × 2^e, where f is approximately 2^fbits (hidden bit + fraction)
+	// Using log10(2) ~= 0.30103
+	// The value is f * 2^e, where f is approximately 2^fbits (hidden bit + fraction)
 	constexpr double LOG10_2 = 0.301029995663981;
-	// log10(f × 2^e) ≈ log10(2^(fbits+e)) = (fbits+e) × log10(2)
+	// log10(f * 2^e) ~= log10(2^(fbits+e)) = (fbits+e) * log10(2)
 	int k = static_cast<int>(std::floor((e + fbits) * LOG10_2));
 
 	// Adjust k to ensure we're in the right range
 	// After scaling, we want 1 <= (r/s) / 10^k < 10
 	// Loop to find correct k
 	while (true) {
-		// Compute r / (s × 10^k) by comparing r with s×10^k
+		// Compute r / (s * 10^k) by comparing r with s*10^k
 		support::decimal s_times_10k = s;
 		if (k > 0) {
 			multiply_by_power_of_5(s_times_10k, k);
@@ -182,13 +182,13 @@ inline std::string dragon4(const support::decimal& f, int e, int fbits, bool is_
 			multiply_by_power_of_2(s_times_10k1, k1);
 		}
 
-		// Check if r/s / 10^k >= 10 (i.e., r >= s × 10^(k+1))
+		// Check if r/s / 10^k >= 10 (i.e., r >= s * 10^(k+1))
 		if (k1 > 0 && support::lessOrEqual(s_times_10k1, r)) {
 			k++;
 			continue;
 		}
 
-		// Check if r/s / 10^k < 1 (i.e., r < s × 10^k)
+		// Check if r/s / 10^k < 1 (i.e., r < s * 10^k)
 		if (k > 0 && support::less(r, s_times_10k)) {
 			k--;
 			continue;
@@ -196,7 +196,7 @@ inline std::string dragon4(const support::decimal& f, int e, int fbits, bool is_
 
 		// For negative k, we need different comparison
 		if (k < 0) {
-			// r/(s×10^k) = r×10^(-k)/s
+			// r/(s*10^k) = r*10^(-k)/s
 			support::decimal r_scaled = r;
 			multiply_by_power_of_5(r_scaled, -k);
 			multiply_by_power_of_2(r_scaled, -k);
@@ -258,7 +258,7 @@ inline std::string dragon4(const support::decimal& f, int e, int fbits, bool is_
 		support::decimal digit_times_s;
 		digit_times_s.setzero();
 
-		// Find the largest digit d such that d×s <= r
+		// Find the largest digit d such that d*s <= r
 		for (int d = 9; d >= 0; --d) {
 			digit_times_s.setzero();
 			for (int mult = 0; mult < d; ++mult) {
@@ -270,7 +270,7 @@ inline std::string dragon4(const support::decimal& f, int e, int fbits, bool is_
 			}
 		}
 
-		// r = r - d×s (the remainder)
+		// r = r - d*s (the remainder)
 		support::sub(r, digit_times_s);
 
 		// Check if we're within bounds
@@ -404,7 +404,7 @@ inline std::string format_decimal_string(bool sign, const std::string& digits, i
 			}
 		}
 	} else {
-		// Scientific notation: d.ddde±ee
+		// Scientific notation: d.ddde+/-ee
 		ss << digits[0];
 		if (ctx.precision > 0 && digits.length() > 1) {
 			ss << '.';

--- a/include/sw/universal/number/support/grisu.hpp
+++ b/include/sw/universal/number/support/grisu.hpp
@@ -13,9 +13,9 @@
 // rounds back to the original value. It falls back to Dragon4 in rare cases (~0.5% of inputs).
 //
 // Algorithm overview:
-// 1. Normalize input to (f, e) where value = f × 2^e, f is odd
-// 2. Find cached power c_k ≈ 10^(-k) stored as (c, q) where c × 2^q ≈ 10^(-k)
-// 3. Multiply (f, e) × (c, q) to get scaled value
+// 1. Normalize input to (f, e) where value = f * 2^e, f is odd
+// 2. Find cached power c_k ~= 10^(-k) stored as (c, q) where c * 2^q ~= 10^(-k)
+// 3. Multiply (f, e) * (c, q) to get scaled value
 // 4. Generate digits from scaled value
 // 5. Check boundaries to ensure shortest representation
 
@@ -39,7 +39,7 @@ namespace internal {
 namespace grisu {
 
 // DiyFp represents a floating-point number as (significand, exponent)
-// Value = significand × 2^exponent
+// Value = significand * 2^exponent
 // Significand is a 64-bit unsigned integer
 struct DiyFp {
 	uint64_t f;  // significand
@@ -54,9 +54,9 @@ struct DiyFp {
 	}
 
 	// Multiply two DiyFp values
-	// Result: (this->f × rhs.f) × 2^(this->e + rhs.e)
+	// Result: (this->f * rhs.f) * 2^(this->e + rhs.e)
 	DiyFp operator*(const DiyFp& rhs) const {
-		// Compute 64-bit × 64-bit = 128-bit product
+		// Compute 64-bit * 64-bit = 128-bit product
 		// We need the upper 64 bits plus rounding information
 
 		uint64_t a = f >> 32;
@@ -91,7 +91,7 @@ struct DiyFp {
 	}
 };
 
-// Cached powers of 10: 10^k ≈ c × 2^q
+// Cached powers of 10: 10^k ~= c * 2^q
 // These are precomputed normalized DiyFp values
 struct CachedPower {
 	uint64_t significand;
@@ -100,7 +100,7 @@ struct CachedPower {
 };
 
 // Cached powers table (subset for testing - full table has ~80 entries)
-// Each entry represents 10^k ≈ significand × 2^binary_exponent
+// Each entry represents 10^k ~= significand * 2^binary_exponent
 static const CachedPower kCachedPowers[] = {
 	{ 0xfa8fd5a0081c0288ULL, -1220, -348 },
 	{ 0xbaaee17fa23ebf76ULL, -1193, -340 },
@@ -195,7 +195,7 @@ static const int kCachedPowersSize = sizeof(kCachedPowers) / sizeof(kCachedPower
 
 // Get cached power for a given exponent
 inline CachedPower GetCachedPower(int e, int* K) {
-	// Find k such that 10^k ≈ 2^e
+	// Find k such that 10^k ~= 2^e
 	double dk = (-61 - e) * 0.30102999566398114 + 347;  // dk = ceil((-61 - e) * log10(2)) + 347
 	int k = static_cast<int>(dk);
 	if (dk - k > 0.0) k++;
@@ -441,7 +441,7 @@ inline std::string FormatGrisu3(bool sign, const char* digits, int len, int K, c
 }
 
 // ==================== MathGeoLib Grisu3 Implementation ====================
-// Complete, working implementation from MathGeoLib by Jukka Jylänki
+// Complete, working implementation from MathGeoLib by Jukka Jylanki
 // Based on "Printing Floating-Point Numbers Quickly and Accurately with Integers"
 // by Florian Loitsch (2010)
 

--- a/include/sw/universal/number/support/teju.hpp
+++ b/include/sw/universal/number/support/teju.hpp
@@ -41,7 +41,7 @@ inline constexpr int log10_pow2(int e) {
 
 // Residual for sub-interval positioning within the exponent range.
 // Computes the fractional part of e * log10(2) mapped to a shift value (0..3).
-// Reference: Teju Jagua common.h — uses low-32-bits-of-product / constant.
+// Reference: Teju Jagua common.h -- uses low-32-bits-of-product / constant.
 inline constexpr unsigned log10_pow2_residual(int e) {
 	return static_cast<uint32_t>(static_cast<int64_t>(1292913987) * e) / 1292913987u;
 }

--- a/include/sw/universal/number/support/teju_formatter.hpp
+++ b/include/sw/universal/number/support/teju_formatter.hpp
@@ -38,7 +38,7 @@ namespace sw { namespace universal {
 
 namespace teju_detail {
 
-// Format a decimal exponent as ±NN or ±NNN
+// Format a decimal exponent as +/-NN or +/-NNN
 inline void append_exponent(std::string& str, int e, bool uppercase) {
 	str += uppercase ? 'E' : 'e';
 	str += (e < 0) ? '-' : '+';
@@ -76,7 +76,7 @@ inline std::string format_scientific(const std::vector<int>& digits, int sci_exp
 	std::string s;
 
 	// digits[0] is the MSD; sci_exponent is its power of 10
-	// scientific format: d.ddddddde±EE
+	// scientific format: d.ddddddde+/-EE
 	auto needed = static_cast<size_t>(1 + precision); // 1 integer digit + precision fraction digits
 
 	// Make a mutable copy and extend/round as needed

--- a/include/sw/universal/number/zfpblock/zfpblock_impl.hpp
+++ b/include/sw/universal/number/zfpblock/zfpblock_impl.hpp
@@ -38,7 +38,7 @@ public:
 	static constexpr size_t MAX_BYTES  = zfp_max_bytes<Real, Dim>::value;
 	using traits_type = zfp_type_traits<Real>;
 
-	// default constructor — leaves buffer uninitialized for triviality
+	// default constructor -- leaves buffer uninitialized for triviality
 	zfpblock() = default;
 
 	// Compress a block of 4^Dim values

--- a/include/sw/universal/quantization/error_metrics.hpp
+++ b/include/sw/universal/quantization/error_metrics.hpp
@@ -8,11 +8,11 @@
 //
 // Two API styles:
 //
-//   1. Scalar-type quantization — matches the qsnr<NumberType>() pattern in qsnr.hpp.
+//   1. Scalar-type quantization -- matches the qsnr<NumberType>() pattern in qsnr.hpp.
 //      Takes a reference vector and a template NumberType that performs the quantization:
 //        rmse<NumberType>(data), snr<NumberType>(data), qsnr<NumberType>(data)
 //
-//   2. Pre-quantized pair — for block formats (mxblock, nvblock, zfparray) or any
+//   2. Pre-quantized pair -- for block formats (mxblock, nvblock, zfparray) or any
 //      external quantization pipeline where src and dst are already available:
 //        rmse(src, dst), snr(src, dst), qsnr(src, dst)
 
@@ -163,7 +163,7 @@ Notice the key differences between QSNR vs SNR:
 
   - Sinusoidal data: QSNR = SNR because the sinusoid has zero mean, so variance == E[x^2]
   - Linear ramp data: QSNR < SNR by ~6 dB because the ramp has a non-zero mean, so variance < E[x^2]
-  — the QSNR correctly measures noise relative to signal variation, not signal power
+  -- the QSNR correctly measures noise relative to signal variation, not signal power
   - zfp rate=16 ramp: QSNR shows a finite 145.74 dB instead of inf because the epsilon guard fires
 
 */

--- a/include/sw/universal/sequences/tribonacci.hpp
+++ b/include/sw/universal/sequences/tribonacci.hpp
@@ -13,7 +13,7 @@
  *
  * https://oeis.org/A000073
  *
- * 0, 0, 1, 1, 2, 4, 7, 13, 24, 44, 81, 149, 274, 504, 927, 1705, 3136, 5768, 10609, 19513, 35890, 66012, … (sequence A000073 in the OEIS) 
+ * 0, 0, 1, 1, 2, 4, 7, 13, 24, 44, 81, 149, 274, 504, 927, 1705, 3136, 5768, 10609, 19513, 35890, 66012, ... (sequence A000073 in the OEIS) 
  *
  * The series was first described formally by Agronomof in 1914, but its first unintentional 
  * use is in the Origin of species by Charles R. Darwin. In the example of illustrating the 

--- a/include/sw/universal/utility/closure_plot_png.hpp
+++ b/include/sw/universal/utility/closure_plot_png.hpp
@@ -117,7 +117,7 @@ private:
             valueEncodingPairs.emplace_back(value, encoding);
         }
 
-        // Sort by actual numerical value: maxneg → ... → zero → ... → maxpos
+        // Sort by actual numerical value: maxneg -> ... -> zero -> ... -> maxpos
         std::sort(valueEncodingPairs.begin(), valueEncodingPairs.end(),
                  [](const auto& a, const auto& b) {
                      // Handle NaN/NaR values - put them at the end

--- a/include/sw/universal/utility/tracked_exact.hpp
+++ b/include/sw/universal/utility/tracked_exact.hpp
@@ -302,7 +302,7 @@ public:
 		double total_error = cumulative_error_ + rhs.cumulative_error_ + std::abs(static_cast<double>(err));
 
 		// Detect absorption: when a small operand is swallowed by a large one
-		// For subtraction a - b, absorption happens when |b| << |a| and result ≈ a
+		// For subtraction a - b, absorption happens when |b| << |a| and result ~= a
 		uint64_t total_absorptions = absorptions_ + rhs.absorptions_;
 		double bits_lost = detect_absorption(value_, rhs.value_, diff);
 		if (bits_lost > 0.0) {
@@ -509,7 +509,7 @@ TrackedExact<T> abs(const TrackedExact<T>& v) {
 }
 
 /// Square root with error propagation (preserves absorptions)
-/// sqrt(a + ea) ≈ sqrt(a) + ea/(2*sqrt(a))
+/// sqrt(a + ea) ~= sqrt(a) + ea/(2*sqrt(a))
 template<typename T>
 TrackedExact<T> sqrt(const TrackedExact<T>& v) {
 	T result = std::sqrt(v.value());

--- a/include/sw/universal/utility/tracked_lns.hpp
+++ b/include/sw/universal/utility/tracked_lns.hpp
@@ -13,15 +13,15 @@
 //   x is stored as log(x)
 //
 // This means:
-//   - Multiplication: log(a*b) = log(a) + log(b)  → EXACT (addition in log domain)
-//   - Division:       log(a/b) = log(a) - log(b)  → EXACT (subtraction in log domain)
-//   - Addition:       log(a+b) requires exp/log   → INTRODUCES ERROR
-//   - Subtraction:    log(a-b) requires exp/log   → INTRODUCES ERROR
+//   - Multiplication: log(a*b) = log(a) + log(b)  -> EXACT (addition in log domain)
+//   - Division:       log(a/b) = log(a) - log(b)  -> EXACT (subtraction in log domain)
+//   - Addition:       log(a+b) requires exp/log   -> INTRODUCES ERROR
+//   - Subtraction:    log(a-b) requires exp/log   -> INTRODUCES ERROR
 //
 // TrackedLNS exploits this by:
 //   1. NOT accumulating error on multiplication/division (they're exact)
 //   2. Only tracking error on addition/subtraction
-//   3. Detecting catastrophic cancellation when a ≈ -b
+//   3. Detecting catastrophic cancellation when a ~= -b
 //   4. Separately counting mults vs adds for algorithm analysis
 //
 // Usage:
@@ -155,7 +155,7 @@ public:
 	/// Number of divisions (exact in LNS!)
 	constexpr uint64_t divisions() const noexcept { return divs_; }
 
-	/// Number of near-cancellation events (a ≈ -b)
+	/// Number of near-cancellation events (a ~= -b)
 	constexpr uint64_t cancellations() const noexcept { return cancellations_; }
 
 	/// Number of absorption events (small operand swallowed)
@@ -215,7 +215,7 @@ public:
 	// ========================================================================
 
 	/// Addition: THE ONLY SOURCE OF ERROR in LNS
-	/// Also detects near-cancellation when a ≈ -b and absorption when |a| >> |b|
+	/// Also detects near-cancellation when a ~= -b and absorption when |a| >> |b|
 	TrackedLNS operator+(const TrackedLNS& rhs) const {
 		LNSType result = value_ + rhs.value_;
 		ShadowType exact = shadow_ + rhs.shadow_;
@@ -250,7 +250,7 @@ public:
 	}
 
 	/// Subtraction: Also introduces error (like addition)
-	/// Detects cancellation when a ≈ b and absorption when |a| >> |b|
+	/// Detects cancellation when a ~= b and absorption when |a| >> |b|
 	TrackedLNS operator-(const TrackedLNS& rhs) const {
 		LNSType result = value_ - rhs.value_;
 		ShadowType exact = shadow_ - rhs.shadow_;

--- a/include/sw/universal/verification/areal_test_suite.hpp
+++ b/include/sw/universal/verification/areal_test_suite.hpp
@@ -286,10 +286,10 @@ namespace sw { namespace universal {
     /// Verify ubit propagation for addition: result.ubit = a.ubit || b.ubit || precision_lost
     ///
     /// Tests four cases:
-    /// 1. exact + exact (ubit=0 + ubit=0) → result.ubit depends on precision loss
-    /// 2. exact + interval (ubit=0 + ubit=1) → result.ubit must be 1
-    /// 3. interval + exact (ubit=1 + ubit=0) → result.ubit must be 1
-    /// 4. interval + interval (ubit=1 + ubit=1) → result.ubit must be 1
+    /// 1. exact + exact (ubit=0 + ubit=0) -> result.ubit depends on precision loss
+    /// 2. exact + interval (ubit=0 + ubit=1) -> result.ubit must be 1
+    /// 3. interval + exact (ubit=1 + ubit=0) -> result.ubit must be 1
+    /// 4. interval + interval (ubit=1 + ubit=1) -> result.ubit must be 1
     /// </summary>
     template<typename TestType>
     int VerifyUbitPropagationAdd(bool reportTestCases) {
@@ -333,7 +333,7 @@ namespace sw { namespace universal {
 		    }
 	    }
 
-	    // Test Case 2 & 3: exact + interval and interval + exact → ubit must be 1
+	    // Test Case 2 & 3: exact + interval and interval + exact -> ubit must be 1
 	    for (size_t i = 0; i < NR_VALUES; i += 2) {
 		    a.setbits(i);
 		    if (a.isnan() || a.isinf()) continue;
@@ -363,7 +363,7 @@ namespace sw { namespace universal {
 		    }
 	    }
 
-	    // Test Case 4: interval + interval → ubit must be 1
+	    // Test Case 4: interval + interval -> ubit must be 1
 	    for (size_t i = 1; i < NR_VALUES; i += 2) {
 		    a.setbits(i);
 		    if (a.isnan() || a.isinf()) continue;

--- a/include/sw/universal/verification/test_suite_mathlib_adaptive.hpp
+++ b/include/sw/universal/verification/test_suite_mathlib_adaptive.hpp
@@ -149,7 +149,7 @@ namespace sw { namespace universal {
 
 	/// <summary>
 	/// Verify a mathematical identity holds within adaptive precision bounds.
-	/// For example: exp(log(x)) == x, or sin²(x) + cos²(x) == 1
+	/// For example: exp(log(x)) == x, or sin^2(x) + cos^2(x) == 1
 	/// </summary>
 	/// <typeparam name="Real">Arithmetic type to test</typeparam>
 	/// <param name="identity_name">Description of the identity (e.g., "exp(log(x)) == x")</param>
@@ -223,7 +223,7 @@ namespace sw { namespace universal {
 
 	/// <summary>
 	/// Error checking strategy for mathematical identities.
-	/// Examples: log(exp(x))=x, sin²(x)+cos²(x)=1, cosh²(x)-sinh²(x)=1
+	/// Examples: log(exp(x))=x, sin^2(x)+cos^2(x)=1, cosh^2(x)-sinh^2(x)=1
 	/// Uses relative error with adaptive precision.
 	/// </summary>
 	template<typename Real>

--- a/internal/conversion/grisu2.cpp
+++ b/internal/conversion/grisu2.cpp
@@ -17,7 +17,7 @@
 namespace grisu2 {
 
 // DiyFp: Do-It-Yourself Floating Point
-// Represents value = f × 2^e where f is a 64-bit unsigned integer
+// Represents value = f * 2^e where f is a 64-bit unsigned integer
 struct DiyFp {
 	uint64_t f;
 	int e;
@@ -64,7 +64,7 @@ struct DiyFp {
 struct CachedPower {
 	uint64_t f;
 	int e;       // binary exponent
-	int dec_exp; // decimal exponent: 10^dec_exp ≈ f × 2^e
+	int dec_exp; // decimal exponent: 10^dec_exp ~= f * 2^e
 };
 
 // Full cached powers table - optimized for typical IEEE-754 double range
@@ -167,7 +167,7 @@ const CachedPower& GetCachedPowerForBinaryExponent(int e, int& dec_exponent) {
 	// We want to scale the number so that after multiplication by 10^-k,
 	// the result is in a range where we can extract decimal digits efficiently.
 	// Estimate k such that v * 10^-k is in range [1, 10)
-	// Since v ≈ 2^e, we want 10^-k ≈ 2^-e, so k ≈ e * log10(2)
+	// Since v ~= 2^e, we want 10^-k ~= 2^-e, so k ~= e * log10(2)
 	int k_est = static_cast<int>(std::ceil((e + 64 - 1) * k));
 
 	// Find closest entry in table
@@ -188,7 +188,7 @@ const CachedPower& GetCachedPowerForBinaryExponent(int e, int& dec_exponent) {
 }
 
 // Generate digits from scaled DiyFp
-// After scaling, the number is in form: significand × 2^exponent
+// After scaling, the number is in form: significand * 2^exponent
 // We want to extract decimal digits from this representation
 bool DigitGen(DiyFp low, DiyFp w, DiyFp high, char* buffer, int* length, int* dec_exponent) {
 	assert(low.e == w.e && w.e == high.e);
@@ -360,7 +360,7 @@ std::string FormatGrisu2(bool negative, const char* digits, int len, int dec_exp
 	std::string result;
 	if (negative) result = "-";
 
-	// Scientific notation: d.ddd...e±xx
+	// Scientific notation: d.ddd...e+/-xx
 	result += digits[0];
 	if (len > 1) {
 		result += '.';

--- a/internal/conversion/grisu3.cpp
+++ b/internal/conversion/grisu3.cpp
@@ -1,6 +1,6 @@
 // grisu3_port.cpp: Direct port of MathGeoLib's grisu3.c to C++
 //
-// Original implementation by Jukka Jylänki (MathGeoLib)
+// Original implementation by Jukka Jylanki (MathGeoLib)
 // Based on "Printing Floating-Point Numbers Quickly and Accurately with Integers"
 // by Florian Loitsch, available at
 // http://www.cs.tufts.edu/~nr/cs257/archive/florian-loitsch/printf.pdf
@@ -47,7 +47,7 @@ struct power {
 	int16_t d_exp;  // decimal exponent
 };
 
-// Cached powers of 10: 10^d_exp ≈ fract × 2^b_exp
+// Cached powers of 10: 10^d_exp ~= fract * 2^b_exp
 static const power pow_cache[] = {
 	{ 0xfa8fd5a0081c0288ULL, -1220, -348 },
 	{ 0xbaaee17fa23ebf76ULL, -1193, -340 },

--- a/internal/floatcascade/api/roundtrip.cpp
+++ b/internal/floatcascade/api/roundtrip.cpp
@@ -6,7 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
 // TEST TOLERANCE:
-// Round-trip conversions (string → parse → to_string → parse) introduce tiny errors
+// Round-trip conversions (string -> parse -> to_string -> parse) introduce tiny errors
 // due to accumulated floating-point operations (multiplication by 10, division, etc.).
 // These errors are on the order of 1e-22 to 1e-30, which is:
 //   - ~1000x smaller than the double-double precision (~1e-31)

--- a/internal/floatcascade/arithmetic/multiplication_precision.cpp
+++ b/internal/floatcascade/arithmetic/multiplication_precision.cpp
@@ -20,16 +20,16 @@
  * 4. Precision Quantification: Measure bits of accuracy
  *
  * RESULTS (see multiplication_precision_rca.md for detailed analysis):
- * ✅ Test 1: PASS - Multiplication achieves 212-220 bits precision
- * ✅ Test 2: PASS - All 4 components contribute to precision
- * ⚠️ Test 3: FAIL - Non-overlapping property violated by 3.24x
- * ✅ Test 4: PASS - Consistent precision across 500 random tests
+ * OK Test 1: PASS - Multiplication achieves 212-220 bits precision
+ * OK Test 2: PASS - All 4 components contribute to precision
+ * WARN Test 3: FAIL - Non-overlapping property violated by 3.24x
+ * OK Test 4: PASS - Consistent precision across 500 random tests
  *
  * ROOT CAUSE: renormalize() function does not strictly enforce Priest's
- *             invariant: |component[i+1]| ≤ ulp(component[i])/2
+ *             invariant: |component[i+1]| <= ulp(component[i])/2
  *
  * IMPACT: 3.24x violation accumulates over ~35 multiplications in pow() chain,
- *         causing 60-70% precision loss (212 bits → 77-92 bits)
+ *         causing 60-70% precision loss (212 bits -> 77-92 bits)
  */
 
 #include <universal/utility/directives.hpp>
@@ -182,7 +182,7 @@ int testComponentVerification(bool reportTestCases) {
 
     int nrOfFailures = 0;
 
-    // Test with well-formed quad-double values (π and e)
+    // Test with well-formed quad-double values (pi and e)
     fc4 a(std::array<double, 4>{3.141592653589793, 1.2246467991473532e-16, -2.9947698097183397e-33, 1.1124542208633652e-49});
     fc4 b(std::array<double, 4>{2.718281828459045, 1.4456468917292502e-16, -2.1277171080381644e-33, 5.7083836057466416e-50});
 
@@ -190,7 +190,7 @@ int testComponentVerification(bool reportTestCases) {
     result *= b;
 
     if (reportTestCases) {
-        std::cout << "Test: π × e\n";
+        std::cout << "Test: pi * e\n";
         std::cout << "a = " << a << "\n";
         std::cout << "b = " << b << "\n";
         std::cout << "result = " << result << "\n";

--- a/internal/floatcascade/arithmetic/multiply_cascades.cpp
+++ b/internal/floatcascade/arithmetic/multiply_cascades.cpp
@@ -12,7 +12,7 @@
  * diagonal partitioning to multiply two N-component floating-point cascades.
  *
  * BACKGROUND:
- * When multiplying two N-component cascades a and b, we generate N² partial products.
+ * When multiplying two N-component cascades a and b, we generate N^2 partial products.
  * These products have different significance levels based on the significance of their
  * input components. The key insight is that products can be organized by "diagonals"
  * where each diagonal represents a specific significance level.
@@ -22,11 +22,11 @@
  * method as the correct way to handle multi-component multiplication:
  *
  * 1. DIAGONAL PARTITIONING:
- *    For indices i,j ∈ [0,N-1], place product a[i]×b[j] and its error term into
+ *    For indices i,j in [0,N-1], place product a[i]*b[j] and its error term into
  *    diagonal k = i+j. This creates 2N-1 diagonals (k = 0 to 2N-2).
- *    - Diagonal 0: Most significant (a[0]×b[0])
+ *    - Diagonal 0: Most significant (a[0]*b[0])
  *    - Diagonal N-1: Middle significance
- *    - Diagonal 2N-2: Least significant (a[N-1]×b[N-1])
+ *    - Diagonal 2N-2: Least significant (a[N-1]*b[N-1])
  *
  * 2. PER-DIAGONAL ACCUMULATION:
  *    Within each diagonal, accumulate all products and error terms from the previous
@@ -41,7 +41,7 @@
  *
  * An incorrect implementation might only handled diagonals 0-2 explicitly, then dumped all
  * remaining terms into result[2]. This will cause several issues:
- * - Uninitialized components for N≥3 (result[3]...result[N-1] will never be assigned)
+ * - Uninitialized components for N>=3 (result[3]...result[N-1] will never be assigned)
  * - Loss of precision from improper accumulation
  * - Violation of the non-overlapping property
  * - Failure to adhere to the diagonal partitioning principle
@@ -125,7 +125,7 @@ void visualize_product_matrix(const floatcascade<N>& a, const floatcascade<N>& b
             }
         }
 
-        std::cout << " → sum ≈ " << std::scientific << std::setprecision(4) << diag_sum << "\n";
+        std::cout << " -> sum ~= " << std::scientific << std::setprecision(4) << diag_sum << "\n";
     }
 }
 
@@ -287,9 +287,9 @@ int main()
 try {
     using namespace sw::universal;
 
-    std::cout << "╔═══════════════════════════════════════════════════════════════════╗\n";
-    std::cout << "║  DEMONSTRATION: Diagonal Partitioning for Cascade Multiplication  ║\n";
-    std::cout << "╚═══════════════════════════════════════════════════════════════════╝\n";
+    std::cout << "+===================================================================+\n";
+    std::cout << "|  DEMONSTRATION: Diagonal Partitioning for Cascade Multiplication  |\n";
+    std::cout << "+===================================================================+\n";
 
     int nrOfFailedTestCases = 0;
 
@@ -298,9 +298,9 @@ try {
     // ========================================================================
     {
         std::cout << "\n\n";
-        std::cout << "┌─────────────────────────────────────────────────────────────────┐\n";
-        std::cout << "│ Demo 1: Simple Well-Separated Triple-Double (N=3)               │\n";
-        std::cout << "└─────────────────────────────────────────────────────────────────┘\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
+        std::cout << "| Demo 1: Simple Well-Separated Triple-Double (N=3)               |\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
 
         floatcascade<3> a, b;
         a[0] = 1.0;
@@ -321,9 +321,9 @@ try {
     // ========================================================================
     {
         std::cout << "\n\n";
-        std::cout << "┌─────────────────────────────────────────────────────────────────┐\n";
-        std::cout << "│ Demo 2: Quad-Double (N=4) - The Bug Revealer                    │\n";
-        std::cout << "└─────────────────────────────────────────────────────────────────┘\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
+        std::cout << "| Demo 2: Quad-Double (N=4) - The Bug Revealer                    |\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
         std::cout << "\nThis case exposed the original bug where result[3] was left\n";
         std::cout << "uninitialized and diagonals 3-6 were improperly accumulated.\n";
 
@@ -347,9 +347,9 @@ try {
     // ========================================================================
     {
         std::cout << "\n\n";
-        std::cout << "┌─────────────────────────────────────────────────────────────────┐\n";
-        std::cout << "│ Corner Case 1: Denormalized Inputs (Overlapping Components)     │\n";
-        std::cout << "└─────────────────────────────────────────────────────────────────┘\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
+        std::cout << "| Corner Case 1: Denormalized Inputs (Overlapping Components)     |\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
         std::cout << "\nInputs have overlapping magnitude components, violating the\n";
         std::cout << "non-overlapping property. The algorithm must handle this robustly.\n";
 
@@ -394,9 +394,9 @@ try {
     // ========================================================================
     {
         std::cout << "\n\n";
-        std::cout << "┌─────────────────────────────────────────────────────────────────┐\n";
-        std::cout << "│ Corner Case 2: Mixed Signs in Components                        │\n";
-        std::cout << "└─────────────────────────────────────────────────────────────────┘\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
+        std::cout << "| Corner Case 2: Mixed Signs in Components                        |\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
         std::cout << "\nComponents have different signs, which can cause cancellation\n";
         std::cout << "in diagonal accumulation. Error tracking is critical.\n";
 
@@ -417,9 +417,9 @@ try {
     // ========================================================================
     {
         std::cout << "\n\n";
-        std::cout << "┌─────────────────────────────────────────────────────────────────┐\n";
-        std::cout << "│ Corner Case 3: Identity Multiplication (1.0 x value)            │\n";
-        std::cout << "└─────────────────────────────────────────────────────────────────┘\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
+        std::cout << "| Corner Case 3: Identity Multiplication (1.0 x value)            |\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
         std::cout << "\nMultiplying by 1.0 should preserve the input structure.\n";
         std::cout << "This tests if the algorithm handles sparse diagonals correctly.\n";
 
@@ -438,7 +438,7 @@ try {
 
         floatcascade<4> result = multiply_cascades(one, value);
 
-        // Verify result ≈ value
+        // Verify result ~= value
         double max_rel_error = 0.0;
         for (size_t i = 0; i < 4; ++i) {
             if (std::abs(value[i]) > 1e-100) {
@@ -461,9 +461,9 @@ try {
     // ========================================================================
     {
         std::cout << "\n\n";
-        std::cout << "┌─────────────────────────────────────────────────────────────────┐\n";
-        std::cout << "│ Corner Case 4: Zero Absorption (0 x value = 0)                  │\n";
-        std::cout << "└─────────────────────────────────────────────────────────────────┘\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
+        std::cout << "| Corner Case 4: Zero Absorption (0 x value = 0)                  |\n";
+        std::cout << "+-----------------------------------------------------------------+\n";
 
         floatcascade<3> zero, value;
         zero[0] = 0.0;
@@ -503,9 +503,9 @@ try {
     // Summary
     // ========================================================================
     std::cout << "\n\n";
-    std::cout << "╔═══════════════════════════════════════════════════════════════════╗\n";
-    std::cout << "║                         DEMONSTRATION SUMMARY                     ║\n";
-    std::cout << "╚═══════════════════════════════════════════════════════════════════╝\n";
+    std::cout << "+===================================================================+\n";
+    std::cout << "|                         DEMONSTRATION SUMMARY                     |\n";
+    std::cout << "+===================================================================+\n";
     std::cout << "\nKey Insights from the Diagonal Partitioning Algorithm:\n\n";
     std::cout << "1. DIAGONAL STRUCTURE: Products are naturally organized by significance\n";
     std::cout << "   level k = i+j, creating 2N-1 diagonals from most to least significant.\n\n";
@@ -526,13 +526,13 @@ try {
     std::cout << "  - Precision preserved through error tracking\n\n";
 
     if (nrOfFailedTestCases == 0) {
-        std::cout << "╔═══════════════════════════════════════════════════════════════════╗\n";
-        std::cout << "║                    ALL DEMONSTRATIONS PASSED                      ║\n";
-        std::cout << "╚═══════════════════════════════════════════════════════════════════╝\n";
+        std::cout << "+===================================================================+\n";
+        std::cout << "|                    ALL DEMONSTRATIONS PASSED                      |\n";
+        std::cout << "+===================================================================+\n";
     } else {
-        std::cout << "╔═══════════════════════════════════════════════════════════════════╗\n";
-        std::cout << "║               " << nrOfFailedTestCases << " DEMONSTRATIONS FAILED                       ║\n";
-        std::cout << "╚═══════════════════════════════════════════════════════════════════╝\n";
+        std::cout << "+===================================================================+\n";
+        std::cout << "|               " << nrOfFailedTestCases << " DEMONSTRATIONS FAILED                       |\n";
+        std::cout << "+===================================================================+\n";
     }
 
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/internal/floatcascade/arithmetic/renormalize_improvement.cpp
+++ b/internal/floatcascade/arithmetic/renormalize_improvement.cpp
@@ -283,7 +283,7 @@ int TestMultiplicationRenormalization() {
 int TestMultipleSizes() {
     int nrOfFailedTests = 0;
 
-    std::cout << "Test 2: Verify Renormalization for N ∈ {2, 3, 4, 8}\n";
+    std::cout << "Test 2: Verify Renormalization for N in {2, 3, 4, 8}\n";
     std::cout << "====================================================\n\n";
 
     // Test N=2

--- a/linalg/blas/blas_operations.cpp
+++ b/linalg/blas/blas_operations.cpp
@@ -43,7 +43,7 @@ namespace sw { namespace blas {
 		{
 			vector<Scalar> x = { Scalar(-1), Scalar(-2), Scalar(3), Scalar(-4) };
 			Scalar result = asum(4, x, 1);
-			// |−1| + |−2| + |3| + |−4| = 10
+			// |-1| + |-2| + |3| + |-4| = 10
 			if (std::abs(double(result) - 10.0) > 0.001) {
 				++nrOfFailedTests;
 				if (reportTestCases) std::cerr << "FAIL: asum([-1,-2,3,-4]) = " << result << " (expected 10)\n";
@@ -312,8 +312,8 @@ namespace sw { namespace blas {
 		{
 			vector<Scalar> x = { Scalar(1), Scalar(0) };
 			vector<Scalar> y = { Scalar(0), Scalar(1) };
-			Scalar c = Scalar(0);  // cos(90°)
-			Scalar s = Scalar(1);  // sin(90°)
+			Scalar c = Scalar(0);  // cos(90 deg)
+			Scalar s = Scalar(1);  // sin(90 deg)
 			rot(2, x, 1, y, 1, c, s);
 			// After rotation: x_new = c*x + s*y = 0*1 + 1*0 = 0 (first element)
 			//                 y_new = c*y - s*x = 0*0 - 1*1 = -1 (first element)

--- a/linalg/blas/matrix_ops.cpp
+++ b/linalg/blas/matrix_ops.cpp
@@ -313,7 +313,7 @@ namespace sw { namespace blas {
 		{
 			vector<Scalar> v = { Scalar(-3), Scalar(4) };
 			Scalar n = norm(v, 1);
-			// |−3| + |4| = 7
+			// |-3| + |4| = 7
 			if (std::abs(double(n) - 7.0) > 0.001) {
 				++nrOfFailedTests;
 				if (reportTestCases) std::cerr << "FAIL: 1-norm of [-3,4] = " << n << " (expected 7)\n";
@@ -324,7 +324,7 @@ namespace sw { namespace blas {
 		{
 			vector<Scalar> v = { Scalar(-5), Scalar(3), Scalar(4) };
 			Scalar n = norm(v, std::numeric_limits<int>::max());  // inf-norm
-			// max(|−5|, |3|, |4|) = 5
+			// max(|-5|, |3|, |4|) = 5
 			if (std::abs(double(n) - 5.0) > 0.001) {
 				++nrOfFailedTests;
 				if (reportTestCases) std::cerr << "FAIL: inf-norm of [-5,3,4] = " << n << " (expected 5)\n";

--- a/linalg/blas/solvers.cpp
+++ b/linalg/blas/solvers.cpp
@@ -45,7 +45,7 @@ namespace sw { namespace blas { namespace solvers {
 
 	////////////////////////////////////////////////////////////////////////
 	// Test LU solve with known solution
-	// Method: Generate A and x, compute b = A*x, solve A*y = b, verify x ≈ y
+	// Method: Generate A and x, compute b = A*x, solve A*y = b, verify x ~= y
 	template<typename Scalar>
 	int VerifyLUSolve(bool reportTestCases) {
 		int nrOfFailedTests = 0;
@@ -315,7 +315,7 @@ namespace sw { namespace blas { namespace solvers {
 				}
 			}
 
-			// Verify L*U ≈ A (with permutation, but for simple cases should be close)
+			// Verify L*U ~= A (with permutation, but for simple cases should be close)
 			matrix<Scalar> LU_product = L * U;
 
 			// Check Frobenius norm of difference
@@ -378,7 +378,7 @@ namespace sw { namespace blas { namespace solvers {
 
 			auto [Q, R] = qr(A, 1);  // Householder method
 
-			// Verify Q*R ≈ A
+			// Verify Q*R ~= A
 			matrix<Scalar> QR = Q * R;
 			Scalar diff_norm = Scalar(0);
 			for (size_t i = 0; i < 3; ++i) {
@@ -394,7 +394,7 @@ namespace sw { namespace blas { namespace solvers {
 				if (reportTestCases) std::cerr << "FAIL: QR decomposition ||A - Q*R|| = " << diff_norm << "\n";
 			}
 
-			// Verify Q is orthogonal: Q'*Q ≈ I
+			// Verify Q is orthogonal: Q'*Q ~= I
 			matrix<Scalar> Qt = Q;
 			Qt.transpose();
 			matrix<Scalar> QtQ = Qt * Q;
@@ -442,7 +442,7 @@ namespace sw { namespace blas { namespace solvers {
 
 			auto [Q, R] = qr(A, 2);  // Modified Gram-Schmidt
 
-			// Verify Q*R ≈ A
+			// Verify Q*R ~= A
 			matrix<Scalar> QR = Q * R;
 			Scalar diff_norm = Scalar(0);
 			for (size_t i = 0; i < 3; ++i) {
@@ -477,7 +477,7 @@ namespace sw { namespace blas { namespace solvers {
 
 			auto [Q, R] = qr(A, 3);  // Givens rotations
 
-			// Verify Q*R ≈ A
+			// Verify Q*R ~= A
 			matrix<Scalar> QR = Q * R;
 			Scalar diff_norm = Scalar(0);
 			for (size_t i = 0; i < 3; ++i) {

--- a/mixedprecision/pop/test_transfer.cpp
+++ b/mixedprecision/pop/test_transfer.cpp
@@ -7,7 +7,7 @@
 //
 // Validates transfer functions against known precision propagation results.
 // Reference: Dorra Ben Khalifa, "Fast and Efficient Bit-Level Precision Tuning,"
-//            PhD thesis, Université de Perpignan, 2021, Chapter 4.
+//            PhD thesis, Universite de Perpignan, 2021, Chapter 4.
 
 #include <universal/utility/directives.hpp>
 #include <universal/mixedprecision/transfer.hpp>

--- a/numeric/faithful/accurate_sum_and_dot.cpp
+++ b/numeric/faithful/accurate_sum_and_dot.cpp
@@ -1,4 +1,4 @@
-﻿// accurate_sum_and_dot.cpp: twosum/twoproduct/cascadingdot
+// accurate_sum_and_dot.cpp: twosum/twoproduct/cascadingdot
 //
 // Copyright (C) 2017-2021 Stillwater Supercomputing, Inc.
 //

--- a/numeric/faithful/arithmetic.cpp
+++ b/numeric/faithful/arithmetic.cpp
@@ -1,4 +1,4 @@
-﻿// arithmetic.cpp: faithfully rounded floating-point arithmetic
+// arithmetic.cpp: faithfully rounded floating-point arithmetic
 //
 // Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
 //

--- a/numeric/functions/factorial.cpp
+++ b/numeric/functions/factorial.cpp
@@ -1,4 +1,4 @@
-﻿// factorial.cpp: evaluation of factorials in the posit number systems
+// factorial.cpp: evaluation of factorials in the posit number systems
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/numeric/functions/lerp.cpp
+++ b/numeric/functions/lerp.cpp
@@ -1,4 +1,4 @@
-﻿// lerp.cpp: evaluation of linear interpolation function
+// lerp.cpp: evaluation of linear interpolation function
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/numeric/functions/logistic_loss.cpp
+++ b/numeric/functions/logistic_loss.cpp
@@ -1,4 +1,4 @@
-﻿// logistic_loss.cpp: logistic loss function and its tempered and bi-tempered variants
+// logistic_loss.cpp: logistic loss function and its tempered and bi-tempered variants
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -35,7 +35,7 @@ try {
 		double tmps[] = { 0.0, 0.2, 0.4, 0.6, 0.8, double(one_minus_1ulp) };   // temperature can't be 1
 
 
-		// logt(x) := (1 / (1 – t)) * (x ^ (1–t) – 1)
+		// logt(x) := (1 / (1 - t)) * (x ^ (1-t) - 1)
 		// plot tempered logarithm
 		for (Posit t : tmps) {
 			Posit upperbound = Posit(4.0);
@@ -49,7 +49,7 @@ try {
 		}
 	}
 
-	// expt(x) : = [1 + (1 – t) x]+ ^ (1 / (1–t))
+	// expt(x) : = [1 + (1 - t) x]+ ^ (1 / (1-t))
 	// plot tempered exponent
 	{
 
@@ -57,7 +57,7 @@ try {
 		double tmps[] = { double(one_plus_1ulp), 1.5, 2.0, 2.5, 3.0, 3.5 };   // temperature can't be 1
 
 
-		// expt(x) : = [1 + (1 – t) x]+ ^ (1 / (1–t))
+		// expt(x) : = [1 + (1 - t) x]+ ^ (1 / (1-t))
 		// plot tempered exponent
 		for (Posit t : tmps) {
 			Posit lowerbound = Posit(-4.0);

--- a/numeric/functions/polynomial.cpp
+++ b/numeric/functions/polynomial.cpp
@@ -1,4 +1,4 @@
-﻿// polynomial.cpp: evaluation of polynomial of degree N and Nd derivatives evaluate at point x
+// polynomial.cpp: evaluation of polynomial of degree N and Nd derivatives evaluate at point x
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT

--- a/numeric/properties/exp_div_factorial.cpp
+++ b/numeric/properties/exp_div_factorial.cpp
@@ -1,4 +1,4 @@
-﻿// exp_div_factorial.cpp: 
+// exp_div_factorial.cpp: 
 //
 // Copyright (C) 2017-2021 Stillwater Supercomputing, Inc.
 //

--- a/numeric/properties/type_traits.cpp
+++ b/numeric/properties/type_traits.cpp
@@ -1,4 +1,4 @@
-﻿// type_traits.cpp: experiments with type traits of native floats, integers, fixpnts, and posit number types
+// type_traits.cpp: experiments with type traits of native floats, integers, fixpnts, and posit number types
 //
 // Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
 //

--- a/numeric/skeleton_code
+++ b/numeric/skeleton_code
@@ -1,4 +1,4 @@
-﻿// skeleton.cpp: 
+// skeleton.cpp: 
 //
 // Copyright (C) 2017-2020 Stillwater Supercomputing, Inc.
 //

--- a/papers/systems-paper/conjugate_gradient.cpp
+++ b/papers/systems-paper/conjugate_gradient.cpp
@@ -3,7 +3,7 @@
 // Demonstrates how the choice of number system affects convergence
 // of the preconditioned Conjugate Gradient method on SPD systems.
 // CG is the canonical Krylov solver for symmetric positive-definite
-// problems and is sensitive to rounding — small representational
+// problems and is sensitive to rounding -- small representational
 // errors can break A-orthogonality of the search directions,
 // causing stagnation or slow convergence.
 //
@@ -67,7 +67,7 @@ sw::numeric::containers::vector<Dst> convert_vector(const sw::numeric::container
 // Template parameters allow the preconditioner and solver to use
 // different scalar types, enabling mixed-precision exploration.
 //
-//   Scalar — working precision for the CG iteration
+//   Scalar -- working precision for the CG iteration
 //
 // Returns (iterations, final_residual_norm, forward_error)
 // -------------------------------------------------------------------------
@@ -481,7 +481,7 @@ Key observations:
      errors destroy A-orthogonality of the CG search directions.
 
   3. Posit<32,2> typically converges in the same iteration count as
-     IEEE float — both have ~24 bits of significand near 1.0.
+     IEEE float -- both have ~24 bits of significand near 1.0.
 
   4. The two-precision configurations show that a low-precision
      preconditioner (half or bfloat16) paired with a higher-precision

--- a/papers/systems-paper/iterative_refinement.cpp
+++ b/papers/systems-paper/iterative_refinement.cpp
@@ -142,9 +142,9 @@ sw::numeric::containers::vector<Dst> convert_vector(const sw::numeric::container
 // -------------------------------------------------------------------------
 // Three-precision iterative refinement
 //
-//   HIGH  — residual computation:  r = b - A*x
-//   WORK  — triangular solves:     c = (LU)^{-1} r
-//   LOW   — LU factorization:     PA = LU
+//   HIGH  -- residual computation:  r = b - A*x
+//   WORK  -- triangular solves:     c = (LU)^{-1} r
+//   LOW   -- LU factorization:     PA = LU
 //
 // Returns (iterations, final_nbe, final_forward_error)
 // -------------------------------------------------------------------------
@@ -407,19 +407,19 @@ try {
 	print_header();
 	results.clear();
 
-	// Half → posit<32,2> working → double high
+	// Half -> posit<32,2> working -> double high
 	results.push_back(run_ir<double, posit<32,2>, sw::universal::half>(
 		"X-1", "half (fp16)", "posit<32,2>", "double (fp64)", N));
 
-	// posit<16,1> low → float working → dd high (double-double)
+	// posit<16,1> low -> float working -> dd high (double-double)
 	results.push_back(run_ir<dd, float, posit<16,1>>(
 		"X-2", "posit<16,1>", "float (fp32)", "dd (2x64)", N));
 
-	// bfloat16 low → posit<32,2> working → dd high
+	// bfloat16 low -> posit<32,2> working -> dd high
 	results.push_back(run_ir<dd, posit<32,2>, sw::universal::bfloat_t>(
 		"X-3", "bfloat16", "posit<32,2>", "dd (2x64)", N));
 
-	// cfloat<16,5> low → cfloat<32,8> working → dd high
+	// cfloat<16,5> low -> cfloat<32,8> working -> dd high
 	results.push_back(run_ir<dd, cf32, cf16>(
 		"X-4", "cfloat<16,5>", "cfloat<32,8>", "dd (2x64)", N));
 
@@ -475,7 +475,7 @@ Key observations:
 
   3. Cross-family X-2 and X-3 use double-double (dd) for the high-precision
      residual.  The 106-bit significand provides a much sharper residual than
-     double, accelerating convergence — especially for larger N where
+     double, accelerating convergence -- especially for larger N where
      kappa(A) grows as O(N^2).
 
   4. As N increases, more IR iterations are needed because the condition
@@ -485,7 +485,7 @@ Key observations:
 
   5. Non-standard cfloat widths (CF-2: 12/24/48) demonstrate the library's
      ability to explore precision points that don't correspond to any
-     hardware format — useful for co-design studies.
+     hardware format -- useful for co-design studies.
 
 Reference:
   Carson, E. and Higham, N. J. (2018). "Accelerating the solution of linear

--- a/skeleton.cpp
+++ b/skeleton.cpp
@@ -1,4 +1,4 @@
-﻿// something.cpp: experiments with numbers
+// something.cpp: experiments with numbers
 //
 // Copyright (C) 2017-2021 Stillwater Supercomputing, Inc.
 //

--- a/static/block/zfpblock/array/array_api.cpp
+++ b/static/block/zfpblock/array/array_api.cpp
@@ -116,7 +116,7 @@ try {
 	// compression ratio
 	std::cout << "+---------    compression ratio   --------+\n";
 	{
-		zfparray1f arr(100, 8.0);  // 8 bpv for float (32 bits native) → ~4x
+		zfparray1f arr(100, 8.0);  // 8 bpv for float (32 bits native) -> ~4x
 		double ratio = arr.compression_ratio();
 		std::cout << "100 floats at 8 bpv: ratio = " << ratio << "x\n";
 		if (ratio < 3.0 || ratio > 5.0) {

--- a/static/block/zfpblock/array/array_cache.cpp
+++ b/static/block/zfpblock/array/array_cache.cpp
@@ -32,9 +32,9 @@ try {
 
 		// access block 0 element
 		float v0 = arr(0);
-		// access block 2 element — triggers eviction of block 0
+		// access block 2 element -- triggers eviction of block 0
 		float v8 = arr(8);
-		// access block 0 again — triggers reload
+		// access block 0 again -- triggers reload
 		float v1 = arr(1);
 
 		float err0 = std::abs(v0 - 1.0f);
@@ -65,11 +65,11 @@ try {
 		// modify element in block 0
 		arr.set(0, 99.0f);
 
-		// access block 1 — evicts block 0, triggering write-back
+		// access block 1 -- evicts block 0, triggering write-back
 		float v4 = arr(4);
 		(void)v4;
 
-		// access block 0 again — should reload with the modified value
+		// access block 0 again -- should reload with the modified value
 		float v0 = arr(0);
 		float err = std::abs(v0 - 99.0f);
 
@@ -94,7 +94,7 @@ try {
 		arr.set(0, 42.0f);
 		arr.flush();
 
-		// same block should still be cached — reading should return the cached value
+		// same block should still be cached -- reading should return the cached value
 		float v0 = arr(0);
 		float err = std::abs(v0 - 42.0f);
 

--- a/static/block/zfpblock/array/array_copy_move.cpp
+++ b/static/block/zfpblock/array/array_copy_move.cpp
@@ -176,7 +176,7 @@ try {
 	{
 		zfparray1f arr(N, rate, src);
 
-		// suppress self-assignment warnings — this is intentional
+		// suppress self-assignment warnings -- this is intentional
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"

--- a/static/block/zfpblock/codec/lifting.cpp
+++ b/static/block/zfpblock/codec/lifting.cpp
@@ -14,7 +14,7 @@
 
 // Test that forward then inverse lifting is near-exact for integers
 // The lifting transform uses truncating right-shifts, so round-trip
-// may differ by ±1 in the LSB — this is expected ZFP behavior.
+// may differ by +/-1 in the LSB -- this is expected ZFP behavior.
 template<typename Int>
 int VerifyLiftingRoundTrip1D(const std::string& tag) {
 	int nrOfFailedTests = 0;
@@ -41,7 +41,7 @@ int VerifyLiftingRoundTrip1D(const std::string& tag) {
 				std::cerr << tag << " FAIL: index " << i
 				          << " expected=" << original[i]
 				          << " got=" << p[i]
-				          << " (diff=" << diff << ", max allowed ±1)\n";
+				          << " (diff=" << diff << ", max allowed +/-1)\n";
 				++nrOfFailedTests;
 			}
 		}
@@ -89,7 +89,7 @@ int VerifyStridedLifting(const std::string& tag) {
 			std::cerr << tag << " strided FAIL: index " << i
 			          << " expected=" << original[i]
 			          << " got=" << block[i]
-			          << " (diff=" << diff << ", max allowed ±1)\n";
+			          << " (diff=" << diff << ", max allowed +/-1)\n";
 			++nrOfFailedTests;
 		}
 	}
@@ -97,12 +97,12 @@ int VerifyStridedLifting(const std::string& tag) {
 }
 
 // Test full multi-dimensional transform round-trip
-// The lifting truncation accumulates across dimensions, allowing ±2 per dim.
+// The lifting truncation accumulates across dimensions, allowing +/-2 per dim.
 template<typename Int, unsigned Dim>
 int VerifyXformRoundTrip(const std::string& tag) {
 	int nrOfFailedTests = 0;
 	constexpr size_t N = sw::universal::zfp_block_size<Dim>::value;
-	constexpr Int max_diff = static_cast<Int>(Dim * 2);  // allow ±2 per dimension
+	constexpr Int max_diff = static_cast<Int>(Dim * 2);  // allow +/-2 per dimension
 
 	Int block[N], original[N];
 	for (size_t i = 0; i < N; ++i) {
@@ -119,7 +119,7 @@ int VerifyXformRoundTrip(const std::string& tag) {
 			std::cerr << tag << " xform FAIL: index " << i
 			          << " expected=" << original[i]
 			          << " got=" << block[i]
-			          << " (diff=" << diff << ", max allowed ±" << max_diff << ")\n";
+			          << " (diff=" << diff << ", max allowed +/-" << max_diff << ")\n";
 			++nrOfFailedTests;
 		}
 	}

--- a/static/block/zfpblock/codec/negabinary.cpp
+++ b/static/block/zfpblock/codec/negabinary.cpp
@@ -33,7 +33,7 @@ int VerifyNegabinaryRoundTrip32(const std::string& tag) {
 		}
 	}
 
-	// verify known encoding: 0 → 0xAAAAAAAA ^ 0xAAAAAAAA = 0
+	// verify known encoding: 0 -> 0xAAAAAAAA ^ 0xAAAAAAAA = 0
 	{
 		uint32_t u = int2uint<int32_t, uint32_t>(0);
 		if (u != 0) {

--- a/static/block/zfpblock/modes/fixed_rate.cpp
+++ b/static/block/zfpblock/modes/fixed_rate.cpp
@@ -20,7 +20,7 @@ int VerifyExactBitCount1D(const std::string& tag) {
 	float input[4] = { 1.0f, -2.0f, 3.0f, -4.0f };
 
 	// test various rates: bits per value
-	// Minimum useful rate for float: header is 1+8=9 bits, so need rate*4 >= 9 → rate >= 2.25
+	// Minimum useful rate for float: header is 1+8=9 bits, so need rate*4 >= 9 -> rate >= 2.25
 	double rates[] = { 4.0, 8.0, 12.0, 16.0, 24.0, 32.0 };
 	for (double rate : rates) {
 		zfp1f blk;
@@ -126,8 +126,8 @@ int VerifyCompressionRatio(const std::string& tag) {
 
 	float input[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
 
-	// rate=8 means 8 bits/value → 32 bits total for 4 values
-	// uncompressed = 4 * 32 = 128 bits → ratio = 128/32 = 4.0
+	// rate=8 means 8 bits/value -> 32 bits total for 4 values
+	// uncompressed = 4 * 32 = 128 bits -> ratio = 128/32 = 4.0
 	zfp1f blk;
 	blk.compress_fixed_rate(input, 8.0);
 	double ratio = blk.compression_ratio();

--- a/static/block/zfpblock/roundtrip/roundtrip_1d.cpp
+++ b/static/block/zfpblock/roundtrip/roundtrip_1d.cpp
@@ -13,7 +13,7 @@
 #include <cmath>
 
 // Verify reversible round-trip for 1D float
-// Note: The ZFP lifting transform has inherent ±1 LSB rounding in the integer domain.
+// Note: The ZFP lifting transform has inherent +/-1 LSB rounding in the integer domain.
 // For values with similar magnitude, this gives near-exact results.
 // For values with very different magnitudes, the quantization to shared exponent
 // causes small values to be quantized to zero.

--- a/static/block/zfpblock/roundtrip/roundtrip_2d.cpp
+++ b/static/block/zfpblock/roundtrip/roundtrip_2d.cpp
@@ -94,7 +94,7 @@ int VerifyFixedRate2DFloat(const std::string& tag) {
 		if (max_err > prev_max_err * 1.01) {  // small tolerance for rounding
 			std::cerr << tag << " WARNING: error increased with higher rate"
 			          << " (" << max_err << " > " << prev_max_err << ")\n";
-			// Not a hard failure — ZFP doesn't strictly guarantee monotonic error reduction
+			// Not a hard failure -- ZFP doesn't strictly guarantee monotonic error reduction
 		}
 		prev_max_err = max_err;
 	}

--- a/static/conversions/adapt_integer_and_posit.cpp
+++ b/static/conversions/adapt_integer_and_posit.cpp
@@ -392,7 +392,7 @@ namespace sw { namespace universal {
 
 		// Test small integers that should round-trip exactly
 		// For small posits like posit<8,0>, only powers of 2 and nearby values are exact
-		// Use conservative set: 0, ±1, ±2, ±4, ±8 (powers of 2 that all posits can represent)
+		// Use conservative set: 0, +/-1, +/-2, +/-4, +/-8 (powers of 2 that all posits can represent)
 		int testValues[] = { 0, 1, -1, 2, -2, 4, -4, 8, -8 };
 
 		for (int val : testValues) {

--- a/static/fixpnt/binary/conversion/mod_subnormal_conversion.cpp
+++ b/static/fixpnt/binary/conversion/mod_subnormal_conversion.cpp
@@ -27,8 +27,8 @@ Exponent     |     fraction = 0     |      fraction != 0      |      Equation
 0x01...0xFE  |                normal value                   |    (-1)sign * 1.fraction * 2^(exponent - 127)
 0xFF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2-126 ~= 1.18 * 10-38.
-The minimum positive(subnormal) value is 2-149 ~= 1.4 * 10-45.
+The minimum positive normal value is 2^-126 ~= 1.18 * 10^-38.
+The minimum positive(subnormal) value is 2^-149 ~= 1.4 * 10^-45.
 */
 
 template<size_t nbits, size_t rbits>
@@ -61,8 +61,8 @@ Exponent      |     fraction = 0     |      fraction != 0      |      Equation
 0x001...0x7FE |                normal value                   |    (-1)^sign * 1.fraction * 2^(exponent - 1023)
 0x7FF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2-1022 ~= 2.22e-308.
-The minimum positive(subnormal) value is 2-1074 ~= 1.4 * 10-45.
+The minimum positive normal value is 2^-1022 ~= 2.22e-308.
+The minimum positive(subnormal) value is 2^-1074 ~= 4.94e-324.
 */
 
 template<size_t nbits, size_t rbits>

--- a/static/fixpnt/binary/conversion/mod_subnormal_conversion.cpp
+++ b/static/fixpnt/binary/conversion/mod_subnormal_conversion.cpp
@@ -1,4 +1,4 @@
-﻿// mod_subnormal_conversion.cpp: test suite runner for subnormal IEEE-754 floating-point to fixed-point 
+// mod_subnormal_conversion.cpp: test suite runner for subnormal IEEE-754 floating-point to fixed-point 
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -22,13 +22,13 @@ IEEE-754 has subnormal numbers that a fixed-point needs to be able to pick up.
 
 The exponent values 0x00 and 0xFF are encoding special cases.
 
-Exponent     |     fraction = 0     |      fraction ≠ 0      |      Equation
+Exponent     |     fraction = 0     |      fraction != 0      |      Equation
 0x00         |       zero           |    subnormal number    |    (-1)sign * 0.fraction * 2^-126
 0x01...0xFE  |                normal value                   |    (-1)sign * 1.fraction * 2^(exponent - 127)
-0xFF         |    ±infinity         |    NaN(quiet, signalling)
+0xFF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2−126 ≈ 1.18 × 10−38.
-The minimum positive(subnormal) value is 2−149 ≈ 1.4 × 10−45.
+The minimum positive normal value is 2-126 ~= 1.18 * 10-38.
+The minimum positive(subnormal) value is 2-149 ~= 1.4 * 10-45.
 */
 
 template<size_t nbits, size_t rbits>
@@ -56,13 +56,13 @@ IEEE-754 has subnormal numbers that a fixed-point needs to be able to pick up.
 
 The exponent values 0x000 and 0x7FF are encoding special cases.
 
-Exponent      |     fraction = 0     |      fraction ≠ 0      |      Equation
+Exponent      |     fraction = 0     |      fraction != 0      |      Equation
 0x000         |       zero           |    subnormal number    |    (-1)^sign * 0.fraction * 2^-1022
 0x001...0x7FE |                normal value                   |    (-1)^sign * 1.fraction * 2^(exponent - 1023)
-0x7FF         |    ±infinity         |    NaN(quiet, signalling)
+0x7FF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2−1022 ≈ 2.22e-308.
-The minimum positive(subnormal) value is 2−1074 ≈ 1.4 × 10−45.
+The minimum positive normal value is 2-1022 ~= 2.22e-308.
+The minimum positive(subnormal) value is 2-1074 ~= 1.4 * 10-45.
 */
 
 template<size_t nbits, size_t rbits>

--- a/static/fixpnt/binary/conversion/sat_subnormal_conversion.cpp
+++ b/static/fixpnt/binary/conversion/sat_subnormal_conversion.cpp
@@ -27,8 +27,8 @@ Exponent     |     fraction = 0     |      fraction != 0      |      Equation
 0x01...0xFE  |                normal value                   |    (-1)sign * 1.fraction * 2^(exponent - 127)
 0xFF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2-126 ~= 1.18 * 10-38.
-The minimum positive(subnormal) value is 2-149 ~= 1.4 * 10-45.
+The minimum positive normal value is 2^-126 ~= 1.18 * 10^-38.
+The minimum positive(subnormal) value is 2^-149 ~= 1.4 * 10^-45.
 */
 
 void TestDenormalizedNumberConversions() {
@@ -63,8 +63,8 @@ Exponent      |     fraction = 0     |      fraction != 0      |      Equation
 0x001...0x7FE |                normal value                   |    (-1)^sign * 1.fraction * 2^(exponent - 1023)
 0x7FF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2-1022 ~= 2.22e-308.
-The minimum positive(subnormal) value is 2-1074 ~= 1.4 * 10-45.
+The minimum positive normal value is 2^-1022 ~= 2.22e-308.
+The minimum positive(subnormal) value is 2^-1074 ~= 4.94e-324.
 */
 
 template<size_t nbits, size_t rbits>

--- a/static/fixpnt/binary/conversion/sat_subnormal_conversion.cpp
+++ b/static/fixpnt/binary/conversion/sat_subnormal_conversion.cpp
@@ -1,4 +1,4 @@
-﻿// sat_subnormal_conversion.cpp: test suite runner for subnormal IEEE-754 floating-point to fixed-point 
+// sat_subnormal_conversion.cpp: test suite runner for subnormal IEEE-754 floating-point to fixed-point 
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -22,13 +22,13 @@ IEEE-754 has subnormal numbers that a fixed-point needs to be able to pick up.
 
 The stored exponents 0x00 and 0xFF are interpreted specially.
 
-Exponent     |     fraction = 0     |      fraction ≠ 0      |      Equation
+Exponent     |     fraction = 0     |      fraction != 0      |      Equation
 0x00         |       zero           |    subnormal number    |    (-1)sign * 0.fraction * 2^-126
 0x01...0xFE  |                normal value                   |    (-1)sign * 1.fraction * 2^(exponent - 127)
-0xFF         |    ±infinity         |    NaN(quiet, signalling)
+0xFF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2−126 ≈ 1.18 × 10−38.
-The minimum positive(subnormal) value is 2−149 ≈ 1.4 × 10−45.
+The minimum positive normal value is 2-126 ~= 1.18 * 10-38.
+The minimum positive(subnormal) value is 2-149 ~= 1.4 * 10-45.
 */
 
 void TestDenormalizedNumberConversions() {
@@ -58,13 +58,13 @@ IEEE-754 has subnormal numbers that a fixed-point needs to be able to pick up.
 
 The stored exponents 0x000 and 0x7FF are interpreted specially.
 
-Exponent      |     fraction = 0     |      fraction ≠ 0      |      Equation
+Exponent      |     fraction = 0     |      fraction != 0      |      Equation
 0x000         |       zero           |    subnormal number    |    (-1)^sign * 0.fraction * 2^-1022
 0x001...0x7FE |                normal value                   |    (-1)^sign * 1.fraction * 2^(exponent - 1023)
-0x7FF         |    ±infinity         |    NaN(quiet, signalling)
+0x7FF         |    +/-infinity         |    NaN(quiet, signalling)
 
-The minimum positive normal value is 2−1022 ≈ 2.22e-308.
-The minimum positive(subnormal) value is 2−1074 ≈ 1.4 × 10−45.
+The minimum positive normal value is 2-1022 ~= 2.22e-308.
+The minimum positive(subnormal) value is 2-1074 ~= 1.4 * 10-45.
 */
 
 template<size_t nbits, size_t rbits>

--- a/static/fixpnt/binary/math/trigonometry.cpp
+++ b/static/fixpnt/binary/math/trigonometry.cpp
@@ -1,4 +1,4 @@
-﻿// trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
+// trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -10,8 +10,8 @@
 #include <universal/verification/fixpnt_test_suite_mathlib.hpp>
 
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In extensive testing, no errors > 0.97 ulp were found in either the sine
 or cosine results, suggesting the results returned are faithfully rounded.
@@ -82,8 +82,8 @@ double cospi(double arg) {
 
 #ifdef CPP17_HEXFLOAT_LITERALS
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In exhaustive testing, the maximum error in sine results was 0.96677 ulp,
 the maximum error in cosine results was 0.96563 ulp, meaning results are

--- a/static/float/cfloat/conversion/assignment.cpp
+++ b/static/float/cfloat/conversion/assignment.cpp
@@ -156,7 +156,7 @@ int VerifySpecialCases(const std::string& tag, bool reportTestCases = false) {
 	// and POWER will quiet the sNaN (clear the signaling bit) and may
 	// also canonicalise the NaN payload.  The resulting native qNaN
 	// may then convert back to a cfloat encoding that no longer matches
-	// the original sNaN — or may even lose the NaN classification
+	// the original sNaN -- or may even lose the NaN classification
 	// entirely for small cfloat formats.  We therefore only test the
 	// sNaN round-trip on platforms where it is known to survive.
 #if UNIVERSAL_SNAN_ROUND_TRIPS_NATIVE_FP

--- a/static/float/cfloat/math/trigonometry.cpp
+++ b/static/float/cfloat/math/trigonometry.cpp
@@ -1,4 +1,4 @@
-﻿// trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
+// trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -10,8 +10,8 @@
 #include <universal/verification/cfloat_test_suite_mathlib.hpp>
 
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In extensive testing, no errors > 0.97 ulp were found in either the sine
 or cosine results, suggesting the results returned are faithfully rounded.
@@ -82,8 +82,8 @@ double cospi(double arg) {
 
 #ifdef CPP17_HEXFLOAT_LITERALS
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In exhaustive testing, the maximum error in sine results was 0.96677 ulp,
 the maximum error in cosine results was 0.96563 ulp, meaning results are

--- a/static/float/dfloat/api/api.cpp
+++ b/static/float/dfloat/api/api.cpp
@@ -1,4 +1,4 @@
-﻿// api.cpp: application programming interface tests for decimal floating-point number system
+// api.cpp: application programming interface tests for decimal floating-point number system
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -19,17 +19,17 @@
 /*
 Table 3.6 of the IEEE 754-2008 spec defines a set of standard decimal floats from the total bit width k using four formulas:
 
-  ┌─────────────────────────────────────────────┬─────────────────────┬─────────────────────┬───────────────────────┐
-  │                   Formula                   │        k=32         │        k=64         │         k=128         │
-  ├─────────────────────────────────────────────┼─────────────────────┼─────────────────────┼───────────────────────┤
-  │ p = 9k/32 - 2 (precision in digits)         │ 9(32)/32 - 2 = 7    │ 9(64)/32 - 2 = 16   │ 9(128)/32 - 2 = 34    │
-  ├─────────────────────────────────────────────┼─────────────────────┼─────────────────────┼───────────────────────┤
-  │ w = k/16 + 4 (exponent continuation bits)   │ 32/16 + 4 = 6       │ 64/16 + 4 = 8       │ 128/16 + 4 = 12       │
-  ├─────────────────────────────────────────────┼─────────────────────┼─────────────────────┼───────────────────────┤
-  │ t = 15k/16 - 10 (trailing significand bits) │ 15(32)/16 - 10 = 20 │ 15(64)/16 - 10 = 50 │ 15(128)/16 - 10 = 110 │
-  ├─────────────────────────────────────────────┼─────────────────────┼─────────────────────┼───────────────────────┤
-  │ emax = 3 × 2^(k/16+3)                       │ 3 × 2^5 = 96        │ 3 × 2^7 = 384       │ 3 × 2^11 = 6144       │
-  └─────────────────────────────────────────────┴─────────────────────┴─────────────────────┴───────────────────────┘
+  +---------------------------------------------+---------------------+---------------------+-----------------------+
+  |                   Formula                   |        k=32         |        k=64         |         k=128         |
+  +---------------------------------------------+---------------------+---------------------+-----------------------+
+  | p = 9k/32 - 2 (precision in digits)         | 9(32)/32 - 2 = 7    | 9(64)/32 - 2 = 16   | 9(128)/32 - 2 = 34    |
+  +---------------------------------------------+---------------------+---------------------+-----------------------+
+  | w = k/16 + 4 (exponent continuation bits)   | 32/16 + 4 = 6       | 64/16 + 4 = 8       | 128/16 + 4 = 12       |
+  +---------------------------------------------+---------------------+---------------------+-----------------------+
+  | t = 15k/16 - 10 (trailing significand bits) | 15(32)/16 - 10 = 20 | 15(64)/16 - 10 = 50 | 15(128)/16 - 10 = 110 |
+  +---------------------------------------------+---------------------+---------------------+-----------------------+
+  | emax = 3 * 2^(k/16+3)                       | 3 * 2^5 = 96        | 3 * 2^7 = 384       | 3 * 2^11 = 6144       |
+  +---------------------------------------------+---------------------+---------------------+-----------------------+
 
   The bit budget for each format:
 
@@ -49,7 +49,7 @@ Table 3.6 of the IEEE 754-2008 spec defines a set of standard decimal floats fro
   - BID has enough bits to hold 10^(p-1) - 1 as a binary integer
   - The exponent range grows proportionally with precision
 
-  dfloat<7, 6> literally means "7 significant decimal digits, 6 exponent continuation bits" — the two independent
+  dfloat<7, 6> literally means "7 significant decimal digits, 6 exponent continuation bits" -- the two independent
   parameters that, together with the fixed 1+5 bit sign+combination field, determine everything else.
  */
 

--- a/static/float/hfloat/standard/short.cpp
+++ b/static/float/hfloat/standard/short.cpp
@@ -93,8 +93,8 @@ try {
 	// Test 4: Wobbling precision demonstration
 	std::cout << "+---------    Wobbling precision\n";
 	{
-		// Value 1.0: binary = 0.0001 in hex → leading hex digit has 3 leading zero bits → less precision
-		// Value 8.0: binary = 0.1000 in hex → leading hex digit fully utilized → more precision
+		// Value 1.0: binary = 0.0001 in hex -> leading hex digit has 3 leading zero bits -> less precision
+		// Value 8.0: binary = 0.1000 in hex -> leading hex digit fully utilized -> more precision
 		Short one(1.0), eight(8.0);
 		std::cout << "  1.0: " << to_binary(one) << '\n';
 		std::cout << "  8.0: " << to_binary(eight) << '\n';

--- a/static/highprecision/dd_cascade/api/api.cpp
+++ b/static/highprecision/dd_cascade/api/api.cpp
@@ -76,7 +76,7 @@ int main() {
     std::cout << "0 + a = " << test_sum << '\n';
     std::cout << "Components preserved: "
               << (test_sum.high() == test_a.high() && test_sum.low() == test_a.low()
-                  ? "YES ✓" : "NO ✗") << '\n';
+                  ? "YES OK" : "NO X") << '\n';
 
     std::cout << "\n" << std::string(70, '=') << '\n';
     std::cout << "Example completed successfully!\n";

--- a/static/highprecision/dd_cascade/arithmetic/corner_cases.hpp
+++ b/static/highprecision/dd_cascade/arithmetic/corner_cases.hpp
@@ -21,7 +21,7 @@
  * has only 53 bits (~16 decimal digits). Comparing dd_cascade arithmetic results to double references
  * is fundamentally flawed:
  *
- *   dd_cascade: ~106 fraction bits (2 × 53-bit doubles with non-overlapping mantissas)
+ *   dd_cascade: ~106 fraction bits (2 * 53-bit doubles with non-overlapping mantissas)
  *   double:      ~53 fraction bits
  *
  * Random testing with double references fails because:
@@ -77,10 +77,10 @@
  *    - Extreme separation: components at maximum exponent range
  *
  * 3. SIGN PATTERN CASES
- *    - (+,+,+) ± (+,+,+) - all positive
- *    - (+,+,+) ± (-,-,-) - opposite signs
- *    - (+,-,+) ± (+,+,+) - mixed internal signs (tests denormalized inputs)
- *    - (+,+,-) ± (+,-,+) - various mixed patterns
+ *    - (+,+,+) +/- (+,+,+) - all positive
+ *    - (+,+,+) +/- (-,-,-) - opposite signs
+ *    - (+,-,+) +/- (+,+,+) - mixed internal signs (tests denormalized inputs)
+ *    - (+,+,-) +/- (+,-,+) - various mixed patterns
  *
  * 4. RENORMALIZATION TRIGGERS
  *    - Upward carry: adding small values that grow component[0]
@@ -91,7 +91,7 @@
  * 5. SPECIAL VALUES
  *    - Zero operations: 0 + a, a + 0, 0 - 0
  *    - Identity: a - a, (a + b) - a
- *    - Infinity: ±∞ + a, ∞ - ∞ (should be NaN)
+ *    - Infinity: +/-inf + a, inf - inf (should be NaN)
  *    - NaN propagation
  *
  * 6. PRECISION BOUNDARY CASES
@@ -105,9 +105,9 @@
  *
  * Instead of comparing to double references, validate using:
  *
- * 1. SELF-CONSISTENCY: (a + b) - b ≈ a (within dd_cascade ULP)
+ * 1. SELF-CONSISTENCY: (a + b) - b ~= a (within dd_cascade ULP)
  * 2. COMPONENT INSPECTION: Verify each component is within expected bounds
- * 3. ASSOCIATIVITY TESTS: (a + b) + c ≈ a + (b + c) (approximately equal)
+ * 3. ASSOCIATIVITY TESTS: (a + b) + c ~= a + (b + c) (approximately equal)
  * 4. KNOWN EXACT RESULTS: Construct cases where exact answer is known
  * 5. CROSS-VALIDATION: Use qd (quad-double) as oracle if available
  */
@@ -116,10 +116,10 @@ namespace sw::universal {
 namespace dd_cascade_corner_cases {
 
 // Epsilon values for multi-component precision
-// Double:         53 bits of precision → epsilon = 2^-52  ≈ 2.22e-16
-// Double-double: 106 bits of precision → epsilon = 2^-106 ≈ 1.23e-32
-// Triple-double: 159 bits of precision → epsilon = 2^-159 ≈ 1.74e-48
-constexpr double DOUBLE_EPS = std::numeric_limits<double>::epsilon(); // 2^-52 ≈ 2.22e-16
+// Double:         53 bits of precision -> epsilon = 2^-52  ~= 2.22e-16
+// Double-double: 106 bits of precision -> epsilon = 2^-106 ~= 1.23e-32
+// Triple-double: 159 bits of precision -> epsilon = 2^-159 ~= 1.74e-48
+constexpr double DOUBLE_EPS = std::numeric_limits<double>::epsilon(); // 2^-52 ~= 2.22e-16
 constexpr double DD_EPS = 1.2325951644078309e-32;  // 2^-106 for double-double
 
 // Test result structure
@@ -185,9 +185,9 @@ inline TestResult verify_normalized(const dd_cascade& value, const std::string& 
     return TestResult(true);
 }
 
-// Verify self-consistency: (a op b) op_inv b ≈ a
-// For addition: (a + b) - b ≈ a
-// For subtraction: (a - b) + b ≈ a
+// Verify self-consistency: (a op b) op_inv b ~= a
+// For addition: (a + b) - b ~= a
+// For subtraction: (a - b) + b ~= a
 inline TestResult verify_self_consistency_add(
     const dd_cascade& a,
     const dd_cascade& b,
@@ -312,7 +312,7 @@ inline dd_cascade create_small_magnitude_separation() {
  * Multiplication has fundamentally different characteristics from addition/subtraction:
  *
  * 1. ALGORITHM STRUCTURE:
- *    - Uses expansion_ops::multiply_cascades() which generates N² products (9 for dd_cascade)
+ *    - Uses expansion_ops::multiply_cascades() which generates N^2 products (9 for dd_cascade)
  *    - Each product computed with two_prod for exact error tracking
  *    - Products accumulated by significance level
  *    - Result renormalized
@@ -320,15 +320,15 @@ inline dd_cascade create_small_magnitude_separation() {
  * 2. UNIQUE MULTIPLICATION CORNER CASES:
  *
  *    a) ZERO ABSORPTION:
- *       - 0 × a = 0, a × 0 = 0, 0 × 0 = 0
+ *       - 0 * a = 0, a * 0 = 0, 0 * 0 = 0
  *       - All components must be exactly zero
  *
  *    b) IDENTITY:
- *       - 1 × a = a, a × 1 = a
+ *       - 1 * a = a, a * 1 = a
  *       - All components must be preserved
  *
  *    c) COMMUTATIVITY:
- *       - a × b should equal b × a
+ *       - a * b should equal b * a
  *       - Tests symmetry of multiplication algorithm
  *
  *    d) POWERS OF 2 (EXACT OPERATIONS):
@@ -337,36 +337,36 @@ inline dd_cascade create_small_magnitude_separation() {
  *       - All components should scale exactly
  *
  *    e) SIGN PATTERNS:
- *       - (+) × (+) = (+), (+) × (-) = (-), (-) × (+) = (-), (-) × (-) = (+)
+ *       - (+) * (+) = (+), (+) * (-) = (-), (-) * (+) = (-), (-) * (-) = (+)
  *
  *    f) MAGNITUDE EXTREMES:
- *       - Small × Large: may cause overflow/underflow in products
- *       - Large × Large: may overflow
- *       - Small × Small: may underflow
+ *       - Small * Large: may cause overflow/underflow in products
+ *       - Large * Large: may overflow
+ *       - Small * Small: may underflow
  *
  *    g) NEAR-1 VALUES:
- *       - (1 + ε) × (1 + δ) = 1 + ε + δ + εδ
+ *       - (1 + eps) * (1 + delta) = 1 + eps + delta + epsdelta
  *       - Tests precision accumulation in lower components
  *
  *    h) COMPONENT INTERACTION:
- *       - All 9 products (3×3) contribute to final result
+ *       - All 9 products (3*3) contribute to final result
  *       - Tests proper accumulation and renormalization
  *
  *    i) ALGEBRAIC PROPERTIES:
- *       - Associativity: (a × b) × c ≈ a × (b × c)
- *       - Distributivity: a × (b + c) ≈ a×b + a×c
+ *       - Associativity: (a * b) * c ~= a * (b * c)
+ *       - Distributivity: a * (b + c) ~= a*b + a*c
  *
  * 3. SELF-CONSISTENCY VALIDATION:
- *    - Commutativity: a × b = b × a (exact within renormalization)
- *    - With division: (a × b) / b ≈ a
- *    - Squares: verify a × a produces expected square
+ *    - Commutativity: a * b = b * a (exact within renormalization)
+ *    - With division: (a * b) / b ~= a
+ *    - Squares: verify a * a produces expected square
  */
 
-// Verify commutativity: a × b should equal b × a
+// Verify commutativity: a * b should equal b * a
 inline TestResult verify_commutativity(
     const dd_cascade& a,
     const dd_cascade& b,
-    const std::string& test_name = "commutativity a×b = b×a")
+    const std::string& test_name = "commutativity a*b = b*a")
 {
     dd_cascade ab = a * b;
     dd_cascade ba = b * a;
@@ -390,18 +390,18 @@ inline TestResult verify_commutativity(
     oss << test_name << " FAILED:\n";
     oss << "  a     = " << to_binary(a) << "\n";
     oss << "  b     = " << to_binary(b) << "\n";
-    oss << "  a×b   = " << to_binary(ab) << "\n";
-    oss << "  b×a   = " << to_binary(ba) << "\n";
+    oss << "  a*b   = " << to_binary(ab) << "\n";
+    oss << "  b*a   = " << to_binary(ba) << "\n";
     oss << "  diff  = " << (ab[0] - ba[0]) << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify self-consistency using division: (a × b) / b ≈ a
+// Verify self-consistency using division: (a * b) / b ~= a
 inline TestResult verify_self_consistency_mul(
     const dd_cascade& a,
     const dd_cascade& b,
-    const std::string& test_name = "self-consistency (a×b)/b=a")
+    const std::string& test_name = "self-consistency (a*b)/b=a")
 {
     // Skip if b is zero or too small (division would be unstable)
     if (std::abs(b[0]) < 1e-100) {
@@ -425,19 +425,19 @@ inline TestResult verify_self_consistency_mul(
     oss << test_name << " FAILED:\n";
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
-    oss << "  (a×b)/b   = " << to_binary(recovered) << "\n";
+    oss << "  (a*b)/b   = " << to_binary(recovered) << "\n";
     oss << "  difference = " << (recovered[0] - a[0]) << "\n";
     oss << "  tolerance  = " << tolerance << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify associativity: (a × b) × c ≈ a × (b × c)
+// Verify associativity: (a * b) * c ~= a * (b * c)
 inline TestResult verify_associativity_mul(
     const dd_cascade& a,
     const dd_cascade& b,
     const dd_cascade& c,
-    const std::string& test_name = "associativity (a×b)×c = a×(b×c)")
+    const std::string& test_name = "associativity (a*b)*c = a*(b*c)")
 {
     dd_cascade ab_c = (a * b) * c;
     dd_cascade a_bc = a * (b * c);
@@ -457,19 +457,19 @@ inline TestResult verify_associativity_mul(
     oss << "  a       = " << to_binary(a) << "\n";
     oss << "  b       = " << to_binary(b) << "\n";
     oss << "  c       = " << to_binary(c) << "\n";
-    oss << "  (a×b)×c = " << to_binary(ab_c) << "\n";
-    oss << "  a×(b×c) = " << to_binary(a_bc) << "\n";
+    oss << "  (a*b)*c = " << to_binary(ab_c) << "\n";
+    oss << "  a*(b*c) = " << to_binary(a_bc) << "\n";
     oss << "  diff    = " << (ab_c[0] - a_bc[0]) << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify distributivity: a × (b + c) ≈ a×b + a×c
+// Verify distributivity: a * (b + c) ~= a*b + a*c
 inline TestResult verify_distributivity(
     const dd_cascade& a,
     const dd_cascade& b,
     const dd_cascade& c,
-    const std::string& test_name = "distributivity a×(b+c) = a×b+a×c")
+    const std::string& test_name = "distributivity a*(b+c) = a*b+a*c")
 {
     dd_cascade a_bc = a * (b + c);
     dd_cascade ab_ac = (a * b) + (a * c);
@@ -489,8 +489,8 @@ inline TestResult verify_distributivity(
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
     oss << "  c         = " << to_binary(c) << "\n";
-    oss << "  a×(b+c)   = " << to_binary(a_bc) << "\n";
-    oss << "  a×b+a×c   = " << to_binary(ab_ac) << "\n";
+    oss << "  a*(b+c)   = " << to_binary(a_bc) << "\n";
+    oss << "  a*b+a*c   = " << to_binary(ab_ac) << "\n";
     oss << "  diff      = " << (a_bc[0] - ab_ac[0]) << "\n";
 
     return TestResult(false, oss.str());
@@ -520,7 +520,7 @@ inline dd_cascade create_near_one(double epsilon_scale = 1.0) {
     return dd_cascade(1.0 + eps, eps * eps / 2.0);
 }
 
-// Generate a perfect square value (for testing a × a)
+// Generate a perfect square value (for testing a * a)
 inline dd_cascade create_square_test_value() {
     return dd_cascade(2.0, 1e-16);
 }
@@ -545,11 +545,11 @@ inline dd_cascade create_square_test_value() {
  *
  *    a) SPECIAL VALUE HANDLING:
  *       - NaN propagation: NaN / a = NaN, a / NaN = NaN
- *       - Division by zero: 0/0 = NaN, a/0 = ±∞ (sign depends on operands)
- *       - Division of infinity: ∞/a, a/∞, ∞/∞
+ *       - Division by zero: 0/0 = NaN, a/0 = +/-inf (sign depends on operands)
+ *       - Division of infinity: inf/a, a/inf, inf/inf
  *
  *    b) NON-COMMUTATIVITY:
- *       - a / b ≠ b / a (except when a = ±b)
+ *       - a / b != b / a (except when a = +/-b)
  *       - Must verify this explicitly
  *
  *    c) IDENTITY AND RECIPROCAL:
@@ -580,16 +580,16 @@ inline dd_cascade create_square_test_value() {
  *       - Large / large, small / small
  *
  * 3. SELF-CONSISTENCY VALIDATION:
- *    - (a / b) × b ≈ a (primary validation method)
- *    - (a × b) / b ≈ a (already tested in multiplication)
- *    - 1 / (1 / a) ≈ a (double reciprocal)
+ *    - (a / b) * b ~= a (primary validation method)
+ *    - (a * b) / b ~= a (already tested in multiplication)
+ *    - 1 / (1 / a) ~= a (double reciprocal)
  */
 
-// Verify self-consistency: (a / b) × b ≈ a
+// Verify self-consistency: (a / b) * b ~= a
 inline TestResult verify_self_consistency_div(
     const dd_cascade& a,
     const dd_cascade& b,
-    const std::string& test_name = "self-consistency (a/b)×b=a")
+    const std::string& test_name = "self-consistency (a/b)*b=a")
 {
     // Skip if b is zero or too small/large (division would be unstable)
     if (std::abs(b[0]) < 1e-100 || std::abs(b[0]) > 1e100) {
@@ -613,7 +613,7 @@ inline TestResult verify_self_consistency_div(
     oss << test_name << " FAILED:\n";
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
-    oss << "  (a/b)×b   = " << to_binary(recovered) << "\n";
+    oss << "  (a/b)*b   = " << to_binary(recovered) << "\n";
     oss << "  difference = " << (recovered[0] - a[0]) << "\n";
     oss << "  tolerance  = " << tolerance << "\n";
 
@@ -648,7 +648,7 @@ inline TestResult verify_division_identity(
     return TestResult(true);
 }
 
-// Verify double reciprocal: 1 / (1 / a) ≈ a
+// Verify double reciprocal: 1 / (1 / a) ~= a
 inline TestResult verify_double_reciprocal(
     const dd_cascade& a,
     const std::string& test_name = "double reciprocal 1/(1/a)=a")
@@ -683,11 +683,11 @@ inline TestResult verify_double_reciprocal(
     return TestResult(false, oss.str());
 }
 
-// Verify non-commutativity: a / b ≠ b / a (except for special cases)
+// Verify non-commutativity: a / b != b / a (except for special cases)
 inline TestResult verify_non_commutativity(
     const dd_cascade& a,
     const dd_cascade& b,
-    const std::string& test_name = "non-commutativity a/b ≠ b/a")
+    const std::string& test_name = "non-commutativity a/b != b/a")
 {
     // Skip if either is zero
     if (a.iszero() || b.iszero()) {

--- a/static/highprecision/dd_cascade/arithmetic/division.cpp
+++ b/static/highprecision/dd_cascade/arithmetic/division.cpp
@@ -74,7 +74,7 @@ try {
 			if (reportTestCases) std::cerr << "0/0 did not produce NaN\n";
 		}
 
-		// a / 0 should be ±Inf
+		// a / 0 should be +/-Inf
 		dd_cascade result_a0 = a / zero;
 		if (!result_a0.isinf()) {
 			nrOfFailedTestCases++;
@@ -187,7 +187,7 @@ try {
 		}
 	}
 
-	// Corner Case 7: Non-commutativity (a / b ≠ b / a)
+	// Corner Case 7: Non-commutativity (a / b != b / a)
 	{
 		dd_cascade a = dd_cascade_corner_cases::create_well_separated(2.0);
 		dd_cascade b = dd_cascade_corner_cases::create_well_separated(3.0);
@@ -197,7 +197,7 @@ try {
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 8: Self-consistency (a / b) × b ≈ a
+	// Corner Case 8: Self-consistency (a / b) * b ~= a
 	{
 		dd_cascade a = dd_cascade_corner_cases::create_well_separated(1.5);
 		dd_cascade b = dd_cascade_corner_cases::create_well_separated(2.5);

--- a/static/highprecision/dd_cascade/arithmetic/multiplication.cpp
+++ b/static/highprecision/dd_cascade/arithmetic/multiplication.cpp
@@ -62,25 +62,25 @@ try {
 
 #if REGRESSION_LEVEL_1
 
-	// Corner Case 1: Zero absorption (0 × a = 0, a × 0 = 0)
+	// Corner Case 1: Zero absorption (0 * a = 0, a * 0 = 0)
 	{
 		dd_cascade zero(0.0, 0.0);
 		dd_cascade a = dd_cascade_corner_cases::create_well_separated(1.0);
 
-		auto result = dd_cascade_corner_cases::verify_zero(zero * a, "0 × a = 0");
+		auto result = dd_cascade_corner_cases::verify_zero(zero * a, "0 * a = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = dd_cascade_corner_cases::verify_zero(a * zero, "a × 0 = 0");
+		result = dd_cascade_corner_cases::verify_zero(a * zero, "a * 0 = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = dd_cascade_corner_cases::verify_zero(zero * zero, "0 × 0 = 0");
+		result = dd_cascade_corner_cases::verify_zero(zero * zero, "0 * 0 = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 2: Identity (1 × a ≈ a, a × 1 ≈ a)
+	// Corner Case 2: Identity (1 * a ~= a, a * 1 ~= a)
 	{
 		dd_cascade one(1.0, 0.0);
 		dd_cascade a = dd_cascade_corner_cases::create_well_separated(2.5);
@@ -93,25 +93,25 @@ try {
 		// Verify the high component is preserved
 		if (std::abs(result_1a[0] - a[0]) > a[0] * dd_cascade_corner_cases::DD_EPS * 10.0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "1 × a: high component not preserved\n";
+			if (reportTestCases) std::cerr << "1 * a: high component not preserved\n";
 		}
 
 		if (std::abs(result_a1[0] - a[0]) > a[0] * dd_cascade_corner_cases::DD_EPS * 10.0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "a × 1: high component not preserved\n";
+			if (reportTestCases) std::cerr << "a * 1: high component not preserved\n";
 		}
 
 		// Verify normalization
-		auto result = dd_cascade_corner_cases::verify_normalized(result_1a, "1 × a normalization");
+		auto result = dd_cascade_corner_cases::verify_normalized(result_1a, "1 * a normalization");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = dd_cascade_corner_cases::verify_normalized(result_a1, "a × 1 normalization");
+		result = dd_cascade_corner_cases::verify_normalized(result_a1, "a * 1 normalization");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 3: Commutativity (a × b = b × a)
+	// Corner Case 3: Commutativity (a * b = b * a)
 	{
 		dd_cascade a = dd_cascade_corner_cases::create_well_separated(1.5);
 		dd_cascade b = dd_cascade_corner_cases::create_well_separated(2.5);
@@ -166,32 +166,32 @@ try {
 		dd_cascade pos(1.5, 1e-17);
 		dd_cascade neg(-1.5, -1e-17);
 
-		// (+) × (+) = (+)
+		// (+) * (+) = (+)
 		dd_cascade result_pp = pos * pos;
 		if (result_pp[0] < 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(+) × (+) produced negative result\n";
+			if (reportTestCases) std::cerr << "(+) * (+) produced negative result\n";
 		}
 
-		// (+) × (-) = (-)
+		// (+) * (-) = (-)
 		dd_cascade result_pn = pos * neg;
 		if (result_pn[0] >= 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(+) × (-) produced non-negative result\n";
+			if (reportTestCases) std::cerr << "(+) * (-) produced non-negative result\n";
 		}
 
-		// (-) × (+) = (-)
+		// (-) * (+) = (-)
 		dd_cascade result_np = neg * pos;
 		if (result_np[0] >= 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(-) × (+) produced non-negative result\n";
+			if (reportTestCases) std::cerr << "(-) * (+) produced non-negative result\n";
 		}
 
-		// (-) × (-) = (+)
+		// (-) * (-) = (+)
 		dd_cascade result_nn = neg * neg;
 		if (result_nn[0] < 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(-) × (-) produced negative result\n";
+			if (reportTestCases) std::cerr << "(-) * (-) produced negative result\n";
 		}
 	}
 
@@ -308,7 +308,7 @@ try {
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 14: Squaring (a × a)
+	// Corner Case 14: Squaring (a * a)
 	{
 		dd_cascade a = dd_cascade_corner_cases::create_square_test_value();
 		dd_cascade square = a * a;

--- a/static/highprecision/qd_cascade/api/api.cpp
+++ b/static/highprecision/qd_cascade/api/api.cpp
@@ -77,7 +77,7 @@ int main() {
     std::cout << "Components preserved: "
               << (test_sum[0] == test_a[0] && test_sum[1] == test_a[1] &&
                   test_sum[2] == test_a[2] && test_sum[3] == test_a[3]
-                  ? "YES ✓" : "NO ✗") << '\n';
+                  ? "YES OK" : "NO X") << '\n';
 
     // Demonstrate quad-double precision advantage
     std::cout << "\nQuad-double precision advantage:\n";

--- a/static/highprecision/qd_cascade/api/cascade_constants.cpp
+++ b/static/highprecision/qd_cascade/api/cascade_constants.cpp
@@ -76,9 +76,9 @@ int main() {
                              tdc_pi[2] == qdc_pi[2]);
 
     std::cout << "ddc_pi[0:1] matches tdc_pi[0:1]: "
-              << (dd_td_consistent ? "✓ PASS" : "✗ FAIL") << '\n';
+              << (dd_td_consistent ? "OK PASS" : "X FAIL") << '\n';
     std::cout << "tdc_pi[0:2] matches qdc_pi[0:2]: "
-              << (td_qd_consistent ? "✓ PASS" : "✗ FAIL") << '\n';
+              << (td_qd_consistent ? "OK PASS" : "X FAIL") << '\n';
 
     // Test arithmetic with constants
     std::cout << "\nArithmetic with Constants:\n";

--- a/static/highprecision/qd_cascade/api/roundtrip.cpp
+++ b/static/highprecision/qd_cascade/api/roundtrip.cpp
@@ -6,7 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
 // TEST TOLERANCE:
-// Round-trip conversions (string → parse → to_string → parse) introduce tiny errors
+// Round-trip conversions (string -> parse -> to_string -> parse) introduce tiny errors
 // due to accumulated floating-point operations (multiplication by 10, division, etc.).
 // These errors are on the order of 1e-22 to 1e-30, which is:
 //   - ~1000x smaller than the quad-double precision (~1e-63)

--- a/static/highprecision/qd_cascade/arithmetic/corner_cases.hpp
+++ b/static/highprecision/qd_cascade/arithmetic/corner_cases.hpp
@@ -21,7 +21,7 @@
  * has only 53 bits (~16 decimal digits). Comparing qd_cascade arithmetic results to double references
  * is fundamentally flawed:
  *
- *   qd_cascade: ~212 fraction bits (4 × 53-bit doubles with non-overlapping mantissas)
+ *   qd_cascade: ~212 fraction bits (4 * 53-bit doubles with non-overlapping mantissas)
  *   double:      ~53 fraction bits
  *
  * Random testing with double references fails because:
@@ -77,10 +77,10 @@
  *    - Extreme separation: components at maximum exponent range
  *
  * 3. SIGN PATTERN CASES
- *    - (+,+,+) ± (+,+,+) - all positive
- *    - (+,+,+) ± (-,-,-) - opposite signs
- *    - (+,-,+) ± (+,+,+) - mixed internal signs (tests denormalized inputs)
- *    - (+,+,-) ± (+,-,+) - various mixed patterns
+ *    - (+,+,+) +/- (+,+,+) - all positive
+ *    - (+,+,+) +/- (-,-,-) - opposite signs
+ *    - (+,-,+) +/- (+,+,+) - mixed internal signs (tests denormalized inputs)
+ *    - (+,+,-) +/- (+,-,+) - various mixed patterns
  *
  * 4. RENORMALIZATION TRIGGERS
  *    - Upward carry: adding small values that grow component[0]
@@ -91,7 +91,7 @@
  * 5. SPECIAL VALUES
  *    - Zero operations: 0 + a, a + 0, 0 - 0
  *    - Identity: a - a, (a + b) - a
- *    - Infinity: ±∞ + a, ∞ - ∞ (should be NaN)
+ *    - Infinity: +/-inf + a, inf - inf (should be NaN)
  *    - NaN propagation
  *
  * 6. PRECISION BOUNDARY CASES
@@ -105,9 +105,9 @@
  *
  * Instead of comparing to double references, validate using:
  *
- * 1. SELF-CONSISTENCY: (a + b) - b ≈ a (within qd_cascade ULP)
+ * 1. SELF-CONSISTENCY: (a + b) - b ~= a (within qd_cascade ULP)
  * 2. COMPONENT INSPECTION: Verify each component is within expected bounds
- * 3. ASSOCIATIVITY TESTS: (a + b) + c ≈ a + (b + c) (approximately equal)
+ * 3. ASSOCIATIVITY TESTS: (a + b) + c ~= a + (b + c) (approximately equal)
  * 4. KNOWN EXACT RESULTS: Construct cases where exact answer is known
  * 5. CROSS-VALIDATION: Use qd (quad-double) as oracle if available
  */
@@ -116,11 +116,11 @@ namespace sw::universal {
 namespace qd_cascade_corner_cases {
 
 // Epsilon values for multi-component precision
-// Double:        53 bits of precision → epsilon = 2^-52  ≈ 2.22e-16
-// Double-double: 106 bits of precision → epsilon = 2^-106 ≈ 1.23e-32
-// Triple-double: 159 bits of precision → epsilon = 2^-159 ≈ 1.74e-48
-// Quad-double:   212 bits of precision → epsilon = 2^-212 ≈ 2.22e-64
-constexpr double DOUBLE_EPS = std::numeric_limits<double>::epsilon(); // 2^-52 ≈ 2.22e-16
+// Double:        53 bits of precision -> epsilon = 2^-52  ~= 2.22e-16
+// Double-double: 106 bits of precision -> epsilon = 2^-106 ~= 1.23e-32
+// Triple-double: 159 bits of precision -> epsilon = 2^-159 ~= 1.74e-48
+// Quad-double:   212 bits of precision -> epsilon = 2^-212 ~= 2.22e-64
+constexpr double DOUBLE_EPS = std::numeric_limits<double>::epsilon(); // 2^-52 ~= 2.22e-16
 constexpr double DD_EPS = 1.2325951644078309e-32;  // 2^-106 for double-double
 constexpr double TD_EPS = 1.7411641656824734e-48;  // 2^-159 for triple-double
 constexpr double QD_EPS = 2.2204460492503131e-64;  // 2^-212 for quad-double
@@ -206,9 +206,9 @@ inline TestResult verify_normalized(const qd_cascade& value, const std::string& 
     return TestResult(true);
 }
 
-// Verify self-consistency: (a op b) op_inv b ≈ a
-// For addition: (a + b) - b ≈ a
-// For subtraction: (a - b) + b ≈ a
+// Verify self-consistency: (a op b) op_inv b ~= a
+// For addition: (a + b) - b ~= a
+// For subtraction: (a - b) + b ~= a
 inline TestResult verify_self_consistency_add(
     const qd_cascade& a,
     const qd_cascade& b,
@@ -333,7 +333,7 @@ inline qd_cascade create_small_magnitude_separation() {
  * Multiplication has fundamentally different characteristics from addition/subtraction:
  *
  * 1. ALGORITHM STRUCTURE:
- *    - Uses expansion_ops::multiply_cascades() which generates N² products (16 for qd_cascade)
+ *    - Uses expansion_ops::multiply_cascades() which generates N^2 products (16 for qd_cascade)
  *    - Each product computed with two_prod for exact error tracking
  *    - Products accumulated by significance level
  *    - Result renormalized
@@ -341,15 +341,15 @@ inline qd_cascade create_small_magnitude_separation() {
  * 2. UNIQUE MULTIPLICATION CORNER CASES:
  *
  *    a) ZERO ABSORPTION:
- *       - 0 × a = 0, a × 0 = 0, 0 × 0 = 0
+ *       - 0 * a = 0, a * 0 = 0, 0 * 0 = 0
  *       - All components must be exactly zero
  *
  *    b) IDENTITY:
- *       - 1 × a = a, a × 1 = a
+ *       - 1 * a = a, a * 1 = a
  *       - All components must be preserved
  *
  *    c) COMMUTATIVITY:
- *       - a × b should equal b × a
+ *       - a * b should equal b * a
  *       - Tests symmetry of multiplication algorithm
  *
  *    d) POWERS OF 2 (EXACT OPERATIONS):
@@ -358,36 +358,36 @@ inline qd_cascade create_small_magnitude_separation() {
  *       - All components should scale exactly
  *
  *    e) SIGN PATTERNS:
- *       - (+) × (+) = (+), (+) × (-) = (-), (-) × (+) = (-), (-) × (-) = (+)
+ *       - (+) * (+) = (+), (+) * (-) = (-), (-) * (+) = (-), (-) * (-) = (+)
  *
  *    f) MAGNITUDE EXTREMES:
- *       - Small × Large: may cause overflow/underflow in products
- *       - Large × Large: may overflow
- *       - Small × Small: may underflow
+ *       - Small * Large: may cause overflow/underflow in products
+ *       - Large * Large: may overflow
+ *       - Small * Small: may underflow
  *
  *    g) NEAR-1 VALUES:
- *       - (1 + ε) × (1 + δ) = 1 + ε + δ + εδ
+ *       - (1 + eps) * (1 + delta) = 1 + eps + delta + epsdelta
  *       - Tests precision accumulation in lower components
  *
  *    h) COMPONENT INTERACTION:
- *       - All 9 products (3×3) contribute to final result
+ *       - All 9 products (3*3) contribute to final result
  *       - Tests proper accumulation and renormalization
  *
  *    i) ALGEBRAIC PROPERTIES:
- *       - Associativity: (a × b) × c ≈ a × (b × c)
- *       - Distributivity: a × (b + c) ≈ a×b + a×c
+ *       - Associativity: (a * b) * c ~= a * (b * c)
+ *       - Distributivity: a * (b + c) ~= a*b + a*c
  *
  * 3. SELF-CONSISTENCY VALIDATION:
- *    - Commutativity: a × b = b × a (exact within renormalization)
- *    - With division: (a × b) / b ≈ a
- *    - Squares: verify a × a produces expected square
+ *    - Commutativity: a * b = b * a (exact within renormalization)
+ *    - With division: (a * b) / b ~= a
+ *    - Squares: verify a * a produces expected square
  */
 
-// Verify commutativity: a × b should equal b × a
+// Verify commutativity: a * b should equal b * a
 inline TestResult verify_commutativity(
     const qd_cascade& a,
     const qd_cascade& b,
-    const std::string& test_name = "commutativity a×b = b×a")
+    const std::string& test_name = "commutativity a*b = b*a")
 {
     qd_cascade ab = a * b;
     qd_cascade ba = b * a;
@@ -411,18 +411,18 @@ inline TestResult verify_commutativity(
     oss << test_name << " FAILED:\n";
     oss << "  a     = " << to_binary(a) << "\n";
     oss << "  b     = " << to_binary(b) << "\n";
-    oss << "  a×b   = " << to_binary(ab) << "\n";
-    oss << "  b×a   = " << to_binary(ba) << "\n";
+    oss << "  a*b   = " << to_binary(ab) << "\n";
+    oss << "  b*a   = " << to_binary(ba) << "\n";
     oss << "  diff  = " << (ab[0] - ba[0]) << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify self-consistency using division: (a × b) / b ≈ a
+// Verify self-consistency using division: (a * b) / b ~= a
 inline TestResult verify_self_consistency_mul(
     const qd_cascade& a,
     const qd_cascade& b,
-    const std::string& test_name = "self-consistency (a×b)/b=a")
+    const std::string& test_name = "self-consistency (a*b)/b=a")
 {
     // Skip if b is zero or too small (division would be unstable)
     if (std::abs(b[0]) < 1e-100) {
@@ -446,19 +446,19 @@ inline TestResult verify_self_consistency_mul(
     oss << test_name << " FAILED:\n";
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
-    oss << "  (a×b)/b   = " << to_binary(recovered) << "\n";
+    oss << "  (a*b)/b   = " << to_binary(recovered) << "\n";
     oss << "  difference = " << (recovered[0] - a[0]) << "\n";
     oss << "  tolerance  = " << tolerance << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify associativity: (a × b) × c ≈ a × (b × c)
+// Verify associativity: (a * b) * c ~= a * (b * c)
 inline TestResult verify_associativity_mul(
     const qd_cascade& a,
     const qd_cascade& b,
     const qd_cascade& c,
-    const std::string& test_name = "associativity (a×b)×c = a×(b×c)")
+    const std::string& test_name = "associativity (a*b)*c = a*(b*c)")
 {
     qd_cascade ab_c = (a * b) * c;
     qd_cascade a_bc = a * (b * c);
@@ -478,19 +478,19 @@ inline TestResult verify_associativity_mul(
     oss << "  a       = " << to_binary(a) << "\n";
     oss << "  b       = " << to_binary(b) << "\n";
     oss << "  c       = " << to_binary(c) << "\n";
-    oss << "  (a×b)×c = " << to_binary(ab_c) << "\n";
-    oss << "  a×(b×c) = " << to_binary(a_bc) << "\n";
+    oss << "  (a*b)*c = " << to_binary(ab_c) << "\n";
+    oss << "  a*(b*c) = " << to_binary(a_bc) << "\n";
     oss << "  diff    = " << (ab_c[0] - a_bc[0]) << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify distributivity: a × (b + c) ≈ a×b + a×c
+// Verify distributivity: a * (b + c) ~= a*b + a*c
 inline TestResult verify_distributivity(
     const qd_cascade& a,
     const qd_cascade& b,
     const qd_cascade& c,
-    const std::string& test_name = "distributivity a×(b+c) = a×b+a×c")
+    const std::string& test_name = "distributivity a*(b+c) = a*b+a*c")
 {
     qd_cascade a_bc = a * (b + c);
     qd_cascade ab_ac = (a * b) + (a * c);
@@ -510,8 +510,8 @@ inline TestResult verify_distributivity(
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
     oss << "  c         = " << to_binary(c) << "\n";
-    oss << "  a×(b+c)   = " << to_binary(a_bc) << "\n";
-    oss << "  a×b+a×c   = " << to_binary(ab_ac) << "\n";
+    oss << "  a*(b+c)   = " << to_binary(a_bc) << "\n";
+    oss << "  a*b+a*c   = " << to_binary(ab_ac) << "\n";
     oss << "  diff      = " << (a_bc[0] - ab_ac[0]) << "\n";
 
     return TestResult(false, oss.str());
@@ -543,7 +543,7 @@ inline qd_cascade create_near_one(double epsilon_scale = 1.0) {
     return qd_cascade(1.0 + eps, eps * eps / 2.0, eps * eps * eps / 6.0, eps * eps * eps * eps / 24.0);
 }
 
-// Generate a perfect square value (for testing a × a)
+// Generate a perfect square value (for testing a * a)
 inline qd_cascade create_square_test_value() {
     return qd_cascade(2.0, 1e-16, 1e-32, 1e-48);
 }
@@ -568,11 +568,11 @@ inline qd_cascade create_square_test_value() {
  *
  *    a) SPECIAL VALUE HANDLING:
  *       - NaN propagation: NaN / a = NaN, a / NaN = NaN
- *       - Division by zero: 0/0 = NaN, a/0 = ±∞ (sign depends on operands)
- *       - Division of infinity: ∞/a, a/∞, ∞/∞
+ *       - Division by zero: 0/0 = NaN, a/0 = +/-inf (sign depends on operands)
+ *       - Division of infinity: inf/a, a/inf, inf/inf
  *
  *    b) NON-COMMUTATIVITY:
- *       - a / b ≠ b / a (except when a = ±b)
+ *       - a / b != b / a (except when a = +/-b)
  *       - Must verify this explicitly
  *
  *    c) IDENTITY AND RECIPROCAL:
@@ -603,16 +603,16 @@ inline qd_cascade create_square_test_value() {
  *       - Large / large, small / small
  *
  * 3. SELF-CONSISTENCY VALIDATION:
- *    - (a / b) × b ≈ a (primary validation method)
- *    - (a × b) / b ≈ a (already tested in multiplication)
- *    - 1 / (1 / a) ≈ a (double reciprocal)
+ *    - (a / b) * b ~= a (primary validation method)
+ *    - (a * b) / b ~= a (already tested in multiplication)
+ *    - 1 / (1 / a) ~= a (double reciprocal)
  */
 
-// Verify self-consistency: (a / b) × b ≈ a
+// Verify self-consistency: (a / b) * b ~= a
 inline TestResult verify_self_consistency_div(
     const qd_cascade& a,
     const qd_cascade& b,
-    const std::string& test_name = "self-consistency (a/b)×b=a")
+    const std::string& test_name = "self-consistency (a/b)*b=a")
 {
     // Skip if b is zero or too small/large (division would be unstable)
     if (std::abs(b[0]) < 1e-100 || std::abs(b[0]) > 1e100) {
@@ -636,7 +636,7 @@ inline TestResult verify_self_consistency_div(
     oss << test_name << " FAILED:\n";
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
-    oss << "  (a/b)×b   = " << to_binary(recovered) << "\n";
+    oss << "  (a/b)*b   = " << to_binary(recovered) << "\n";
     oss << "  difference = " << (recovered[0] - a[0]) << "\n";
     oss << "  tolerance  = " << tolerance << "\n";
 
@@ -671,7 +671,7 @@ inline TestResult verify_division_identity(
     return TestResult(true);
 }
 
-// Verify double reciprocal: 1 / (1 / a) ≈ a
+// Verify double reciprocal: 1 / (1 / a) ~= a
 inline TestResult verify_double_reciprocal(
     const qd_cascade& a,
     const std::string& test_name = "double reciprocal 1/(1/a)=a")
@@ -706,11 +706,11 @@ inline TestResult verify_double_reciprocal(
     return TestResult(false, oss.str());
 }
 
-// Verify non-commutativity: a / b ≠ b / a (except for special cases)
+// Verify non-commutativity: a / b != b / a (except for special cases)
 inline TestResult verify_non_commutativity(
     const qd_cascade& a,
     const qd_cascade& b,
-    const std::string& test_name = "non-commutativity a/b ≠ b/a")
+    const std::string& test_name = "non-commutativity a/b != b/a")
 {
     // Skip if either is zero
     if (a.iszero() || b.iszero()) {

--- a/static/highprecision/qd_cascade/arithmetic/corner_cases.hpp
+++ b/static/highprecision/qd_cascade/arithmetic/corner_cases.hpp
@@ -370,7 +370,7 @@ inline qd_cascade create_small_magnitude_separation() {
  *       - Tests precision accumulation in lower components
  *
  *    h) COMPONENT INTERACTION:
- *       - All 9 products (3*3) contribute to final result
+ *       - All 16 products (4*4) contribute to final result
  *       - Tests proper accumulation and renormalization
  *
  *    i) ALGEBRAIC PROPERTIES:

--- a/static/highprecision/qd_cascade/arithmetic/division.cpp
+++ b/static/highprecision/qd_cascade/arithmetic/division.cpp
@@ -74,7 +74,7 @@ try {
 			if (reportTestCases) std::cerr << "0/0 did not produce NaN\n";
 		}
 
-		// a / 0 should be ±Inf
+		// a / 0 should be +/-Inf
 		qd_cascade result_a0 = a / zero;
 		if (!result_a0.isinf()) {
 			nrOfFailedTestCases++;
@@ -187,7 +187,7 @@ try {
 		}
 	}
 
-	// Corner Case 7: Non-commutativity (a / b ≠ b / a)
+	// Corner Case 7: Non-commutativity (a / b != b / a)
 	{
 		qd_cascade a = qd_cascade_corner_cases::create_well_separated(2.0);
 		qd_cascade b = qd_cascade_corner_cases::create_well_separated(3.0);
@@ -197,7 +197,7 @@ try {
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 8: Self-consistency (a / b) × b ≈ a
+	// Corner Case 8: Self-consistency (a / b) * b ~= a
 	{
 		qd_cascade a = qd_cascade_corner_cases::create_well_separated(1.5);
 		qd_cascade b = qd_cascade_corner_cases::create_well_separated(2.5);

--- a/static/highprecision/qd_cascade/arithmetic/multiplication.cpp
+++ b/static/highprecision/qd_cascade/arithmetic/multiplication.cpp
@@ -62,25 +62,25 @@ try {
 
 #if REGRESSION_LEVEL_1
 
-	// Corner Case 1: Zero absorption (0 × a = 0, a × 0 = 0)
+	// Corner Case 1: Zero absorption (0 * a = 0, a * 0 = 0)
 	{
 		qd_cascade zero(0.0, 0.0, 0.0, 0.0);
 		qd_cascade a = qd_cascade_corner_cases::create_well_separated(1.0);
 
-		auto result = qd_cascade_corner_cases::verify_zero(zero * a, "0 × a = 0");
+		auto result = qd_cascade_corner_cases::verify_zero(zero * a, "0 * a = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = qd_cascade_corner_cases::verify_zero(a * zero, "a × 0 = 0");
+		result = qd_cascade_corner_cases::verify_zero(a * zero, "a * 0 = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = qd_cascade_corner_cases::verify_zero(zero * zero, "0 × 0 = 0");
+		result = qd_cascade_corner_cases::verify_zero(zero * zero, "0 * 0 = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 2: Identity (1 × a ≈ a, a × 1 ≈ a)
+	// Corner Case 2: Identity (1 * a ~= a, a * 1 ~= a)
 	{
 		qd_cascade one(1.0, 0.0, 0.0, 0.0);
 		qd_cascade a = qd_cascade_corner_cases::create_well_separated(2.5);
@@ -93,25 +93,25 @@ try {
 		// Verify the high component is preserved
 		if (std::abs(result_1a[0] - a[0]) > a[0] * qd_cascade_corner_cases::QD_EPS * 10.0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "1 × a: high component not preserved\n";
+			if (reportTestCases) std::cerr << "1 * a: high component not preserved\n";
 		}
 
 		if (std::abs(result_a1[0] - a[0]) > a[0] * qd_cascade_corner_cases::QD_EPS * 10.0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "a × 1: high component not preserved\n";
+			if (reportTestCases) std::cerr << "a * 1: high component not preserved\n";
 		}
 
 		// Verify normalization
-		auto result = qd_cascade_corner_cases::verify_normalized(result_1a, "1 × a normalization");
+		auto result = qd_cascade_corner_cases::verify_normalized(result_1a, "1 * a normalization");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = qd_cascade_corner_cases::verify_normalized(result_a1, "a × 1 normalization");
+		result = qd_cascade_corner_cases::verify_normalized(result_a1, "a * 1 normalization");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 3: Commutativity (a × b = b × a)
+	// Corner Case 3: Commutativity (a * b = b * a)
 	{
 		qd_cascade a = qd_cascade_corner_cases::create_well_separated(1.5);
 		qd_cascade b = qd_cascade_corner_cases::create_well_separated(2.5);
@@ -166,32 +166,32 @@ try {
 		qd_cascade pos(1.5, 1e-17, 1e-34, 1e-51);
 		qd_cascade neg(-1.5, -1e-17, -1e-34, -1e-51);
 
-		// (+) × (+) = (+)
+		// (+) * (+) = (+)
 		qd_cascade result_pp = pos * pos;
 		if (result_pp[0] < 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(+) × (+) produced negative result\n";
+			if (reportTestCases) std::cerr << "(+) * (+) produced negative result\n";
 		}
 
-		// (+) × (-) = (-)
+		// (+) * (-) = (-)
 		qd_cascade result_pn = pos * neg;
 		if (result_pn[0] >= 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(+) × (-) produced non-negative result\n";
+			if (reportTestCases) std::cerr << "(+) * (-) produced non-negative result\n";
 		}
 
-		// (-) × (+) = (-)
+		// (-) * (+) = (-)
 		qd_cascade result_np = neg * pos;
 		if (result_np[0] >= 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(-) × (+) produced non-negative result\n";
+			if (reportTestCases) std::cerr << "(-) * (+) produced non-negative result\n";
 		}
 
-		// (-) × (-) = (+)
+		// (-) * (-) = (+)
 		qd_cascade result_nn = neg * neg;
 		if (result_nn[0] < 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(-) × (-) produced negative result\n";
+			if (reportTestCases) std::cerr << "(-) * (-) produced negative result\n";
 		}
 	}
 
@@ -308,7 +308,7 @@ try {
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 14: Squaring (a × a)
+	// Corner Case 14: Squaring (a * a)
 	{
 		qd_cascade a = qd_cascade_corner_cases::create_square_test_value();
 		qd_cascade square = a * a;

--- a/static/highprecision/td_cascade/api/api.cpp
+++ b/static/highprecision/td_cascade/api/api.cpp
@@ -74,7 +74,7 @@ int main() {
     std::cout << "0 + a = " << test_sum << '\n';
     std::cout << "Components preserved: "
               << (test_sum[0] == test_a[0] && test_sum[1] == test_a[1] && test_sum[2] == test_a[2]
-                  ? "YES ✓" : "NO ✗") << '\n';
+                  ? "YES OK" : "NO X") << '\n';
 
     // Demonstrate triple-double precision advantage
     std::cout << "\nTriple-double precision advantage:\n";

--- a/static/highprecision/td_cascade/api/roundtrip.cpp
+++ b/static/highprecision/td_cascade/api/roundtrip.cpp
@@ -6,7 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
 // TEST TOLERANCE:
-// Round-trip conversions (string → parse → to_string → parse) introduce tiny errors
+// Round-trip conversions (string -> parse -> to_string -> parse) introduce tiny errors
 // due to accumulated floating-point operations (multiplication by 10, division, etc.).
 // These errors are on the order of 1e-22 to 1e-30, which is:
 //   - ~1000x smaller than the triple-double precision (~1e-47)

--- a/static/highprecision/td_cascade/arithmetic/corner_cases.hpp
+++ b/static/highprecision/td_cascade/arithmetic/corner_cases.hpp
@@ -21,7 +21,7 @@
  * has only 53 bits (~16 decimal digits). Comparing td_cascade arithmetic results to double references
  * is fundamentally flawed:
  *
- *   td_cascade:     ~159 fraction bits (3 × 53-bit doubles with non-overlapping mantissas)
+ *   td_cascade:     ~159 fraction bits (3 * 53-bit doubles with non-overlapping mantissas)
  *   double: ~53 fraction bits
  *
  * Random testing with double references fails because:
@@ -77,10 +77,10 @@
  *    - Extreme separation: components at maximum exponent range
  *
  * 3. SIGN PATTERN CASES
- *    - (+,+,+) ± (+,+,+) - all positive
- *    - (+,+,+) ± (-,-,-) - opposite signs
- *    - (+,-,+) ± (+,+,+) - mixed internal signs (tests denormalized inputs)
- *    - (+,+,-) ± (+,-,+) - various mixed patterns
+ *    - (+,+,+) +/- (+,+,+) - all positive
+ *    - (+,+,+) +/- (-,-,-) - opposite signs
+ *    - (+,-,+) +/- (+,+,+) - mixed internal signs (tests denormalized inputs)
+ *    - (+,+,-) +/- (+,-,+) - various mixed patterns
  *
  * 4. RENORMALIZATION TRIGGERS
  *    - Upward carry: adding small values that grow component[0]
@@ -91,7 +91,7 @@
  * 5. SPECIAL VALUES
  *    - Zero operations: 0 + a, a + 0, 0 - 0
  *    - Identity: a - a, (a + b) - a
- *    - Infinity: ±∞ + a, ∞ - ∞ (should be NaN)
+ *    - Infinity: +/-inf + a, inf - inf (should be NaN)
  *    - NaN propagation
  *
  * 6. PRECISION BOUNDARY CASES
@@ -105,9 +105,9 @@
  *
  * Instead of comparing to double references, validate using:
  *
- * 1. SELF-CONSISTENCY: (a + b) - b ≈ a (within td_cascade ULP)
+ * 1. SELF-CONSISTENCY: (a + b) - b ~= a (within td_cascade ULP)
  * 2. COMPONENT INSPECTION: Verify each component is within expected bounds
- * 3. ASSOCIATIVITY TESTS: (a + b) + c ≈ a + (b + c) (approximately equal)
+ * 3. ASSOCIATIVITY TESTS: (a + b) + c ~= a + (b + c) (approximately equal)
  * 4. KNOWN EXACT RESULTS: Construct cases where exact answer is known
  * 5. CROSS-VALIDATION: Use qd (quad-double) as oracle if available
  */
@@ -116,10 +116,10 @@ namespace sw::universal {
 namespace td_cascade_corner_cases {
 
 // Epsilon values for multi-component precision
-// Double:        53 bits of precision → epsilon = 2^-52  ≈ 2.22e-16
-// Double-double: 106 bits of precision → epsilon = 2^-106 ≈ 1.23e-32
-// Triple-double: 159 bits of precision → epsilon = 2^-159 ≈ 1.74e-48
-constexpr double DOUBLE_EPS = std::numeric_limits<double>::epsilon(); // 2^-52 ≈ 2.22e-16
+// Double:        53 bits of precision -> epsilon = 2^-52  ~= 2.22e-16
+// Double-double: 106 bits of precision -> epsilon = 2^-106 ~= 1.23e-32
+// Triple-double: 159 bits of precision -> epsilon = 2^-159 ~= 1.74e-48
+constexpr double DOUBLE_EPS = std::numeric_limits<double>::epsilon(); // 2^-52 ~= 2.22e-16
 constexpr double DD_EPS = 1.2325951644078309e-32;  // 2^-106 for double-double
 constexpr double TD_EPS = 1.7411641656824734e-48;  // 2^-159 for triple-double cascade
 
@@ -195,9 +195,9 @@ inline TestResult verify_normalized(const td_cascade& value, const std::string& 
     return TestResult(true);
 }
 
-// Verify self-consistency: (a op b) op_inv b ≈ a
-// For addition: (a + b) - b ≈ a
-// For subtraction: (a - b) + b ≈ a
+// Verify self-consistency: (a op b) op_inv b ~= a
+// For addition: (a + b) - b ~= a
+// For subtraction: (a - b) + b ~= a
 inline TestResult verify_self_consistency_add(
     const td_cascade& a,
     const td_cascade& b,
@@ -322,7 +322,7 @@ inline td_cascade create_small_magnitude_separation() {
  * Multiplication has fundamentally different characteristics from addition/subtraction:
  *
  * 1. ALGORITHM STRUCTURE:
- *    - Uses expansion_ops::multiply_cascades() which generates N² products (9 for td_cascade)
+ *    - Uses expansion_ops::multiply_cascades() which generates N^2 products (9 for td_cascade)
  *    - Each product computed with two_prod for exact error tracking
  *    - Products accumulated by significance level
  *    - Result renormalized
@@ -330,15 +330,15 @@ inline td_cascade create_small_magnitude_separation() {
  * 2. UNIQUE MULTIPLICATION CORNER CASES:
  *
  *    a) ZERO ABSORPTION:
- *       - 0 × a = 0, a × 0 = 0, 0 × 0 = 0
+ *       - 0 * a = 0, a * 0 = 0, 0 * 0 = 0
  *       - All components must be exactly zero
  *
  *    b) IDENTITY:
- *       - 1 × a = a, a × 1 = a
+ *       - 1 * a = a, a * 1 = a
  *       - All components must be preserved
  *
  *    c) COMMUTATIVITY:
- *       - a × b should equal b × a
+ *       - a * b should equal b * a
  *       - Tests symmetry of multiplication algorithm
  *
  *    d) POWERS OF 2 (EXACT OPERATIONS):
@@ -347,36 +347,36 @@ inline td_cascade create_small_magnitude_separation() {
  *       - All components should scale exactly
  *
  *    e) SIGN PATTERNS:
- *       - (+) × (+) = (+), (+) × (-) = (-), (-) × (+) = (-), (-) × (-) = (+)
+ *       - (+) * (+) = (+), (+) * (-) = (-), (-) * (+) = (-), (-) * (-) = (+)
  *
  *    f) MAGNITUDE EXTREMES:
- *       - Small × Large: may cause overflow/underflow in products
- *       - Large × Large: may overflow
- *       - Small × Small: may underflow
+ *       - Small * Large: may cause overflow/underflow in products
+ *       - Large * Large: may overflow
+ *       - Small * Small: may underflow
  *
  *    g) NEAR-1 VALUES:
- *       - (1 + ε) × (1 + δ) = 1 + ε + δ + εδ
+ *       - (1 + eps) * (1 + delta) = 1 + eps + delta + epsdelta
  *       - Tests precision accumulation in lower components
  *
  *    h) COMPONENT INTERACTION:
- *       - All 9 products (3×3) contribute to final result
+ *       - All 9 products (3*3) contribute to final result
  *       - Tests proper accumulation and renormalization
  *
  *    i) ALGEBRAIC PROPERTIES:
- *       - Associativity: (a × b) × c ≈ a × (b × c)
- *       - Distributivity: a × (b + c) ≈ a×b + a×c
+ *       - Associativity: (a * b) * c ~= a * (b * c)
+ *       - Distributivity: a * (b + c) ~= a*b + a*c
  *
  * 3. SELF-CONSISTENCY VALIDATION:
- *    - Commutativity: a × b = b × a (exact within renormalization)
- *    - With division: (a × b) / b ≈ a
- *    - Squares: verify a × a produces expected square
+ *    - Commutativity: a * b = b * a (exact within renormalization)
+ *    - With division: (a * b) / b ~= a
+ *    - Squares: verify a * a produces expected square
  */
 
-// Verify commutativity: a × b should equal b × a
+// Verify commutativity: a * b should equal b * a
 inline TestResult verify_commutativity(
     const td_cascade& a,
     const td_cascade& b,
-    const std::string& test_name = "commutativity a×b = b×a")
+    const std::string& test_name = "commutativity a*b = b*a")
 {
     td_cascade ab = a * b;
     td_cascade ba = b * a;
@@ -400,18 +400,18 @@ inline TestResult verify_commutativity(
     oss << test_name << " FAILED:\n";
     oss << "  a     = " << to_binary(a) << "\n";
     oss << "  b     = " << to_binary(b) << "\n";
-    oss << "  a×b   = " << to_binary(ab) << "\n";
-    oss << "  b×a   = " << to_binary(ba) << "\n";
+    oss << "  a*b   = " << to_binary(ab) << "\n";
+    oss << "  b*a   = " << to_binary(ba) << "\n";
     oss << "  diff  = " << (ab[0] - ba[0]) << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify self-consistency using division: (a × b) / b ≈ a
+// Verify self-consistency using division: (a * b) / b ~= a
 inline TestResult verify_self_consistency_mul(
     const td_cascade& a,
     const td_cascade& b,
-    const std::string& test_name = "self-consistency (a×b)/b=a")
+    const std::string& test_name = "self-consistency (a*b)/b=a")
 {
     // Skip if b is zero or too small (division would be unstable)
     if (std::abs(b[0]) < 1e-100) {
@@ -435,19 +435,19 @@ inline TestResult verify_self_consistency_mul(
     oss << test_name << " FAILED:\n";
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
-    oss << "  (a×b)/b   = " << to_binary(recovered) << "\n";
+    oss << "  (a*b)/b   = " << to_binary(recovered) << "\n";
     oss << "  difference = " << (recovered[0] - a[0]) << "\n";
     oss << "  tolerance  = " << tolerance << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify associativity: (a × b) × c ≈ a × (b × c)
+// Verify associativity: (a * b) * c ~= a * (b * c)
 inline TestResult verify_associativity_mul(
     const td_cascade& a,
     const td_cascade& b,
     const td_cascade& c,
-    const std::string& test_name = "associativity (a×b)×c = a×(b×c)")
+    const std::string& test_name = "associativity (a*b)*c = a*(b*c)")
 {
     td_cascade ab_c = (a * b) * c;
     td_cascade a_bc = a * (b * c);
@@ -467,19 +467,19 @@ inline TestResult verify_associativity_mul(
     oss << "  a       = " << to_binary(a) << "\n";
     oss << "  b       = " << to_binary(b) << "\n";
     oss << "  c       = " << to_binary(c) << "\n";
-    oss << "  (a×b)×c = " << to_binary(ab_c) << "\n";
-    oss << "  a×(b×c) = " << to_binary(a_bc) << "\n";
+    oss << "  (a*b)*c = " << to_binary(ab_c) << "\n";
+    oss << "  a*(b*c) = " << to_binary(a_bc) << "\n";
     oss << "  diff    = " << (ab_c[0] - a_bc[0]) << "\n";
 
     return TestResult(false, oss.str());
 }
 
-// Verify distributivity: a × (b + c) ≈ a×b + a×c
+// Verify distributivity: a * (b + c) ~= a*b + a*c
 inline TestResult verify_distributivity(
     const td_cascade& a,
     const td_cascade& b,
     const td_cascade& c,
-    const std::string& test_name = "distributivity a×(b+c) = a×b+a×c")
+    const std::string& test_name = "distributivity a*(b+c) = a*b+a*c")
 {
     td_cascade a_bc = a * (b + c);
     td_cascade ab_ac = (a * b) + (a * c);
@@ -499,8 +499,8 @@ inline TestResult verify_distributivity(
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
     oss << "  c         = " << to_binary(c) << "\n";
-    oss << "  a×(b+c)   = " << to_binary(a_bc) << "\n";
-    oss << "  a×b+a×c   = " << to_binary(ab_ac) << "\n";
+    oss << "  a*(b+c)   = " << to_binary(a_bc) << "\n";
+    oss << "  a*b+a*c   = " << to_binary(ab_ac) << "\n";
     oss << "  diff      = " << (a_bc[0] - ab_ac[0]) << "\n";
 
     return TestResult(false, oss.str());
@@ -531,7 +531,7 @@ inline td_cascade create_near_one(double epsilon_scale = 1.0) {
     return td_cascade(1.0 + eps, eps * eps / 2.0, eps * eps * eps / 6.0);
 }
 
-// Generate a perfect square value (for testing a × a)
+// Generate a perfect square value (for testing a * a)
 inline td_cascade create_square_test_value() {
     return td_cascade(2.0, 1e-16, 1e-32);
 }
@@ -556,11 +556,11 @@ inline td_cascade create_square_test_value() {
  *
  *    a) SPECIAL VALUE HANDLING:
  *       - NaN propagation: NaN / a = NaN, a / NaN = NaN
- *       - Division by zero: 0/0 = NaN, a/0 = ±∞ (sign depends on operands)
- *       - Division of infinity: ∞/a, a/∞, ∞/∞
+ *       - Division by zero: 0/0 = NaN, a/0 = +/-inf (sign depends on operands)
+ *       - Division of infinity: inf/a, a/inf, inf/inf
  *
  *    b) NON-COMMUTATIVITY:
- *       - a / b ≠ b / a (except when a = ±b)
+ *       - a / b != b / a (except when a = +/-b)
  *       - Must verify this explicitly
  *
  *    c) IDENTITY AND RECIPROCAL:
@@ -591,16 +591,16 @@ inline td_cascade create_square_test_value() {
  *       - Large / large, small / small
  *
  * 3. SELF-CONSISTENCY VALIDATION:
- *    - (a / b) × b ≈ a (primary validation method)
- *    - (a × b) / b ≈ a (already tested in multiplication)
- *    - 1 / (1 / a) ≈ a (double reciprocal)
+ *    - (a / b) * b ~= a (primary validation method)
+ *    - (a * b) / b ~= a (already tested in multiplication)
+ *    - 1 / (1 / a) ~= a (double reciprocal)
  */
 
-// Verify self-consistency: (a / b) × b ≈ a
+// Verify self-consistency: (a / b) * b ~= a
 inline TestResult verify_self_consistency_div(
     const td_cascade& a,
     const td_cascade& b,
-    const std::string& test_name = "self-consistency (a/b)×b=a")
+    const std::string& test_name = "self-consistency (a/b)*b=a")
 {
     // Skip if b is zero or too small/large (division would be unstable)
     if (std::abs(b[0]) < 1e-100 || std::abs(b[0]) > 1e100) {
@@ -624,7 +624,7 @@ inline TestResult verify_self_consistency_div(
     oss << test_name << " FAILED:\n";
     oss << "  a         = " << to_binary(a) << "\n";
     oss << "  b         = " << to_binary(b) << "\n";
-    oss << "  (a/b)×b   = " << to_binary(recovered) << "\n";
+    oss << "  (a/b)*b   = " << to_binary(recovered) << "\n";
     oss << "  difference = " << (recovered[0] - a[0]) << "\n";
     oss << "  tolerance  = " << tolerance << "\n";
 
@@ -659,7 +659,7 @@ inline TestResult verify_division_identity(
     return TestResult(true);
 }
 
-// Verify double reciprocal: 1 / (1 / a) ≈ a
+// Verify double reciprocal: 1 / (1 / a) ~= a
 inline TestResult verify_double_reciprocal(
     const td_cascade& a,
     const std::string& test_name = "double reciprocal 1/(1/a)=a")
@@ -694,11 +694,11 @@ inline TestResult verify_double_reciprocal(
     return TestResult(false, oss.str());
 }
 
-// Verify non-commutativity: a / b ≠ b / a (except for special cases)
+// Verify non-commutativity: a / b != b / a (except for special cases)
 inline TestResult verify_non_commutativity(
     const td_cascade& a,
     const td_cascade& b,
-    const std::string& test_name = "non-commutativity a/b ≠ b/a")
+    const std::string& test_name = "non-commutativity a/b != b/a")
 {
     // Skip if either is zero
     if (a.iszero() || b.iszero()) {

--- a/static/highprecision/td_cascade/arithmetic/division.cpp
+++ b/static/highprecision/td_cascade/arithmetic/division.cpp
@@ -74,7 +74,7 @@ try {
 			if (reportTestCases) std::cerr << "0/0 did not produce NaN\n";
 		}
 
-		// a / 0 should be ±Inf
+		// a / 0 should be +/-Inf
 		td_cascade result_a0 = a / zero;
 		if (!result_a0.isinf()) {
 			nrOfFailedTestCases++;
@@ -187,7 +187,7 @@ try {
 		}
 	}
 
-	// Corner Case 7: Non-commutativity (a / b ≠ b / a)
+	// Corner Case 7: Non-commutativity (a / b != b / a)
 	{
 		td_cascade a = td_cascade_corner_cases::create_well_separated(2.0);
 		td_cascade b = td_cascade_corner_cases::create_well_separated(3.0);
@@ -197,7 +197,7 @@ try {
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 8: Self-consistency (a / b) × b ≈ a
+	// Corner Case 8: Self-consistency (a / b) * b ~= a
 	{
 		td_cascade a = td_cascade_corner_cases::create_well_separated(1.5);
 		td_cascade b = td_cascade_corner_cases::create_well_separated(2.5);

--- a/static/highprecision/td_cascade/arithmetic/multiplication.cpp
+++ b/static/highprecision/td_cascade/arithmetic/multiplication.cpp
@@ -62,25 +62,25 @@ try {
 
 #if REGRESSION_LEVEL_1
 
-	// Corner Case 1: Zero absorption (0 × a = 0, a × 0 = 0)
+	// Corner Case 1: Zero absorption (0 * a = 0, a * 0 = 0)
 	{
 		td_cascade zero(0.0, 0.0, 0.0);
 		td_cascade a = td_cascade_corner_cases::create_well_separated(1.0);
 
-		auto result = td_cascade_corner_cases::verify_zero(zero * a, "0 × a = 0");
+		auto result = td_cascade_corner_cases::verify_zero(zero * a, "0 * a = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = td_cascade_corner_cases::verify_zero(a * zero, "a × 0 = 0");
+		result = td_cascade_corner_cases::verify_zero(a * zero, "a * 0 = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = td_cascade_corner_cases::verify_zero(zero * zero, "0 × 0 = 0");
+		result = td_cascade_corner_cases::verify_zero(zero * zero, "0 * 0 = 0");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 2: Identity (1 × a ≈ a, a × 1 ≈ a)
+	// Corner Case 2: Identity (1 * a ~= a, a * 1 ~= a)
 	{
 		td_cascade one(1.0, 0.0, 0.0);
 		td_cascade a = td_cascade_corner_cases::create_well_separated(2.5);
@@ -93,25 +93,25 @@ try {
 		// Verify the high component is preserved
 		if (std::abs(result_1a[0] - a[0]) > a[0] * td_cascade_corner_cases::TD_EPS * 10.0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "1 × a: high component not preserved\n";
+			if (reportTestCases) std::cerr << "1 * a: high component not preserved\n";
 		}
 
 		if (std::abs(result_a1[0] - a[0]) > a[0] * td_cascade_corner_cases::TD_EPS * 10.0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "a × 1: high component not preserved\n";
+			if (reportTestCases) std::cerr << "a * 1: high component not preserved\n";
 		}
 
 		// Verify normalization
-		auto result = td_cascade_corner_cases::verify_normalized(result_1a, "1 × a normalization");
+		auto result = td_cascade_corner_cases::verify_normalized(result_1a, "1 * a normalization");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 
-		result = td_cascade_corner_cases::verify_normalized(result_a1, "a × 1 normalization");
+		result = td_cascade_corner_cases::verify_normalized(result_a1, "a * 1 normalization");
 		nrOfFailedTestCases += (result.passed ? 0 : 1);
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 3: Commutativity (a × b = b × a)
+	// Corner Case 3: Commutativity (a * b = b * a)
 	{
 		td_cascade a = td_cascade_corner_cases::create_well_separated(1.5);
 		td_cascade b = td_cascade_corner_cases::create_well_separated(2.5);
@@ -166,32 +166,32 @@ try {
 		td_cascade pos(1.5, 1e-17, 1e-34);
 		td_cascade neg(-1.5, -1e-17, -1e-34);
 
-		// (+) × (+) = (+)
+		// (+) * (+) = (+)
 		td_cascade result_pp = pos * pos;
 		if (result_pp[0] < 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(+) × (+) produced negative result\n";
+			if (reportTestCases) std::cerr << "(+) * (+) produced negative result\n";
 		}
 
-		// (+) × (-) = (-)
+		// (+) * (-) = (-)
 		td_cascade result_pn = pos * neg;
 		if (result_pn[0] >= 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(+) × (-) produced non-negative result\n";
+			if (reportTestCases) std::cerr << "(+) * (-) produced non-negative result\n";
 		}
 
-		// (-) × (+) = (-)
+		// (-) * (+) = (-)
 		td_cascade result_np = neg * pos;
 		if (result_np[0] >= 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(-) × (+) produced non-negative result\n";
+			if (reportTestCases) std::cerr << "(-) * (+) produced non-negative result\n";
 		}
 
-		// (-) × (-) = (+)
+		// (-) * (-) = (+)
 		td_cascade result_nn = neg * neg;
 		if (result_nn[0] < 0) {
 			nrOfFailedTestCases++;
-			if (reportTestCases) std::cerr << "(-) × (-) produced negative result\n";
+			if (reportTestCases) std::cerr << "(-) * (-) produced negative result\n";
 		}
 	}
 
@@ -308,7 +308,7 @@ try {
 		if (!result.passed && reportTestCases) std::cerr << result.message;
 	}
 
-	// Corner Case 14: Squaring (a × a)
+	// Corner Case 14: Squaring (a * a)
 	{
 		td_cascade a = td_cascade_corner_cases::create_square_test_value();
 		td_cascade square = a * a;

--- a/static/logarithmic/lns/arithmetic/addition.cpp
+++ b/static/logarithmic/lns/arithmetic/addition.cpp
@@ -43,7 +43,7 @@ namespace sw::universal {
   Why ArnoldBailey fails the standard addition.cpp regression
 
   addition.cpp does a bit-exact comparison: c = a + b (through whatever lns algorithm is selected) vs cref = encode(double(a) + double(b)). 
-  That comparison only passes when lns_encode(algorithm_result) == lns_encode(true_result) — which requires the algorithm error to 
+  That comparison only passes when lns_encode(algorithm_result) == lns_encode(true_result) -- which requires the algorithm error to 
   stay strictly below the ULP-flipping boundary.
 
   For lns<8, 2>:
@@ -56,16 +56,16 @@ namespace sw::universal {
   Bit-exact regression flags those as failures.
 
   The math:
-  - ArnoldBailey <= 2.5% relative error → ~0.02 absolute in log domain
+  - ArnoldBailey <= 2.5% relative error -> ~0.02 absolute in log domain
   - lns<8,2> ULP = 25% relative -> ~0.25 in log domain
   - Algorithm error / ULP ~ 8% -> small enough to round-correctly most of the time, not small enough to round-correctly all of the time
 
   What the framework prescribes
 
-  The sister test suite in log_add_algorithms.cpp was designed as the algorithm-correctness test bench for this exact reason — 
+  The sister test suite in log_add_algorithms.cpp was designed as the algorithm-correctness test bench for this exact reason -- 
   it uses value-domain relative tolerance (5% in the algorithm-agreement sweeps, scaled per-algorithm in corner cases) instead of bit-exact comparison.
 
-  The decision tree in docs/design/lns-add-sub.md flags this implicitly: ArnoldBailey is positioned as "lowest energy, ~2.5% rel error" — meaning users
+  The decision tree in docs/design/lns-add-sub.md flags this implicitly: ArnoldBailey is positioned as "lowest energy, ~2.5% rel error" -- meaning users
   opting into it accept that bit-exact-against-double is not part of the contract.
 
   Recommendation for this regression suite

--- a/static/logarithmic/lns/math/trigonometry.cpp
+++ b/static/logarithmic/lns/math/trigonometry.cpp
@@ -1,4 +1,4 @@
-﻿// trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
+// trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -10,8 +10,8 @@
 #include <universal/verification/lns_test_suite_mathlib.hpp>
 
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In extensive testing, no errors > 0.97 ulp were found in either the sine
 or cosine results, suggesting the results returned are faithfully rounded.
@@ -82,8 +82,8 @@ double cospi(double arg) {
 
 #ifdef CPP17_HEXFLOAT_LITERALS
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In exhaustive testing, the maximum error in sine results was 0.96677 ulp,
 the maximum error in cosine results was 0.96563 ulp, meaning results are

--- a/static/quire/api/cfloat.cpp
+++ b/static/quire/api/cfloat.cpp
@@ -37,12 +37,12 @@ namespace sw { namespace universal {
 //
 // To target limb boundary N*32, we need: 235 + scale + bit_in_sig = N*32
 // For the hidden-bit (bit 47 in 48-bit MUL significand):
-//   235 + scale + 47 = N*32  →  scale = N*32 - 282
-// Limb  8: 256 → scale = -26   (radix limb lower boundary)
-// Limb  9: 288 → scale =   6   (radix limb upper boundary)
-// Limb 10: 320 → scale =  38
-// Limb  7: 224 → scale = -58
-// Limb  0:   0 → scale = -282  (below quire range, would be clipped)
+//   235 + scale + 47 = N*32  ->  scale = N*32 - 282
+// Limb  8: 256 -> scale = -26   (radix limb lower boundary)
+// Limb  9: 288 -> scale =   6   (radix limb upper boundary)
+// Limb 10: 320 -> scale =  38
+// Limb  7: 224 -> scale = -58
+// Limb  0:   0 -> scale = -282  (below quire range, would be clipped)
 
 // Helper: compute the exact double-precision dot product of two cfloat vectors
 template<typename Scalar>
@@ -145,7 +145,7 @@ int TestQuireMul() {
 	}
 
 	// --- Products placed at limb boundaries ---
-	// scale=-26 → MSB at accumulator bit 256 (limb 8/9 boundary)
+	// scale=-26 -> MSB at accumulator bit 256 (limb 8/9 boundary)
 	{
 		// 2^(-26) has scale -26 in fp32
 		float val_a = std::ldexp(1.0f, -13);  // 2^-13
@@ -162,7 +162,7 @@ int TestQuireMul() {
 		}
 	}
 
-	// scale=6 → MSB at accumulator bit 288 (limb 9/10 boundary)
+	// scale=6 -> MSB at accumulator bit 288 (limb 9/10 boundary)
 	{
 		float val_a = std::ldexp(1.0f, 3);  // 2^3
 		float val_b = std::ldexp(1.0f, 3);  // product scale = 6
@@ -177,7 +177,7 @@ int TestQuireMul() {
 		}
 	}
 
-	// scale=38 → MSB at accumulator bit 320 (limb 10/11 boundary)
+	// scale=38 -> MSB at accumulator bit 320 (limb 10/11 boundary)
 	{
 		float val_a = std::ldexp(1.0f, 19);  // 2^19
 		float val_b = std::ldexp(1.0f, 19);  // product scale = 38
@@ -368,7 +368,7 @@ int TestLimbBoundaryCarryBorrow() {
 	// base_offset = 235 + scale (for MUL bt with radix=46)
 	// A product at scale S occupies accumulator bits [235+S .. 235+S+47]
 
-	// Case 1: carry propagation across limb 8→9 boundary (bit 256)
+	// Case 1: carry propagation across limb 8->9 boundary (bit 256)
 	// Two products at scale=-26 that sum to carry across bit 256
 	{
 		// products at scale -26: base = 235 + (-26) = 209, spans bits [209..256]
@@ -387,7 +387,7 @@ int TestLimbBoundaryCarryBorrow() {
 		}
 	}
 
-	// Case 2: carry propagation across limb 9→10 boundary (bit 288)
+	// Case 2: carry propagation across limb 9->10 boundary (bit 288)
 	{
 		// products at scale 6: base = 241, spans [241..288]
 		// MSB at exactly bit 288 (limb boundary)
@@ -404,7 +404,7 @@ int TestLimbBoundaryCarryBorrow() {
 		}
 	}
 
-	// Case 3: carry chain through 3 limbs (10→11→12)
+	// Case 3: carry chain through 3 limbs (10->11->12)
 	{
 		// products at scale 38: base = 273, spans [273..320]
 		// MSB at bit 320 (limb 10/11 boundary)
@@ -425,7 +425,7 @@ int TestLimbBoundaryCarryBorrow() {
 		}
 	}
 
-	// Case 4: borrow across limb 9→8 boundary
+	// Case 4: borrow across limb 9->8 boundary
 	{
 		quire<Scalar> q;
 		// Add large value at scale 6 (spans limb 9)
@@ -451,7 +451,7 @@ int TestLimbBoundaryCarryBorrow() {
 		}
 	}
 
-	// Case 6: carry at limb 7→8 boundary (below radix, bit 224)
+	// Case 6: carry at limb 7->8 boundary (below radix, bit 224)
 	{
 		// products at scale -58: base = 177, spans [177..224]
 		float v = std::ldexp(1.0f, -29);  // 2^-29 * 2^-29 = 2^-58
@@ -467,7 +467,7 @@ int TestLimbBoundaryCarryBorrow() {
 		}
 	}
 
-	// Case 7: carry at high limb (13→14 boundary, bit 416)
+	// Case 7: carry at high limb (13->14 boundary, bit 416)
 	{
 		// scale = 416 - 282 = 134. Need product scale 134: use 2^67 * 2^67
 		// But 2^67 overflows fp32. Use 2^63 * 2^63 = 2^126, scale 126
@@ -611,7 +611,7 @@ int TestFdp1024() {
 	// The 1023 small values each contribute 1/1024, totaling just under 1.0.
 	// This 1.0 is the LSB of the large 1024th product (1024.0 * 1.0 = 1024).
 	// Naive fp32: 1024 + (small sum) = 1024 (LSB lost due to rounding)
-	// FDP: quire accumulates all, result = 1024 + 1023/1024 ≈ 1024.999...
+	// FDP: quire accumulates all, result = 1024 + 1023/1024 ~= 1024.999...
 	// ------------------------------------------------------------------
 	{
 		std::vector<Scalar> x(1024), y(1024);
@@ -742,8 +742,8 @@ int TestFdp1024() {
 	}
 
 	// ------------------------------------------------------------------
-	// Case 7: Mixed positive/negative products with carry across limb 8→9
-	// Products placed at scale ≈ -26 (limb 8/9 boundary)
+	// Case 7: Mixed positive/negative products with carry across limb 8->9
+	// Products placed at scale ~= -26 (limb 8/9 boundary)
 	// ------------------------------------------------------------------
 	{
 		std::vector<Scalar> x(1024), y(1024);
@@ -803,7 +803,7 @@ int TestFdp1024() {
 				// product = 2^-20
 			}
 		}
-		// 512 * 1.0 + 512 * 2^-20 = 512 + 512/1048576 ≈ 512.000488
+		// 512 * 1.0 + 512 * 2^-20 = 512 + 512/1048576 ~= 512.000488
 		double expected = 512.0 + 512.0 * std::ldexp(1.0, -20);
 		Scalar result = fdp(x, y);
 		Scalar exp_cfloat(static_cast<float>(expected));
@@ -880,7 +880,7 @@ int TestFdpQcStress() {
 		std::vector<Scalar> x1(255, Scalar(1.0f));
 		std::vector<Scalar> y1(255, Scalar(1.0f));
 		fdp_qc(q, size_t(255), x1, size_t(1), y1, size_t(1));
-		// q = 255, continuation adds 1 → 256 = 2^8 (potential carry)
+		// q = 255, continuation adds 1 -> 256 = 2^8 (potential carry)
 		std::vector<Scalar> x2 = { Scalar(1.0f) };
 		std::vector<Scalar> y2 = { Scalar(1.0f) };
 		fdp_qc(q, size_t(1), x2, size_t(1), y2, size_t(1));
@@ -1054,7 +1054,7 @@ int TestFdpQcStress() {
 			}
 			fdp_qc(q, size_t(256), x1, size_t(1), y1, size_t(1));
 		}
-		// Each product ≈ 1.0 (with rounding from cfloat), sum ≈ 1024
+		// Each product ~= 1.0 (with rounding from cfloat), sum ~= 1024
 		double result = q.convert_to<double>();
 		// The quire result should match the exact double reference rounded to cfloat
 		if (std::abs(result - expected) > 1.0) {
@@ -1130,7 +1130,7 @@ int TestCatastrophicCancellation() {
 		}
 	}
 
-	// Case 6: 1024 alternating ±1e8 products, expected 0
+	// Case 6: 1024 alternating +/-1e8 products, expected 0
 	{
 		std::vector<Scalar> x(1024), y(1024);
 		for (int i = 0; i < 1024; ++i) {
@@ -1193,7 +1193,7 @@ int TestCatastrophicCancellation() {
 		double expected = double(float(Scalar(1e-30f)));
 		double result = double(fdp(x, y));
 		if (result != expected) {
-			std::cerr << "FAIL: catastrophic 10 (maxpos→minpos), expected " << expected
+			std::cerr << "FAIL: catastrophic 10 (maxpos->minpos), expected " << expected
 			          << ", got " << result << '\n';
 			++nrOfFailedTestCases;
 		}

--- a/static/quire/api/cfloat_fdp.cpp
+++ b/static/quire/api/cfloat_fdp.cpp
@@ -37,12 +37,12 @@ namespace sw { namespace universal {
 //
 // To target limb boundary N*32, we need: 235 + scale + bit_in_sig = N*32
 // For the hidden-bit (bit 47 in 48-bit MUL significand):
-//   235 + scale + 47 = N*32  →  scale = N*32 - 282
-// Limb  8: 256 → scale = -26   (radix limb lower boundary)
-// Limb  9: 288 → scale =   6   (radix limb upper boundary)
-// Limb 10: 320 → scale =  38
-// Limb  7: 224 → scale = -58
-// Limb  0:   0 → scale = -282  (below quire range, would be clipped)
+//   235 + scale + 47 = N*32  ->  scale = N*32 - 282
+// Limb  8: 256 -> scale = -26   (radix limb lower boundary)
+// Limb  9: 288 -> scale =   6   (radix limb upper boundary)
+// Limb 10: 320 -> scale =  38
+// Limb  7: 224 -> scale = -58
+// Limb  0:   0 -> scale = -282  (below quire range, would be clipped)
 
 // Helper: compute the exact double-precision dot product of two cfloat vectors
 template<typename Scalar>
@@ -111,7 +111,7 @@ int TestFdp1024() {
 	// The 1023 small values each contribute 1/1024, totaling just under 1.0.
 	// This 1.0 is the LSB of the large 1024th product (1024.0 * 1.0 = 1024).
 	// Naive fp32: 1024 + (small sum) = 1024 (LSB lost due to rounding)
-	// FDP: quire accumulates all, result = 1024 + 1023/1024 ≈ 1024.999...
+	// FDP: quire accumulates all, result = 1024 + 1023/1024 ~= 1024.999...
 	// ------------------------------------------------------------------
 	{
 		std::vector<Scalar> x(1024), y(1024);
@@ -242,8 +242,8 @@ int TestFdp1024() {
 	}
 
 	// ------------------------------------------------------------------
-	// Case 7: Mixed positive/negative products with carry across limb 8→9
-	// Products placed at scale ≈ -26 (limb 8/9 boundary)
+	// Case 7: Mixed positive/negative products with carry across limb 8->9
+	// Products placed at scale ~= -26 (limb 8/9 boundary)
 	// ------------------------------------------------------------------
 	{
 		std::vector<Scalar> x(1024), y(1024);
@@ -303,7 +303,7 @@ int TestFdp1024() {
 				// product = 2^-20
 			}
 		}
-		// 512 * 1.0 + 512 * 2^-20 = 512 + 512/1048576 ≈ 512.000488
+		// 512 * 1.0 + 512 * 2^-20 = 512 + 512/1048576 ~= 512.000488
 		double expected = 512.0 + 512.0 * std::ldexp(1.0, -20);
 		Scalar result = fdp(x, y);
 		Scalar exp_cfloat(static_cast<float>(expected));
@@ -380,7 +380,7 @@ int TestFdpQcStress() {
 		std::vector<Scalar> x1(255, Scalar(1.0f));
 		std::vector<Scalar> y1(255, Scalar(1.0f));
 		fdp_qc(q, size_t(255), x1, size_t(1), y1, size_t(1));
-		// q = 255, continuation adds 1 → 256 = 2^8 (potential carry)
+		// q = 255, continuation adds 1 -> 256 = 2^8 (potential carry)
 		std::vector<Scalar> x2 = { Scalar(1.0f) };
 		std::vector<Scalar> y2 = { Scalar(1.0f) };
 		fdp_qc(q, size_t(1), x2, size_t(1), y2, size_t(1));
@@ -554,7 +554,7 @@ int TestFdpQcStress() {
 			}
 			fdp_qc(q, size_t(256), x1, size_t(1), y1, size_t(1));
 		}
-		// Each product ≈ 1.0 (with rounding from cfloat), sum ≈ 1024
+		// Each product ~= 1.0 (with rounding from cfloat), sum ~= 1024
 		double result = q.convert_to<double>();
 		// The quire result should match the exact double reference rounded to cfloat
 		if (std::abs(result - expected) > 1.0) {
@@ -630,7 +630,7 @@ int TestCatastrophicCancellation() {
 		}
 	}
 
-	// Case 6: 1024 alternating ±1e8 products, expected 0
+	// Case 6: 1024 alternating +/-1e8 products, expected 0
 	{
 		std::vector<Scalar> x(1024), y(1024);
 		for (int i = 0; i < 1024; ++i) {
@@ -693,7 +693,7 @@ int TestCatastrophicCancellation() {
 		double expected = double(float(Scalar(1e-30f)));
 		double result = double(fdp(x, y));
 		if (result != expected) {
-			std::cerr << "FAIL: catastrophic 10 (maxpos→minpos), expected " << expected
+			std::cerr << "FAIL: catastrophic 10 (maxpos->minpos), expected " << expected
 			          << ", got " << result << '\n';
 			++nrOfFailedTestCases;
 		}

--- a/static/quire/api/dbns_fdp.cpp
+++ b/static/quire/api/dbns_fdp.cpp
@@ -172,7 +172,7 @@ int TestFdp1024() {
 		}
 	}
 
-	// Case 2: cancellation — 512 pairs of (+1, -1) = 0
+	// Case 2: cancellation -- 512 pairs of (+1, -1) = 0
 	{
 		std::vector<Scalar> x(1024), y(1024, Scalar(1.0));
 		for (int i = 0; i < 1024; i += 2) {
@@ -299,7 +299,7 @@ int TestFdpQc() {
 int TestDifferentConfigs() {
 	int nrOfFailedTestCases = 0;
 
-	// dbns<9, 5> — wider first-base field
+	// dbns<9, 5> -- wider first-base field
 	{
 		using Scalar = dbns<9, 5, uint16_t>;
 		std::vector<Scalar> x = { Scalar(1.0), Scalar(2.0) };
@@ -313,7 +313,7 @@ int TestDifferentConfigs() {
 		}
 	}
 
-	// dbns<10, 5> — balanced
+	// dbns<10, 5> -- balanced
 	{
 		using Scalar = dbns<10, 5, uint16_t>;
 		std::vector<Scalar> x = { Scalar(4.0), Scalar(2.0), Scalar(1.0) };

--- a/static/quire/api/fixpnt_fdp.cpp
+++ b/static/quire/api/fixpnt_fdp.cpp
@@ -10,13 +10,13 @@
 // ============================================================================
 //
 // fixpnt<16, 8>: 16-bit signed fixed-point, 8 integer bits + 8 fraction bits
-//   Value range: [-128.0, +127.99609375]    (max positive ≈ 127.996)
+//   Value range: [-128.0, +127.99609375]    (max positive ~= 127.996)
 //   Resolution: 2^-8 = 0.00390625
 //
 // Product of two fixpnt<16,8> values:
 //   Full product width: 2*nbits = 32 bits (2's complement)
 //   Product fraction bits: 2*rbits = 16 bits
-//   Max product: ~127.996^2 ≈ 16383.02, fits in 14 integer bits
+//   Max product: ~127.996^2 ~= 16383.02, fits in 14 integer bits
 //
 // quire_traits<fixpnt<16,8>>:
 //   range      = 2*nbits = 32
@@ -35,10 +35,10 @@
 //
 // A product of value V has quire MSB at bit (radix_point + scale)
 //   = (16 + floor(log2(|V|)))
-//   - Product V≈1    → MSB at bit 16 (limb 0)
-//   - Product V≈128  → MSB at bit 23 (limb 0)
-//   - Product V≈16384 → MSB at bit 30 (limb 0, near boundary)
-//   - Accumulation sum≈65536 → MSB at bit 32 (limb boundary!)
+//   - Product V~=1    -> MSB at bit 16 (limb 0)
+//   - Product V~=128  -> MSB at bit 23 (limb 0)
+//   - Product V~=16384 -> MSB at bit 30 (limb 0, near boundary)
+//   - Accumulation sum~=65536 -> MSB at bit 32 (limb boundary!)
 // ============================================================================
 //
 #include <universal/utility/directives.hpp>
@@ -249,7 +249,7 @@ int TestFdp1024() {
 	using Scalar = fixpnt<16, 8, Modulo, uint8_t>;
 
 	// Case 1: 1024 ones dot product: sum = 1024
-	// fixpnt<16,8> can't represent 1024 (max ≈ 127.996), so use smaller values
+	// fixpnt<16,8> can't represent 1024 (max ~= 127.996), so use smaller values
 	// 1024 * (0.125 * 0.125) = 1024 * 0.015625 = 16
 	{
 		std::vector<Scalar> x(1024, Scalar(0.125));
@@ -438,7 +438,7 @@ int TestLimbBoundaryCarryBorrow() {
 	// Case 1: Carry across limb boundary via repeated accumulation
 	// 127 * 127 = 16129. Scale = 13, MSB at quire bit 29 (limb 0).
 	// Accumulate 5 such products: 5 * 16129 = 80645.
-	// log2(80645) ≈ 16.3, MSB at quire bit 32 → crosses into limb 1.
+	// log2(80645) ~= 16.3, MSB at quire bit 32 -> crosses into limb 1.
 	{
 		quire<Scalar> q;
 		Scalar a(127), b(127);
@@ -459,12 +459,12 @@ int TestLimbBoundaryCarryBorrow() {
 	{
 		quire<Scalar> q;
 		Scalar big(100), one(1);
-		// Accumulate 400 products of 100*1 = 100 each → total 40000
+		// Accumulate 400 products of 100*1 = 100 each -> total 40000
 		// MSB at quire bit 31 (still limb 0)
 		for (int i = 0; i < 400; ++i) {
 			q += quire_mul(big, one);
 		}
-		// Now subtract 500 products of 100*1 → total -10000
+		// Now subtract 500 products of 100*1 -> total -10000
 		Scalar neg(-100);
 		for (int i = 0; i < 500; ++i) {
 			q += quire_mul(neg, one);
@@ -482,9 +482,9 @@ int TestLimbBoundaryCarryBorrow() {
 	{
 		quire<Scalar> q;
 		Scalar a(100), b(100);
-		// +100*100 = 10000, four times → 40000 (MSB near bit 31)
+		// +100*100 = 10000, four times -> 40000 (MSB near bit 31)
 		for (int i = 0; i < 4; ++i) q += quire_mul(a, b);
-		// Add more to push past limb boundary: 4 more → 80000
+		// Add more to push past limb boundary: 4 more -> 80000
 		for (int i = 0; i < 4; ++i) q += quire_mul(a, b);
 		// Subtract 80 products of 100*10: 80*1000 = 80000
 		Scalar ten(10);
@@ -500,9 +500,9 @@ int TestLimbBoundaryCarryBorrow() {
 	{
 		quire<Scalar> q;
 		Scalar a(127), b(127);
-		// Accumulate 8 * 127*127 = 8 * 16129 ≈ 129032 (MSB at bit 33, limb 1)
+		// Accumulate 8 * 127*127 = 8 * 16129 ~= 129032 (MSB at bit 33, limb 1)
 		for (int i = 0; i < 8; ++i) q += quire_mul(a, b);
-		// Subtract 8 * 127*127 → 0, then add tiny positive
+		// Subtract 8 * 127*127 -> 0, then add tiny positive
 		for (int i = 0; i < 8; ++i) q -= quire_mul(a, b);
 		Scalar quarter(0.25);
 		q += quire_mul(quarter, Scalar(1));
@@ -562,7 +562,7 @@ int TestCatastrophicCancellation() {
 	// The quire must preserve the LSBs during the large accumulation
 	{
 		std::vector<Scalar> x(1024), y(1024);
-		// 1023 products of 100*1 = 100, one product of -99999/1000*1 ≈ -100.0
+		// 1023 products of 100*1 = 100, one product of -99999/1000*1 ~= -100.0
 		// Adjusted for fixpnt range: 511 pairs of (+10 * 1) and 511 pairs of (-10 * 1)
 		// Plus 2 extra elements to create small residual
 		for (int i = 0; i < 511; ++i) {
@@ -615,7 +615,7 @@ int TestCatastrophicCancellation() {
 			y[i] = (i % 2 == 0) ? b : b_minus;
 		}
 		// Each pair contributes 10*10 + 10*(-10 + eps) = 10*eps = 0.0390625
-		// 512 pairs → 512 * 0.0390625 = 20.0
+		// 512 pairs -> 512 * 0.0390625 = 20.0
 		Scalar result = fdp(x, y);
 		double expected = 0.0;
 		for (int i = 0; i < 1024; ++i) {
@@ -661,7 +661,7 @@ int TestCatastrophicCancellation() {
 int TestDifferentConfigs() {
 	int nrOfFailedTestCases = 0;
 
-	// fixpnt<8, 4> — tiny fixed-point (4 integer bits, 4 fraction bits)
+	// fixpnt<8, 4> -- tiny fixed-point (4 integer bits, 4 fraction bits)
 	{
 		using Scalar = fixpnt<8, 4, Modulo, uint8_t>;
 		std::vector<Scalar> x = { Scalar(1), Scalar(2) };
@@ -678,7 +678,7 @@ int TestDifferentConfigs() {
 		}
 	}
 
-	// fixpnt<32, 16> — wider fixed-point
+	// fixpnt<32, 16> -- wider fixed-point
 	{
 		using Scalar = fixpnt<32, 16, Modulo, uint32_t>;
 		std::vector<Scalar> x = { Scalar(100), Scalar(200) };
@@ -691,7 +691,7 @@ int TestDifferentConfigs() {
 		}
 	}
 
-	// fixpnt<16, 0> — pure integer fixed-point
+	// fixpnt<16, 0> -- pure integer fixed-point
 	{
 		using Scalar = fixpnt<16, 0, Modulo, uint16_t>;
 		std::vector<Scalar> x = { Scalar(10), Scalar(20), Scalar(30) };

--- a/static/quire/api/lns_fdp.cpp
+++ b/static/quire/api/lns_fdp.cpp
@@ -182,7 +182,7 @@ int TestBasicFdp() {
 		}
 	}
 
-	// General dot product: [3,5].[2,7] ≈ 6 + 35 = 41
+	// General dot product: [3,5].[2,7] ~= 6 + 35 = 41
 	{
 		std::vector<Scalar> x = { Scalar(3.0), Scalar(5.0) };
 		std::vector<Scalar> y = { Scalar(2.0), Scalar(7.0) };
@@ -196,7 +196,7 @@ int TestBasicFdp() {
 		}
 	}
 
-	// Cancellation: [100, -100].[1, 1] ≈ 0
+	// Cancellation: [100, -100].[1, 1] ~= 0
 	{
 		std::vector<Scalar> x = { Scalar(100.0), Scalar(-100.0) };
 		std::vector<Scalar> y = { Scalar(1.0),   Scalar(1.0) };
@@ -246,7 +246,7 @@ int TestFdp1024() {
 		}
 	}
 
-	// Case 2: cancellation — 512 pairs of (+1*1) and (-1*1) = 0
+	// Case 2: cancellation -- 512 pairs of (+1*1) and (-1*1) = 0
 	{
 		std::vector<Scalar> x(1024), y(1024, Scalar(1.0));
 		for (int i = 0; i < 1024; i += 2) {
@@ -313,7 +313,7 @@ int TestFdp1024() {
 		}
 	}
 
-	// Case 6: large dynamic range — mix of very small and very large products
+	// Case 6: large dynamic range -- mix of very small and very large products
 	{
 		std::vector<Scalar> x(1024), y(1024);
 		double expected = 0.0;
@@ -352,7 +352,7 @@ int TestLimbBoundaryCarryBorrow() {
 
 	// Case 1: Carry across limb boundary at bit 128 (radix point)
 	// Accumulate 1.0 * 1.0 products: each at quire bit 128.
-	// 33 such products → sum = 33, MSB at bit 133 (crosses into next region)
+	// 33 such products -> sum = 33, MSB at bit 133 (crosses into next region)
 	{
 		quire<Scalar> q;
 		Scalar one(1.0);
@@ -403,7 +403,7 @@ int TestLimbBoundaryCarryBorrow() {
 		Scalar big(1024.0), one(1.0), tiny(0.25);
 		for (int i = 0; i < 50; ++i) q += quire_mul(big, one);   // +51200
 		Scalar neg(-1024.0);
-		for (int i = 0; i < 50; ++i) q += quire_mul(neg, one);   // -51200 → 0
+		for (int i = 0; i < 50; ++i) q += quire_mul(neg, one);   // -51200 -> 0
 		q += quire_mul(tiny, one);  // +0.25
 		double result = q.convert_to<double>();
 		if (std::abs(result - double(tiny)) > 0.1) {
@@ -415,7 +415,7 @@ int TestLimbBoundaryCarryBorrow() {
 
 	// Case 5: Products spanning deep fractional region
 	// 0.0625 * 0.0625 = 0.00390625 = 2^-8, scale = -8, quire bit 120
-	// 256 such products → 256 * 2^-8 = 1.0
+	// 256 such products -> 256 * 2^-8 = 1.0
 	{
 		quire<Scalar> q;
 		Scalar small(0.0625);  // 2^-4
@@ -462,7 +462,7 @@ int TestCatastrophicCancellation() {
 
 	// Case 2: Near-equal subtraction
 	// x = [A, A, A, ...], y = [1, -1+eps, 1, -1+eps, ...]
-	// Each pair contributes A*eps ≈ small value
+	// Each pair contributes A*eps ~= small value
 	{
 		Scalar a(32.0);
 		Scalar one(1.0);
@@ -588,7 +588,7 @@ int TestFdpQc() {
 int TestDifferentConfigs() {
 	int nrOfFailedTestCases = 0;
 
-	// lns<8, 4> — tiny lns (3 integer exponent bits, 4 fractional)
+	// lns<8, 4> -- tiny lns (3 integer exponent bits, 4 fractional)
 	{
 		using Scalar = lns<8, 4, uint8_t>;
 		std::vector<Scalar> x = { Scalar(1.0), Scalar(2.0) };
@@ -602,7 +602,7 @@ int TestDifferentConfigs() {
 		}
 	}
 
-	// lns<12, 6> — medium lns
+	// lns<12, 6> -- medium lns
 	{
 		using Scalar = lns<12, 6, uint8_t>;
 		std::vector<Scalar> x = { Scalar(4.0), Scalar(8.0), Scalar(2.0) };
@@ -616,7 +616,7 @@ int TestDifferentConfigs() {
 		}
 	}
 
-	// lns<32, 16> — wider lns
+	// lns<32, 16> -- wider lns
 	{
 		using Scalar = lns<32, 16, uint32_t>;
 		std::vector<Scalar> x = { Scalar(100.0), Scalar(200.0) };

--- a/static/range/areal/conversion/integer_conversion.cpp
+++ b/static/range/areal/conversion/integer_conversion.cpp
@@ -389,15 +389,15 @@ int VerifyIntegerDoubleConsistency(bool reportTestCases) {
 
 /*
 
-  - VerifySmallIntegerConversion — powers of 2, small odd integers, and signed integers within the type's representable range; 
+  - VerifySmallIntegerConversion -- powers of 2, small odd integers, and signed integers within the type's representable range; 
                                    tests both the double-delegation path (fbits < 53) and the native path (fbits >= 53)
 
-  - VerifyLargeUnsignedIntegerConversion — values beyond 2^53 (2^53+1, 2^54+1, 2^53+3, large powers of 2, UINT64_MAX) 
+  - VerifyLargeUnsignedIntegerConversion -- values beyond 2^53 (2^53+1, 2^54+1, 2^53+3, large powers of 2, UINT64_MAX) 
                                            with verification that the ubit is correctly set when bits are truncated and clear when representation is exact
 
-  - VerifyLargeSignedIntegerConversion — -(2^53+1), INT64_MIN, INT64_MIN+1, INT64_MAX with sign bit and ubit verification
+  - VerifyLargeSignedIntegerConversion -- -(2^53+1), INT64_MIN, INT64_MIN+1, INT64_MAX with sign bit and ubit verification
 
-  - VerifyIntegerDoubleConsistency — verifies bit-for-bit agreement between the integer assignment path and the 
+  - VerifyIntegerDoubleConsistency -- verifies bit-for-bit agreement between the integer assignment path and the 
                                      double assignment path for integers up to 2^53 (where both should produce identical results)
 
  */

--- a/static/range/interval/api/educational_demo.cpp
+++ b/static/range/interval/api/educational_demo.cpp
@@ -40,11 +40,11 @@ try {
 	using Real = interval<double>;
 
 	// =========================================================================
-	// PART 1: Tight & Useful — Engineering Tolerance Analysis
+	// PART 1: Tight & Useful -- Engineering Tolerance Analysis
 	// =========================================================================
 	{
 		std::cout << "+=========================================================================+\n";
-		std::cout << "| PART 1: Tight & Useful — Engineering Tolerance Analysis                 |\n";
+		std::cout << "| PART 1: Tight & Useful -- Engineering Tolerance Analysis                 |\n";
 		std::cout << "+=========================================================================+\n\n";
 
 		std::cout << "Scenario: An electronic circuit with uncertain components.\n";
@@ -112,11 +112,11 @@ try {
 	}
 
 	// =========================================================================
-	// PART 2: Wide & Useless — The Dependency Problem
+	// PART 2: Wide & Useless -- The Dependency Problem
 	// =========================================================================
 	{
 		std::cout << "+=========================================================================+\n";
-		std::cout << "| PART 2: Wide & Useless — The Dependency Problem                         |\n";
+		std::cout << "| PART 2: Wide & Useless -- The Dependency Problem                         |\n";
 		std::cout << "+=========================================================================+\n\n";
 
 		// --- Scenario A: x - x ---
@@ -136,7 +136,7 @@ try {
 
 			std::cout << "The interval [2,5] - [2,5] computes [2-5, 5-2] = [-3, 3].\n";
 			std::cout << "Each 'x' is treated as an independent variable that could take\n";
-			std::cout << "any value in [2,5] — the subtraction doesn't know both are the same x.\n\n";
+			std::cout << "any value in [2,5] -- the subtraction doesn't know both are the same x.\n\n";
 		}
 
 		// --- Scenario B: Polynomial evaluation ---

--- a/static/tapered/posit1/complex/arithmetic/addition.cpp
+++ b/static/tapered/posit1/complex/arithmetic/addition.cpp
@@ -127,10 +127,10 @@ try {
 		using Real = posit<16,1>;
 #if defined(__GNUG__)
 /* TODO: this doesn't compile under g++
- error: conversion from ‘__complex__ double’ to non-scalar type ‘std::complex<sw::universal::posit<16, 1> >’ requested
+ error: conversion from '__complex__ double' to non-scalar type 'std::complex<sw::universal::posit<16, 1> >' requested
    std::complex<Real> z4 = 1. + 2i, z5 = 1. - 2i; // conjugates
                            ~~~^~~~
- error: conversion from ‘__complex__ double’ to non-scalar type ‘std::complex<sw::universal::posit<16, 1> >’ requested
+ error: conversion from '__complex__ double' to non-scalar type 'std::complex<sw::universal::posit<16, 1> >' requested
    std::complex<Real> z4 = 1. + 2i, z5 = 1. - 2i; // conjugates
                                          ~~~^~~~
 */

--- a/static/tapered/posit1/conversion/conversion_algorithm_development.cpp_
+++ b/static/tapered/posit1/conversion/conversion_algorithm_development.cpp_
@@ -239,7 +239,7 @@ bool _anyAfter(const sw::universal::bitblock<nbits>& bits, unsigned msb) {
 p[x_] := Module[{s, y, r, e, f, run, reg, esval, nf, len, fv, sb, pt, blast, bafter, bsticky, rb, ptt, p},
 s     = Boole[x < 0];
 y     = Max[minpos, Min[maxpos, Abs[x]]];
-r     = Boole[y ≥ 1];
+r     = Boole[y >= 1];
 e     = Floor[Log[2, y]];
 f     = y / 2^e - 1;
 run   = Abs[Floor[e / 2^es]] + r;

--- a/static/tapered/posit1/math/trigonometry.cpp
+++ b/static/tapered/posit1/math/trigonometry.cpp
@@ -1,4 +1,4 @@
-﻿// function_trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
+// function_trigonometry.cpp: test suite runner for trigonometric functions (sin/cos/tan/atan/acos/asin)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -12,8 +12,8 @@
 #include <universal/verification/posit_test_suite_mathlib.hpp>
 
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In extensive testing, no errors > 0.97 ulp were found in either the sine
 or cosine results, suggesting the results returned are faithfully rounded.
@@ -84,8 +84,8 @@ double cospi(double arg) {
 
 #ifdef CPP17_HEXFLOAT_LITERALS
 /* 
-Writes result sine result sin(πa) to the location pointed to by sp
-Writes result cosine result cos(πa) to the location pointed to by cp
+Writes result sine result sin(pia) to the location pointed to by sp
+Writes result cosine result cos(pia) to the location pointed to by cp
 
 In exhaustive testing, the maximum error in sine results was 0.96677 ulp,
 the maximum error in cosine results was 0.96563 ulp, meaning results are

--- a/static/utility/test_tracked.cpp
+++ b/static/utility/test_tracked.cpp
@@ -1,4 +1,4 @@
-﻿// test_tracked.cpp: comprehensive test of unified Tracked<T> interface
+// test_tracked.cpp: comprehensive test of unified Tracked<T> interface
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -326,8 +326,8 @@ There are Two different Meanings of "Precision"
 
 What we're measuring (Result Accuracy): 
 True mathematical result : 1.0 + 1e-7 = 1.0000001 
-Computed result : 1.0 + ulp(1.0) ≈ 1.00000012 
-Absolute error : ~1.9e-8 Relative error : 1.9e-8 / 1.0 ≈ 1.9e-8
+Computed result : 1.0 + ulp(1.0) ~= 1.00000012 
+Absolute error : ~1.9e-8 Relative error : 1.9e-8 / 1.0 ~= 1.9e-8
 
 By this measure, the result IS accurate to ~25 bits because 1.00000012 is 
 very close to 1.0000001. The relative error is tiny.
@@ -338,13 +338,13 @@ After addition: almost ALL of b's bits were discarded The ULP bit in the
 result is an approximation of b, not b itself
 
  Precision and Information Preservation are two different metrics:
-  ┌───────────────────────┬──────────────┬───────────────────────────────────────┐
-  │ Metric                │    Value     │            Interpretation             │
-  ├───────────────────────┼──────────────┼───────────────────────────────────────┤
-  │ Result accuracy       │ 24+ bits     │ "How close is result to true answer?" │
-  ├───────────────────────┼──────────────┼───────────────────────────────────────┤
-  │ Information preserved │ ~0 bits of b │ "How much of b survived?"             │
-  └───────────────────────┴──────────────┴───────────────────────────────────────┘ 
+  +-----------------------+--------------+---------------------------------------+
+  | Metric                |    Value     |            Interpretation             |
+  +-----------------------+--------------+---------------------------------------+
+  | Result accuracy       | 24+ bits     | "How close is result to true answer?" |
+  +-----------------------+--------------+---------------------------------------+
+  | Information preserved | ~0 bits of b | "How much of b survived?"             |
+  +-----------------------+--------------+---------------------------------------+ 
   
 # The Absorption Problem
 
@@ -352,9 +352,9 @@ This is the dual of cancellation. In subtraction of nearly-equal values,
 error gets magnified.In addition of vastly-different magnitudes,
 information gets absorbed :
 
-    1.0f     = 1.00000000000000000000000 × 2 ^ 0
-    1e-7f    = 0.00000000000000000000000 11010110111... × 2 ^ 0(shifted)
-                                         ↑ These bits fall off the end
+    1.0f     = 1.00000000000000000000000 * 2 ^ 0
+    1e-7f    = 0.00000000000000000000000 11010110111... * 2 ^ 0(shifted)
+                                         ^ These bits fall off the end
 
 The bits of 1e-7 that would appear after position 24 are simply lost.
 The result's ULP is a 1-bit approximation of a value that had 24 bits of information.

--- a/static/utility/test_tracked_bounded.cpp
+++ b/static/utility/test_tracked_bounded.cpp
@@ -71,7 +71,7 @@ void test_interval_growth() {
 	for (int i = 0; i < 100; ++i) {
 		sum += TrackedBounded<double>(0.1);
 	}
-	std::cout << "\nSum of 100 × 0.1:\n";
+	std::cout << "\nSum of 100 * 0.1:\n";
 	std::cout << "  Interval: " << sum << "\n";
 	std::cout << "  Midpoint: " << sum.value() << "\n";
 	std::cout << "  Width: " << std::scientific << sum.width() << "\n";
@@ -124,7 +124,7 @@ void test_sqrt() {
 	TrackedBounded<double> a = da;
 	TrackedBounded<double> b = db;
 	auto c = sqrt(a * a + b * b);
-	std::cout << "\nsqrt(3² + 4²) = " << c << "\n";
+	std::cout << "\nsqrt(3^2 + 4^2) = " << c << "\n";
 	std::cout << to_binary(c.value()) << " : midpoint = " << c.value() << "\n";
 	std::cout << "  True (5) in interval: "
 	          << (c.lo() <= 5.0 && 5.0 <= c.hi() ? "yes" : "no") << "\n";
@@ -135,10 +135,10 @@ void test_uncertain_inputs() {
 
 	// Create a measurement with 1% uncertainty
 	auto x = make_uncertain(100.0, 0.01);
-	std::cout << "x = 100 ± 1% = " << x << "\n";
+	std::cout << "x = 100 +/- 1% = " << x << "\n";
 
 	auto y = make_uncertain(50.0, 0.02);
-	std::cout << "y = 50 ± 2% = " << y << "\n";
+	std::cout << "y = 50 +/- 2% = " << y << "\n";
 
 	auto sum = x + y;
 	std::cout << "\nx + y = " << sum << "\n";

--- a/static/utility/test_tracked_exact.cpp
+++ b/static/utility/test_tracked_exact.cpp
@@ -224,7 +224,7 @@ TrackedShadow (tracked_shadow.hpp):
 TrackedLNS (tracked_lns.hpp):
   - Added absorption tracking to complement existing cancellation detection
   - LNS can now track both:
-    - Cancellations: when a ≈ -b causes precision loss (subtraction-like)
+    - Cancellations: when a ~= -b causes precision loss (subtraction-like)
     - Absorptions: when |a| >> |b| causes the smaller operand to be swallowed
 
 Detection logic:
@@ -234,6 +234,6 @@ Detection logic:
 Test results:
   1.0 + 1e-20:    Absorptions: 1  (correctly detected)
   1.0 + 0.5:      Absorptions: 0  (correctly not flagged)
-  1.0 + 10×1e-20: Absorptions: 10 (each addition detected)
+  1.0 + 10*1e-20: Absorptions: 10 (each addition detected)
 */
 

--- a/static/utility/test_tracked_lns.cpp
+++ b/static/utility/test_tracked_lns.cpp
@@ -110,7 +110,7 @@ void test_cancellation() {
 	TrackedLNS<LNS> a = la;
 	TrackedLNS<LNS> b = lb;
 
-	// Near-cancellation: a - b when a ≈ b
+	// Near-cancellation: a - b when a ~= b
 	LNS lc = la - lb;
 	auto c = a - b;
 	std::cout << "1.0 - 0.95 (near-cancellation):\n";

--- a/static/utility/test_tracked_statistical.cpp
+++ b/static/utility/test_tracked_statistical.cpp
@@ -31,7 +31,7 @@ void test_ulp_function() {
 	std::cout << to_binary(d1em10) << " : 1e-10, ulp = " << ulp(d1em10) << "\n";
 	std::cout << to_binary(d0) << " : 0.0,   ulp = " << ulp(d0) << " (denorm_min)\n";
 
-	std::cout << "\nExpected ulp(1.0) ≈ 2.22e-16 (machine epsilon)\n";
+	std::cout << "\nExpected ulp(1.0) ~= 2.22e-16 (machine epsilon)\n";
 	std::cout << "Actual epsilon    = " << std::numeric_limits<double>::epsilon() << "\n";
 }
 
@@ -236,7 +236,7 @@ void test_validation() {
 	auto validation = StatisticalValidation<double, ErrorModel::RandomWalk>::compute(
 		stat_sum, static_cast<double>(shadow_sum));
 
-	std::cout << "Sum of 50 × 0.1:\n";
+	std::cout << "Sum of 50 * 0.1:\n";
 	validation.report(std::cout);
 }
 

--- a/tools/scripts/check-ascii.sh
+++ b/tools/scripts/check-ascii.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# check-ascii.sh - enforce the ASCII-only rule for source and build files.
+#
+# Rationale: Unicode characters (box-drawing, smart quotes, math symbols,
+# em-dashes, superscripts, etc.) do not render correctly on Windows consoles
+# and can break tooling. All C/C++ source, CMake, and build/automation scripts
+# in this repository must contain only 7-bit ASCII bytes.
+#
+# This script scans the git-tracked source and build files and fails (exit 1)
+# if any non-ASCII byte is found, printing the offending file:line:char so the
+# problem is easy to locate. Documentation (*.md) and binary assets are NOT
+# checked - the rule applies to source and build/script files only.
+#
+# Usage:
+#   tools/scripts/check-ascii.sh            # scan the whole tracked tree
+#   tools/scripts/check-ascii.sh file ...   # scan specific files
+#
+# Wired into CI by .github/workflows/ascii-guard.yml.
+
+set -euo pipefail
+
+# Non-ASCII = any byte outside 0x00-0x7F. grep -P with this negated class
+# matches such bytes; grep -I skips binary files.
+PATTERN='[^\x00-\x7F]'
+
+# File globs that constitute "source and build files".
+is_in_scope() {
+	case "$1" in
+		*.hpp|*.cpp|*.h|*.c|*.cc|*.cxx|*.hxx|*.inc|*.cpp_) return 0 ;;
+		*.cmake|*/CMakeLists.txt|CMakeLists.txt)           return 0 ;;
+		*.sh|*.py|*.mjs|*.js|*.bash)                       return 0 ;;
+		*Dockerfile|*Dockerfile.*|*/Dockerfile)            return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+# Build the candidate list: explicit args, else all git-tracked files.
+if [ "$#" -gt 0 ]; then
+	candidates=("$@")
+else
+	mapfile -t candidates < <(git ls-files)
+fi
+
+violations=0
+for f in "${candidates[@]}"; do
+	[ -f "$f" ] || continue
+	is_in_scope "$f" || continue
+	if LC_ALL=C grep -InP "$PATTERN" -- "$f" >/dev/null 2>&1; then
+		violations=$((violations + 1))
+		echo "Non-ASCII bytes in: $f"
+		# Show line:col context for each offending line (cap to keep output sane).
+		LC_ALL=C grep -nP "$PATTERN" -- "$f" | head -20 | sed 's/^/    /'
+	fi
+done
+
+if [ "$violations" -ne 0 ]; then
+	echo ""
+	echo "ERROR: $violations source/build file(s) contain non-ASCII characters."
+	echo "Replace them with ASCII equivalents (see CLAUDE.md 'No Unicode Characters')."
+	echo "  ~= for approx, != not-equal, <= >= for inequalities, -> for arrow,"
+	echo "  -- for em-dash, +/- for plus-minus, pi for greek pi, ^2 for superscript, etc."
+	exit 1
+fi
+
+echo "OK: all source/build/script files are pure ASCII."


### PR DESCRIPTION
## Summary

Three cleanly-separated cleanups, bundled into one branch so CI runs once.

1. **ASCII-only sweep (188 files)** - replace all non-ASCII characters in source, CMake, and script files with ASCII equivalents:
   - box-drawing -> single-width `- | + =` (keeps tables aligned)
   - math symbols -> `~= != <= >= -> <- +/- sqrt inf`
   - superscript/subscript runs -> `^2`, `10^-8`, `x1`, `log2`
   - greek -> `pi eps delta mu lambda`; smart quotes/dashes -> `' " -- -`
   - strip UTF-8 BOMs and a stray Latin-1 `0xBF` byte (a mangled minus) in the `long_double` headers
   - docs (`*.md`) and binary assets are out of scope

2. **CI enforcement** - `tools/scripts/check-ascii.sh` (byte-mode scan with `LC_ALL=C` to catch invalid-UTF-8 bytes) + `.github/workflows/ascii-guard.yml`. Rule + equivalences documented in `CLAUDE.md`.

3. **Two GCC 13 build-warning fixes** broken out as their own commits:
   - `fix(internal)`: avoid `-Warray-bounds` false positive in `renormalize_expansion` (split the size<=1 fast path; behavior unchanged)
   - `style(ereal)`: split test increment onto its own line to fix `-Wmisleading-indentation` (42 lines, 4 files)

## Commits
- `style:` ASCII sweep + CI guard (188 files)
- `fix(internal):` renormalize_expansion -Warray-bounds workaround (1 file)
- `style(ereal):` -Wmisleading-indentation fix (4 files)

## Validation
- `tools/scripts/check-ascii.sh` reports the whole tracked tree is pure ASCII
- Affected translation units recompile at `-O2 -Wall` with the targeted warnings gone and no new warnings
- ASCII changes are confined to comments and string literals (no identifier/semantic changes)

The new `ASCII Guard` workflow will validate the sweep on this PR.

Co-Authored-By: Claude Opus 4.8 (1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "ASCII Guard" CI workflow to enforce ASCII-only source/build files on pushes and pull requests to main.

* **Documentation**
  * Expanded ASCII-only policy guidance and concrete ASCII-equivalent examples; updated various docs and session notes.

* **Style**
  * Normalized Unicode/math/punctuation to ASCII across the codebase for consistent, ASCII-friendly comments and output.

* **Chores**
  * Added a repository script to scan for non-ASCII bytes and fail CI on violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->