### PR TITLE
fix(elreal): addRec_step renormalization breaks 0-overlap (#1034)

### DIFF
--- a/elastic/elreal/arithmetic/add_renormalization.cpp
+++ b/elastic/elreal/arithmetic/add_renormalization.cpp
@@ -1,0 +1,144 @@
+// add_renormalization.cpp: regression for #1034 -- add() must produce a fully
+// 0-overlap (DBL_k) stream even when the result needs multiple blocks whose
+// components are spaced closer than k.
+//
+// The bug: addRec_step's "one operand stream empty, workspace non-empty" cases
+// drained the workspace without merging the still-pending blocks of the other
+// operand, emitting out-of-order / overlapping blocks. Minimal trigger:
+//
+//   add(2^-90, [2^0, 2^-60])  ->  [2^0, 2^-90, 2^-60]   (WRONG: out of order)
+//   correct (priestRenorm)    ->  [2^0, 2^-60]
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+using sw::universal::block;
+using sw::universal::ZBCL;
+
+// 0-overlap check + descending-exponent sanity over the first n blocks.
+template <typename FpType>
+int check_canonical(const ZBCL<FpType>& z, std::size_t n, const std::string& tag) {
+    using namespace sw::universal;
+    auto b = z.take(n);
+    int fails = 0;
+    for (std::size_t i = 0; i + 1 < b.size(); ++i) {
+        if (!zero_overlap(b[i], b[i + 1])) {
+            std::cout << tag << " 0-overlap FAILED at block " << i
+                      << " (E=" << b[i].exponent() << " then E=" << b[i + 1].exponent() << ")\n";
+            ++fails;
+        }
+    }
+    return fails;
+}
+
+// Compare the exact value of an add() result to a dyadic reference.
+template <typename FpType>
+sw::universal::dyadic exact_block(const block<FpType>& b) {
+    using namespace sw::universal;
+    if (b.is_zero_block()) return dyadic();
+    // FpType here is double in this test; <=53 bits -> exact via from_double.
+    dyadic d = dyadic::from_double(static_cast<double>(b.v));
+    d.scale += b.exp;
+    return d;
+}
+
+template <typename FpType>
+sw::universal::dyadic exact_value(const ZBCL<FpType>& z) {
+    using namespace sw::universal;
+    dyadic acc;
+    for (const auto& blk : z.take(32)) acc = acc + exact_block(blk);
+    return acc;
+}
+
+// pow2 singleton ZBCL.
+ZBCL<double> p2(int e) {
+    using namespace sw::universal;
+    return from_native<double>(std::ldexp(1.0, e));
+}
+
+// Build a 0-overlap multi-block operand directly from blocks (caller ensures
+// the 0-overlap spacing).
+ZBCL<double> stream(std::vector<block<double>> bs) {
+    ZBCL<double> out{};
+    for (std::size_t i = bs.size(); i-- > 0;) out = ZBCL<double>::cons(bs[i], out);
+    return out;
+}
+
+int verify() {
+    using namespace sw::universal;
+    int n = 0;
+
+    // (1) Minimal #1034 trigger: add a small block that lands between the two
+    // blocks of a 0-overlap operand.
+    {
+        ZBCL<double> Y = stream({ block<double>{1.0, 0}, block<double>{std::ldexp(1.0, -60), 0} });
+        ZBCL<double> r = add(p2(-90), Y);
+        n += check_canonical(r, 16, "add(2^-90,[2^0,2^-60])");
+        dyadic got = exact_value(r);
+        dyadic ref = exact_value(Y);
+        { dyadic t = dyadic::from_double(std::ldexp(1.0, -90)); ref = ref + t; }
+        if (!(got == ref)) { std::cout << "add(2^-90,Y) value mismatch\n"; ++n; }
+    }
+
+    // (2) Fold of 2^(-30 i): components 30 apart must regroup into k-separated
+    // blocks (k=53 for double): exps 0, -60, -120 (+ trailing zero).
+    {
+        ZBCL<double> acc{};
+        std::vector<ZBCL<double>> terms;
+        for (int i = 0; i < 6; ++i) terms.push_back(p2(-30 * i));
+        for (int i = 5; i >= 0; --i) acc = add(terms[i], acc);
+        n += check_canonical(acc, 16, "fold 2^(-30 i)");
+        // exact value == sum of 2^(-30 i)
+        dyadic ref;
+        for (int i = 0; i < 6; ++i) { dyadic t = dyadic::from_double(std::ldexp(1.0, -30 * i)); ref = ref + t; }
+        if (!(exact_value(acc) == ref)) { std::cout << "fold 2^(-30 i) value mismatch\n"; ++n; }
+    }
+
+    // (3) Operand smaller than the workspace tail, several levels.
+    {
+        ZBCL<double> Y = stream({ block<double>{1.0, 0},
+                                  block<double>{std::ldexp(1.0, -60), 0},
+                                  block<double>{std::ldexp(1.0, -120), 0} });
+        ZBCL<double> r = add(p2(-90), Y);   // -90 lands between -60 and -120
+        n += check_canonical(r, 16, "add(2^-90,[0,-60,-120])");
+        dyadic got = exact_value(r);
+        dyadic ref = exact_value(Y);
+        { dyadic t = dyadic::from_double(std::ldexp(1.0, -90)); ref = ref + t; }
+        if (!(got == ref)) { std::cout << "add(2^-90,[0,-60,-120]) value mismatch\n"; ++n; }
+    }
+
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal add() renormalization (regression #1034)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify();
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/threeAdd.hpp
+++ b/include/sw/universal/number/elreal/threeAdd.hpp
@@ -427,6 +427,15 @@ inline std::vector<T> tail_vec(const std::vector<T>& xs) {
     return std::vector<T>(xs.begin() + 1, xs.end());
 }
 
+// Build a finite ZBCL from a 0-overlap block list (front-first). Used to
+// re-inject a leftover workspace tail into an operand slot (see addRec_step).
+template <typename FpType>
+inline ZBCL<FpType> zbcl_of_vec(const std::vector<block<FpType>>& bs) {
+    ZBCL<FpType> out{};
+    for (std::size_t i = bs.size(); i-- > 0;) out = ZBCL<FpType>::cons(bs[i], out);
+    return out;
+}
+
 // addRec_step: produce the next emitted block, mutating the state.
 // Returns nullopt when the stream terminates.
 //
@@ -495,17 +504,25 @@ addRec_step(addRec_state<FpType>& st) {
             return head;
         }
         if (st.gs.is_empty()) {
-            // fs is non-empty, gs empty: Haskell addRec fs [] (e:es) does
-            // e : addRec fs es [] ((getExp e) - getSize e). We translate.
+            // fs non-empty, gs empty, workspace = (e:es). Haskell:
+            //   addRec fs [] (e:es) bound = e : addRec fs es [] (getExp e - k)
+            // i.e. emit e, then RE-INJECT the workspace tail `es` as the (empty)
+            // gs operand so it keeps merging with fs. Previously this drained the
+            // workspace without merging fs against es, emitting fs's blocks after
+            // es's even when an fs block belonged between two es blocks -> a
+            // non-0-overlap result (#1034).
             B e = st.workspace.front();
-            st.workspace = tail_vec(st.workspace);
+            st.gs = zbcl_of_vec(removeZeros(tail_vec(st.workspace)));
+            st.workspace.clear();
             st.bound = e.exponent() - k;
-            // Future iterations stream from fs alone; gs stays empty.
             return e;
         }
         if (st.fs.is_empty()) {
+            // Symmetric: gs non-empty, fs empty. Re-inject the workspace tail as
+            // the (empty) fs operand so it merges with gs (#1034).
             B e = st.workspace.front();
-            st.workspace = tail_vec(st.workspace);
+            st.fs = zbcl_of_vec(removeZeros(tail_vec(st.workspace)));
+            st.workspace.clear();
             st.bound = e.exponent() - k;
             return e;
         }


### PR DESCRIPTION
## Summary
Fixes the `add()` correctness bug found while building Phase 5 (#929). `add()` could emit a **value-correct but non-0-overlap** (even out-of-order) ZBCL whenever one operand stream became empty while the workspace still held blocks that belong *between* the other operand's pending blocks.

**Minimal trigger (single `add()`, no laziness):**
```cpp
// Y = [2^0, 2^-60]  (a valid 0-overlap stream)
add(2^-90, Y)  ->  [2^0, 2^-90, 2^-60]   // WRONG: out of order, non-0-overlap
correct        ->  [2^0, 2^-60]
```

## Root cause
In `addRec_step`'s "one operand empty, workspace non-empty" cases (`threeAdd.hpp`), the code drained the workspace and then streamed the non-empty operand — **never merging that operand against the leftover workspace**. The dissertation's `addRec` re-injects the workspace tail into the operand slot:
```
addRec fs [] (e:es) bound = e : addRec fs es []   -- es moves into the gs slot
```
The comment in the code even stated this, but the implementation kept `es` in the workspace and emitted operand blocks afterward (out of order). 

**Fix:** after emitting the workspace head, re-inject `removeZeros(workspace tail)` as a ZBCL into the now-empty operand slot (symmetric for `fs`/`gs`) so the `twoSum`/`threeAdd` merge continues. Adds a small `zbcl_of_vec` helper.

This corrects both the single-`add()` case **and** the deep lazy-fold composition that Phase 5 had to work around with `priestRenorm`.

## Why it was latent
`addition.cpp` only exercised single-block / widely-separated results (`1+0.25`, `7+13`, `1e3+1`), which never hit the regroup path. Bug has been present since Phase 4 (#928).

## Changes
| File | What |
|------|------|
| `number/elreal/threeAdd.hpp` | re-inject workspace tail into the empty operand slot (2 cases) + `zbcl_of_vec` helper |
| `elastic/elreal/arithmetic/add_renormalization.cpp` | regression test: minimal trigger, `2^(-30 i)` regroup fold, operand-between-blocks; checks 0-overlap + exact dyadic value |

## Test results (local)
| Suite | gcc | clang | asserts (gcc) |
|-------|-----|-------|---------------|
| Full elreal ctest (21 tests incl. addition, threeAdd, summation, new regression) | 21/21 | 21/21 | core tests pass |

No regression in `addition.cpp` / `threeAdd.cpp`. The previously-aborting lazy `add()` fold of `(1/3)^n` now yields 3 blocks, 0-overlap, exact value.

## Test plan
- [ ] Fast CI (gcc + clang CI_LITE — builds elreal)
- [ ] Promote to ready: `gh pr ready <N>`

Resolves #1034

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the addition operation where blocks could be emitted out-of-order or overlapping in edge cases, improving numerical correctness.

* **Tests**
  * Added regression test for issue `#1034` with targeted scenarios validating block ordering and result accuracy in addition operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->