### PR TITLE
ci: run the ARM64 job on a native ubuntu-24.04-arm runner (drop QEMU)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -177,12 +177,15 @@ jobs:
             cross: ppc64le
             toolchain: cmake/toolchains/ppc64le-linux-gnu.cmake
             cmake_flags: -DUNIVERSAL_BUILD_CI_LITE=ON
-          # ARM64 cross-compilation with QEMU emulation
-          - os: ubuntu-latest
-            name: Linux ARM64 (GCC cross)
+          # ARM64 on a NATIVE GitHub-hosted ARM64 runner (no QEMU). Compiling and
+          # running the tests natively is both faster and higher fidelity than the
+          # old QEMU-emulated cross job: cross-compilation ran natively but ctest
+          # executed every test binary under qemu-user-static (~10-50x slower), which
+          # dominated the job and which ccache cannot help. A native runner removes
+          # the emulation entirely and lets ccache actually accelerate the build.
+          - os: ubuntu-24.04-arm
+            name: Linux ARM64 (GCC native)
             artifact: linux-aarch64-gcc
-            cross: aarch64
-            toolchain: cmake/toolchains/aarch64-linux-gnu.cmake
             cmake_flags: -DUNIVERSAL_BUILD_CI_LITE=ON
           # Windows cross-compilation with MinGW-w64
           - os: ubuntu-latest


### PR DESCRIPTION
## Summary
The `Linux ARM64 (GCC cross)` job cross-compiles natively but runs `ctest` under **`qemu-user-static`**, emulating every ARM64 test binary on x86 (~10-50x slower than native). That emulated test execution -- which **ccache cannot accelerate** -- dominates the job's wall-clock (e.g. ~17 min vs ~6.5 min for native Linux x64 on #1055).

GitHub now offers **free hosted ARM64 runners** for public repos, so this runs the job **natively** instead.

## Change (one matrix entry, `cmake.yml`)
```diff
-          # ARM64 cross-compilation with QEMU emulation
-          - os: ubuntu-latest
-            name: Linux ARM64 (GCC cross)
-            artifact: linux-aarch64-gcc
-            cross: aarch64
-            toolchain: cmake/toolchains/aarch64-linux-gnu.cmake
-            cmake_flags: -DUNIVERSAL_BUILD_CI_LITE=ON
+          # ARM64 on a NATIVE GitHub-hosted ARM64 runner (no QEMU).
+          - os: ubuntu-24.04-arm
+            name: Linux ARM64 (GCC native)
+            cmake_flags: -DUNIVERSAL_BUILD_CI_LITE=ON
```
Dropping `cross`/`toolchain` makes the QEMU install step (gated on `matrix.cross == 'aarch64'`) and the cross-toolchain config no-op; the job builds with the runner's native `g++` and runs tests natively. ccache still runs (`runner.os != Windows`).

## Why this is strictly better
- **Faster**: no QEMU-emulated test execution (the dominant cost).
- **Higher fidelity**: real ARM64 execution, not emulation -- catches issues emulation can mask.
- **ccache effective**: native compile objects are cacheable and actually reused.

## Notes
- `cmake/toolchains/aarch64-linux-gnu.cmake` is now unused by CI but **kept** for local cross-compilation.
- RISC-V and POWER keep their QEMU cross jobs (no native hosted runners for those).
- Branch protection lists **no required status checks**, so renaming the job (`cross` -> `native`) is safe.

## Test plan
- [ ] This PR's own CI run validates the native ARM64 job builds + tests green and is materially faster than the old emulated job.
- [ ] Promote to ready when confirmed.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Linux ARM64 build performance by transitioning to native compilation, resulting in faster and more reliable builds for ARM64 architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->