### PR TITLE
feat(elreal): sinh / cosh / tanh (Phase 7.4, #931)

### DIFF
--- a/elastic/elreal/math/hyperbolic.cpp
+++ b/elastic/elreal/math/hyperbolic.cpp
@@ -1,0 +1,92 @@
+// hyperbolic.cpp: Phase 7.4 (#931) tests for sinh / cosh / tanh on ZBCL.
+//
+// These are direct identities on exp() (Phase 7.3), so like exp they are tested
+// on {double, float} (bfloat16's narrow significand drives the underlying series
+// past its range -- see exponent.cpp / constants.cpp). Checks: value vs std::<fn>,
+// the identity cosh^2 - sinh^2 == 1, tanh == sinh/cosh, parity sinh(-x)==-sinh(x)
+// and cosh(-x)==cosh(x), and 0-overlap on every result.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/elreal/math/hyperbolic.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "../arithmetic/arithmetic_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_arith_test;
+
+template <typename FpType>
+int near(const sw::universal::ZBCL<FpType>& z, double ref, double tol, const std::string& tag) {
+    using namespace sw::universal;
+    int n = 0;
+    if (std::abs(est::approx(z) - ref) > tol) {
+        std::cout << tag << " = " << est::approx(z) << " != " << ref << " (tol " << tol << ")\n"; ++n;
+    }
+    n += est::check_zero_overlap<FpType>(z, 16, tag);
+    return n;
+}
+
+template <typename FpType>
+int verify_all(double tol, const std::string& host) {
+    using namespace sw::universal;
+    int n = 0;
+
+    for (double x : { 0.0, 0.5, 1.0, -1.5, 2.0, -0.25 }) {
+        const std::string sx = std::to_string(x);
+        n += near(sinh(from_native<FpType>(x)), std::sinh(x), tol, host + " sinh(" + sx + ")");
+        n += near(cosh(from_native<FpType>(x)), std::cosh(x), tol, host + " cosh(" + sx + ")");
+        n += near(tanh(from_native<FpType>(x)), std::tanh(x), tol, host + " tanh(" + sx + ")");
+    }
+
+    // cosh^2 - sinh^2 == 1
+    for (double x : { 0.5, 1.3, 2.0 }) {
+        ZBCL<FpType> c = cosh(from_native<FpType>(x)), s = sinh(from_native<FpType>(x));
+        double id = est::approx(add(mul(c, c), negate(mul(s, s))));
+        if (std::abs(id - 1.0) > tol) { std::cout << host << " cosh^2-sinh^2 != 1 at " << x << " (" << id << ")\n"; ++n; }
+    }
+    // tanh == sinh/cosh
+    for (double x : { 0.7, 1.5 }) {
+        ZBCL<FpType> th = tanh(from_native<FpType>(x));
+        ZBCL<FpType> sc = div(sinh(from_native<FpType>(x)), cosh(from_native<FpType>(x)));
+        if (std::abs(est::approx(th) - est::approx(sc)) > tol) { std::cout << host << " tanh!=sinh/cosh at " << x << '\n'; ++n; }
+    }
+    // parity
+    {
+        ZBCL<FpType> a = from_native<FpType>(1.1);
+        if (std::abs(est::approx(sinh(negate(a))) + est::approx(sinh(a))) > tol) { std::cout << host << " sinh parity\n"; ++n; }
+        if (std::abs(est::approx(cosh(negate(a))) - est::approx(cosh(a))) > tol) { std::cout << host << " cosh parity\n"; ++n; }
+    }
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 7.4 (#931) sinh / cosh / tanh";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_all<double>(1e-10, "hyp<double>");
+    nrOfFailedTestCases += verify_all<float>(1e-5, "hyp<float>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -38,3 +38,4 @@
 #include <universal/number/elreal/math/hypot.hpp>
 #include <universal/number/elreal/math/constants.hpp>
 #include <universal/number/elreal/math/exponent.hpp>
+#include <universal/number/elreal/math/hyperbolic.hpp>

--- a/include/sw/universal/number/elreal/math/hyperbolic.hpp
+++ b/include/sw/universal/number/elreal/math/hyperbolic.hpp
@@ -1,0 +1,54 @@
+// hyperbolic.hpp: McCleeary LFPERA sinh / cosh / tanh on ZBCL<FpType> (Phase 7.4, #931).
+//
+//   sinh(x) = (e^x - e^-x) / 2
+//   cosh(x) = (e^x + e^-x) / 2
+//   tanh(x) = (e^2x - 1) / (e^2x + 1)
+//
+// Direct identities on the Phase 7.3 exp(). depth carries the same modest default
+// and ~O(depth^4) cost characteristics as exp/log (see exponent.hpp and #1040).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cstddef>
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+#include <universal/number/elreal/zbcl_helpers.hpp>
+#include <universal/number/elreal/threeAdd.hpp>     // add
+#include <universal/number/elreal/negate.hpp>
+#include <universal/number/elreal/multiply.hpp>     // mul_scalar
+#include <universal/number/elreal/divide.hpp>       // div
+#include <universal/number/elreal/math/exponent.hpp>
+
+namespace sw { namespace universal {
+
+// sinh(x, depth) = (e^x - e^-x) / 2.
+template <typename FpType>
+inline ZBCL<FpType> sinh(ZBCL<FpType> x, std::size_t depth = 4) {
+    ZBCL<FpType> ex  = exp(x, depth);
+    ZBCL<FpType> emx = exp(negate(x), depth);
+    return mul_scalar(block<FpType>{ static_cast<FpType>(0.5), 0 }, add(ex, negate(emx)), depth);
+}
+
+// cosh(x, depth) = (e^x + e^-x) / 2.
+template <typename FpType>
+inline ZBCL<FpType> cosh(ZBCL<FpType> x, std::size_t depth = 4) {
+    ZBCL<FpType> ex  = exp(x, depth);
+    ZBCL<FpType> emx = exp(negate(x), depth);
+    return mul_scalar(block<FpType>{ static_cast<FpType>(0.5), 0 }, add(ex, emx), depth);
+}
+
+// tanh(x, depth) = (e^2x - 1) / (e^2x + 1). tanh(0) = 0.
+template <typename FpType>
+inline ZBCL<FpType> tanh(ZBCL<FpType> x, std::size_t depth = 4) {
+    if (x.is_empty()) return ZBCL<FpType>{};                 // tanh(0) = 0
+    ZBCL<FpType> e2 = exp(mul_scalar(block<FpType>{ static_cast<FpType>(2.0), 0 }, x, depth), depth);
+    ZBCL<FpType> one = from_native<FpType>(1.0);
+    return div(add(e2, negate(one)), add(e2, one), depth);
+}
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary
Sub-phase **7.4** of Phase 7 (Epic #923): the hyperbolic functions as direct identities on the Phase 7.3 `exp()`.

- `sinh(x) = (e^x - e^-x)/2`
- `cosh(x) = (e^x + e^-x)/2`
- `tanh(x) = (e^2x - 1)/(e^2x + 1)`

Same modest default depth (4) and ~O(depth^4) time/precision profile as exp/log (see #1040). Scoped to `{double, float}` (exp-based series, like 7.3; bfloat16's narrow significand drives the underlying series past its range).

## Changes
| File | What |
|------|------|
| `elreal/math/hyperbolic.hpp` | `sinh`, `cosh`, `tanh` |
| `elreal/elreal.hpp` | include it |
| `elastic/elreal/math/hyperbolic.cpp` | identity + std-ref tests |

## Test results (local)
| Suite | gcc | clang | asserts | RISC-V |
|-------|-----|-------|---------|--------|
| Full elreal ctest (30 tests, +sinh/cosh/tanh) | 30/30 | 30/30 | pass (~0.4s) | clean |

Verified: values vs `std::<fn>`, `cosh^2 - sinh^2 == 1`, `tanh == sinh/cosh`, parity; 0-overlap everywhere. ASCII clean.

Relates to #931 (sub-phase 7.4).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hyperbolic trigonometric functions (`sinh`, `cosh`, `tanh`) now available with adjustable computation depth parameter for flexible precision-performance tradeoffs.

* **Tests**
  * Comprehensive test suite added validating hyperbolic functions against standard implementations and verifying mathematical identities and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->