### PR TITLE
feat(elreal): atan / asin / acos (Phase 7.5, #931)

### DIFF
--- a/elastic/elreal/math/trigonometry.cpp
+++ b/elastic/elreal/math/trigonometry.cpp
@@ -1,0 +1,115 @@
+// trigonometry.cpp: Phase 7.5 (#931) tests for atan / asin / acos on ZBCL.
+//
+// atan is robust and tested on {double, float}. asin/acos are tested on {double}
+// only: they are the deepest compositions in the suite (sqrt . atan . div . pi),
+// and a float host's narrow exponent range (min_exponent ~ -125) underflows the
+// intermediate expansions for arguments toward the domain boundary, where
+// 1 - x^2 also loses bits to cancellation. A double host (min_exponent ~ -1022)
+// has ample headroom. See the host-scope note in trigonometry.hpp.
+//
+// Checks: value vs std::<fn>, asin(x)+acos(x)==pi/2, atan(x)+atan(1/x)==pi/2
+// (x>0), 4*atan(1)==pi, parity, domain (|x|>1 -> empty for asin/acos); 0-overlap.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/elreal/math/trigonometry.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+#include <universal/verification/test_suite.hpp>
+
+#include "../arithmetic/arithmetic_oracle.hpp"
+
+namespace {
+
+namespace est = sw::universal::elreal_arith_test;
+
+template <typename FpType>
+int near(const sw::universal::ZBCL<FpType>& z, double ref, double tol, const std::string& tag) {
+    using namespace sw::universal;
+    int n = 0;
+    if (std::abs(est::approx(z) - ref) > tol) {
+        std::cout << tag << " = " << est::approx(z) << " != " << ref << " (tol " << tol << ")\n"; ++n;
+    }
+    n += est::check_zero_overlap<FpType>(z, 16, tag);
+    return n;
+}
+
+// atan -- {double, float}.
+template <typename FpType>
+int verify_atan(double tol, const std::string& host) {
+    using namespace sw::universal;
+    int n = 0;
+    for (double x : { 0.0, 0.5, 1.0, -1.0, 2.0, -3.0, 0.25, 7.0 })
+        n += near(atan(from_native<FpType>(x)), std::atan(x), tol, host + " atan(" + std::to_string(x) + ")");
+    const double pi = std::acos(-1.0);
+    // atan(x) + atan(1/x) == pi/2, x > 0
+    for (double x : { 0.5, 2.0, 5.0 }) {
+        double s = est::approx(add(atan(from_native<FpType>(x)), atan(from_native<FpType>(1.0 / x))));
+        if (std::abs(s - pi / 2.0) > tol) { std::cout << host << " atan(x)+atan(1/x)!=pi/2 at " << x << '\n'; ++n; }
+    }
+    // 4*atan(1) == pi ; parity atan(-x)==-atan(x)
+    {
+        double q = est::approx(atan(from_native<FpType>(1.0)));
+        if (std::abs(4.0 * q - pi) > tol) { std::cout << host << " 4*atan(1)!=pi (" << 4.0 * q << ")\n"; ++n; }
+        ZBCL<FpType> a = from_native<FpType>(0.7);
+        if (std::abs(est::approx(atan(negate(a))) + est::approx(atan(a))) > tol) { std::cout << host << " atan parity\n"; ++n; }
+    }
+    return n;
+}
+
+// asin / acos -- {double} only (see header note).
+template <typename FpType>
+int verify_asin_acos(double tol, const std::string& host) {
+    using namespace sw::universal;
+    int n = 0;
+
+    for (double x : { 0.0, 0.5, -0.5, 0.8, 0.9, 1.0, -1.0 })
+        n += near(asin(from_native<FpType>(x)), std::asin(x), tol, host + " asin(" + std::to_string(x) + ")");
+    for (double x : { 0.0, 0.5, -0.5, 0.9, 1.0, -0.9 })
+        n += near(acos(from_native<FpType>(x)), std::acos(x), tol, host + " acos(" + std::to_string(x) + ")");
+
+    const double pi = std::acos(-1.0);
+    // asin(x) + acos(x) == pi/2
+    for (double x : { 0.3, -0.6, 0.9 }) {
+        double s = est::approx(add(asin(from_native<FpType>(x)), acos(from_native<FpType>(x))));
+        if (std::abs(s - pi / 2.0) > tol) { std::cout << host << " asin+acos!=pi/2 at " << x << " (" << s << ")\n"; ++n; }
+    }
+    // parity asin(-x) == -asin(x)
+    {
+        ZBCL<FpType> a = from_native<FpType>(0.7);
+        if (std::abs(est::approx(asin(negate(a))) + est::approx(asin(a))) > tol) { std::cout << host << " asin parity\n"; ++n; }
+    }
+    // domain: asin/acos of |x|>1 -> empty
+    if (!asin(from_native<FpType>(1.5)).is_empty()) { std::cout << host << " asin(1.5) not empty\n"; ++n; }
+    if (!acos(from_native<FpType>(2.0)).is_empty()) { std::cout << host << " acos(2.0) not empty\n"; ++n; }
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal Phase 7.5 (#931) atan / asin / acos";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_atan<double>(1e-10, "atan<double>");
+    nrOfFailedTestCases += verify_atan<float>(1e-5, "atan<float>");
+    nrOfFailedTestCases += verify_asin_acos<double>(1e-10, "iasin<double>");
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -39,3 +39,4 @@
 #include <universal/number/elreal/math/constants.hpp>
 #include <universal/number/elreal/math/exponent.hpp>
 #include <universal/number/elreal/math/hyperbolic.hpp>
+#include <universal/number/elreal/math/trigonometry.hpp>

--- a/include/sw/universal/number/elreal/math/trigonometry.hpp
+++ b/include/sw/universal/number/elreal/math/trigonometry.hpp
@@ -1,0 +1,99 @@
+// trigonometry.hpp: McCleeary LFPERA inverse trig on ZBCL<FpType> (Phase 7.5, #931).
+// (Forward trig sin/cos/tan arrive in Phase 7.6.)
+//
+//   atan(x) = 2*atan( x / (1 + sqrt(1 + x^2)) )   -- argument halving until small,
+//             then the alternating Taylor series, scaled back by 2^k.
+//   asin(x) = atan( x / sqrt(1 - x^2) )           (|x| < 1; |x|=1 -> +/- pi/2)
+//   acos(x) = pi/2 - asin(x)
+//
+// Same modest default depth (4) and ~O(depth^4) time/precision profile as the
+// rest of the math suite (see exponent.hpp and #1040).
+//
+// Host range: atan is robust on any host. asin/acos are the deepest compositions
+// here (sqrt . atan . div . pi); on a narrow exponent range (float, bfloat16) the
+// intermediate expansions underflow for arguments toward the domain boundary
+// (where 1 - x^2 also cancels), so asin/acos are intended for a double host.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+#include <universal/number/elreal/zbcl_helpers.hpp>
+#include <universal/number/elreal/threeAdd.hpp>     // add
+#include <universal/number/elreal/negate.hpp>
+#include <universal/number/elreal/multiply.hpp>     // mul, mul_scalar
+#include <universal/number/elreal/divide.hpp>       // div
+#include <universal/number/elreal/math/sqrt.hpp>
+#include <universal/number/elreal/math/constants.hpp>   // pi_zbcl, detail::odd_power_series
+
+namespace sw { namespace universal {
+
+// atan(x, depth): arctangent over all x.
+template <typename FpType>
+inline ZBCL<FpType> atan(ZBCL<FpType> x, std::size_t depth = 4) {
+    using B = block<FpType>;
+    if (x.is_empty()) return ZBCL<FpType>{};                 // atan(0) = 0
+
+    // Halve the argument until |xr| is small (fast series convergence):
+    //   atan(x) = 2 * atan( x / (1 + sqrt(1 + x^2)) ).
+    int k = 0;
+    ZBCL<FpType> xr = x;
+    double xa = to_double_approx(x, 2);
+    ZBCL<FpType> one = from_native<FpType>(1.0);
+    while (std::abs(xa) > 0.25 && k < 48) {
+        ZBCL<FpType> s = sqrt(add(one, mul(xr, xr, depth)), depth);     // sqrt(1 + xr^2)
+        xr = div(xr, add(one, s), depth);
+        xa = to_double_approx(xr, 2);
+        ++k;
+    }
+    ZBCL<FpType> a = detail::odd_power_series(xr, true, depth);          // atan(xr), |xr| <= 0.25
+    if (k > 0) a = mul_scalar(B{ static_cast<FpType>(1.0), k }, a, depth);   // * 2^k (exact)
+    return a;
+}
+
+// asin(x, depth): |x| <= 1; |x| > 1 -> empty (domain).
+template <typename FpType>
+inline ZBCL<FpType> asin(ZBCL<FpType> x, std::size_t depth = 4) {
+    using B = block<FpType>;
+    if (x.is_empty()) return ZBCL<FpType>{};                 // asin(0) = 0
+    const double xa = to_double_approx(x, 2);
+    if (std::abs(xa) > 1.0 + 1e-9) return ZBCL<FpType>{};     // out of domain
+
+    ZBCL<FpType> oneMx2 = add(from_native<FpType>(1.0), negate(mul(x, x, depth)));   // 1 - x^2
+    if (oneMx2.is_empty() || to_double_approx(oneMx2, 2) <= 0.0) {
+        // |x| == 1 -> +/- pi/2 (avoid the 1/0 in x/sqrt(1-x^2)).
+        ZBCL<FpType> halfpi = mul_scalar(B{ static_cast<FpType>(0.5), 0 }, pi_zbcl<FpType>(depth), depth);
+        return (xa < 0.0) ? negate(halfpi) : halfpi;
+    }
+
+    // For |x| > 1/sqrt(2), x/sqrt(1-x^2) blows up and atan would need a very deep
+    // argument reduction (underflowing the host's exponent range). Reflect:
+    //   asin(x) = sign(x) * ( pi/2 - asin(sqrt(1-x^2)) ),  sqrt(1-x^2) < 1/sqrt(2),
+    // so the recursive asin sees a small, well-conditioned argument.
+    if (std::abs(xa) > 0.70710678118654752) {
+        ZBCL<FpType> reduced = asin(sqrt(oneMx2, depth), depth);
+        ZBCL<FpType> halfpi  = mul_scalar(B{ static_cast<FpType>(0.5), 0 }, pi_zbcl<FpType>(depth), depth);
+        ZBCL<FpType> r = add(halfpi, negate(reduced));
+        return (xa < 0.0) ? negate(r) : r;
+    }
+    // |x| <= 1/sqrt(2): asin(x) = atan( x / sqrt(1 - x^2) ), argument <= 1.
+    return atan(div(x, sqrt(oneMx2, depth), depth), depth);
+}
+
+// acos(x, depth) = pi/2 - asin(x); |x| <= 1.
+template <typename FpType>
+inline ZBCL<FpType> acos(ZBCL<FpType> x, std::size_t depth = 4) {
+    using B = block<FpType>;
+    if (to_double_approx(x.is_empty() ? ZBCL<FpType>{} : x, 2) > 1.0 + 1e-9) return ZBCL<FpType>{};
+    ZBCL<FpType> halfpi = mul_scalar(B{ static_cast<FpType>(0.5), 0 }, pi_zbcl<FpType>(depth), depth);
+    return add(halfpi, negate(asin(x, depth)));
+}
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary
Sub-phase **7.5** of Phase 7 (Epic #923): inverse trigonometry on `ZBCL<FpType>`, on the 7.1 (`pi`) / 7.2 (`sqrt`) foundation.

- **`atan(x)`** = `2·atan(x/(1+√(1+x²)))` — argument halving until small, then the alternating Taylor series, scaled back by `2^k`.
- **`asin(x)`** — `atan(x/√(1−x²))` for `|x| ≤ 1/√2`; else the **reflection** `asin(x)=sign(x)·(π/2−asin(√(1−x²)))`. (Important: the naive `x/√(1−x²)` blows up near `|x|=1`, forcing an `atan` reduction so deep it underflows *even double's* exponent range at x≈0.99 — the reflection keeps the argument bounded.) `|x|=1 → ±π/2`; `|x|>1 → empty`.
- **`acos(x)`** = `π/2 − asin(x)`.

## Host scope
- **`atan` → {double, float}** (robust, incl. large args via halving).
- **`asin`/`acos` → {double}** — they are the deepest compositions in the suite (`sqrt∘atan∘div∘pi`); a float host's narrow exponent range (`min_exponent ~ -125`) underflows the intermediate expansions toward the domain boundary (where `1−x²` also cancels). A double host (`~ -1022`) has ample headroom. Documented in the header.

## Changes
| File | What |
|------|------|
| `elreal/math/trigonometry.hpp` | `atan`, `asin`, `acos` |
| `elreal/elreal.hpp` | include it |
| `elastic/elreal/math/trigonometry.cpp` | identity + std-ref tests |

## Test results (local)
| Suite | gcc | clang | asserts | RISC-V |
|-------|-----|-------|---------|--------|
| Full elreal ctest (31 tests, +atan/asin/acos) | 31/31 | 31/31 | pass (~1s) | clean |

Identities: value vs `std::<fn>`, `asin(x)+acos(x)==π/2`, `atan(x)+atan(1/x)==π/2`, `4·atan(1)==π`, parity, domain; 0-overlap on every result. ASCII clean.

Relates to #931 (sub-phase 7.5).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inverse trigonometric functions (`atan`, `asin`, `acos`) for universal number operations with configurable precision control.

* **Tests**
  * Added comprehensive test coverage validating trigonometric identities, domain constraints, and numerical accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->