### PR TITLE
fix(elreal): addRec_step emits the canonical 0-overlap form (#1057)

### DIFF
--- a/elastic/elreal/arithmetic/add_renormalization.cpp
+++ b/elastic/elreal/arithmetic/add_renormalization.cpp
@@ -16,6 +16,7 @@
 #include <universal/utility/directives.hpp>
 #include <cmath>
 #include <iostream>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -106,17 +107,66 @@ int verify() {
     return n;
 }
 
+// verify_1057: add() must emit the unique 0-overlap CANONICAL form, matching
+// priestRenorm. Regression for #1057: addRec_step's gs/fs-empty re-injection used to
+// emit the workspace head unconditionally, but a prior twoSum merge can lower that
+// head's exponent toward an un-merged operand block (with a carry, the operand can even
+// land one bit above), leaving an adjacent pair closer than k -- a value-correct but
+// non-canonical (0-overlap-violating) result. The fix folds any overlapping operand
+// block into the workspace (accounting for a carry, hence ">=") before emitting.
+int verify_1057() {
+    using namespace sw::universal;
+    int n = 0;
+
+    // Minimal repro: a 5-block canonical operand + one block inserted near the top.
+    {
+        ZBCL<double> a = zbcl_from_blocks<double>(priestRenorm(std::vector<block<double>>{
+            block<double>{-1.6585293272722507751,        200},
+            block<double>{ 9.8712660049348273631e-17,    200},
+            block<double>{-2.4280874679101948698e-33,    200},
+            block<double>{ 1.1460774358321607147e-53,    200},
+            block<double>{ 5.2596609909677645217e-70,    200} }));
+        ZBCL<double> b = ZBCL<double>::singleton(block<double>{3.2964886804071818101e58, 0});
+        ZBCL<double> s = add(a, b);
+        n += check_canonical(s, 16, "#1057 minimal-repro add()");
+        if (exact_value(s) != exact_value(a) + exact_value(b)) {
+            std::cout << "#1057 minimal-repro value mismatch\n"; ++n;
+        }
+    }
+
+    // Deterministic fuzz: canonical multi-block operand + a single block; add() must be
+    // 0-overlap and value-exact against the dyadic oracle. (50k at sanity level.)
+    {
+        std::mt19937_64 rng(20260605);
+        std::uniform_int_distribution<int> nb(1, 5), stepd(53, 70), sd(0, 1);
+        std::uniform_real_distribution<double> md(1.0, 2.0);
+        const int trials = REGRESSION_LEVEL_1 ? 50000 : 5000;
+        for (int t = 0; t < trials; ++t) {
+            std::vector<block<double>> ab; int e = 200, na = nb(rng);
+            for (int i = 0; i < na; ++i) { ab.push_back(block<double>{ md(rng) * (sd(rng) ? 1.0 : -1.0), e }); e -= stepd(rng); }
+            ZBCL<double> a = zbcl_from_blocks<double>(priestRenorm(ab));
+            int be = 200 - static_cast<int>(rng() % static_cast<unsigned>(na * 70 + 80));
+            ZBCL<double> b = from_native<double>(std::ldexp(md(rng) * (sd(rng) ? 1.0 : -1.0), be));
+            ZBCL<double> s = add(a, b);
+            if (check_canonical(s, 32, "#1057 fuzz") > 0) { ++n; break; }
+            if (exact_value(s) != exact_value(a) + exact_value(b)) { std::cout << "#1057 fuzz value mismatch at t=" << t << "\n"; ++n; break; }
+        }
+    }
+    return n;
+}
+
 } // anonymous
 
 int main()
 try {
     using namespace sw::universal;
-    std::string test_suite = "elreal add() renormalization (regression #1034)";
+    std::string test_suite = "elreal add() renormalization (regression #1034, #1057)";
     int nrOfFailedTestCases = 0;
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
     nrOfFailedTestCases += verify();
+    nrOfFailedTestCases += verify_1057();
 
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/include/sw/universal/number/elreal/threeAdd.hpp
+++ b/include/sw/universal/number/elreal/threeAdd.hpp
@@ -586,6 +586,20 @@ addRec_step(addRec_state<FpType>& st) {
             // workspace without merging fs against es, emitting fs's blocks after
             // es's even when an fs block belonged between two es blocks -> a
             // non-0-overlap result (#1034).
+            //
+            // FCL.hs emits `e` unconditionally, but that is only valid when the
+            // remaining fs head is >= k below e. A prior twoSum merge can LOWER e's
+            // exponent toward an un-merged fs block (e.g. a1@146 + residual -> @142
+            // while the canonical a2@91 is now only 51 < k below it), so emitting e
+            // would put a2 within k of e -> non-0-overlap (#1057). Fold any fs block
+            // that overlaps the workspace head into the workspace first (priestAdd
+            // renormalises), so the head we emit is >= k above the operand following it.
+            while (!st.fs.is_empty() && !st.workspace.empty()
+                   && st.fs.head().exponent() >= st.workspace.front().exponent() - k) {
+                st.workspace = priestAdd(st.workspace, std::vector<B>{ st.fs.head() });
+                st.fs = st.fs.tail();
+            }
+            if (st.workspace.empty()) continue;   // folded to nothing; re-evaluate
             B e = st.workspace.front();
             st.gs = zbcl_of_vec(removeZeros(tail_vec(st.workspace)));
             st.workspace.clear();
@@ -594,7 +608,14 @@ addRec_step(addRec_state<FpType>& st) {
         }
         if (st.fs.is_empty()) {
             // Symmetric: gs non-empty, fs empty. Re-inject the workspace tail as
-            // the (empty) fs operand so it merges with gs (#1034).
+            // the (empty) fs operand so it merges with gs (#1034). Same #1057 guard:
+            // fold any gs block overlapping the workspace head before emitting.
+            while (!st.gs.is_empty() && !st.workspace.empty()
+                   && st.gs.head().exponent() >= st.workspace.front().exponent() - k) {
+                st.workspace = priestAdd(st.workspace, std::vector<B>{ st.gs.head() });
+                st.gs = st.gs.tail();
+            }
+            if (st.workspace.empty()) continue;
             B e = st.workspace.front();
             st.fs = zbcl_of_vec(removeZeros(tail_vec(st.workspace)));
             st.workspace.clear();


### PR DESCRIPTION
## Summary
`add()`'s streaming `addRec_step` could emit a **value-correct but non-canonical** (0-overlap-violating) expansion for some inputs. This is the root of both #1057's exact-cancellation symptom (`asin(x)+acos(x)`) and the #1061 streaming-`infSum` blocker (repeated `add` composition), and it subsumes the leading-pair overlap class (#1044) in the streaming path.

## Root cause (instrumented trace)
The gs-empty / fs-empty re-injection path (FCL.hs `addRec fs [] (e:es) bound = e:...`) emitted the workspace head `e` **unconditionally**. But a prior `twoSum` merge can *lower* `e`'s exponent toward an un-merged operand block:
```
a1@146 + residual -> s@142     (exponent dropped 4 bits)
a2@91  (canonically 55 below the original 146) is now only 51 < k below 142
emit s@142, then stream a2@91 raw  ->  gap 51 < k=53  -> non-0-overlap
```
A same-exponent merge can also *carry up* by one bit (e.g. `e199` then `a1@146+res -> @147`), giving a 52-bit leading pair.

## Fix
Before emitting the workspace head, **fold any remaining operand block whose exponent is `>= head.exponent() - k` into the workspace** via `priestAdd` (which renormalises). The `>=` accounts for the +1 carry a same-exponent merge can produce. Applied symmetrically to the gs-empty and fs-empty paths. ~20 lines; value semantics unchanged (priestAdd is value-preserving).

## Validation
- **Minimal repro**: `add` now gives the canonical `(...,87,...)` matching `priestRenorm`.
- **1,000,000 randomized single-adds**: 0 0-overlap violations (asserts ON), value exact vs the dyadic oracle.
- **Left-fold composition** n=3..20: 0 violations, value == eager `sum()`.
- **Streaming infSum** == eager `sum()` (value + 0-overlap) across 4000 random series, asserts ON.
- **Full elreal suite (34 tests): PASS on gcc AND clang**, no regressions.
- **Regression test** added to `el_arith_add_renormalization` (minimal repro + 50k fuzz vs the exact-dyadic oracle); passes gcc + clang.

## Changes
- `threeAdd.hpp` -- the gs/fs-empty fold-before-emit guard.
- `arithmetic/add_renormalization.cpp` -- `verify_1057()` regression test.

Resolves #1057

## Test plan
- [ ] Fast CI (gcc + clang)
- [ ] Promote to ready

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a canonical form violation in arithmetic addition operations that could produce non-canonical outputs, specifically addressing overlap adjacency issues.

* **Tests**
  * Added comprehensive regression tests, including fixed reproduction cases and deterministic randomized fuzzing, to ensure the fix remains stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->