### PR TITLE
feat(elreal): sin / cos / tan via octant reduction (Phase 7.6, #931)

### DIFF
--- a/elastic/elreal/math/trigonometry.cpp
+++ b/elastic/elreal/math/trigonometry.cpp
@@ -1,14 +1,21 @@
-// trigonometry.cpp: Phase 7.5 (#931) tests for atan / asin / acos on ZBCL.
+// trigonometry.cpp: Phase 7.5/7.6 (#931) tests for atan/asin/acos and sin/cos/tan
+// on ZBCL.
 //
-// atan is robust and tested on {double, float}. asin/acos are tested on {double}
-// only: they are the deepest compositions in the suite (sqrt . atan . div . pi),
-// and a float host's narrow exponent range (min_exponent ~ -125) underflows the
-// intermediate expansions for arguments toward the domain boundary, where
-// 1 - x^2 also loses bits to cancellation. A double host (min_exponent ~ -1022)
-// has ample headroom. See the host-scope note in trigonometry.hpp.
+// atan and sin/cos/tan are robust and tested on {double, float}. asin/acos are
+// tested on {double} only: they are the deepest compositions in the suite
+// (sqrt . atan . div . pi), and a float host's narrow exponent range
+// (min_exponent ~ -125) underflows the intermediate expansions for arguments
+// toward the domain boundary, where 1 - x^2 also loses bits to cancellation. A
+// double host (min_exponent ~ -1022) has ample headroom. See the host-scope note
+// in trigonometry.hpp.
 //
-// Checks: value vs std::<fn>, asin(x)+acos(x)==pi/2, atan(x)+atan(1/x)==pi/2
-// (x>0), 4*atan(1)==pi, parity, domain (|x|>1 -> empty for asin/acos); 0-overlap.
+// Forward trig exercises the octant reduction t = x - n*(pi/2): for x near a
+// multiple of pi/2 this cancels, and the reduced argument must renormalise to a
+// 0-overlap stream (see #1044) or sin/cos of a tiny t would trip the invariant.
+//
+// Checks: value vs std::<fn>, sin^2+cos^2==1, tan==sin/cos, parity,
+// asin(x)+acos(x)==pi/2, atan(x)+atan(1/x)==pi/2 (x>0), 4*atan(1)==pi, domain
+// (|x|>1 -> empty for asin/acos); 0-overlap.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -92,12 +99,69 @@ int verify_asin_acos(double tol, const std::string& host) {
     return n;
 }
 
