### PR TITLE
feat(elreal): lift the 2^-1022 precision floor to reach 300+ digits (#1052)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -71,8 +71,10 @@ jobs:
           UBSAN_OPTIONS: ${{ matrix.sanitizer == 'UBSan' && 'print_stacktrace=1:halt_on_error=1' || '' }}
         # -j 2 matches the 2-vCPU ubuntu-latest runner; safe under ASan's ~2-3x
         # shadow-memory multiplier in 7 GB. --timeout caps any hung instrumented
-        # test at 180s instead of CTest's 1500s default.
-        run: ctest -j 2 --timeout 180 --output-on-failure
+        # test instead of CTest's 1500s default. 300s (not 180s): the slowest
+        # legitimate test, er_math_hyperbolic, runs ~197s solo under UBSan -O0
+        # (and longer under -j 2 contention), so 180s failed a correct test.
+        run: ctest -j 2 --timeout 300 --output-on-failure
 
       - name: Rerun failed tests
         if: failure()
@@ -80,7 +82,7 @@ jobs:
         env:
           ASAN_OPTIONS: ${{ matrix.sanitizer == 'ASan' && 'detect_leaks=0:halt_on_error=1' || '' }}
           UBSAN_OPTIONS: ${{ matrix.sanitizer == 'UBSan' && 'print_stacktrace=1:halt_on_error=1' || '' }}
-        run: ctest -j 2 --timeout 180 --rerun-failed --output-on-failure
+        run: ctest -j 2 --timeout 300 --rerun-failed --output-on-failure
 
       - name: Upload test logs
         if: failure()

--- a/elastic/elreal/math/constants_highprecision.cpp
+++ b/elastic/elreal/math/constants_highprecision.cpp
@@ -14,14 +14,15 @@
 //   - euler_gamma_zbcl returns a bare double literal (~17 digits) -- a stub with no
 //     high-precision algorithm yet (#1053), excluded below.
 //
-// Current ceiling
-// ---------------
-// A double-hosted ZBCL near 1.0 currently tops out at ~19 components (~280 decimal
-// digits) because the generator / mul / div / renorm pipeline floors at the double
-// normal range (~2^-1022) instead of using the block's symbolic int32 exponent.
-// Lifting that floor to reach 300+ digits is tracked as its own core-arithmetic
-// issue (#1052). This test therefore asserts the honest current ceiling
-// (>= 270 digits); the threshold is raised once the floor is lifted.
+// Ceiling
+// -------
+// A double-hosted ZBCL near 1.0 tops out at ~19 components (~308 decimal digits):
+// the smallest non-overlapping component sits near 2^-1022, the host's normal-range
+// floor. #1052 lifted the artificial pipeline floors (divide.hpp exp_floor; the
+// series-accumulation guard in odd_power_series / e_zbcl) so the generators now
+// reach that architectural ceiling rather than stopping ~30 digits short. This test
+// asserts >= 300 digits; going beyond ~308-312 would require a host with a wider
+// exponent range and is out of scope here.
 //
 // Cost / placement
 // ----------------
@@ -66,7 +67,7 @@ namespace {
 // Generation depth. The double-host ceiling is reached by ~depth 18-20 (each
 // 53-bit block ~ 16 digits); 20 clears the >= 270-digit threshold with margin.
 constexpr std::size_t kDepth = 20;
-constexpr int kMinDigits = 270;
+constexpr int kMinDigits = 300;
 
 int check(const char* name, const sw::universal::ZBCL<double>& z,
           std::string_view ref, bool reportTestCases) {

--- a/elastic/elreal/math/constants_highprecision.cpp
+++ b/elastic/elreal/math/constants_highprecision.cpp
@@ -65,7 +65,7 @@ namespace {
 
 #if REGRESSION_LEVEL_4
 // Generation depth. The double-host ceiling is reached by ~depth 18-20 (each
-// 53-bit block ~ 16 digits); 20 clears the >= 270-digit threshold with margin.
+// 53-bit block ~ 16 digits); 20 clears the >= 300-digit threshold with margin.
 constexpr std::size_t kDepth = 20;
 constexpr int kMinDigits = 300;
 

--- a/include/sw/universal/number/elreal/divide.hpp
+++ b/include/sw/universal/number/elreal/divide.hpp
@@ -50,15 +50,26 @@ inline ZBCL<FpType> div(ZBCL<FpType> x, ZBCL<FpType> y, std::size_t depth = 64) 
     const B y0 = y.head();                       // leading divisor block (non-zero)
     const std::vector<B> yb = y.take(depth);     // materialise the divisor blocks
 
-    // Stop refining a couple of block-widths above the denormal floor: the
-    // remainder reductions (block_two_mult residuals / twoSumRN inside
-    // priestRenorm) stay normalised only while the operands sit clear of it.
-    // Denormal blocks (no implicit leading bit) would break the 0-overlap
-    // accounting. The floor is hit quickly for narrow types (bfloat16,
-    // min_exponent ~ -125, k = 7) and is far below FpType's reliable precision
-    // anyway, so nothing of value is lost.
+    // Refinement floor on the leading remainder's combined exponent.
+    //
+    // The block EFTs (block_two_mult / block_two_div) are scale-invariant: they
+    // operate on the normalised significand v (in [1,2), always a normal host
+    // value) and track the scale symbolically in the int32 exp, so a block at an
+    // arbitrarily negative combined exponent is still a normal host double -- the
+    // remainder reductions never denormalise. A WIDE host (double/float, k>=24)
+    // therefore has the headroom to refine all the way to its natural ~19-component
+    // ceiling (~308 decimal digits for double), so the floor is lifted (#1052);
+    // the loop still terminates on an exact remainder, no-progress, or a genuinely
+    // non-normalised leading block.
+    //
+    // A NARROW host (bfloat16 k=8, fp16 k=11) has min_exponent ~ -125 and genuinely
+    // denormalises a couple of block-widths above it -- there the remainder
+    // reductions stop staying normalised and 0-overlap accounting breaks -- so it
+    // keeps the floor (this is the same denormal floor #1044 respects).
     constexpr int k = block<FpType>::k;
-    constexpr int exp_floor = std::numeric_limits<FpType>::min_exponent + 2 * k;
+    constexpr int exp_floor = (k >= 24)
+        ? (std::numeric_limits<int>::min() / 2)                       // wide host: no floor
+        : (std::numeric_limits<FpType>::min_exponent + 2 * k);        // narrow host: denormal floor
 
     // Keep only normalised blocks (drop zeros and sub-floor denormals). On a
     // priestRenorm'd (descending, 0-overlap) list this only widens gaps, so the

--- a/include/sw/universal/number/elreal/math/constants.hpp
+++ b/include/sw/universal/number/elreal/math/constants.hpp
@@ -35,6 +35,25 @@ namespace sw { namespace universal {
 
 namespace detail {
 
+// Guard blocks the series helpers carry internally. A truncated Taylor/artanh
+// series run at the output depth tops out ~2 components below what div() alone
+// delivers, because mul/div/sum accumulation error consumes the deepest output
+// blocks. Running the internal mul/div/sum a few blocks deeper (output + guard)
+// absorbs that loss, so the series reaches the same ceiling as div (#1052).
+constexpr std::size_t kSeriesGuard = 4;
+
+// Wide-host series stop_exp: on a wide host (k>=24) the EFTs are scale-invariant
+// and div has no denormal floor, so refine to the working-depth precision; on a
+// narrow host keep the denormal floor.
+template <typename FpType>
+constexpr int series_stop_exp(std::size_t wdepth) {
+    constexpr int k = block<FpType>::k;
+    const int target = -static_cast<int>(wdepth) * k - 8;
+    const int floor  = (k >= 24) ? (std::numeric_limits<int>::min() / 2)
+                                 : (std::numeric_limits<FpType>::min_exponent + 2 * k);
+    return target > floor ? target : floor;
+}
+
 // odd_power_series(x, alternating, depth):
 //   alternating=false -> artanh(x) = sum_n x^(2n+1)/(2n+1)
 //   alternating=true  -> atan(x)   = sum_n (-1)^n x^(2n+1)/(2n+1)
@@ -42,16 +61,12 @@ namespace detail {
 // below the target precision (depth*k bits) and summed via priestRenorm.
 template <typename FpType>
 inline ZBCL<FpType> odd_power_series(ZBCL<FpType> x, bool alternating, std::size_t depth) {
-    constexpr int k = block<FpType>::k;
-    // Stop at the target precision (depth*k bits), but never refine into the
-    // denormal range -- terms below min_exponent + 2k would create denormal
-    // blocks that break 0-overlap (the same floor div()/mul() respect). For
-    // narrow hosts (bfloat16) the floor bounds the work; for double/float the
-    // precision target stops first.
-    const int stop_exp = std::max(-static_cast<int>(depth) * k - 8,
-                                  std::numeric_limits<FpType>::min_exponent + 2 * k);
+    // Carry kSeriesGuard extra working blocks internally (see above) and stop at
+    // the working-depth precision (wide host) / denormal floor (narrow host).
+    const std::size_t wdepth = depth + kSeriesGuard;
+    const int stop_exp = series_stop_exp<FpType>(wdepth);
 
-    ZBCL<FpType> step = mul(x, x, depth);            // x^2
+    ZBCL<FpType> step = mul(x, x, wdepth);           // x^2
     if (alternating) step = negate(step);            // -x^2 for atan
 
     std::vector<ZBCL<FpType>> terms;
@@ -59,8 +74,8 @@ inline ZBCL<FpType> odd_power_series(ZBCL<FpType> x, bool alternating, std::size
     for (std::size_t n = 0; ; ++n) {
         if (power.is_empty() || power.head().exponent() < stop_exp) break;   // converged
         const double denom = 2.0 * static_cast<double>(n) + 1.0;
-        terms.push_back(div(power, from_native<FpType>(denom), depth));
-        power = mul(power, step, depth);             // *x^2 (or *-x^2)
+        terms.push_back(div(power, from_native<FpType>(denom), wdepth));
+        power = mul(power, step, wdepth);            // *x^2 (or *-x^2)
     }
     return sum(series_from_vector(terms), terms.size() + 1);
 }
@@ -75,17 +90,17 @@ inline ZBCL<FpType> e_zbcl(std::size_t depth = 32) {
     // only good to ~k bits (~16 digits for double) no matter how many terms -- the
     // exact-dyadic oracle caught this. Instead accumulate the reciprocal factorial
     // as a ZBCL: term_n = term_{n-1} / n (exact div), so 1/n! keeps depth-block
-    // precision. Stop at the target precision (depth*k bits), clamped above the
-    // denormal floor like odd_power_series so we never build a denormal block.
-    constexpr int k = block<FpType>::k;
-    const int stop_exp = std::max(-static_cast<int>(depth) * k - 8,
-                                  std::numeric_limits<FpType>::min_exponent + 2 * k);
+    // precision. Carry kSeriesGuard extra working blocks (like odd_power_series) so
+    // accumulation error does not eat the deepest output components, and stop at the
+    // working-depth precision / denormal floor.
+    const std::size_t wdepth = depth + detail::kSeriesGuard;
+    const int stop_exp = detail::series_stop_exp<FpType>(wdepth);
     std::vector<ZBCL<FpType>> terms;
     ZBCL<FpType> term = from_native<FpType>(1.0);    // 1/0! = 1
     terms.push_back(term);
     const std::size_t maxTerms = 64 * depth + 64;    // generous; convergence breaks first
     for (std::size_t n = 1; n < maxTerms; ++n) {
-        term = div(term, from_native<FpType>(static_cast<double>(n)), depth);   // 1/n!
+        term = div(term, from_native<FpType>(static_cast<double>(n)), wdepth);   // 1/n!
         if (term.is_empty() || term.head().exponent() < stop_exp) break;
         terms.push_back(term);
     }


### PR DESCRIPTION
## Summary
The elreal constant generators plateaued at **~276-282 digits** regardless of depth -- short of the ~308-digit ceiling of a `double` host -- because the pipeline floored at the double normal range (`~2^-1022`) instead of the block's symbolic `int32` exponent. The #1048 oracle measured the plateau; this lifts it. **All nine constants now reach 307-312 digits.**

## Diagnosis (two layered causes, each spike-verified)
1. **`div()` floor.** `divide.hpp` stopped the long division at `exp_floor = min_exponent + 2k`. But the block EFTs (`block_two_mult`/`block_two_div`) are **scale-invariant** -- they work on the significand `v in [1,2)` (always normal) and track scale in `exp` -- so remainders never denormalise on a wide host. Lifting the floor lets `div()` reach its true ~19-component ceiling (`div(1/7)`: 276 -> **308** digits). **Gated to wide hosts (`k>=24`);** bfloat16/fp16 keep the floor (they genuinely denormalise -- the #1044 floor).
2. **Series-accumulation loss.** Even with `div()` lifted, pi/ln2/e capped ~2 components low: `odd_power_series`/`e_zbcl` ran internal `mul`/`div`/`sum` at the *output* depth, so accumulation error ate the deepest blocks. They now carry **`kSeriesGuard` (=4) extra working blocks** + wide-host `series_stop_exp()`.

## Result (depth 20, vs the 320-digit reference)
| | pi | e | ln2 | ln10 | log2_10 | phi | sqrt2 | sqrt3 | sqrt5 |
|---|----|---|-----|------|---------|-----|-------|-------|-------|
| was | 276 | 276 | 276 | 276 | 277 | 280 | 282 | 276 | 280 |
| **now** | **307** | **309** | **308** | **308** | **309** | **312** | **311** | **308** | **312** |

`constants_highprecision.cpp` threshold raised **270 -> 300**. euler_gamma stays a stub (#1053).

**Ceiling:** ~308-312 is the hard `double`-host limit (~19 components to `2^-1022`); beyond needs a wider-exponent host (out of scope).

## Changes
- `divide.hpp` -- `exp_floor` gated to narrow hosts; wide hosts lifted.
- `math/constants.hpp` -- `kSeriesGuard` + `series_stop_exp()` helper; guard applied to `odd_power_series` and `e_zbcl`.
- `constants_highprecision.cpp` -- threshold 270 -> 300; ceiling comment.

## Test results
| | gcc | clang | RISC-V |
|---|-----|-------|--------|
| Release (33) | PASS | PASS | compiles |
| Debug + assertions (33) | PASS | PASS | - |

**Crucially bfloat16 0-overlap does not regress** (floor retained for narrow hosts). Level-4 deep run confirms all nine >= 300. ASCII clean.

Resolves #1052

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved division and series-based constant computations to ensure consistent high-precision behavior across different host precisions.

* **Tests**
  * Raised the high-precision constant validation threshold from ~270 to 300 agreed decimal digits.

* **Chores**
  * Increased test runner timeout to accommodate longer high-precision test executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->