### PR TITLE
feat(elreal): negation, multiplication, division (Phase 6, #930)

### DIFF
--- a/elastic/elreal/arithmetic/arithmetic_oracle.hpp
+++ b/elastic/elreal/arithmetic/arithmetic_oracle.hpp
@@ -1,0 +1,83 @@
+// arithmetic_oracle.hpp: shared exact-dyadic oracle helpers for the Phase 6
+// (#930) negate/mul/div tests. Template helpers (implicitly inline) so including
+// this header in several test TUs is ODR-safe. Mirrors the helpers in
+// addition.cpp / summation_oracle.hpp (consolidation tracked by #1035).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+
+namespace sw { namespace universal { namespace elreal_arith_test {
+
+// Exact value of a binary float as a dyadic, lossless at any significand width.
+template <typename T>
+inline dyadic exact_real(T v) {
+    if (v == T(0)) return dyadic();
+    if constexpr (std::numeric_limits<T>::digits <= 53) {
+        return dyadic::from_double(static_cast<double>(v));
+    } else if constexpr (has_universal_fp_api_v<T>) {
+        constexpr int fbits = std::numeric_limits<T>::digits - 1;
+        assert(v.isnormal() && "exact_real bit path expects a normal value");
+        dyadic::bigint F(0);
+        for (int i = 0; i < fbits; ++i) {
+            if (v.test(static_cast<unsigned>(i))) {
+                dyadic::bigint bit(1); bit <<= i; F = F + bit;
+            }
+        }
+        dyadic::bigint M(1); M <<= fbits; M = M + F;
+        return dyadic(v.sign() ? -M : M, v.scale() - fbits);
+    } else {
+        static_assert(has_universal_fp_api_v<T>, "exact_real: unsupported wide host");
+        return dyadic();
+    }
+}
+
+template <typename FpType>
+inline dyadic exact_block(const block<FpType>& b) {
+    if (b.is_zero_block()) return dyadic();
+    dyadic d = exact_real(b.v);
+    d.scale += b.exp;
+    return d;
+}
+
+template <typename FpType>
+inline dyadic exact_value(const ZBCL<FpType>& z) {
+    dyadic acc;
+    for (const auto& blk : z.take(64)) acc = acc + exact_block(blk);
+    return acc;
+}
+
+// Approximate value as double (for tolerance-based checks, e.g. division).
+template <typename FpType>
+inline double approx(const ZBCL<FpType>& z) {
+    double s = 0.0;
+    for (const auto& b : z.take(64)) s += b.template value_as<double>();
+    return s;
+}
+
+// 0-overlap over the first n blocks. Returns failure count.
+template <typename FpType>
+inline int check_zero_overlap(const ZBCL<FpType>& z, std::size_t n, const std::string& tag) {
+    auto b = z.take(n);
+    int fails = 0;
+    for (std::size_t i = 0; i + 1 < b.size(); ++i) {
+        if (!zero_overlap(b[i], b[i + 1])) {
+            std::cout << tag << " 0-overlap FAILED at block " << i << '\n';
+            ++fails;
+        }
+    }
+    return fails;
+}
+
+}}} // namespace sw::universal::elreal_arith_test

--- a/elastic/elreal/arithmetic/division.cpp
+++ b/elastic/elreal/arithmetic/division.cpp
@@ -1,0 +1,112 @@
+// division.cpp: Phase 6 (#930) tests for div() (dissertation 4.2.6).
+//
+// Verifies exact divisors (6/2 = 3) bit-exactly, the identities x/1 = x and
+// x/x = 1, the round-trip (x/y)*y ~= x to a host-scaled tolerance, the
+// default divide-by-zero behaviour (empty co-list), and 0-overlap, parameterised
+// over {double, float, bfloat16}. The throwing path is covered by
+// division_exceptions.cpp.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "arithmetic_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_arith_test;
+
+template <typename FpType>
+int verify_all(const std::string& host) {
+    using namespace sw::universal;
+    int n = 0;
+    const double host_eps = static_cast<double>(std::numeric_limits<FpType>::epsilon());
+
+    // (1) Exact divisors: result is bit-exact.
+    struct { double a, b, q; } exact[] = {
+        {6.0, 2.0, 3.0}, {12.0, 4.0, 3.0}, {-10.0, 2.0, -5.0}, {7.0, 1.0, 7.0}, {9.0, -3.0, -3.0}
+    };
+    for (auto& t : exact) {
+        ZBCL<FpType> r = div(from_native<FpType>(t.a), from_native<FpType>(t.b));
+        if (!(est::exact_value(r) == est::exact_value(from_native<FpType>(t.q)))) {
+            std::cout << host << " " << t.a << "/" << t.b << " != " << t.q << '\n'; ++n;
+        }
+        n += est::check_zero_overlap<FpType>(r, 16, host + " div-exact");
+    }
+
+    // (2) x / 1 = x (exact).
+    {
+        ZBCL<FpType> x = from_native<FpType>(123.5);
+        if (!(est::exact_value(div(x, from_native<FpType>(1.0))) == est::exact_value(x))) {
+            std::cout << host << " x/1 != x\n"; ++n;
+        }
+    }
+
+    // (3) x / x = 1 (exact).
+    {
+        ZBCL<FpType> x = from_native<FpType>(42.0);
+        if (!(est::exact_value(div(x, x)) == est::exact_value(from_native<FpType>(1.0)))) {
+            std::cout << host << " x/x != 1\n"; ++n;
+        }
+    }
+
+    // (4) Round-trip (x/y)*y ~= x to a host-scaled tolerance (div is iterative).
+    struct { double a, b; } rt[] = { {1.0, 3.0}, {2.0, 7.0}, {22.0, 7.0}, {-5.0, 6.0} };
+    for (auto& t : rt) {
+        ZBCL<FpType> x = from_native<FpType>(t.a), y = from_native<FpType>(t.b);
+        ZBCL<FpType> back = mul(div(x, y), y);
+        double tol = 16.0 * host_eps * std::max(1.0, std::abs(t.a));
+        if (std::abs(est::approx(back) - t.a) > tol) {
+            std::cout << host << " (" << t.a << "/" << t.b << ")*" << t.b
+                      << " = " << est::approx(back) << " != " << t.a
+                      << " (tol " << tol << ")\n"; ++n;
+        }
+        n += est::check_zero_overlap<FpType>(div(x, y), 16, host + " div-rt");
+    }
+
+    // (5) Default divide-by-zero (ELREAL_THROW_ARITHMETIC_EXCEPTION == 0): empty.
+    {
+        ZBCL<FpType> x = from_native<FpType>(5.0);
+        if (!div(x, ZBCL<FpType>{}).is_empty()) { std::cout << host << " x/0 not empty\n"; ++n; }
+    }
+    // 0 / y = 0.
+    {
+        if (!div(ZBCL<FpType>{}, from_native<FpType>(3.0)).is_empty()) {
+            std::cout << host << " 0/y not empty\n"; ++n;
+        }
+    }
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 6 (#930) div()";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_all<double>("div<double>");
+    nrOfFailedTestCases += verify_all<float>("div<float>");
+    nrOfFailedTestCases += verify_all<bfloat16>("div<bfloat16>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/division.cpp
+++ b/elastic/elreal/arithmetic/division.cpp
@@ -11,6 +11,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <limits>

--- a/elastic/elreal/arithmetic/division_exceptions.cpp
+++ b/elastic/elreal/arithmetic/division_exceptions.cpp
@@ -1,0 +1,59 @@
+// division_exceptions.cpp: Phase 6 (#930) -- div() divide-by-zero THROWING path.
+//
+// With ELREAL_THROW_ARITHMETIC_EXCEPTION == 1, dividing by the empty (zero)
+// co-list must throw elreal_divide_by_zero. (The default non-throwing behaviour
+// -- returning the empty co-list -- is covered in division.cpp.)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// Opt in to throwing BEFORE the umbrella header is included.
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 1
+
+#include <iostream>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template <typename FpType>
+int verify(const std::string& host) {
+    using namespace sw::universal;
+    int n = 0;
+    try {
+        ZBCL<FpType> r = div(from_native<FpType>(5.0), ZBCL<FpType>{});
+        (void)r.take(1);
+        std::cout << host << " expected elreal_divide_by_zero, none thrown\n"; ++n;
+    }
+    catch (const elreal_divide_by_zero&) { /* expected */ }
+    catch (const std::exception& e) {
+        std::cout << host << " wrong exception: " << e.what() << '\n'; ++n;
+    }
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 6 (#930) div() divide-by-zero throw";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify<double>("div<double>");
+    nrOfFailedTestCases += verify<float>("div<float>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/multiplication.cpp
+++ b/elastic/elreal/arithmetic/multiplication.cpp
@@ -1,0 +1,112 @@
+// multiplication.cpp: Phase 6 (#930) tests for mul() (dissertation 4.2.5).
+//
+// Verifies the exact-product contract exact_value(mul(x,y)) == exact(x)*exact(y)
+// (finite operands), the identity x*1 = x, commutativity x*y = y*x,
+// distributivity x*(y+z) = x*y + x*z, zero and signed operands, and 0-overlap,
+// parameterised over {double, float, bfloat16}.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "arithmetic_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_arith_test;
+
+// exact_value(mul(x,y)) == exact(x) * exact(y), plus 0-overlap.
+template <typename FpType>
+int verify_exact(double a, double b, const std::string& tag) {
+    using namespace sw::universal;
+    int n = 0;
+    ZBCL<FpType> x = from_native<FpType>(a), y = from_native<FpType>(b);
+    ZBCL<FpType> p = mul(x, y);
+    if (!(est::exact_value(p) == est::exact_value(x) * est::exact_value(y))) {
+        std::cout << tag << " exact product mismatch\n"; ++n;
+    }
+    n += est::check_zero_overlap<FpType>(p, 16, tag);
+    return n;
+}
+
+template <typename FpType>
+int verify_all(const std::string& host) {
+    using namespace sw::universal;
+    int n = 0;
+
+    // exact product contract over a spread of operands (representable in all hosts)
+    const double vals[] = { 1.0, 2.0, 3.0, 0.5, -4.0, 7.0, -0.25 };
+    for (double a : vals)
+        for (double b : vals)
+            n += verify_exact<FpType>(a, b, host + " mul");
+
+    // identity x * 1 = x (exact)
+    {
+        ZBCL<FpType> x = from_native<FpType>(6.0), one = from_native<FpType>(1.0);
+        if (!(est::exact_value(mul(x, one)) == est::exact_value(x))) {
+            std::cout << host << " x*1 != x\n"; ++n;
+        }
+    }
+    // commutativity x*y = y*x
+    {
+        ZBCL<FpType> x = from_native<FpType>(3.0), y = from_native<FpType>(-5.0);
+        if (!(est::exact_value(mul(x, y)) == est::exact_value(mul(y, x)))) {
+            std::cout << host << " x*y != y*x\n"; ++n;
+        }
+    }
+    // distributivity x*(y+z) = x*y + x*z
+    {
+        ZBCL<FpType> x = from_native<FpType>(2.0), y = from_native<FpType>(3.0), z = from_native<FpType>(4.0);
+        dyadic lhs = est::exact_value(mul(x, add(y, z)));
+        dyadic rhs = est::exact_value(add(mul(x, y), mul(x, z)));
+        if (!(lhs == rhs)) { std::cout << host << " distributivity failed\n"; ++n; }
+    }
+    // zero operand: x * 0 = 0 (empty)
+    {
+        ZBCL<FpType> x = from_native<FpType>(9.0);
+        if (!mul(x, ZBCL<FpType>{}).is_empty()) { std::cout << host << " x*0 not empty\n"; ++n; }
+    }
+    // mul_scalar(s, y): single block s times ZBCL y == exact(s) * exact(y)
+    {
+        block<FpType> s{ static_cast<FpType>(3.0), 0 };
+        ZBCL<FpType> y = from_native<FpType>(5.0);
+        dyadic got = est::exact_value(mul_scalar<FpType>(s, y));
+        dyadic ref = est::exact_block(s) * est::exact_value(y);
+        if (!(got == ref)) { std::cout << host << " mul_scalar mismatch\n"; ++n; }
+        if (!mul_scalar<FpType>(block<FpType>{ static_cast<FpType>(0.0), 0 }, y).is_empty()) {
+            std::cout << host << " mul_scalar(0,y) not empty\n"; ++n;
+        }
+    }
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 6 (#930) mul()";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_all<double>("mul<double>");
+    nrOfFailedTestCases += verify_all<float>("mul<float>");
+    nrOfFailedTestCases += verify_all<bfloat16>("mul<bfloat16>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/negation.cpp
+++ b/elastic/elreal/arithmetic/negation.cpp
@@ -1,0 +1,83 @@
+// negation.cpp: Phase 6 (#930) tests for negate() (dissertation 4.2.4).
+//
+// Verifies exact_value(negate(x)) == -exact_value(x), the involution
+// -(-x) == x (bit-identical stream), 0-overlap preservation, and the empty
+// (zero) co-list special case, parameterised over {double, float, bfloat16}.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "arithmetic_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_arith_test;
+
+template <typename FpType>
+int verify_one(double v, const std::string& tag) {
+    using namespace sw::universal;
+    int n = 0;
+    ZBCL<FpType> x = from_native<FpType>(v);
+    ZBCL<FpType> nx = negate(x);
+
+    // exact_value(negate(x)) == -exact_value(x)
+    if (!(est::exact_value(nx) == -est::exact_value(x))) {
+        std::cout << tag << " value mismatch\n"; ++n;
+    }
+    // involution: -(-x) == x, block-for-block
+    auto xb = x.take(16);
+    auto nnb = negate(nx).take(16);
+    if (xb.size() != nnb.size()) { std::cout << tag << " -(-x) size mismatch\n"; ++n; }
+    else for (std::size_t i = 0; i < xb.size(); ++i) {
+        if (xb[i].v != nnb[i].v || xb[i].exp != nnb[i].exp) {
+            std::cout << tag << " -(-x) block " << i << " mismatch\n"; ++n; break;
+        }
+    }
+    // 0-overlap preserved
+    n += est::check_zero_overlap<FpType>(nx, 16, tag);
+    return n;
+}
+
+template <typename FpType>
+int verify_all(const std::string& host) {
+    using namespace sw::universal;
+    int n = 0;
+    for (double v : { 1.0, -1.0, 6.0, 0.25, -123.5, 1e6, 7.0 })
+        n += verify_one<FpType>(v, host + " negate(" + std::to_string(v) + ")");
+    // empty (zero) co-list negates to empty
+    if (!negate(ZBCL<FpType>{}).is_empty()) { std::cout << host << " negate(0) not empty\n"; ++n; }
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 6 (#930) negate()";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_all<double>("negate<double>");
+    nrOfFailedTestCases += verify_all<float>("negate<float>");
+    nrOfFailedTestCases += verify_all<bfloat16>("negate<bfloat16>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/riscv_long_double.hpp
@@ -203,7 +203,10 @@ inline void extract_fp_components_(long double fp, bool& _sign, int& _exponent, 
 	if (std::numeric_limits<long double>::digits <= 64) {
 		if (sizeof(long double) == 8) { // it is just a double
 			_sign = fp < 0.0 ? true : false;
-			_fr = frexp(double(fp), &_exponent);
+			// Qualify as std::frexp: unqualified frexp becomes ambiguous once a
+			// bfloat16 frexp overload is visible (double -> bfloat16 is itself an
+			// ambiguous conversion). std::frexp(double, int*) is the exact match.
+			_fr = std::frexp(double(fp), &_exponent);
 			_fraction = uint64_t(0x000FFFFFFFFFFFFFull) & reinterpret_cast<uint64_t&>(_fr);
 		}
 		else if (sizeof(long double) == 16) {

--- a/include/sw/universal/number/elreal/divide.hpp
+++ b/include/sw/universal/number/elreal/divide.hpp
@@ -1,0 +1,109 @@
+// divide.hpp: McCleeary LFPERA division on ZBCL<FpType> (dissertation 4.2.6).
+//
+// Long-division-style refinement against the leading divisor block. At each step
+// the next quotient block is q_i = block_two_div_rn(rem_0, y_0), where rem_0 is
+// the leading remainder block and y_0 the leading divisor block. We then reduce
+// the remainder by q_i * y (rem <- rem - q_i*y, via mul_scalar + negate + add)
+// and repeat. The committed quotient blocks are renormalised into the unique
+// 0-overlap stream.
+//
+// Termination: the remainder's leading exponent strictly decreases each step
+// (by ~k bits), so for exact divisors the remainder reaches 0; for general
+// (irrational) quotients the `depth` budget bounds the number of quotient blocks
+// emitted. A no-progress guard stops early if the remainder fails to shrink.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/block_eft.hpp>   // block_two_div_rn, block_two_mult
+#include <universal/number/elreal/zbcl.hpp>
+#include <universal/number/elreal/threeAdd.hpp>     // priestRenorm
+#include <universal/number/elreal/sum.hpp>          // zbcl_from_blocks
+#include <universal/number/elreal/exceptions.hpp>
+
+namespace sw { namespace universal {
+
+// div(x, y, depth): x / y as a 0-overlap ZBCL, refined to at most `depth`
+// quotient blocks. Empty divisor (zero) -> elreal_divide_by_zero if
+// ELREAL_THROW_ARITHMETIC_EXCEPTION, else the empty co-list. 0 / y = 0.
+template <typename FpType>
+inline ZBCL<FpType> div(ZBCL<FpType> x, ZBCL<FpType> y, std::size_t depth = 64) {
+    using B = block<FpType>;
+
+    if (y.is_empty()) {
+#if ELREAL_THROW_ARITHMETIC_EXCEPTION
+        throw elreal_divide_by_zero("elreal div: divisor is the empty co-list (zero)");
+#else
+        return ZBCL<FpType>{};
+#endif
+    }
+    if (x.is_empty()) return ZBCL<FpType>{};   // 0 / y = 0
+
+    const B y0 = y.head();                       // leading divisor block (non-zero)
+    const std::vector<B> yb = y.take(depth);     // materialise the divisor blocks
+
+    // Stop refining a couple of block-widths above the denormal floor: the
+    // remainder reductions (block_two_mult residuals / twoSumRN inside
+    // priestRenorm) stay normalised only while the operands sit clear of it.
+    // Denormal blocks (no implicit leading bit) would break the 0-overlap
+    // accounting. The floor is hit quickly for narrow types (bfloat16,
+    // min_exponent ~ -125, k = 7) and is far below FpType's reliable precision
+    // anyway, so nothing of value is lost.
+    constexpr int k = block<FpType>::k;
+    constexpr int exp_floor = std::numeric_limits<FpType>::min_exponent + 2 * k;
+
+    // Keep only normalised blocks (drop zeros and sub-floor denormals). On a
+    // priestRenorm'd (descending, 0-overlap) list this only widens gaps, so the
+    // 0-overlap property is preserved.
+    auto keep_normalised = [](std::vector<B> v) {
+        std::vector<B> out;
+        out.reserve(v.size());
+        for (const auto& b : v) if (b.is_normalised()) out.push_back(b);
+        return out;
+    };
+
+    // The remainder is carried as an eager, renormalised block list (long
+    // division on expansions) -- never as a lazy ZBCL -- so no lazy tower of
+    // add()s forms and no near-floor denormal is ever forced.
+    std::vector<B> rem = keep_normalised(x.take(depth));
+    std::vector<B> qblocks;
+    qblocks.reserve(depth);
+    bool havePrev = false;
+    int  prevLead = 0;
+    for (std::size_t step = 0; step < depth; ++step) {
+        if (rem.empty()) break;                  // exact division: remainder is 0
+        const B r0 = rem.front();                // leading block (descending order)
+        if (!r0.is_normalised() || r0.exponent() < exp_floor) break;
+        const int lead = r0.exponent();
+        if (havePrev && lead >= prevLead) break; // no progress -> stop refining
+        prevLead = lead;
+        havePrev = true;
+
+        const B q = block_two_div_rn(r0, y0);    // next quotient block
+        if (q.is_zero_block()) break;
+        qblocks.push_back(q);
+
+        // rem <- rem - q*y : append the (negated) exact q*y product blocks and
+        // renormalise the whole pool back to a 0-overlap list.
+        std::vector<B> pool = rem;
+        for (const auto& yj : yb) {
+            if (!yj.is_normalised()) continue;
+            auto pr = block_two_mult(q, yj);
+            if (pr.first.is_normalised())  pool.push_back(B{ -pr.first.v,  pr.first.exp });
+            if (pr.second.is_normalised()) pool.push_back(B{ -pr.second.v, pr.second.exp });
+        }
+        rem = keep_normalised(priestRenorm(pool));
+    }
+
+    return zbcl_from_blocks<FpType>(priestRenorm(qblocks));
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -9,9 +9,10 @@
 //   Phase 4 (#928): threeAdd + add() lazy ZBCL combinator.
 //   Phase 5 (#929): infinite summation -- series<FpType> co-list of ZBCL terms
 //                   and sum() (dissertation 4.2.3).
+//   Phase 6 (#930): negate / mul / div (dissertation 4.2.4 / 4.2.5 / 4.2.6).
 //
 // Higher-level pieces (math suite, real-FP conversion) arrive in later phases
-// (#930-#933 under epic #923).
+// (#931-#933 under epic #923).
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -29,3 +30,6 @@
 #include <universal/number/elreal/exceptions.hpp>
 #include <universal/number/elreal/series.hpp>
 #include <universal/number/elreal/sum.hpp>
+#include <universal/number/elreal/negate.hpp>
+#include <universal/number/elreal/multiply.hpp>
+#include <universal/number/elreal/divide.hpp>

--- a/include/sw/universal/number/elreal/exceptions.hpp
+++ b/include/sw/universal/number/elreal/exceptions.hpp
@@ -2,8 +2,9 @@
 //
 // elreal is an experimental, header-only research type. Its streaming
 // operations already surface non-convergence bugs by throwing std::runtime_error
-// (see threeAdd.hpp). Phase 5 (#929) adds one caller-facing exception: a series
-// handed to sum() that does not Cauchy-stabilise within the depth budget.
+// (see threeAdd.hpp). Phase 5 (#929) adds elreal_sum_budget_exceeded (a series
+// handed to sum() that does not Cauchy-stabilise within the depth budget).
+// Phase 6 (#930) adds elreal_divide_by_zero for div() with a zero divisor.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -13,6 +14,14 @@
 
 #include <stdexcept>
 #include <string>
+
+// Arithmetic-exception guard, consistent with the other Universal number
+// systems. When 0 (default), div() by zero returns the empty co-list (the
+// undefined/zero result) instead of throwing; define it to 1 to opt in to
+// throwing elreal_divide_by_zero.
+#if !defined(ELREAL_THROW_ARITHMETIC_EXCEPTION)
+#define ELREAL_THROW_ARITHMETIC_EXCEPTION 0
+#endif
 
 namespace sw { namespace universal {
 
@@ -28,6 +37,13 @@ struct elreal_exception : public std::runtime_error {
 // trigger this: it is truncated at the budget and the partial sum is returned.
 struct elreal_sum_budget_exceeded : public elreal_exception {
     explicit elreal_sum_budget_exceeded(const std::string& what) : elreal_exception(what) {}
+};
+
+// Thrown by div() when the divisor is the empty co-list (zero), and only when
+// ELREAL_THROW_ARITHMETIC_EXCEPTION is enabled.
+struct elreal_divide_by_zero : public elreal_exception {
+    explicit elreal_divide_by_zero(const std::string& what = "elreal: division by zero")
+        : elreal_exception(what) {}
 };
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/elreal/multiply.hpp
+++ b/include/sw/universal/number/elreal/multiply.hpp
@@ -1,0 +1,76 @@
+// multiply.hpp: McCleeary LFPERA multiplication on ZBCL<FpType> (dissertation 4.2.5).
+//
+// x * y = sum_{i,j} (x_i * y_j), where each block-pair product x_i * y_j is the
+// exact 2-block decomposition from block_two_mult. We gather all partial-product
+// blocks and renormalise them into the unique 0-overlap stream with priestRenorm
+// (exactly what sum() does internally with these blocks as terms).
+//
+// Phase 6 model: FINITE-PREFIX multiplication. We materialise the first `depth`
+// blocks of each operand and multiply them out. For finite operands (the common
+// case: reals with a few blocks) take(depth) returns the whole operand and the
+// result is the EXACT product. For infinite operands (general exact reals) this
+// truncates both factors at `depth` blocks; a fully streaming anti-diagonal
+// product is deferred to the Phase 7 math suite.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/block_eft.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+#include <universal/number/elreal/threeAdd.hpp>   // priestRenorm
+#include <universal/number/elreal/sum.hpp>         // zbcl_from_blocks
+
+namespace sw { namespace universal {
+
+// mul_scalar(s, y): single block s times a ZBCL y. Each y_j contributes the
+// exact 2-block product block_two_mult(s, y_j); the pool is renormalised to a
+// 0-overlap stream. Used by div() (a quotient block times the divisor); also a
+// useful primitive on its own. Zero s or empty y -> empty (value 0).
+template <typename FpType>
+inline ZBCL<FpType> mul_scalar(const block<FpType>& s, ZBCL<FpType> y,
+                               std::size_t depth = 256) {
+    using B = block<FpType>;
+    if (s.is_zero_block() || y.is_empty()) return ZBCL<FpType>{};
+    std::vector<B> pool;
+    for (const auto& yj : y.take(depth)) {
+        if (!yj.is_normalised()) continue;
+        auto pr = block_two_mult(s, yj);
+        // Keep only normalised product blocks: drop zeros and sub-floor
+        // denormals (denormals would break 0-overlap accounting; their value is
+        // below FpType's reliable precision).
+        if (pr.first.is_normalised())  pool.push_back(pr.first);
+        if (pr.second.is_normalised()) pool.push_back(pr.second);
+    }
+    return zbcl_from_blocks<FpType>(priestRenorm(pool));
+}
+
+// mul(x, y, depth): finite-prefix product (see header note). Exact for finite
+// operands; truncates each operand to `depth` blocks otherwise.
+template <typename FpType>
+inline ZBCL<FpType> mul(ZBCL<FpType> x, ZBCL<FpType> y, std::size_t depth = 64) {
+    using B = block<FpType>;
+    if (x.is_empty() || y.is_empty()) return ZBCL<FpType>{};   // 0 * y = x * 0 = 0
+    auto xs = x.take(depth);
+    auto ys = y.take(depth);
+    std::vector<B> pool;
+    pool.reserve(2 * xs.size() * ys.size());
+    for (const auto& xi : xs) {
+        if (!xi.is_normalised()) continue;
+        for (const auto& yj : ys) {
+            if (!yj.is_normalised()) continue;
+            auto pr = block_two_mult(xi, yj);
+            if (pr.first.is_normalised())  pool.push_back(pr.first);
+            if (pr.second.is_normalised()) pool.push_back(pr.second);
+        }
+    }
+    return zbcl_from_blocks<FpType>(priestRenorm(pool));
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/negate.hpp
+++ b/include/sw/universal/number/elreal/negate.hpp
@@ -1,0 +1,31 @@
+// negate.hpp: McCleeary LFPERA unary negation on ZBCL<FpType> (dissertation 4.2.4).
+//
+// negate(x) flips the sign of every block. value(-b) = -value(b) exactly, and
+// the combined exponent E(b) = scale_of_v(v) + exp is unchanged by a sign flip
+// (the IEEE exponent field does not depend on the sign bit), so the 0-overlap
+// invariant is preserved without any renormalisation. The empty co-list (which
+// represents 0) negates to itself.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+
+namespace sw { namespace universal {
+
+// negate(x): lazy per-block sign flip. Forcing the i-th block of negate(x)
+// forces the i-th block of x and returns its negation, so negate is as lazy as
+// its operand.
+template <typename FpType>
+inline ZBCL<FpType> negate(ZBCL<FpType> x) {
+    if (x.is_empty()) return ZBCL<FpType>{};
+    const block<FpType>& h = x.head();
+    block<FpType> nh{ -h.v, h.exp };
+    return ZBCL<FpType>::cons(nh, [x]() { return negate(x.tail()); });
+}
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary
Implements **Phase 6** of the McCleeary LFPERA elreal track (Epic #923): the remaining field operations on `ZBCL<FpType>` (dissertation 4.2.4/4.2.5/4.2.6), on the corrected `add()`/`sum()`/`priestRenorm` foundation. Depends on Phase 5 (#929, merged) and the `add()` fix (#1034, merged).

## Operations
- **`negate(x)`** — lazy per-block sign flip `{-v, exp}`. Exact and 0-overlap-preserving (the combined exponent doesn't depend on the sign bit), no renormalization.
- **`mul(x, y, depth)`** — finite-prefix product (your approved design): `take(depth)` both operands, multiply out with `block_two_mult`, renormalize the pooled partial-product blocks via `priestRenorm`. **Exact** for finite operands; truncates infinite operands at `depth` (anti-diagonal streaming deferred to Phase 7). Plus `mul_scalar(s, y)`.
- **`div(x, y, depth)`** — long division on expansions: the **remainder is carried as an eager `priestRenorm`'d block list, not a lazy ZBCL**, so no lazy `add()`-tower forms. Each step extracts `q = block_two_div_rn(rem0, y0)`, subtracts `q*y`, renormalizes. Stops on exact remainder / depth budget / no-progress / **a margin above the denormal floor** (`min_exponent + 2k`).

## Notable design points
- **Denormal floor (bfloat16, k=7):** deep refinement underflows into denormal blocks, which have no implicit leading bit and break 0-overlap accounting. `div` stops `2k` above the floor and filters non-normalised blocks; `mul` keeps only normalised product blocks. Nothing of value is lost (those bits are below the type's reliable precision). This is why `div` carries the remainder eagerly rather than as a lazy `add()` chain.
- **Divide-by-zero:** empty divisor returns the empty co-list by default, or throws `elreal_divide_by_zero` under `ELREAL_THROW_ARITHMETIC_EXCEPTION` (new guard, default 0, consistent with other Universal types).

## Changes
| File | What |
|------|------|
| `elreal/negate.hpp` | `negate()` |
| `elreal/multiply.hpp` | `mul()`, `mul_scalar()` |
| `elreal/divide.hpp` | `div()` |
| `elreal/exceptions.hpp` | `elreal_divide_by_zero` + `ELREAL_THROW_ARITHMETIC_EXCEPTION` |
| `elreal/elreal.hpp` | include the 3 headers |
| `elastic/elreal/arithmetic/{negation,multiplication,division,division_exceptions}.cpp` + `arithmetic_oracle.hpp` | dyadic-oracle tests over `{double,float,bfloat16}` |

## Acceptance criteria (#930)
- [x] negate/mul/div per 4.2.4/4.2.5/4.2.6
- [x] validity (value + 0-overlap) argued inline
- [x] algebraic laws: `-(-x)=x`, `x*1=x`, `x/x=1`, `x*y=y*x`, distributivity — stream-wise via dyadic oracle
- [x] edge cases: zero, signed operands, exact/irrational quotients
- [x] divide-by-zero under the exception guard
- [x] `{double, float, bfloat16}`; tests in `elastic/elreal/arithmetic/`

## Test results (local)
| Suite | gcc | clang | asserts |
|-------|-----|-------|---------|
| Full elreal ctest (25 tests, incl. 4 new Phase 6) | 25/25 | 25/25 | all pass, 0-overlap holds on every result (3 hosts) |

ASCII Guard clean.

## Test plan
- [ ] Fast CI (gcc + clang CI_LITE builds elreal)
- [ ] Promote to ready: `gh pr ready <N>`

Resolves #930

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported negate, multiply, and divide operations for extended real numbers; division supports bounded precision depth and configurable divide-by-zero behavior (throw or return empty) with a new divide-by-zero exception.

* **Tests**
  * Added comprehensive test suites for negation, multiplication, division, and divide-by-zero handling, plus improved exact/approximation and zero-overlap validation and diagnostic helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->