### PR TITLE
feat(elreal): infinite summation (Phase 5, #929)

### DIFF
--- a/elastic/elreal/CMakeLists.txt
+++ b/elastic/elreal/CMakeLists.txt
@@ -4,14 +4,17 @@
 # Phase 2 (#926): ZBCL<FpType> co-list of blocks.
 # Phase 3 (#927): block-level EFTs (twoSum / twoMult / twoDiv).
 # Phase 4 (#928): threeAdd helper + add() lazy ZBCL combinator.
-# Phase 5+ (#929-#933): infinite summation, math suite, real-FP conversion.
+# Phase 5 (#929): infinite summation (series<FpType> co-list + sum()).
+# Phase 6+ (#930-#933): negation/mul/div, math suite, real-FP conversion.
 
 file (GLOB BLOCK_SRCS       "./block/*.cpp")
 file (GLOB ZBCL_SRCS        "./zbcl/*.cpp")
 file (GLOB BLOCK_EFT_SRCS   "./block_eft/*.cpp")
 file (GLOB ARITHMETIC_SRCS  "./arithmetic/*.cpp")
+file (GLOB SUMMATION_SRCS   "./summation/*.cpp")
 
 compile_all("true" "el_block"      "Number Systems/elastic/floating-point/binary/elreal/block"      "${BLOCK_SRCS}")
 compile_all("true" "el_zbcl"       "Number Systems/elastic/floating-point/binary/elreal/zbcl"       "${ZBCL_SRCS}")
 compile_all("true" "el_block_eft"  "Number Systems/elastic/floating-point/binary/elreal/block_eft"  "${BLOCK_EFT_SRCS}")
 compile_all("true" "el_arith"      "Number Systems/elastic/floating-point/binary/elreal/arithmetic" "${ARITHMETIC_SRCS}")
+compile_all("true" "el_sum"        "Number Systems/elastic/floating-point/binary/elreal/summation"  "${SUMMATION_SRCS}")

--- a/elastic/elreal/summation/alternating.cpp
+++ b/elastic/elreal/summation/alternating.cpp
@@ -1,0 +1,96 @@
+// alternating.cpp: Phase 5 (#929) summation test on a slowly-converging
+// alternating series.
+//
+//     pi/4 = sum_{n>=0} (-1)^n / (2n+1)   (Leibniz)
+//
+// This is an infinite series with slow (1/n) convergence, exercising many
+// lazy add() compositions under a depth budget. We check:
+//   - the bounded sum reproduces the exact dyadic sum of the terms it folds
+//     (exact-oracle contract),
+//   - the 0-overlap invariant holds on the result,
+//   - the result approximates pi/4 within the Leibniz truncation error,
+//   - a convergent infinite series does NOT trip the budget guard.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "summation_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_sum_test;
+
+// Leibniz term n: (-1)^n / (2n+1).
+template <typename FpType>
+sw::universal::ZBCL<FpType> leibniz_term(std::size_t n) {
+    using namespace sw::universal;
+    double sign = (n % 2 == 0) ? 1.0 : -1.0;
+    return from_native<FpType>(sign / (2.0 * static_cast<double>(n) + 1.0));
+}
+
+template <typename FpType>
+int verify_leibniz(std::size_t depth, double tol, const std::string& tag) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+
+    auto gen = [](std::size_t n) { return leibniz_term<FpType>(n); };
+    auto result = sum<FpType>(series_from_generator<FpType>(gen), depth);
+
+    // (1) Exact-oracle contract: the bounded sum equals the exact dyadic sum of
+    // the first `depth` represented terms.
+    std::vector<ZBCL<FpType>> folded;
+    folded.reserve(depth);
+    for (std::size_t n = 0; n < depth; ++n) folded.push_back(gen(n));
+    dyadic got = est::exact_value(result);
+    dyadic ref = est::exact_series_sum<FpType>(folded);
+    if (!(got == ref)) {
+        std::cout << tag << " exact mismatch vs folded-term oracle\n";
+        ++nrFailures;
+    }
+
+    // (2) 0-overlap on the result.
+    nrFailures += est::check_zero_overlap<FpType>(result, 16, tag);
+
+    // (3) Approximation to pi/4 within the Leibniz truncation bound ~ 1/(2*depth).
+    double approx = to_double_approx(result, 64);
+    double pi_over_4 = std::atan(1.0);   // = pi/4
+    if (std::abs(approx - pi_over_4) > tol) {
+        std::cout << tag << " pi/4 approx FAILED: got " << approx
+                  << " expected ~" << pi_over_4 << " (tol " << tol << ")\n";
+        ++nrFailures;
+    }
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 5 (#929) summation: alternating (Leibniz pi/4)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    // depth=256 -> truncation error <= 1/512 ~ 2e-3; use a comfortable tolerance.
+    nrOfFailedTestCases += verify_leibniz<double>(256, 5e-3, "leibniz<double>");
+    nrOfFailedTestCases += verify_leibniz<float>(256, 5e-3, "leibniz<float>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/summation/depth_budget.cpp
+++ b/elastic/elreal/summation/depth_budget.cpp
@@ -85,6 +85,15 @@ try {
     };
     nrOfFailedTestCases += expect_abort<double>(growing, 8, "sum (n+1) (divergent)");
 
+    // Divergent: oscillating non-decaying series 1 - 1/2 + 1 - 1/2 + ... (leading
+    // exponents 0,-1,0,-1,...). The endpoint heuristic would miss this; the
+    // window-based guard must still reject it.
+    auto oscillating = []() {
+        return series_from_generator<double>(
+            [](std::size_t n) { return from_native<double>(n % 2 == 0 ? 1.0 : -0.5); });
+    };
+    nrOfFailedTestCases += expect_abort<double>(oscillating, 16, "sum (osc 1,-1/2) (divergent)");
+
     // Budget of 0 is always an error.
     auto any_series = []() {
         return series_from_generator<double>([](std::size_t) { return from_native<double>(1.0); });

--- a/elastic/elreal/summation/depth_budget.cpp
+++ b/elastic/elreal/summation/depth_budget.cpp
@@ -1,0 +1,108 @@
+// depth_budget.cpp: Phase 5 (#929) summation depth-budget / convergence guard.
+//
+// The dissertation defines summation only for Cauchy series. sum() trusts the
+// caller for convergent series but guards against ill-formed (divergent) input:
+// if the budget is reached before natural termination AND the term magnitudes
+// are not decreasing, it throws elreal_sum_budget_exceeded.
+//
+// Verifies:
+//   - divergent constant series (sum 1) aborts within budget,
+//   - divergent growing series (sum (n+1)) aborts,
+//   - max_depth == 0 aborts,
+//   - a convergent infinite series (sum (1/2)^n) does NOT abort (it truncates).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "summation_oracle.hpp"
+
+namespace {
+
+// Expect sum() to throw elreal_sum_budget_exceeded.
+template <typename FpType, typename SeriesFactory>
+int expect_abort(SeriesFactory make_series, std::size_t max_depth, const std::string& tag) {
+    using namespace sw::universal;
+    try {
+        auto result = sum<FpType>(make_series(), max_depth);
+        // Force a block so any lazy work is realised; should not get here.
+        (void)result.take(1);
+        std::cout << tag << " FAILED: expected elreal_sum_budget_exceeded, none thrown\n";
+        return 1;
+    }
+    catch (const elreal_sum_budget_exceeded&) {
+        return 0;   // expected
+    }
+}
+
+// Expect sum() to succeed (no throw) and produce a non-empty result.
+template <typename FpType, typename SeriesFactory>
+int expect_ok(SeriesFactory make_series, std::size_t max_depth, const std::string& tag) {
+    using namespace sw::universal;
+    try {
+        auto result = sum<FpType>(make_series(), max_depth);
+        if (result.is_empty()) {
+            std::cout << tag << " FAILED: convergent series produced empty sum\n";
+            return 1;
+        }
+        return 0;
+    }
+    catch (const elreal_sum_budget_exceeded& e) {
+        std::cout << tag << " FAILED: convergent series wrongly aborted: " << e.what() << '\n';
+        return 1;
+    }
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 5 (#929) summation: depth-budget guard";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    // Divergent: constant series 1 + 1 + 1 + ... (magnitudes do not decrease).
+    auto constant = []() {
+        return series_from_generator<double>([](std::size_t) { return from_native<double>(1.0); });
+    };
+    nrOfFailedTestCases += expect_abort<double>(constant, 8, "sum 1 (divergent)");
+
+    // Divergent: growing series 1 + 2 + 3 + ... (magnitudes increase).
+    auto growing = []() {
+        return series_from_generator<double>(
+            [](std::size_t n) { return from_native<double>(static_cast<double>(n) + 1.0); });
+    };
+    nrOfFailedTestCases += expect_abort<double>(growing, 8, "sum (n+1) (divergent)");
+
+    // Budget of 0 is always an error.
+    auto any_series = []() {
+        return series_from_generator<double>([](std::size_t) { return from_native<double>(1.0); });
+    };
+    nrOfFailedTestCases += expect_abort<double>(any_series, 0, "max_depth == 0");
+
+    // Convergent infinite series must NOT abort -- it truncates at the budget.
+    auto geometric = []() {
+        return series_from_generator<double>([](std::size_t n) {
+            return from_native<double>(std::ldexp(1.0, -static_cast<int>(n)));  // (1/2)^n
+        });
+    };
+    nrOfFailedTestCases += expect_ok<double>(geometric, 8, "sum (1/2)^n (convergent)");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/summation/exp_preview.cpp
+++ b/elastic/elreal/summation/exp_preview.cpp
@@ -1,0 +1,95 @@
+// exp_preview.cpp: Phase 5 (#929) summation test on the exp(1) Taylor series.
+//
+//     e = sum_{n>=0} 1/n!
+//
+// A Phase 7 preview: this is exactly how transcendentals will drive sum(). The
+// series converges fast (1/n! drops below double eps by n ~ 18), so a small
+// depth budget already gives full precision. We check the exact-oracle contract
+// on the folded terms, 0-overlap, and the double-precision value against
+// std::exp(1).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "summation_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_sum_test;
+
+// Taylor term n of exp(1): 1/n!.
+template <typename FpType>
+sw::universal::ZBCL<FpType> recip_factorial(std::size_t n) {
+    using namespace sw::universal;
+    double fact = 1.0;
+    for (std::size_t i = 2; i <= n; ++i) fact *= static_cast<double>(i);
+    return from_native<FpType>(1.0 / fact);
+}
+
+template <typename FpType>
+int verify_exp(std::size_t depth, double tol, const std::string& tag) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+
+    auto gen = [](std::size_t n) { return recip_factorial<FpType>(n); };
+    auto result = sum<FpType>(series_from_generator<FpType>(gen), depth);
+
+    // (1) Exact-oracle contract on the folded terms.
+    std::vector<ZBCL<FpType>> folded;
+    folded.reserve(depth);
+    for (std::size_t n = 0; n < depth; ++n) folded.push_back(gen(n));
+    dyadic got = est::exact_value(result);
+    dyadic ref = est::exact_series_sum<FpType>(folded);
+    if (!(got == ref)) {
+        std::cout << tag << " exact mismatch vs folded-term oracle\n";
+        ++nrFailures;
+    }
+
+    // (2) 0-overlap on the result.
+    nrFailures += est::check_zero_overlap<FpType>(result, 16, tag);
+
+    // (3) Value against std::exp(1).
+    double approx = to_double_approx(result, 64);
+    double e = std::exp(1.0);
+    if (std::abs(approx - e) > tol) {
+        std::cout << tag << " exp(1) FAILED: got " << approx
+                  << " expected ~" << e << " (tol " << tol << ")\n";
+        ++nrFailures;
+    }
+    return nrFailures;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 5 (#929) summation: exp(1) = sum 1/n! (Phase 7 preview)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    // depth=20 -> 1/20! ~ 4e-19 << double eps, so full double precision.
+    nrOfFailedTestCases += verify_exp<double>(20, 1e-12, "exp<double>");
+    // float host: the represented terms sum to e at float precision; compare in
+    // double with a float-eps-scaled tolerance.
+    nrOfFailedTestCases += verify_exp<float>(20, 1e-5, "exp<float>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/summation/geometric.cpp
+++ b/elastic/elreal/summation/geometric.cpp
@@ -1,0 +1,118 @@
+// geometric.cpp: Phase 5 (#929) summation tests on geometric series.
+//
+// Verifies sum() against an INDEPENDENT exact dyadic oracle (not long double):
+// for a finite list of terms, sum() must reproduce the exact sum of the
+// REPRESENTED terms bit-for-bit:
+//     exact_value(sum(series)) == sum_i exact_value(term_i).
+// Also checks the 0-overlap invariant on the result and a closed-form sanity
+// approximation (sum_{i<N} r^i = (1 - r^N)/(1 - r)).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "summation_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_sum_test;
+
+// Build the finite geometric series [r^0, r^1, ..., r^{N-1}] as singleton ZBCLs.
+template <typename FpType>
+std::vector<sw::universal::ZBCL<FpType>> geometric_terms(double ratio, std::size_t N) {
+    using namespace sw::universal;
+    std::vector<ZBCL<FpType>> terms;
+    terms.reserve(N);
+    double term = 1.0;                       // r^0
+    for (std::size_t i = 0; i < N; ++i) {
+        terms.push_back(from_native<FpType>(term));
+        term *= ratio;
+    }
+    return terms;
+}
+
+template <typename FpType>
+int verify_geometric(double ratio, std::size_t N, double closed_form, double tol,
+                     const std::string& tag) {
+    using namespace sw::universal;
+    int nrFailures = 0;
+
+    auto terms  = geometric_terms<FpType>(ratio, N);
+    auto result = sum<FpType>(series_from_vector<FpType>(terms));   // finite -> exact
+
+    // (1) Exact-oracle bit-for-bit contract on the represented terms.
+    dyadic got = est::exact_value(result);
+    dyadic ref = est::exact_series_sum<FpType>(terms);
+    if (!(got == ref)) {
+        std::cout << tag << " exact mismatch: sum(series) != sum of terms\n";
+        ++nrFailures;
+    }
+
+    // (2) 0-overlap invariant on the result prefix.
+    nrFailures += est::check_zero_overlap<FpType>(result, 16, tag);
+
+    // (3) Closed-form sanity. The result is the exact sum of the REPRESENTED
+    // terms, so for a ratio that is not exactly representable (e.g. 1/3) it
+    // deviates from the ideal closed form by the host's rounding of the terms
+    // (~N * eps). Scale the tolerance by host precision so the check is
+    // meaningful on float / cfloat<32,8> too; the exact-oracle check above is
+    // the rigorous one.
+    double approx   = to_double_approx(result, 64);
+    double host_eps = static_cast<double>(std::numeric_limits<FpType>::epsilon());
+    double eff_tol  = tol + 8.0 * static_cast<double>(N) * host_eps * std::abs(closed_form);
+    if (std::abs(approx - closed_form) > eff_tol) {
+        std::cout << tag << " closed-form sanity FAILED: got " << approx
+                  << " expected ~" << closed_form << " (tol " << eff_tol << ")\n";
+        ++nrFailures;
+    }
+    return nrFailures;
+}
+
+template <typename FpType>
+int verify_all(const std::string& host) {
+    int n = 0;
+    // sum (1/2)^n -> 2 ; exactly representable terms
+    n += verify_geometric<FpType>(0.5,      32, 2.0,        1e-9, host + " (1/2)^n");
+    // sum (1/4)^n -> 4/3
+    n += verify_geometric<FpType>(0.25,     16, 4.0 / 3.0,  1e-9, host + " (1/4)^n");
+    // sum (-1/2)^n -> 2/3 ; alternating geometric
+    n += verify_geometric<FpType>(-0.5,     32, 2.0 / 3.0,  1e-9, host + " (-1/2)^n");
+    // sum (1/3)^n -> 3/2 ; 1/3 is NOT exactly representable, so the oracle
+    // compares the represented terms (the exact contract still holds).
+    n += verify_geometric<FpType>(1.0/3.0,  24, 1.5,        1e-9, host + " (1/3)^n");
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 5 (#929) summation: geometric series";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_all<double>("sum<double>");
+    nrOfFailedTestCases += verify_all<float>("sum<float>");
+    nrOfFailedTestCases += verify_all<single>("sum<cfloat<32,8>>");   // single = cfloat<32,8>
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/summation/summation_oracle.hpp
+++ b/elastic/elreal/summation/summation_oracle.hpp
@@ -1,0 +1,92 @@
+// summation_oracle.hpp: shared exact-dyadic oracle helpers for the Phase 5
+// (#929) summation tests.
+//
+// These mirror the exact_real / exact_block / exact_value helpers used by the
+// Phase 4 addition tests and the #1022 oracle (exact_value_oracle.cpp). They are
+// templates (implicitly inline), so including this header in several test TUs is
+// ODR-safe. Kept local to elastic/elreal/summation/ -- not part of the library
+// include tree.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+
+namespace sw { namespace universal { namespace elreal_sum_test {
+
+// Exact value of a binary float v as a dyadic, with no precision loss at any
+// significand width (identical to the #1022 oracle's exact_real).
+template <typename T>
+inline dyadic exact_real(T v) {
+    if (v == T(0)) return dyadic();
+    if constexpr (std::numeric_limits<T>::digits <= 53) {
+        return dyadic::from_double(static_cast<double>(v));
+    } else if constexpr (has_universal_fp_api_v<T>) {
+        constexpr int fbits = std::numeric_limits<T>::digits - 1;
+        assert(v.isnormal() && "exact_real bit path expects a normal value");
+        dyadic::bigint F(0);
+        for (int i = 0; i < fbits; ++i) {
+            if (v.test(static_cast<unsigned>(i))) {
+                dyadic::bigint bit(1); bit <<= i; F = F + bit;
+            }
+        }
+        dyadic::bigint M(1); M <<= fbits; M = M + F;     // hidden bit + fraction
+        return dyadic(v.sign() ? -M : M, v.scale() - fbits);
+    } else {
+        static_assert(has_universal_fp_api_v<T>,
+            "exact_real: wide native hosts not supported yet (add std::frexp path).");
+        return dyadic();
+    }
+}
+
+// Exact value of a block as a dyadic rational: value(b) = v * 2^exp.
+template <typename FpType>
+inline dyadic exact_block(const block<FpType>& b) {
+    if (b.is_zero_block()) return dyadic();
+    dyadic d = exact_real(b.v);
+    d.scale += b.exp;
+    return d;
+}
+
+// Exact value of a ZBCL prefix (32-block window, matching the #1022 oracle).
+template <typename FpType>
+inline dyadic exact_value(const ZBCL<FpType>& z) {
+    dyadic acc;
+    for (const auto& blk : z.take(32)) acc = acc + exact_block(blk);
+    return acc;
+}
+
+// Exact value of a finite list of ZBCL terms: sum_i exact_value(term_i). This is
+// the reference value a correct sum() must reproduce bit-for-bit on the terms it
+// actually folds (the represented values, not the ideal mathematical series).
+template <typename FpType>
+inline dyadic exact_series_sum(const std::vector<ZBCL<FpType>>& terms) {
+    dyadic acc;
+    for (const auto& t : terms) acc = acc + exact_value(t);
+    return acc;
+}
+
+// 0-overlap check over the first `n` blocks of a stream. Returns failure count.
+template <typename FpType>
+inline int check_zero_overlap(const ZBCL<FpType>& z, std::size_t n, const std::string& tag) {
+    auto blocks = z.take(n);
+    int fails = 0;
+    for (std::size_t i = 0; i + 1 < blocks.size(); ++i) {
+        if (!zero_overlap(blocks[i], blocks[i + 1])) {
+            std::cout << tag << " 0-overlap FAILED at block " << i << '\n';
+            ++fails;
+        }
+    }
+    return fails;
+}
+
+}}} // namespace sw::universal::elreal_sum_test

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -6,9 +6,12 @@
 //                   to_double_approx helpers.
 //   Phase 3 (#927): block-level EFTs (block_two_sum / _mult / _div + RN
 //                   variants).
+//   Phase 4 (#928): threeAdd + add() lazy ZBCL combinator.
+//   Phase 5 (#929): infinite summation -- series<FpType> co-list of ZBCL terms
+//                   and sum() (dissertation 4.2.3).
 //
-// Higher-level pieces (stream arithmetic, math suite, real-FP conversion)
-// arrive in later phases (#928-#933 under epic #923).
+// Higher-level pieces (math suite, real-FP conversion) arrive in later phases
+// (#930-#933 under epic #923).
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -23,3 +26,6 @@
 #include <universal/number/elreal/zbcl_helpers.hpp>
 #include <universal/number/elreal/block_eft.hpp>
 #include <universal/number/elreal/threeAdd.hpp>
+#include <universal/number/elreal/exceptions.hpp>
+#include <universal/number/elreal/series.hpp>
+#include <universal/number/elreal/sum.hpp>

--- a/include/sw/universal/number/elreal/exceptions.hpp
+++ b/include/sw/universal/number/elreal/exceptions.hpp
@@ -1,0 +1,33 @@
+// exceptions.hpp: exception types for the McCleeary LFPERA elreal number system.
+//
+// elreal is an experimental, header-only research type. Its streaming
+// operations already surface non-convergence bugs by throwing std::runtime_error
+// (see threeAdd.hpp). Phase 5 (#929) adds one caller-facing exception: a series
+// handed to sum() that does not Cauchy-stabilise within the depth budget.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace sw { namespace universal {
+
+// Base class for elreal exceptions, so callers can catch the whole family.
+struct elreal_exception : public std::runtime_error {
+    explicit elreal_exception(const std::string& what) : std::runtime_error(what) {}
+};
+
+// Thrown by sum() when the depth budget is exhausted before the series'
+// partial-sum sequence shows convergence (term magnitudes not trending toward
+// zero). The dissertation defines summation only for Cauchy series; this guards
+// against ill-formed (divergent) input. A convergent-but-slow series does NOT
+// trigger this: it is truncated at the budget and the partial sum is returned.
+struct elreal_sum_budget_exceeded : public elreal_exception {
+    explicit elreal_sum_budget_exceeded(const std::string& what) : elreal_exception(what) {}
+};
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/series.hpp
+++ b/include/sw/universal/number/elreal/series.hpp
@@ -1,0 +1,153 @@
+// series.hpp: McCleeary LFPERA series<FpType> -- a lazy co-list of ZBCL terms.
+//
+// Phase 5 (#929) needs to sum a "stream of streams": a (possibly infinite)
+// sequence of ZBCL<FpType> terms x_0, x_1, x_2, ... whose partial sums form a
+// Cauchy sequence. This is the issue's `colist<ZBCL<FpType>>`. ZBCL<FpType> is
+// itself a co-list of block<FpType>; series<FpType> is the next level up: a
+// co-list whose elements are whole ZBCL streams.
+//
+// Representation (identical idiom to zbcl.hpp)
+//   - Empty co-list = the empty series (its sum is 0).
+//   - Non-empty co-list = (head ZBCL, tail thunk). The tail thunk is a
+//     std::function<series()>, evaluated on demand by tail()/take(n) and
+//     memoised on the node so a thunk fires at most once. Nodes are shared via
+//     std::shared_ptr so series values are cheap to copy.
+//   - End-of-stream sentinel is an empty thunk (default-constructed
+//     std::function); a finite series terminates at its last materialised term.
+//
+// A series may be finite (built from a vector of terms) or infinite (built from
+// an index generator). sum() in sum.hpp bounds an infinite series with a depth
+// budget; see dissertation 4.2.3.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include <universal/number/elreal/zbcl.hpp>
+
+namespace sw { namespace universal {
+
+template <typename FpType>
+class series {
+public:
+    using value_type = ZBCL<FpType>;            // each element is a whole stream
+    using thunk_type = std::function<series<FpType>()>;
+
+private:
+    struct Node {
+        value_type            head;
+        thunk_type            tail_thunk;
+        mutable bool          tail_evaluated;
+        mutable series<FpType> tail_value;
+
+        Node(const value_type& h, thunk_type t)
+            : head(h),
+              tail_thunk(std::move(t)),
+              tail_evaluated(false),
+              tail_value() {}
+    };
+
+    std::shared_ptr<const Node> _node;
+
+    explicit series(std::shared_ptr<const Node> n) noexcept : _node(std::move(n)) {}
+
+public:
+    // Default constructor: empty series (its sum is 0).
+    series() noexcept : _node() {}
+
+    // cons(head, tail): non-empty series. An empty `tail` function terminates
+    // the series at `head`.
+    static series<FpType> cons(const value_type& head_term, thunk_type tail) {
+        auto node = std::make_shared<Node>(head_term, std::move(tail));
+        return series<FpType>(std::move(node));
+    }
+
+    // Convenience: cons with an already-materialised tail.
+    static series<FpType> cons(const value_type& head_term, series<FpType> tail) {
+        return cons(head_term, [tail]() { return tail; });
+    }
+
+    // Convenience: single-term series (tail is empty).
+    static series<FpType> singleton(const value_type& head_term) {
+        return cons(head_term, thunk_type{});
+    }
+
+    bool is_empty() const noexcept { return !_node; }
+    explicit operator bool() const noexcept { return !is_empty(); }
+
+    // head(): undefined on the empty series (assertion-checked).
+    const value_type& head() const noexcept {
+        assert(_node && "head() called on empty series");
+        return _node->head;
+    }
+
+    // tail(): forces the thunk on first call, memoises the result. Returns the
+    // empty series for a node with an empty thunk.
+    series<FpType> tail() const {
+        assert(_node && "tail() called on empty series");
+        if (!_node->tail_evaluated) {
+            if (_node->tail_thunk) {
+                _node->tail_value = _node->tail_thunk();
+            } else {
+                _node->tail_value = series<FpType>{};
+            }
+            _node->tail_evaluated = true;
+        }
+        return _node->tail_value;
+    }
+
+    // take(n): force the first n terms; returns fewer if the series terminates
+    // earlier. Like ZBCL::take, it does not force the (n+1)-th thunk.
+    std::vector<value_type> take(std::size_t n) const {
+        std::vector<value_type> result;
+        result.reserve(n);
+        series<FpType> cur = *this;
+        while (result.size() < n) {
+            if (cur.is_empty()) break;
+            result.push_back(cur.head());
+            if (result.size() == n) break;
+            cur = cur.tail();
+        }
+        return result;
+    }
+};
+
+// -----------------------------------------------------------------------------
+// Generators
+// -----------------------------------------------------------------------------
+
+// series_from_vector: a finite series from an already-materialised list of
+// terms. The resulting series terminates after the last term, so sum() over it
+// is an exact finite sum (no depth-budget truncation). Empty ZBCL terms (which
+// represent 0) are retained -- a 0 term is a legitimate element, distinct from
+// end-of-series.
+template <typename FpType>
+inline series<FpType> series_from_vector(const std::vector<ZBCL<FpType>>& terms) {
+    series<FpType> tail{};
+    for (std::size_t i = terms.size(); i-- > 0;) {
+        tail = series<FpType>::cons(terms[i], tail);
+    }
+    return tail;
+}
+
+// series_from_generator: an infinite series whose i-th term is gen(i), i >= 0.
+// Each call lazily produces the next node, so only the consumed prefix is
+// realised. Callers must bound consumption (sum()'s max_depth does this).
+template <typename FpType>
+inline series<FpType> series_from_generator(std::function<ZBCL<FpType>(std::size_t)> gen,
+                                            std::size_t index = 0) {
+    ZBCL<FpType> head_term = gen(index);
+    return series<FpType>::cons(head_term, [gen, index]() {
+        return series_from_generator<FpType>(gen, index + 1);
+    });
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/sum.hpp
+++ b/include/sw/universal/number/elreal/sum.hpp
@@ -39,13 +39,16 @@
 // Convergence guard
 // -----------------
 // The dissertation defines summation only for Cauchy series and trusts the
-// caller for non-trivial (e.g. transcendental) ones. We add a guard rail: if
-// the budget is reached *before* the series terminates on its own AND the term
-// magnitudes are not trending toward zero (the leading exponent of the most
-// recent term is not below that of the first), the series is not Cauchy-stable
-// within budget and we throw elreal_sum_budget_exceeded. A convergent-but-slow
-// series (term magnitudes decreasing) is simply truncated at the budget and its
-// partial sum returned -- trusting the caller, per the dissertation.
+// caller for non-trivial (e.g. transcendental) ones. We add a heuristic guard
+// rail (full Cauchy-stability is undecidable in general): if the budget is
+// reached *before* the series terminates AND the term magnitudes are not
+// decaying, we throw elreal_sum_budget_exceeded. "Decaying" is judged over
+// windows rather than endpoints, so it rejects constant, growing, AND
+// oscillating non-decaying series (e.g. leading exponents 0,-1,0,-1,...): the
+// largest leading exponent over the most recent window of terms must be strictly
+// below the largest over the first window. A convergent-but-slow series (term
+// magnitudes decreasing) is truncated at the budget and its partial sum returned
+// -- trusting the caller, per the dissertation.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -53,7 +56,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <vector>
 
 #include <universal/number/elreal/block.hpp>
@@ -100,25 +105,23 @@ inline ZBCL<FpType> sum(series<FpType> s, std::size_t max_depth = 1024) {
 
     std::vector<B> components;
 
-    // Track the leading-block exponent of the first and most-recent NON-zero
-    // terms to assess convergence. An empty ZBCL term represents 0.
-    bool haveFirstLead = false;
-    int  firstLead = 0;
-    int  lastLead  = 0;
+    // Per-term leading-block exponent, used to assess convergence. An empty ZBCL
+    // term represents 0 and gets a -infinity sentinel so it never inflates a
+    // window maximum.
+    std::vector<int> leads;
+    constexpr int neg_inf = std::numeric_limits<int>::min();
     bool sawNonzero = false;
 
     series<FpType> cur = s;
     bool naturalEnd = false;
-    std::size_t nterms = 0;
     while (true) {
         if (cur.is_empty()) { naturalEnd = true; break; }
-        if (nterms == max_depth) break;            // budget reached
+        if (leads.size() == max_depth) break;      // budget reached
         ZBCL<FpType> t = cur.head();
-        ++nterms;
-        if (!t.is_empty()) {
-            int lead = t.head().exponent();
-            if (!haveFirstLead) { firstLead = lead; haveFirstLead = true; }
-            lastLead = lead;
+        if (t.is_empty()) {
+            leads.push_back(neg_inf);
+        } else {
+            leads.push_back(t.head().exponent());
             sawNonzero = true;
             // flatten the term's blocks into the renormalisation pool
             ZBCL<FpType> bcur = t;
@@ -128,15 +131,34 @@ inline ZBCL<FpType> sum(series<FpType> s, std::size_t max_depth = 1024) {
                 bcur = bcur.tail();
                 ++taken;
             }
+            // Refuse to silently truncate a term that exceeds the block cap --
+            // dropping its suffix would return an incorrect sum.
+            if (!bcur.is_empty()) {
+                throw elreal_sum_budget_exceeded(
+                    "sum: a term has more than per_term_cap blocks; refusing to "
+                    "silently truncate it (would corrupt the sum). Pre-renormalise "
+                    "the term or raise per_term_cap.");
+            }
         }
         cur = cur.tail();
     }
 
-    // Convergence guard (only when we stopped at the budget, not on natural end).
-    if (!naturalEnd && sawNonzero && lastLead >= firstLead) {
-        throw elreal_sum_budget_exceeded(
-            "sum: series did not converge within max_depth terms "
-            "(term magnitudes not decreasing); not Cauchy-stable.");
+    // Convergence guard rail (only when we stopped at the budget, not on natural
+    // end). Compare the largest leading exponent over the most recent window of
+    // terms to the largest over the first window; if the tail is not strictly
+    // smaller, the magnitudes are not decaying -> reject. Window-based so it
+    // catches oscillating non-decaying series, not just monotone ones.
+    if (!naturalEnd && sawNonzero) {
+        const std::size_t n = leads.size();
+        const std::size_t w = (n / 4 == 0) ? 1 : n / 4;
+        int headMax = neg_inf, tailMax = neg_inf;
+        for (std::size_t i = 0; i < w; ++i)     headMax = std::max(headMax, leads[i]);
+        for (std::size_t i = n - w; i < n; ++i) tailMax = std::max(tailMax, leads[i]);
+        if (tailMax >= headMax) {
+            throw elreal_sum_budget_exceeded(
+                "sum: series did not converge within max_depth terms "
+                "(term magnitudes not decaying); not Cauchy-stable.");
+        }
     }
 
     // Renormalise the exact total of all collected blocks into the unique

--- a/include/sw/universal/number/elreal/sum.hpp
+++ b/include/sw/universal/number/elreal/sum.hpp
@@ -1,0 +1,148 @@
+// sum.hpp: McCleeary LFPERA infinite summation (dissertation 4.2.3).
+//
+// Phase 5 (#929). Given a series<FpType> (a co-list of ZBCL<FpType> terms whose
+// partial sums form a Cauchy sequence), produce a single ZBCL<FpType> equal to
+// their sum. This is the workhorse for Taylor series and transcendentals in
+// Phase 7.
+//
+// Algorithm
+// ---------
+// The dissertation defines summation as the right fold of the Phase 4 add()
+// combinator:
+//
+//     sum [x0, x1, x2, ...] = add x0 (add x1 (add x2 (... empty)))
+//
+// Because the ZBCL value of a finite block multiset is exactly the (two-sum
+// exact) total of its blocks, this fold equals the canonical 0-overlap
+// renormalisation of all the terms' blocks. We realise it that way over a
+// depth-bounded prefix of the series:
+//   1. Lazily collect up to `max_depth` terms (the budget), flattening each
+//      term's blocks into one pool.
+//   2. Guard against divergence (see "Convergence guard" below).
+//   3. priestRenorm() the pool into the unique 0-overlap (DBL_k) block list and
+//      wrap it as a ZBCL.
+//
+// priestRenorm is the same exact, value-preserving renormalisation add() uses
+// internally; computing the sum this way yields a result that is bit-exact on
+// the represented terms AND satisfies the 0-overlap invariant. (A naive lazy
+// foldr over add() builds a deep lazy tower that, when forced, can emit a
+// value-correct but non-0-overlap stream -- add()'s lazy composition does not
+// preserve the invariant across many nested calls. Evaluating eagerly here
+// avoids that; a future fully-lazy summation would need a Phase 4 add() that
+// composes lazily without breaking 0-overlap.)
+//
+// This makes sum() eager over the budgeted prefix. For the depth budgets used
+// by convergent series (and by transcendentals in Phase 7) that is the intended
+// behaviour: the budget bounds the work and the result is exact for the terms
+// folded.
+//
+// Convergence guard
+// -----------------
+// The dissertation defines summation only for Cauchy series and trusts the
+// caller for non-trivial (e.g. transcendental) ones. We add a guard rail: if
+// the budget is reached *before* the series terminates on its own AND the term
+// magnitudes are not trending toward zero (the leading exponent of the most
+// recent term is not below that of the first), the series is not Cauchy-stable
+// within budget and we throw elreal_sum_budget_exceeded. A convergent-but-slow
+// series (term magnitudes decreasing) is simply truncated at the budget and its
+// partial sum returned -- trusting the caller, per the dissertation.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+#include <universal/number/elreal/threeAdd.hpp>
+#include <universal/number/elreal/series.hpp>
+#include <universal/number/elreal/exceptions.hpp>
+
+namespace sw { namespace universal {
+
+// Build a ZBCL from a finite, already-0-overlap block list, dropping trailing
+// zero blocks (which do not change the value).
+template <typename FpType>
+inline ZBCL<FpType> zbcl_from_blocks(std::vector<block<FpType>> blocks) {
+    while (!blocks.empty() && blocks.back().is_zero_block()) blocks.pop_back();
+    ZBCL<FpType> out{};
+    for (std::size_t i = blocks.size(); i-- > 0;) {
+        out = ZBCL<FpType>::cons(blocks[i], out);
+    }
+    return out;
+}
+
+// sum(series, max_depth): infinite summation per dissertation 4.2.3.
+//
+//   max_depth -- maximum number of series terms to absorb. A finite series that
+//                terminates before the budget is summed exactly. An infinite
+//                series is truncated at the budget (if convergent) or rejected
+//                (if not Cauchy-stable; see the convergence guard above).
+//
+// Throws elreal_sum_budget_exceeded when max_depth == 0, or when the budget is
+// reached on a non-terminating, non-converging series.
+template <typename FpType>
+inline ZBCL<FpType> sum(series<FpType> s, std::size_t max_depth = 1024) {
+    using B = block<FpType>;
+
+    if (max_depth == 0) {
+        throw elreal_sum_budget_exceeded("sum: max_depth must be >= 1");
+    }
+
+    // Per-term block cap: terms are expected to be finite ZBCLs (Phase 5 uses
+    // singletons). The cap bounds the flatten of any (pathological) infinite
+    // term so the pool stays finite.
+    constexpr std::size_t per_term_cap = 256;
+
+    std::vector<B> components;
+
+    // Track the leading-block exponent of the first and most-recent NON-zero
+    // terms to assess convergence. An empty ZBCL term represents 0.
+    bool haveFirstLead = false;
+    int  firstLead = 0;
+    int  lastLead  = 0;
+    bool sawNonzero = false;
+
+    series<FpType> cur = s;
+    bool naturalEnd = false;
+    std::size_t nterms = 0;
+    while (true) {
+        if (cur.is_empty()) { naturalEnd = true; break; }
+        if (nterms == max_depth) break;            // budget reached
+        ZBCL<FpType> t = cur.head();
+        ++nterms;
+        if (!t.is_empty()) {
+            int lead = t.head().exponent();
+            if (!haveFirstLead) { firstLead = lead; haveFirstLead = true; }
+            lastLead = lead;
+            sawNonzero = true;
+            // flatten the term's blocks into the renormalisation pool
+            ZBCL<FpType> bcur = t;
+            std::size_t taken = 0;
+            while (!bcur.is_empty() && taken < per_term_cap) {
+                components.push_back(bcur.head());
+                bcur = bcur.tail();
+                ++taken;
+            }
+        }
+        cur = cur.tail();
+    }
+
+    // Convergence guard (only when we stopped at the budget, not on natural end).
+    if (!naturalEnd && sawNonzero && lastLead >= firstLead) {
+        throw elreal_sum_budget_exceeded(
+            "sum: series did not converge within max_depth terms "
+            "(term magnitudes not decreasing); not Cauchy-stable.");
+    }
+
+    // Renormalise the exact total of all collected blocks into the unique
+    // 0-overlap (DBL_k) representation, then wrap as a ZBCL.
+    std::vector<B> renorm = priestRenorm(components);
+    return zbcl_from_blocks<FpType>(std::move(renorm));
+}
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary
Implements **Phase 5** of the McCleeary LFPERA elreal track (Epic #923): `sum()` over a series of `ZBCL` terms (dissertation 4.2.3), the workhorse for Taylor series / transcendentals in Phase 7. Dependencies were satisfied: precondition #1022 (exact dyadic oracle) and Phase 4 #928 (`add()`) are merged.

## Design decisions (approved before implementation)
- **Colist representation:** a dedicated `series<FpType>` lazy cons-list (`value_type = ZBCL<FpType>`), mirroring `zbcl.hpp`'s memoised-thunk idiom.
- **Algorithm:** bounded right-fold semantics, realised by pooling the budgeted terms' blocks and renormalising with `priestRenorm` (the exact, value-preserving renormalisation `add()` uses internally).

## Why `priestRenorm` instead of chaining `add()`
The dissertation defines `sum = foldr add`. A naive **lazy** foldr over Phase 4's `add()` builds a deep lazy tower that, when forced, emits a **value-correct but non-0-overlap** stream — `add()`'s lazy composition does not preserve the ZBCL 0-overlap invariant across many nested calls (confirmed: forcing partial sums eagerly gives the correct 0-overlap layout; forcing the whole tower at the end does not). Since a finite block multiset's ZBCL value is exactly its two-sum-exact total, pooling all term blocks and `priestRenorm`-ing them yields a result that is **bit-exact on the represented terms AND 0-overlap**. This makes `sum()` eager over the budgeted prefix — the intended behaviour for a depth-bounded summation.

> ⚠️ **Follow-up worth filing for Phase 4:** the `add()` lazy-tower 0-overlap limitation. It does not block Phase 5 (this PR works around it via `priestRenorm`), but a future *fully-lazy* summation would need an `add()` that composes lazily without breaking the invariant.

## Changes
| File | What |
|------|------|
| `number/elreal/series.hpp` | `series<FpType>` colist + `series_from_vector` / `series_from_generator` |
| `number/elreal/exceptions.hpp` | `elreal_exception` base + `elreal_sum_budget_exceeded` |
| `number/elreal/sum.hpp` | `sum<FpType>(series, max_depth)` + divergence guard |
| `number/elreal/elreal.hpp` | umbrella: include the 3 headers, bump phase comment |
| `elastic/elreal/CMakeLists.txt` | register `summation/` (`el_sum` targets) |
| `elastic/elreal/summation/*.cpp` (+`summation_oracle.hpp`) | dyadic-oracle tests |

## Acceptance criteria
- [x] `sum<FpType>` per dissertation 4.2.3
- [x] Geometric series `(1/2)^n`, `(1/4)^n`, `(-1/2)^n`, `(1/3)^n` checked against the exact dyadic oracle + closed form
- [x] Alternating `(-1)^n/(2n+1) -> pi/4` (slow convergence)
- [x] Taylor `sum 1/n! -> e` (Phase 7 preview)
- [x] Depth-budget guard: divergent series abort; convergent series truncate
- [x] Tests in `elastic/elreal/summation/`

## Test results (local)
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| el_sum_geometric    | OK | PASS | OK | PASS |
| el_sum_alternating  | OK | PASS | OK | PASS |
| el_sum_exp_preview  | OK | PASS | OK | PASS |
| el_sum_depth_budget | OK | PASS | OK | PASS |

Full elreal suite: **20/20 ctest pass** (16 existing + 4 new), gcc + clang Release, and gcc with assertions on (0-overlap invariant verified on every result). ASCII Guard clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE — CI_LITE builds elreal)
- [ ] Promote to ready when satisfied: `gh pr ready <N>`

Resolves #929

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added infinite series summation with configurable depth budgets, convergence heuristics, and canonical result normalization.
  * Introduced a lazy series abstraction for on-demand term generation.
  * Added dedicated exceptions for summation budget/exhaustion cases.

* **Tests**
  * New tests covering alternating (Leibniz), exponential, geometric, and depth-budget/convergence-guard scenarios.
  * Expanded verification of numerical accuracy, zero-overlap invariants, and budget-exceeded behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->