### PR TITLE
feat(elreal): widen block exponent to integer<256> (#1061)

### DIFF
--- a/elastic/elreal/arithmetic/exact_value_oracle.cpp
+++ b/elastic/elreal/arithmetic/exact_value_oracle.cpp
@@ -88,12 +88,12 @@ using namespace sw::universal::elreal_oracle;
 template <typename FpType>
 double dval(const block<FpType>& b) {
     if (b.is_zero_block()) return 0.0;
-    return std::ldexp(static_cast<double>(b.v), b.exp);
+    return std::ldexp(static_cast<double>(b.v), static_cast<int>(b.exp));
 }
 
 template <typename FpType>
 double block_ulp(const block<FpType>& b) {
-    const int E = b.is_zero_block() ? b.exp : b.exponent();
+    const int E = static_cast<int>(b.is_zero_block() ? b.exp : b.exponent());
     return std::ldexp(1.0, E - (block<FpType>::k - 1));
 }
 

--- a/elastic/elreal/arithmetic/threeAdd.cpp
+++ b/elastic/elreal/arithmetic/threeAdd.cpp
@@ -14,8 +14,10 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <random>
 
 #include <universal/number/elreal/elreal.hpp>
@@ -43,8 +45,14 @@ int verify_one(const sw::universal::block<FpType>& ia,
     // sums is indistinguishable from a genuine algorithm bug. Skip the
     // property there rather than relax the tolerance and mask real issues.
 #if LONG_DOUBLE_SUPPORT
+    using EXP = typename block<FpType>::exp_t;
     auto block_value = [](const block<FpType>& b) -> long double {
         if (b.is_zero_block()) return 0.0L;
+        // host-range blocks by construction; fail loud if the wide exponent
+        // ever exceeds int range before narrowing it for ldexp.
+        assert(b.exp <= EXP(std::numeric_limits<int>::max())
+            && b.exp >= EXP(std::numeric_limits<int>::min())
+            && "threeAdd test: block exponent outside host int range");
         return static_cast<long double>(b.v) * std::ldexp(1.0L, static_cast<int>(b.exp));
     };
     long double ref = block_value(ia) + block_value(ib) + block_value(ic);
@@ -76,8 +84,8 @@ int verify_one(const sw::universal::block<FpType>& ia,
     const auto& a_sorted = arr[0];
     if (!a_sorted.is_zero_block() && !r.out1.is_zero_block()) {
         constexpr int k = block<FpType>::k;
-        std::int32_t a_exp = static_cast<std::int32_t>(a_sorted.exponent());
-        std::int32_t o1_exp = static_cast<std::int32_t>(r.out1.exponent());
+        auto a_exp = a_sorted.exponent();    // keep the wide exp_t; no narrowing
+        auto o1_exp = r.out1.exponent();
         if (o1_exp > a_exp + 2 || o1_exp < a_exp - k) {
             std::cout << tag << " exp-bound FAILED: o1_exp=" << o1_exp
                       << " a_exp=" << a_exp << " k=" << k << '\n';

--- a/elastic/elreal/arithmetic/threeAdd.cpp
+++ b/elastic/elreal/arithmetic/threeAdd.cpp
@@ -45,7 +45,7 @@ int verify_one(const sw::universal::block<FpType>& ia,
 #if LONG_DOUBLE_SUPPORT
     auto block_value = [](const block<FpType>& b) -> long double {
         if (b.is_zero_block()) return 0.0L;
-        return static_cast<long double>(b.v) * std::ldexp(1.0L, b.exp);
+        return static_cast<long double>(b.v) * std::ldexp(1.0L, static_cast<int>(b.exp));
     };
     long double ref = block_value(ia) + block_value(ib) + block_value(ic);
     long double got = block_value(r.out1) + block_value(r.out2) + block_value(r.out3);
@@ -76,8 +76,8 @@ int verify_one(const sw::universal::block<FpType>& ia,
     const auto& a_sorted = arr[0];
     if (!a_sorted.is_zero_block() && !r.out1.is_zero_block()) {
         constexpr int k = block<FpType>::k;
-        std::int32_t a_exp = a_sorted.exponent();
-        std::int32_t o1_exp = r.out1.exponent();
+        std::int32_t a_exp = static_cast<std::int32_t>(a_sorted.exponent());
+        std::int32_t o1_exp = static_cast<std::int32_t>(r.out1.exponent());
         if (o1_exp > a_exp + 2 || o1_exp < a_exp - k) {
             std::cout << tag << " exp-bound FAILED: o1_exp=" << o1_exp
                       << " a_exp=" << a_exp << " k=" << k << '\n';

--- a/elastic/elreal/block_eft/two_div.cpp
+++ b/elastic/elreal/block_eft/two_div.cpp
@@ -63,7 +63,7 @@ int verify_two_div_one(const sw::universal::block<FpType>& a,
         ++nrFailures;
     }
 
-    std::int32_t expected_off = static_cast<std::int32_t>(a.exp - b.exp);
+    auto expected_off = a.exp - b.exp;   // keep the wide exp_t; no narrowing
     if (q.exp != expected_off || r.exp != expected_off) {
         std::cout << tag << " exp mismatch: expected " << expected_off
                   << " got q=" << q.exp << " r=" << r.exp

--- a/elastic/elreal/block_eft/two_div.cpp
+++ b/elastic/elreal/block_eft/two_div.cpp
@@ -63,7 +63,7 @@ int verify_two_div_one(const sw::universal::block<FpType>& a,
         ++nrFailures;
     }
 
-    std::int32_t expected_off = a.exp - b.exp;
+    std::int32_t expected_off = static_cast<std::int32_t>(a.exp - b.exp);
     if (q.exp != expected_off || r.exp != expected_off) {
         std::cout << tag << " exp mismatch: expected " << expected_off
                   << " got q=" << q.exp << " r=" << r.exp

--- a/elastic/elreal/block_eft/two_mult.cpp
+++ b/elastic/elreal/block_eft/two_mult.cpp
@@ -82,7 +82,7 @@ int verify_two_mult_one(const sw::universal::block<FpType>& a,
         ++nrFailures;
     }
 
-    std::int32_t expected_off = static_cast<std::int32_t>(a.exp + b.exp);
+    auto expected_off = a.exp + b.exp;   // keep the wide exp_t; no narrowing
     if (high.exp != expected_off || low.exp != expected_off) {
         std::cout << tag << " exp mismatch: expected " << expected_off
                   << " got high=" << high.exp << " low=" << low.exp

--- a/elastic/elreal/block_eft/two_mult.cpp
+++ b/elastic/elreal/block_eft/two_mult.cpp
@@ -82,7 +82,7 @@ int verify_two_mult_one(const sw::universal::block<FpType>& a,
         ++nrFailures;
     }
 
-    std::int32_t expected_off = a.exp + b.exp;
+    std::int32_t expected_off = static_cast<std::int32_t>(a.exp + b.exp);
     if (high.exp != expected_off || low.exp != expected_off) {
         std::cout << tag << " exp mismatch: expected " << expected_off
                   << " got high=" << high.exp << " low=" << low.exp

--- a/include/sw/universal/number/elreal/block.hpp
+++ b/include/sw/universal/number/elreal/block.hpp
@@ -7,7 +7,7 @@
 //                  all zeros (the zero block)
 //
 // We pack (s, bv) into a host FpType `v` and carry `e` as an explicit
-// int32_t. The relationship is:
+// wide integer `exp` (block<FpType>::exp_t). The relationship is:
 //
 //     E(b) = scale_of(v) + b.exp        (non-zero v)
 //     E(b) = b.exp                      (zero v)
@@ -16,6 +16,19 @@
 // that |v| in [2^e, 2^(e+1)) for non-zero v). The dissertation's getExp(b)
 // returns E(b) above. The dissertation's 0-overlap predicate compares E(.)
 // of consecutive blocks: `E(b_n) >= E(b_{n+1}) + k`.
+//
+// Why a WIDE exponent (integer<256>, not int32):
+//   McCleeary's exponents live in Z (Haskell `Integer`, unbounded). The
+//   streaming division (online_divide.hpp, dissertation 4.2.6) recurses with
+//   newdiv = g0*divisor each level, so the divisor's magnitude -- hence its
+//   exponent -- roughly DOUBLES per level. A 32- or 64-bit exponent overflows
+//   after only ~11 / ~59 levels, capping multi-block division precision. We
+//   follow the dissertation and carry the exponent in the library's fixed-size
+//   integer<256, uint32_t> -- a trivially-copyable POD (so block stays
+//   hardware-shareable per #925) that never overflows for any realizable host
+//   (its ~2^255 range outlasts even a quad host's denormal floor by orders of
+//   magnitude). This is the spirit of Ryan's unbounded exponent realized
+//   without giving up the trivial block layout. See online_divide.hpp.
 //
 // Note on the historical exp_offset:
 //   Earlier drafts of this file used `exp_offset` as a coarse multiplier
@@ -41,6 +54,7 @@
 
 #include <universal/number/cfloat/cfloat_fwd.hpp>
 #include <universal/number/bfloat16/bfloat16_fwd.hpp>
+#include <universal/number/integer/integer.hpp>   // exp_t: wide, trivially-copyable exponent
 
 namespace sw { namespace universal {
 
@@ -63,14 +77,22 @@ template <typename T>
 inline constexpr bool has_universal_fp_api_v = has_universal_fp_api<T>::value;
 
 // block<FpType>: McCleeary's (sign, exp, bv) packed into FpType's value field
-// plus an explicit int32_t exponent.
+// plus an explicit wide exponent (exp_t).
 //
 // Trivial layout: no in-class member initialisers. Use {v, exp} literal
 // construction to initialise. Default construction leaves members
 // indeterminate (consistent with Universal's other trivial number types).
+// exp_t (integer<256>) is itself a trivially-copyable POD, so block remains
+// trivially copyable / destructible -- the #925 hardware-shareable invariant.
 template <typename FpType>
 struct block {
     using fp_type = FpType;
+
+    // exp_t: the per-block exponent type. A fixed-size, trivially-copyable
+    // integer wide enough that the division recursion (which doubles the
+    // exponent per level) never overflows for any realizable host. See the
+    // file header for the rationale.
+    using exp_t = integer<256, std::uint32_t>;
 
     // k = total significand-vector width per the dissertation. For IEEE-style
     // formats this includes the hidden bit. Tracks numeric_limits::digits
@@ -79,7 +101,7 @@ struct block {
     static constexpr int k = std::numeric_limits<FpType>::digits;
 
     FpType        v;
-    std::int32_t  exp;
+    exp_t         exp;
 
     // sign: -1 for negative, +1 for non-negative. Sign of +0.0 and -0.0 follow
     // signbit / Universal's .sign() respectively.
@@ -103,9 +125,9 @@ struct block {
     }
 
     // Combined exponent E(b) per the dissertation's getExp.
-    constexpr std::int32_t exponent() const noexcept {
+    constexpr exp_t exponent() const noexcept {
         if (is_zero_block()) return exp;
-        return static_cast<std::int32_t>(scale_of_v()) + exp;
+        return exp_t(scale_of_v()) + exp;
     }
 
     constexpr bool is_zero_block() const noexcept {
@@ -139,14 +161,14 @@ struct block {
                       "value_as<T>() requires a native floating-point T");
         T base = static_cast<T>(v);
         if (exp == 0) return base;
-        return std::ldexp(base, exp);
+        return std::ldexp(base, static_cast<int>(exp));
     }
 };
 
 // createZero<FpType>(exp): the dissertation's createZero(k, e). Block size k
 // is fixed by FpType; the returned block has v=0 and the requested exponent.
 template <typename FpType>
-constexpr block<FpType> createZero(std::int32_t e) noexcept {
+constexpr block<FpType> createZero(typename block<FpType>::exp_t e) noexcept {
     return block<FpType>{ FpType{0}, e };
 }
 
@@ -178,8 +200,8 @@ constexpr bool dominate(const block<FpType>& b1, const block<FpType>& b2) noexce
     if (b2.is_zero_block()) return true; // anything dominates the zero block
     if (b1.is_zero_block()) return false; // zero block dominates nothing
     constexpr int k = block<FpType>::k;
-    std::int32_t e1 = b1.exponent();
-    std::int32_t e2 = b2.exponent();
+    typename block<FpType>::exp_t e1 = b1.exponent();
+    typename block<FpType>::exp_t e2 = b2.exponent();
     if (e1 > e2 + k) return true;
     if (e1 == e2 + k && singleBit(b2)) return true;
     return false;

--- a/include/sw/universal/number/elreal/block_eft.hpp
+++ b/include/sw/universal/number/elreal/block_eft.hpp
@@ -215,7 +215,7 @@ inline std::pair<block<FpType>, block<FpType>>
 block_two_mult(const block<FpType>& a, const block<FpType>& b) {
     FpType p, r;
     detail::two_prod_host(a.v, b.v, p, r);
-    std::int32_t out_exp = a.exp + b.exp;
+    auto out_exp = a.exp + b.exp;
     return { block<FpType>{p, out_exp}, block<FpType>{r, out_exp} };
 }
 
@@ -223,7 +223,7 @@ block_two_mult(const block<FpType>& a, const block<FpType>& b) {
 template <typename FpType>
 inline block<FpType>
 block_two_mult_rn(const block<FpType>& a, const block<FpType>& b) {
-    std::int32_t out_exp = a.exp + b.exp;
+    auto out_exp = a.exp + b.exp;
     return block<FpType>{ a.v * b.v, out_exp };
 }
 
@@ -236,7 +236,7 @@ block_two_div(const block<FpType>& a, const block<FpType>& b) {
     assert(!b.is_zero_block() && "block_two_div: divisor is zero");
     FpType q, r;
     detail::two_div_host(a.v, b.v, q, r);
-    std::int32_t out_exp = a.exp - b.exp;
+    auto out_exp = a.exp - b.exp;
     return { block<FpType>{q, out_exp}, block<FpType>{r, out_exp} };
 }
 
@@ -245,7 +245,7 @@ template <typename FpType>
 inline block<FpType>
 block_two_div_rn(const block<FpType>& a, const block<FpType>& b) {
     assert(!b.is_zero_block() && "block_two_div_rn: divisor is zero");
-    std::int32_t out_exp = a.exp - b.exp;
+    auto out_exp = a.exp - b.exp;
     return block<FpType>{ a.v / b.v, out_exp };
 }
 

--- a/include/sw/universal/number/elreal/divide.hpp
+++ b/include/sw/universal/number/elreal/divide.hpp
@@ -93,7 +93,7 @@ inline ZBCL<FpType> div(ZBCL<FpType> x, ZBCL<FpType> y, std::size_t depth = 64) 
         if (rem.empty()) break;                  // exact division: remainder is 0
         const B r0 = rem.front();                // leading block (descending order)
         if (!r0.is_normalised() || r0.exponent() < exp_floor) break;
-        const int lead = r0.exponent();
+        const int lead = static_cast<int>(r0.exponent());
         if (havePrev && lead >= prevLead) break; // no progress -> stop refining
         prevLead = lead;
         havePrev = true;

--- a/include/sw/universal/number/elreal/math/exponent.hpp
+++ b/include/sw/universal/number/elreal/math/exponent.hpp
@@ -81,7 +81,7 @@ inline ZBCL<FpType> log(ZBCL<FpType> x, std::size_t depth = 4) {
 
     // Range reduction: x = m * 2^e with m in [1,2). e is the binary scale of the
     // leading block; m = x * 2^-e.
-    const int e = x.head().exponent();
+    const int e = static_cast<int>(x.head().exponent());
     ZBCL<FpType> m = mul_scalar(B{ static_cast<FpType>(1.0), -e }, x, depth);   // m = x / 2^e
 
     // ln(m) = 2 * artanh(u), u = (m-1)/(m+1), |u| <= 1/3.

--- a/include/sw/universal/number/elreal/sum.hpp
+++ b/include/sw/universal/number/elreal/sum.hpp
@@ -121,7 +121,9 @@ inline ZBCL<FpType> sum(series<FpType> s, std::size_t max_depth = 1024) {
         if (t.is_empty()) {
             leads.push_back(neg_inf);
         } else {
-            leads.push_back(t.head().exponent());
+            // eager sum operates on host-range blocks, so the combined exponent
+            // fits an int (the convergence window only needs relative magnitude).
+            leads.push_back(static_cast<int>(t.head().exponent()));
             sawNonzero = true;
             // flatten the term's blocks into the renormalisation pool
             ZBCL<FpType> bcur = t;

--- a/include/sw/universal/number/elreal/sum.hpp
+++ b/include/sw/universal/number/elreal/sum.hpp
@@ -123,7 +123,17 @@ inline ZBCL<FpType> sum(series<FpType> s, std::size_t max_depth = 1024) {
         } else {
             // eager sum operates on host-range blocks, so the combined exponent
             // fits an int (the convergence window only needs relative magnitude).
-            leads.push_back(static_cast<int>(t.head().exponent()));
+            // Fail loud rather than wrap if a non-host-range exponent ever reaches
+            // here -- a wrapped lead would distort the convergence guard decision.
+            const auto lead = t.head().exponent();
+            using EXP = typename block<FpType>::exp_t;
+            if (lead > EXP(std::numeric_limits<int>::max()) ||
+                lead < EXP(std::numeric_limits<int>::min())) {
+                throw elreal_sum_budget_exceeded(
+                    "sum: a term's leading exponent exceeds int range for the "
+                    "convergence guard (non-host-range term in the eager sum).");
+            }
+            leads.push_back(static_cast<int>(lead));
             sawNonzero = true;
             // flatten the term's blocks into the renormalisation pool
             ZBCL<FpType> bcur = t;

--- a/include/sw/universal/number/elreal/threeAdd.hpp
+++ b/include/sw/universal/number/elreal/threeAdd.hpp
@@ -101,11 +101,11 @@ twoSumRN(const block<FpType>& a, const block<FpType>& b) {
     if (b.is_zero_block()) {
         return { a, createZero<FpType>(a.exp - k) };
     }
-    std::int32_t e_max = std::max(a.exp, b.exp);
+    auto e_max = std::max(a.exp, b.exp);
     FpType va = (a.exp == e_max) ? a.v
-                                 : detail_mccleeary::ldexp_block(a.v, a.exp - e_max);
+                                 : detail_mccleeary::ldexp_block(a.v, static_cast<int>(a.exp - e_max));
     FpType vb = (b.exp == e_max) ? b.v
-                                 : detail_mccleeary::ldexp_block(b.v, b.exp - e_max);
+                                 : detail_mccleeary::ldexp_block(b.v, static_cast<int>(b.exp - e_max));
     FpType s, r;
     detail_mccleeary::host_two_sum(va, vb, s, r);
     return { block<FpType>{s, e_max}, block<FpType>{r, e_max} };
@@ -491,7 +491,7 @@ struct addRec_state {
     ZBCL<FpType> fs;
     ZBCL<FpType> gs;
     std::vector<block<FpType>> workspace; // [prev, e1, e2, ...] (front-first)
-    std::int32_t bound;
+    typename block<FpType>::exp_t bound;
     bool initialised; // whether `bound` and workspace have been seeded
 };
 

--- a/include/sw/universal/verification/elreal_oracle.hpp
+++ b/include/sw/universal/verification/elreal_oracle.hpp
@@ -80,7 +80,12 @@ inline dyadic exact_block(const block<FpType>& b) {
     if (b.is_zero_block()) return dyadic();
     dyadic d = exact_real(b.v);
     // block exp is a wide integer<256>; the oracle verifies host-range test
-    // values whose combined exponent fits an int, so narrow it here.
+    // values whose combined exponent fits an int. Fail loud rather than silently
+    // truncate if that invariant is ever violated (it would corrupt the reference).
+    using EXP = typename block<FpType>::exp_t;
+    assert(b.exp <= EXP(std::numeric_limits<int>::max())
+        && b.exp >= EXP(std::numeric_limits<int>::min())
+        && "elreal oracle: block exponent outside host int range");
     d.scale += static_cast<int>(b.exp);   // multiply by 2^exp exactly (value = v * 2^exp)
     return d;
 }

--- a/include/sw/universal/verification/elreal_oracle.hpp
+++ b/include/sw/universal/verification/elreal_oracle.hpp
@@ -79,7 +79,9 @@ template <typename FpType>
 inline dyadic exact_block(const block<FpType>& b) {
     if (b.is_zero_block()) return dyadic();
     dyadic d = exact_real(b.v);
-    d.scale += b.exp;          // multiply by 2^exp exactly (value = v * 2^exp)
+    // block exp is a wide integer<256>; the oracle verifies host-range test
+    // values whose combined exponent fits an int, so narrow it here.
+    d.scale += static_cast<int>(b.exp);   // multiply by 2^exp exactly (value = v * 2^exp)
     return d;
 }
 


### PR DESCRIPTION
## Summary
- McCleeary's LFPERA carries the per-block exponent in **Z** (Haskell `Integer`, unbounded). The streaming division (dissertation 4.2.6) recurses with `newdiv = g0*divisor` each level, so the divisor's magnitude -- and its block exponent -- roughly **doubles per level**. A fixed `int32` exponent overflows after ~11 levels (`int64` after ~59), capping multi-block division precision.
- Rather than reformulate Ryan's proven algorithm to fit a narrow exponent (a prior attempt that was reverted), **follow the dissertation**: carry the exponent in the library's fixed-size `integer<256, uint32_t>`.
- `integer<256>` is a **trivially-copyable POD**, so `block<FpType>` stays trivially copyable / destructible -- the **#925 hardware-shareable invariant** the construction test enforces -- while its ~2^255 range never overflows for any realizable host (it outlasts even a quad host's denormal floor by orders of magnitude).

This unblocks the multi-block streaming division in the `#1061` online mul/div work (which rebases on top of this).

## Changes
- `block.hpp` -- add `block<FpType>::exp_t = integer<256,uint32_t>`; `exp` and `exponent()` become `exp_t`; `createZero` takes `exp_t`; `value_as` narrows for `ldexp`. Rationale documented in the file header.
- `threeAdd.hpp` / `block_eft.hpp` -- alignment and product/quotient exponents flow as `exp_t` (`auto`); `ldexp` shift args narrowed to `int` (host-range alignment).
- `sum.hpp` / `divide.hpp` / `math/exponent.hpp` -- eager + math paths keep `int` (their blocks are host-range) with explicit narrowing of `exponent()`.
- `elreal_oracle.hpp` + block/eft/threeAdd tests -- narrow `exp_t` to `int` for the dyadic oracle / `ldexp` (host-range verification values).

## Test Results
| Suite | gcc build | gcc test | clang build | clang test |
|-------|-----------|----------|-------------|------------|
| elreal (34 targets) | OK | 34/34 PASS | OK | 34/34 PASS |

Block construction triviality `static_assert`s (`is_trivially_copyable`/`is_trivially_destructible`) still hold.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Relates to #1061

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded exponent representation to support a much wider numeric range in extended real numbers.
  * Improved type safety and consistency for exponent handling to reduce platform-dependent behavior.
  * Adjusted arithmetic primitives (add, multiply, divide, sum, log) to work with the new exponent type.

* **Tests**
  * Updated and added tests to validate exponent handling, narrowing checks, and wider-range behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->