+// sin / cos / tan -- {double, float}.
+//
+// nearZeroSquares: test the sin^2+cos^2 identity at points where one component is
+// a near-zero (cos(pi/2), sin(pi), cos(3pi/2)). Squaring a ~1e-8 component needs
+// ~2k bits below the unit leading term, which underflows a float host's exponent
+// floor (~ -126) -- an inherent host-range limit, like asin/acos. So this is
+// enabled for double only; on float the identity is still checked at the
+// well-conditioned points where both components are O(1).
+template <typename FpType>
+int verify_forward_trig(double tol, const std::string& host, bool nearZeroSquares) {
+    using namespace sw::universal;
+    int n = 0;
+    const double pi = std::acos(-1.0);
+
+    // value vs std over a spread that includes the octant boundaries and the
+    // near-zero values cos(pi/2), sin(pi), cos(3pi/2) (the cancellation cases).
+    // The direct values are representable on both hosts; only squaring them is not.
+    for (double x : { 0.0, 0.3, pi / 6, pi / 4, 1.0, pi / 2, 2.0, pi, 3.0,
+                      3 * pi / 2, 2.3, -0.7, -1.1, -pi / 2 }) {
+        n += near(sin(from_native<FpType>(x)), std::sin(x), tol, host + " sin(" + std::to_string(x) + ")");
+        n += near(cos(from_native<FpType>(x)), std::cos(x), tol, host + " cos(" + std::to_string(x) + ")");
+    }
+
+    // sin^2 + cos^2 == 1 (also forces the reduced-argument 0-overlap path).
+    // Well-conditioned points (both components O(1)) -- all hosts.
+    for (double x : { 0.4, 1.2, 2.7, -1.1 }) {
+        ZBCL<FpType> s = sin(from_native<FpType>(x)), c = cos(from_native<FpType>(x));
+        double id = est::approx(add(mul(s, s), mul(c, c)));
+        if (std::abs(id - 1.0) > tol) { std::cout << host << " sin^2+cos^2!=1 at " << x << " (" << id << ")\n"; ++n; }
+    }
+    // Near-zero points (one component ~1e-8) -- double host only.
+    if (nearZeroSquares) {
+        for (double x : { pi / 2, pi, 3 * pi / 2 }) {
+            ZBCL<FpType> s = sin(from_native<FpType>(x)), c = cos(from_native<FpType>(x));
+            double id = est::approx(add(mul(s, s), mul(c, c)));
+            if (std::abs(id - 1.0) > tol) { std::cout << host << " sin^2+cos^2!=1 at " << x << " (" << id << ")\n"; ++n; }
+        }
+    }
+
+    // tan == sin/cos vs std::tan, away from the cos==0 poles (relative test).
+    for (double x : { 0.0, 0.3, pi / 6, pi / 4, 1.0, -0.7, -1.1, 2.3 }) {
+        double got = est::approx(tan(from_native<FpType>(x)));
+        double ref = std::tan(x);
+        if (std::abs(got - ref) > tol * std::max(1.0, std::abs(ref))) {
+            std::cout << host << " tan(" << x << ") = " << got << " != " << ref << '\n'; ++n;
+        }
+    }
+
+    // parity: sin(-x) == -sin(x), cos(-x) == cos(x).
+    {
+        ZBCL<FpType> a = from_native<FpType>(0.9);
+        if (std::abs(est::approx(sin(negate(a))) + est::approx(sin(a))) > tol) { std::cout << host << " sin parity\n"; ++n; }
+        if (std::abs(est::approx(cos(negate(a))) - est::approx(cos(a))) > tol) { std::cout << host << " cos parity\n"; ++n; }
+    }
+    return n;
+}
+
 } // anonymous
 
 int main()
 try {
     using namespace sw::universal;
-    std::string test_suite = "elreal Phase 7.5 (#931) atan / asin / acos";
+    std::string test_suite = "elreal Phase 7.5/7.6 (#931) atan/asin/acos and sin/cos/tan";
     int nrOfFailedTestCases = 0;
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -105,6 +169,8 @@ try {
     nrOfFailedTestCases += verify_atan<double>(1e-10, "atan<double>");
     nrOfFailedTestCases += verify_atan<float>(1e-5, "atan<float>");
     nrOfFailedTestCases += verify_asin_acos<double>(1e-10, "iasin<double>");
+    nrOfFailedTestCases += verify_forward_trig<double>(1e-10, "trig<double>", true);
+    nrOfFailedTestCases += verify_forward_trig<float>(1e-5, "trig<float>", false);
 
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/include/sw/universal/number/elreal/math/trigonometry.hpp
+++ b/include/sw/universal/number/elreal/math/trigonometry.hpp
@@ -1,18 +1,26 @@
-// trigonometry.hpp: McCleeary LFPERA inverse trig on ZBCL<FpType> (Phase 7.5, #931).
-// (Forward trig sin/cos/tan arrive in Phase 7.6.)
+// trigonometry.hpp: McCleeary LFPERA trig on ZBCL<FpType> (Phase 7.5/7.6, #931).
 //
+// Inverse trig (7.5):
 //   atan(x) = 2*atan( x / (1 + sqrt(1 + x^2)) )   -- argument halving until small,
 //             then the alternating Taylor series, scaled back by 2^k.
 //   asin(x) = atan( x / sqrt(1 - x^2) )           (|x| < 1; |x|=1 -> +/- pi/2)
 //   acos(x) = pi/2 - asin(x)
 //
+// Forward trig (7.6) via octant reduction x = n*(pi/2) + t, |t| <= pi/4:
+//   sin/cos(t) from their Maclaurin series (no cancellation for |t| <= pi/4),
+//   recombined per n mod 4; tan(x) = sin(x) / cos(x).
+//   A value near a zero (e.g. cos(pi/2)) becomes the series of a tiny reduced
+//   argument t, so it relies on priestRenorm separating the cancellation in
+//   x - n*(pi/2) to a 0-overlap list (see #1044).
+//
 // Same modest default depth (4) and ~O(depth^4) time/precision profile as the
 // rest of the math suite (see exponent.hpp and #1040).
 //
-// Host range: atan is robust on any host. asin/acos are the deepest compositions
-// here (sqrt . atan . div . pi); on a narrow exponent range (float, bfloat16) the
-// intermediate expansions underflow for arguments toward the domain boundary
-// (where 1 - x^2 also cancels), so asin/acos are intended for a double host.
+// Host range: atan and sin/cos/tan are robust on a wide host (double/float).
+// asin/acos are the deepest compositions here (sqrt . atan . div . pi); on a
+// narrow exponent range the intermediate expansions underflow for arguments
+// toward the domain boundary (where 1 - x^2 also cancels), so asin/acos are
+// intended for a double host.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -22,6 +30,8 @@
 
 #include <cmath>
 #include <cstddef>
+#include <utility>
+#include <vector>
 
 #include <universal/number/elreal/block.hpp>
 #include <universal/number/elreal/zbcl.hpp>
@@ -30,6 +40,8 @@
 #include <universal/number/elreal/negate.hpp>
 #include <universal/number/elreal/multiply.hpp>     // mul, mul_scalar
 #include <universal/number/elreal/divide.hpp>       // div
+#include <universal/number/elreal/series.hpp>       // series_from_vector
+#include <universal/number/elreal/sum.hpp>          // sum
 #include <universal/number/elreal/math/sqrt.hpp>
 #include <universal/number/elreal/math/constants.hpp>   // pi_zbcl, detail::odd_power_series
 
@@ -94,6 +106,103 @@ inline ZBCL<FpType> acos(ZBCL<FpType> x, std::size_t depth = 4) {
     if (to_double_approx(x.is_empty() ? ZBCL<FpType>{} : x, 2) > 1.0 + 1e-9) return ZBCL<FpType>{};
     ZBCL<FpType> halfpi = mul_scalar(B{ static_cast<FpType>(0.5), 0 }, pi_zbcl<FpType>(depth), depth);
     return add(halfpi, negate(asin(x, depth)));
+}
+
+namespace detail {
+
+// Raw Maclaurin series for sin(t)/cos(t), well-conditioned only for small |t|
+// (the octant reduction below keeps |t| <= pi/4, where there is no catastrophic
+// cancellation -- cos(pi/4)=sin(pi/4)=0.707, both O(1)).
+template <typename FpType>
+inline ZBCL<FpType> sin_series(ZBCL<FpType> t, std::size_t depth) {
+    using B = block<FpType>;
+    if (t.is_empty()) return ZBCL<FpType>{};
+    const int stop_exp = -static_cast<int>(depth) * block<FpType>::k - 8;
+    ZBCL<FpType> neg_t2 = negate(mul(t, t, depth));
+    std::vector<ZBCL<FpType>> terms{ t };                    // t^1 / 1!
+    ZBCL<FpType> term = t;
+    for (std::size_t nn = 1; nn < 8 * depth; ++nn) {
+        const double denom = static_cast<double>(2 * nn) * static_cast<double>(2 * nn + 1);
+        term = mul_scalar(B{ static_cast<FpType>(1.0 / denom), 0 }, mul(term, neg_t2, depth), depth);
+        if (term.is_empty()) break;
+        terms.push_back(term);
+        if (term.head().exponent() < stop_exp) break;
+    }
+    return sum(series_from_vector<FpType>(terms), terms.size() + 1);
+}
+template <typename FpType>
+inline ZBCL<FpType> cos_series(ZBCL<FpType> t, std::size_t depth) {
+    using B = block<FpType>;
+    const int stop_exp = -static_cast<int>(depth) * block<FpType>::k - 8;
+    ZBCL<FpType> neg_t2 = t.is_empty() ? ZBCL<FpType>{} : negate(mul(t, t, depth));
+    std::vector<ZBCL<FpType>> terms{ from_native<FpType>(1.0) };   // 1
+    ZBCL<FpType> term = from_native<FpType>(1.0);
+    for (std::size_t nn = 1; nn < 8 * depth; ++nn) {
+        const double denom = static_cast<double>(2 * nn - 1) * static_cast<double>(2 * nn);
+        term = mul_scalar(B{ static_cast<FpType>(1.0 / denom), 0 }, mul(term, neg_t2, depth), depth);
+        if (term.is_empty()) break;
+        terms.push_back(term);
+        if (term.head().exponent() < stop_exp) break;
+    }
+    return sum(series_from_vector<FpType>(terms), terms.size() + 1);
+}
+
+// Octant reduction: x = n*(pi/2) + t with |t| <= pi/4. Returns {sin(x), cos(x)}
+// built from sin(t)/cos(t) per n mod 4, so a value near a zero (e.g. cos(pi/2))
+// is computed as the series of a tiny argument -- no large-term cancellation.
+// n is taken from the host-double estimate; very large |x| (Payne-Hanek) is
+// deferred, so callers should keep |x| modest.
+template <typename FpType>
+inline std::pair<ZBCL<FpType>, ZBCL<FpType>> sincos(ZBCL<FpType> x, std::size_t depth) {
+    using B = block<FpType>;
+    ZBCL<FpType> halfpi = mul_scalar(B{ static_cast<FpType>(0.5), 0 }, pi_zbcl<FpType>(depth), depth);
+    const double xa = x.is_empty() ? 0.0 : to_double_approx(x, 2);
+    const double nd = std::round(xa / 1.5707963267948966);   // round(x / (pi/2))
+    ZBCL<FpType> t = x;
+    if (nd != 0.0) {
+        // t = x - nd*(pi/2). This subtraction *cancels* (x is near a multiple of
+        // pi/2), so a lazy add() would leave the collapsed leading term closer than
+        // k to the following limb -- a non-0-overlap ZBCL that trips the invariant
+        // when the series forces it (#1044). Combine the operand blocks and
+        // renormalise eagerly instead: priestRenorm separates the cancellation
+        // residual to a 0-overlap stream.
+        ZBCL<FpType> nhalf = negate(mul_scalar(B{ static_cast<FpType>(nd), 0 }, halfpi, depth));
+        std::vector<B> pool;
+        for (const auto& b : x.take(depth)) pool.push_back(b);
+        for (const auto& b : nhalf.take(depth)) pool.push_back(b);
+        t = zbcl_from_blocks<FpType>(priestRenorm(pool));
+    }
+    ZBCL<FpType> st = sin_series(t, depth);
+    ZBCL<FpType> ct = cos_series(t, depth);
+    const int n = ((static_cast<long long>(nd) % 4) + 4) % 4;
+    switch (n) {
+        case 0:  return { st, ct };
+        case 1:  return { ct, negate(st) };
+        case 2:  return { negate(st), negate(ct) };
+        default: return { negate(ct), st };                  // n == 3
+    }
+}
+
+} // namespace detail
+
+// sin(x, depth) -- reduced to [-pi/4, pi/4] by octant before the series.
+template <typename FpType>
+inline ZBCL<FpType> sin(ZBCL<FpType> x, std::size_t depth = 4) {
+    if (x.is_empty()) return ZBCL<FpType>{};                 // sin(0) = 0
+    return detail::sincos(x, depth).first;
+}
+
+// cos(x, depth).
+template <typename FpType>
+inline ZBCL<FpType> cos(ZBCL<FpType> x, std::size_t depth = 4) {
+    return detail::sincos(x, depth).second;                  // cos(0) = 1
+}
+
+// tan(x, depth) = sin(x) / cos(x).
+template <typename FpType>
+inline ZBCL<FpType> tan(ZBCL<FpType> x, std::size_t depth = 4) {
+    auto sc = detail::sincos(x, depth);
+    return div(sc.first, sc.second, depth);
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/elreal/threeAdd.hpp
+++ b/include/sw/universal/number/elreal/threeAdd.hpp
@@ -393,17 +393,34 @@ inline std::vector<block<FpType>>
 priestRenorm(std::vector<block<FpType>> as) {
     std::vector<block<FpType>> single = priestRenorm_pass(std::move(as));
     if constexpr (block<FpType>::k >= 24) {
-        // #1044's signature is a *leading-pair* overlap: catastrophic cancellation
-        // collapses the high-order term so it sits closer than k to the next limb.
-        // Rescue only that signature with one extra pass. A deep-tail overlap, by
-        // contrast, is benign -- a single pass already leaves it where the lazy
-        // ZBCL never forces it, exactly as main does -- so we leave those results
-        // untouched (no divergence, no extra work) to keep well-conditioned
-        // computations identical and fast.
-        if (single.size() >= 2 && !zero_overlap(single[0], single[1])) {
-            std::vector<block<FpType>> twice = priestRenorm_pass(single);
-            if (zero_overlap_list(twice)) return twice; // one extra pass rescued it (#1044)
-            // fall through: could not reach 0-overlap; return the single pass (== main)
+        // #1044: catastrophic cancellation (the signature of trig argument
+        // reduction t = x - n*(pi/2) near a zero) cancels the high-order terms; the
+        // collapsed leading term shrinks and its gap to a following limb drops below
+        // k. A single Priest pass does not restore 0-overlap, and one extra pass is
+        // not enough either: the first extra pass folds the cancelling pair
+        // (shrinking the leading exponent), a second pushes the tail down to a >= k
+        // gap, e.g. [-191 -192 -246] -> [-195 -246] -> [-195 -249]. So when the
+        // single pass is not 0-overlap, iterate to a 0-overlap fixpoint (bounded).
+        //
+        // This is correct only on a *wide* host (k >= 24): there is no denormal
+        // floor in range, so the iteration converges in a couple of passes. On a
+        // narrow host (bfloat16 k=8, fp16 k=11) a deep expansion bottoms out at the
+        // denormal floor where the two smallest limbs are closer than k and cannot
+        // be separated; iteration never converges and only corrupts the lazy ZBCL
+        // structure (tripping the 0-overlap assertion downstream). Narrow hosts are
+        // therefore excluded (gate above) and get exactly the single Priest pass --
+        // byte-identical to what every merged narrow-host test was validated against
+        // (the series/trig functions that need this rescue are wide-host only, since
+        // a narrow mantissa cannot hold the expansions anyway). If the bound is hit
+        // without converging we fall back to the single pass rather than return a
+        // grown, still-overlapping list.
+        if (!zero_overlap_list(single)) {
+            std::vector<block<FpType>> r = single;
+            for (int pass = 0; pass < 6; ++pass) {
+                r = priestRenorm_pass(std::move(r));
+                if (zero_overlap_list(r)) return r;     // converged to 0-overlap (#1044)
+            }
+            // did not converge within the bound: fall back to the single pass
         }
     }
     return single;                                      // narrow host, benign, or unrescuable


### PR DESCRIPTION
## Summary
Completes the Phase 7 math suite (#931): forward trigonometry on `ZBCL<FpType>`.

- `sin/cos(x)` via octant reduction `x = n*(pi/2) + t`, `|t| <= pi/4` (Maclaurin series of the reduced argument, recombined per `n mod 4`); `tan = sin/cos`.
- A value near a zero (`cos(pi/2)`, `sin(pi)`, `cos(3pi/2)`) is the series of a tiny reduced argument -> accurate, not catastrophically cancelled. `cos(pi/2) = 6.12e-17` (matches `std`).

## Two foundational fixes for the cancellation
1. **Renormalising reduction** (`trigonometry.hpp`): `t = x - n*(pi/2)` cancels near a multiple of `pi/2`; a lazy `add()` leaves the collapsed leading term closer than `k` to the next limb (non-0-overlap, trips the invariant when the series forces it). Build `t` by pooling the operand blocks and renormalising eagerly instead.
2. **`priestRenorm` rescue strengthened** (`threeAdd.hpp`): a cancellation residual needs **two** extra passes, not one, to reach 0-overlap (`[-191 -192 -246] -> [-195 -246] -> [-195 -249]`). On a wide host (`k >= 24`) iterate to a 0-overlap fixpoint (bounded) when the single pass is not 0-overlap. This extends the leading-pair/one-pass rescue from #1044 (#1045) to the full cancellation class. Narrow hosts (bfloat16 `k=8`, fp16 `k=11`) bottom out at the denormal floor where iteration cannot converge, so they stay on the single Priest pass (gate unchanged) -- byte-identical to before.

## Host scope
`sin/cos/tan` tested on `{double, float}`. The `sin^2+cos^2` identity at a near-zero point squares a `~1e-8` component (needs `~2k` bits below the unit term), underflowing a float host's exponent floor (`~ -126`); that identity case is **double-only** (direct values checked on both hosts) -- the same inherent range limit as asin/acos. Large `|x|` (Payne-Hanek) deferred.

## Test results (local)
| Suite | gcc | clang | RISC-V |
|-------|-----|-------|--------|
| Full elreal ctest (32), Release | 32/32 | 32/32 | compiles |
| Full elreal ctest (32), Debug + assertions | 32/32 | 32/32 | - |

`elastic/elreal/math/trigonometry.cpp`: value vs `std`, `sin^2+cos^2==1`, `tan==sin/cos`, parity, over octant boundaries and near-zero cancellation points.

Relates to #931

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forward trigonometric functions: sine, cosine, and tangent with configurable precision depth.

* **Bug Fixes**
  * Enhanced numerical stability in trigonometric computations by improving the handling of precision loss in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->