### PR TITLE
fix(elreal): e_zbcl full-precision terms + exact constant oracle (#1048)

### DIFF
--- a/elastic/elreal/math/constants_highprecision.cpp
+++ b/elastic/elreal/math/constants_highprecision.cpp
@@ -1,0 +1,118 @@
+// constants_highprecision.cpp: exact high-precision validation of the elreal
+// constant generators against the 320-digit decimal reference strings (#1048).
+//
+// Why this exists
+// ---------------
+// The per-PR constants test (constants.cpp) only compares against std::numbers
+// (~16 digits). For an exact-lazy real type that validates almost nothing: the
+// mul/div/priestRenorm/series machinery the generators are built from is untested
+// past ~16 digits, so high-precision operator bugs are invisible. The exact-dyadic
+// oracle here (verification/elreal_reference_digits.hpp) compares a generated
+// constant to the mpmath 320-digit reference to hundreds of digits. It already
+// caught two bugs the double-tolerance test missed:
+//   - e_zbcl summed host-double 1/n! terms -> only ~17 correct digits (now fixed);
+//   - euler_gamma_zbcl returns a bare double literal (~17 digits) -- a stub with no
+//     high-precision algorithm yet (#1053), excluded below.
+//
+// Current ceiling
+// ---------------
+// A double-hosted ZBCL near 1.0 currently tops out at ~19 components (~280 decimal
+// digits) because the generator / mul / div / renorm pipeline floors at the double
+// normal range (~2^-1022) instead of using the block's symbolic int32 exponent.
+// Lifting that floor to reach 300+ digits is tracked as its own core-arithmetic
+// issue (#1052). This test therefore asserts the honest current ceiling
+// (>= 270 digits); the threshold is raised once the floor is lifted.
+//
+// Cost / placement
+// ----------------
+// Generating a constant to its ceiling is O(depth^4): ~10s each at -O2 (depth 20),
+// far more under -O0/instrumented builds. This test is gated to REGRESSION_LEVEL_4
+// (stress / manual) and is a no-op at the sanity level CI / sanitizers / coverage
+// use, so it never re-bloats those tiers.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// Regression testing guards: typically set by the cmake configuration, but
+// MANUAL_TESTING is an override. A bare manual compile (no -D) runs everything.
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/elreal/math/constants.hpp>
+#include <universal/verification/elreal_reference_digits.hpp>
+#include <universal/verification/test_suite.hpp>
+#include <math/constants/reference_constants.hpp>
+
+namespace {
+
+#if REGRESSION_LEVEL_4
+// Generation depth. The double-host ceiling is reached by ~depth 18-20 (each
+// 53-bit block ~ 16 digits); 20 clears the >= 270-digit threshold with margin.
+constexpr std::size_t kDepth = 20;
+constexpr int kMinDigits = 270;
+
+int check(const char* name, const sw::universal::ZBCL<double>& z,
+          std::string_view ref, bool reportTestCases) {
+    using namespace sw::universal;
+    int got = agreed_decimal_digits(z, ref);
+    if (got < kMinDigits) {
+        std::cout << "  FAIL " << name << ": agreed " << got
+                  << " digits, want >= " << kMinDigits << '\n';
+        return 1;
+    }
+    if (reportTestCases) std::cout << "  ok   " << name << ": " << got << " digits\n";
+    return 0;
+}
+#endif
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal high-precision constants vs 320-digit reference (#1048)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = true;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if REGRESSION_LEVEL_4
+    // The nine constants with both a high-precision generator and a reference
+    // string. euler_gamma is excluded: euler_gamma_zbcl is a double-precision stub
+    // (no high-precision algorithm yet) -- tracked in #1053.
+    nrOfFailedTestCases += check("pi",      pi_zbcl<double>(kDepth),      s_pi,      reportTestCases);
+    nrOfFailedTestCases += check("e",       e_zbcl<double>(kDepth),       s_e,       reportTestCases);
+    nrOfFailedTestCases += check("ln2",     ln2_zbcl<double>(kDepth),     s_ln2,     reportTestCases);
+    nrOfFailedTestCases += check("ln10",    ln10_zbcl<double>(kDepth),    s_ln10,    reportTestCases);
+    nrOfFailedTestCases += check("log2_10", log2_10_zbcl<double>(kDepth), s_log2_10, reportTestCases);
+    nrOfFailedTestCases += check("phi",     phi_zbcl<double>(kDepth),     s_phi,     reportTestCases);
+    nrOfFailedTestCases += check("sqrt2",   sqrt2_zbcl<double>(kDepth),   s_sqrt2,   reportTestCases);
+    nrOfFailedTestCases += check("sqrt3",   sqrt3_zbcl<double>(kDepth),   s_sqrt3,   reportTestCases);
+    nrOfFailedTestCases += check("sqrt5",   sqrt5_zbcl<double>(kDepth),   s_sqrt5,   reportTestCases);
+#else
+    std::cout << "  high-precision constant validation runs at REGRESSION_LEVEL_4 (stress) only\n";
+#endif
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/math/constants.hpp
+++ b/include/sw/universal/number/elreal/math/constants.hpp
@@ -70,18 +70,24 @@ inline ZBCL<FpType> odd_power_series(ZBCL<FpType> x, bool alternating, std::size
 // e = exp(1) = sum_{n>=0} 1/n!
 template <typename FpType>
 inline ZBCL<FpType> e_zbcl(std::size_t depth = 32) {
-    // Stop once 1/n! drops below FpType's smallest NORMAL value: from_native
-    // requires a normalised block, so feeding it a subnormal term is invalid
-    // (and the term is below FpType precision anyway). min_normal bounds the loop
-    // for narrow hosts (float/bfloat16) well before the depth budget.
-    const double min_normal = static_cast<double>(std::numeric_limits<FpType>::min());
+    // Each term must carry FULL ZBCL precision. A previous version built the term
+    // as a host double 1.0/n!, so every term was rounded to ~k bits and the sum was
+    // only good to ~k bits (~16 digits for double) no matter how many terms -- the
+    // exact-dyadic oracle caught this. Instead accumulate the reciprocal factorial
+    // as a ZBCL: term_n = term_{n-1} / n (exact div), so 1/n! keeps depth-block
+    // precision. Stop at the target precision (depth*k bits), clamped above the
+    // denormal floor like odd_power_series so we never build a denormal block.
+    constexpr int k = block<FpType>::k;
+    const int stop_exp = std::max(-static_cast<int>(depth) * k - 8,
+                                  std::numeric_limits<FpType>::min_exponent + 2 * k);
     std::vector<ZBCL<FpType>> terms;
-    double fact = 1.0;
-    for (std::size_t n = 0; n < 4 * depth; ++n) {
-        if (n > 0) fact *= static_cast<double>(n);
-        const double term = 1.0 / fact;
-        if (term < min_normal) break;                // would be subnormal / underflow
-        terms.push_back(from_native<FpType>(term));
+    ZBCL<FpType> term = from_native<FpType>(1.0);    // 1/0! = 1
+    terms.push_back(term);
+    const std::size_t maxTerms = 64 * depth + 64;    // generous; convergence breaks first
+    for (std::size_t n = 1; n < maxTerms; ++n) {
+        term = div(term, from_native<FpType>(static_cast<double>(n)), depth);   // 1/n!
+        if (term.is_empty() || term.head().exponent() < stop_exp) break;
+        terms.push_back(term);
     }
     return sum(series_from_vector<FpType>(terms), terms.size() + 1);
 }

--- a/include/sw/universal/verification/elreal_reference_digits.hpp
+++ b/include/sw/universal/verification/elreal_reference_digits.hpp
@@ -1,0 +1,92 @@
+#pragma once
+// elreal_reference_digits.hpp: exact decimal-agreement oracle for elreal ZBCL values.
+//
+// Converts a ZBCL<FpType> to its EXACT dyadic value and reports how many leading
+// significant decimal digits it agrees with a decimal reference string (e.g. the
+// 320-digit constant strings in include/sw/math/constants/reference_constants.hpp).
+// This is the verification substrate for validating elreal constants and
+// transcendentals to hundreds of digits (issues #1048 / #1049): a host-double
+// tolerance check (~16 digits) cannot see high-precision operator bugs, but an
+// exact comparison can -- it caught e_zbcl summing host-double 1/n! terms (only
+// ~17 digits correct) and euler_gamma_zbcl returning a bare double literal.
+//
+// Method: a ZBCL is an exact dyadic rational  sum_i (v_i * 2^exp_i)  with each v_i
+// an IEEE double, so it equals  M * 2^s  for integers M, s (the einteger-backed
+// `dyadic` oracle in dyadic_exact.hpp). A decimal reference "d.dddd..." is the
+// exact rational  N / 10^frac. The two are compared by cross-multiplication in
+// einteger -- no rounding, no shared code path with elreal arithmetic.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>
+#include <string_view>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+
+namespace sw { namespace universal {
+
+// Exact dyadic value of a ZBCL: sum of (block value exactly) * 2^block.exp. Each
+// block value v_i is an IEEE float widened losslessly to double, so the result is
+// exact for any host FpType. `maxBlocks` bounds the (otherwise lazy) materialisation.
+template <typename FpType>
+inline dyadic zbcl_to_dyadic(const ZBCL<FpType>& z, std::size_t maxBlocks = 512) {
+	dyadic acc;  // 0
+	for (const auto& b : z.take(maxBlocks)) {
+		dyadic d = dyadic::from_double(static_cast<double>(b.v));
+		d.scale += b.exp;       // block value == v * 2^exp
+		acc = acc + d;
+	}
+	return acc;
+}
+
+// Number of leading significant decimal digits to which the exact value V agrees
+// with the positive decimal reference string `ref` (e.g. "3.14159..."). Returns
+// `cap` if they agree to at least `cap` digits (or are exactly equal).
+//
+//   relative error  = |V - ref| / |ref|
+//   with  V == Vn/Vd  and  ref == N / 10^frac, the error numerator (cross-
+//   multiplied) is  |Vn*10^frac - N*Vd|  over denominator  Vd*N, so the value
+//   agrees to >= d digits iff  |Vn*10^frac - N*Vd| * 10^d  <=  Vd*N.
+inline int agreed_decimal_digits(const dyadic& V, std::string_view ref, int cap = 320) {
+	using bigint = dyadic::bigint;
+
+	// Parse the positive reference into numerator N and fractional-digit count.
+	std::string digits;
+	int frac = -1;                        // -1 until the '.' is seen
+	for (char c : ref) {
+		if (c == '.') { frac = 0; continue; }
+		if (c >= '0' && c <= '9') { digits.push_back(c); if (frac >= 0) ++frac; }
+	}
+	if (frac < 0) frac = 0;               // integer-only reference
+	bigint N; N.assign(digits);           // ref == N / 10^frac
+
+	// V == Vn / Vd  (Vd a power of two, or 1).
+	bigint Vn = V.numerator, Vd(1);
+	if (V.scale >= 0) Vn <<= V.scale; else Vd <<= (-V.scale);
+
+	bigint tenFrac; tenFrac.assign("1" + std::string(static_cast<std::size_t>(frac), '0'));
+	bigint diff = Vn * tenFrac - N * Vd;  // error numerator (signed)
+	if (diff.sign()) diff.setsign(false); // |error numerator|
+	bigint denom = Vd * N;                // positive
+
+	if (diff.iszero()) return cap;        // exact to the cap
+
+	// largest d with diff * 10^d <= denom
+	bigint cur = diff, ten; ten.assign("10");
+	for (int d = 1; d <= cap; ++d) {
+		cur = cur * ten;
+		if (denom < cur) return d - 1;    // diff*10^d > denom: agreement lost at digit d
+	}
+	return cap;
+}
+
+// Convenience overload: agreement of a ZBCL directly against a reference string.
+template <typename FpType>
+inline int agreed_decimal_digits(const ZBCL<FpType>& z, std::string_view ref, int cap = 320) {
+	return agreed_decimal_digits(zbcl_to_dyadic(z), ref, cap);
+}
+
+}}  // namespace sw::universal

--- a/include/sw/universal/verification/elreal_reference_digits.hpp
+++ b/include/sw/universal/verification/elreal_reference_digits.hpp
@@ -20,6 +20,8 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <limits>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 
@@ -33,6 +35,14 @@ namespace sw { namespace universal {
 // exact for any host FpType. `maxBlocks` bounds the (otherwise lazy) materialisation.
 template <typename FpType>
 inline dyadic zbcl_to_dyadic(const ZBCL<FpType>& z, std::size_t maxBlocks = 512) {
+	// The exact dyadic value relies on widening each block value v_i to double
+	// LOSSLESSLY. That holds for every host the library uses (bfloat16 k=8,
+	// fp16 k=11, float k=24, double k=53) but not for a host wider than double
+	// (e.g. long double k=64), which would silently make the "exact" oracle
+	// inexact. Reject that at compile time.
+	static_assert(std::numeric_limits<FpType>::digits <= std::numeric_limits<double>::digits,
+	              "zbcl_to_dyadic widens each block value to double exactly; an FpType "
+	              "wider than double (e.g. long double) would lose precision");
 	dyadic acc;  // 0
 	for (const auto& b : z.take(maxBlocks)) {
 		dyadic d = dyadic::from_double(static_cast<double>(b.v));
@@ -54,12 +64,25 @@ inline int agreed_decimal_digits(const dyadic& V, std::string_view ref, int cap 
 	using bigint = dyadic::bigint;
 
 	// Parse the positive reference into numerator N and fractional-digit count.
+	// Reject malformed input rather than silently skipping it: for a verification
+	// oracle an unsupported reference (a typo like "3e10", a sign, whitespace)
+	// must fail fast, not be reinterpreted as a different number.
 	std::string digits;
 	int frac = -1;                        // -1 until the '.' is seen
 	for (char c : ref) {
-		if (c == '.') { frac = 0; continue; }
-		if (c >= '0' && c <= '9') { digits.push_back(c); if (frac >= 0) ++frac; }
+		if (c == '.') {
+			if (frac >= 0) throw std::invalid_argument("decimal reference: multiple '.'");
+			frac = 0;
+			continue;
+		}
+		if (c >= '0' && c <= '9') {
+			digits.push_back(c);
+			if (frac >= 0) ++frac;
+			continue;
+		}
+		throw std::invalid_argument("decimal reference: unsupported character");
 	}
+	if (digits.empty()) throw std::invalid_argument("decimal reference: no digits");
 	if (frac < 0) frac = 0;               // integer-only reference
 	bigint N; N.assign(digits);           // ref == N / 10^frac
 


### PR DESCRIPTION
## Summary
First slice of #1048: an **exact-dyadic oracle** that validates elreal constants to *hundreds* of digits against the 320-digit reference strings -- and the two bugs it immediately caught. A host-double tolerance check (~16 digits) cannot see high-precision operator bugs; this can.

## Oracle
`include/sw/universal/verification/elreal_reference_digits.hpp` -- converts a `ZBCL` to its exact dyadic value (einteger-backed `dyadic_exact.hpp`, no shared code with elreal arithmetic) and reports how many leading significant decimal digits it agrees with a decimal reference, via cross-multiplied einteger comparison (no rounding).

## Bugs caught
1. **`e_zbcl` was correct to only ~17 digits** -- it summed host-`double` `1.0/n!` terms (each ~53 bits), so the sum was double-precision no matter the depth. **Fixed:** accumulate the reciprocal factorial as a `ZBCL` (`term_n = term_{n-1}/n`, exact `div`). `e` now reaches **276 digits**.
2. **`euler_gamma_zbcl` is a bare `double` literal** (~17 digits, `depth` unused) -- a stub. Filed as **#1053**, excluded from the deep check.

## Validation test
`elastic/elreal/math/constants_highprecision.cpp` -- asserts the 9 constants with a real generator + reference agree to **>= 270 digits**. Measured (depth 20):

| pi | e | ln2 | ln10 | log2_10 | phi | sqrt2 | sqrt3 | sqrt5 |
|----|---|-----|------|---------|-----|-------|-------|-------|
| 276 | 276 | 276 | 276 | 277 | 280 | 282 | 276 | 280 |

## Why 270, not 300
The double-host pipeline floors at the normal range (~2^-1022) instead of the block's symbolic `int32` exponent, capping precision at ~19 components (~280 digits). Lifting that floor to reach 300+ is a core-arithmetic change tracked in **#1052**; this test asserts the honest current ceiling and the threshold rises when #1052 lands.

## Cost / placement
O(depth^4) (~12s/constant at -O2). Gated to **`REGRESSION_LEVEL_4`** (stress/manual); a **0.00s no-op** at the sanity level CI / sanitizers / coverage use -- never re-bloats those tiers.

## Validation
Full elreal suite (**33 tests**) passes on **gcc + clang**, Debug + assertions; deep level-4 run passes (all 9 >= 270); ASCII clean.

Relates to #1048

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a gated high-precision regression that validates core mathematical constants against multi-hundred-digit references.

* **Improvements**
  * Improved Euler number computation to preserve high-precision term construction and reduce loss from host-floating intermediate steps.

* **New Features**
  * Added utilities to compute exact decimal agreement between computed values and reference decimal strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->