### PR TITLE
feat(elreal): full-precision exp/sin/cos coefficients (#1061 Phase 3a, closes #1058)

### DIFF
--- a/elastic/elreal/math/transcendentals_highprecision.cpp
+++ b/elastic/elreal/math/transcendentals_highprecision.cpp
@@ -48,14 +48,14 @@
 // (acos = pi/2 - asin), which add() does not renormalize to 0-overlap -- it aborts
 // the ZBCL invariant in assert-enabled builds (#1057). The value is still correct;
 // only the canonical form is violated. Gated off until #1057 lands; flip to 1 then.
-#define ELREAL_ADD_EXACT_CANCEL_FIXED 0
+#define ELREAL_ADD_EXACT_CANCEL_FIXED 1
 
 // exp / sin / cos (and tan / sinh / cosh / tanh built on them) cap at host-double
 // precision because their Taylor/Maclaurin series scale each term by a host-double
 // reciprocal coefficient (#1058, same bug class as e_zbcl #1054). Their 300-digit
 // checks are gated off until #1058 lands; flip to 1 then. log/atan/asin/acos use the
 // full-precision odd_power_series and already reach 300+, so they stay active.
-#define ELREAL_EXP_SERIES_HIGH_PRECISION 0
+#define ELREAL_EXP_SERIES_HIGH_PRECISION 1
 
 #include <cmath>
 #include <iostream>

--- a/include/sw/universal/number/elreal/math/exponent.hpp
+++ b/include/sw/universal/number/elreal/math/exponent.hpp
@@ -56,12 +56,11 @@ inline ZBCL<FpType> exp(ZBCL<FpType> x, std::size_t depth = 4) {
     ZBCL<FpType> term = from_native<FpType>(1.0);          // term_0
     terms.push_back(term);
     for (std::size_t n = 1; n < 8 * depth; ++n) {
-        // term_n = term_{n-1} * xr / n. Divide by the small integer n with a
-        // mul_scalar by its (host-double) reciprocal -- O(depth) rather than the
-        // O(depth^2)+ of a full div() -- keeping x^n high-precision while the 1/n
-        // coefficient carries host-double accuracy (ample for exp's range).
-        term = mul_scalar(B{ static_cast<FpType>(1.0 / static_cast<double>(n)), 0 },
-                          mul(term, xr, depth), depth);
+        // term_n = term_{n-1} * xr / n. Divide by the integer n EXACTLY (div by a
+        // single-block divisor) -- NOT by a host-double reciprocal 1.0/n, which would
+        // cap every term (hence the whole series) at host-double precision (~17
+        // digits, #1058). from_native(n) is exact for n < 2^53. (#1061 Phase 3a)
+        term = div(mul(term, xr, depth), from_native<FpType>(static_cast<double>(n)), depth);
         if (term.is_empty()) break;
         terms.push_back(term);
         if (term.head().exponent() < stop_exp) break;      // converged

--- a/include/sw/universal/number/elreal/math/trigonometry.hpp
+++ b/include/sw/universal/number/elreal/math/trigonometry.hpp
@@ -115,15 +115,17 @@ namespace detail {
 // cancellation -- cos(pi/4)=sin(pi/4)=0.707, both O(1)).
 template <typename FpType>
 inline ZBCL<FpType> sin_series(ZBCL<FpType> t, std::size_t depth) {
-    using B = block<FpType>;
     if (t.is_empty()) return ZBCL<FpType>{};
     const int stop_exp = -static_cast<int>(depth) * block<FpType>::k - 8;
     ZBCL<FpType> neg_t2 = negate(mul(t, t, depth));
     std::vector<ZBCL<FpType>> terms{ t };                    // t^1 / 1!
     ZBCL<FpType> term = t;
     for (std::size_t nn = 1; nn < 8 * depth; ++nn) {
+        // Divide by the integer denom (2n)(2n+1) EXACTLY -- not by a host-double
+        // reciprocal 1.0/denom, which capped the series at ~17 digits (#1058).
+        // denom < 2^53 for any realistic n, so from_native is exact. (#1061 Phase 3a)
         const double denom = static_cast<double>(2 * nn) * static_cast<double>(2 * nn + 1);
-        term = mul_scalar(B{ static_cast<FpType>(1.0 / denom), 0 }, mul(term, neg_t2, depth), depth);
+        term = div(mul(term, neg_t2, depth), from_native<FpType>(denom), depth);
         if (term.is_empty()) break;
         terms.push_back(term);
         if (term.head().exponent() < stop_exp) break;
@@ -132,14 +134,14 @@ inline ZBCL<FpType> sin_series(ZBCL<FpType> t, std::size_t depth) {
 }
 template <typename FpType>
 inline ZBCL<FpType> cos_series(ZBCL<FpType> t, std::size_t depth) {
-    using B = block<FpType>;
     const int stop_exp = -static_cast<int>(depth) * block<FpType>::k - 8;
     ZBCL<FpType> neg_t2 = t.is_empty() ? ZBCL<FpType>{} : negate(mul(t, t, depth));
     std::vector<ZBCL<FpType>> terms{ from_native<FpType>(1.0) };   // 1
     ZBCL<FpType> term = from_native<FpType>(1.0);
     for (std::size_t nn = 1; nn < 8 * depth; ++nn) {
+        // Exact integer division (see sin_series) -- removes the host-double cap (#1058).
         const double denom = static_cast<double>(2 * nn - 1) * static_cast<double>(2 * nn);
-        term = mul_scalar(B{ static_cast<FpType>(1.0 / denom), 0 }, mul(term, neg_t2, depth), depth);
+        term = div(mul(term, neg_t2, depth), from_native<FpType>(denom), depth);
         if (term.is_empty()) break;
         terms.push_back(term);
         if (term.head().exponent() < stop_exp) break;


### PR DESCRIPTION
## Summary
- `exp`, `sin_series`, `cos_series` scaled each Taylor term by a **host-double reciprocal coefficient** (`mul_scalar(1.0/n, ...)`, `1.0/denom`), capping the whole series at ~17 digits regardless of depth (#1058) -- the same bug class as `e_zbcl` #1054, but in the **functions**.
- Fix: divide by the integer denominator **exactly** via a single-block `div()` (`from_native(n)` is exact for n < 2^53), now fast thanks to the online single-block division (#1069).

## Result
| | before | after (depth 20) |
|---|---|---|
| exp(1) | 17 digits | **309** |
| sin(0.5) | 17 | **309** |
| cos(0.5) | 18 | **311** |

**No default-path regression** -- measured identical before/after at the default depth 4 (exp 0.002s, sin 0.39s; the "75x" trap from #1058's naive fix did not materialize). High-precision identities hold to the working precision and scale with depth (178-196 digits agreement at depth 10; **exact 320** for `asin+acos==pi/2`).

## Changes
- `include/sw/universal/number/elreal/math/exponent.hpp` -- exact integer div in the `exp` Taylor recurrence.
- `include/sw/universal/number/elreal/math/trigonometry.hpp` -- same in `sin_series` / `cos_series`.
- `elastic/elreal/math/transcendentals_highprecision.cpp` -- re-enable the #1049 gated checks: `ELREAL_EXP_SERIES_HIGH_PRECISION` (this fix) and `ELREAL_ADD_EXACT_CANCEL_FIXED` (the #1057 exact-cancel add, merged via #1064).

## Scope (Phase 3a of #1061)
This is the **correctness half** of #1061 Phase 3 -- remove the host-double cap, re-enable the #1049 gated identities. **Phase 3b** -- making the series genuinely pull-driven/memoized over online mul/div, which would also make the LEVEL_4 depth-20 identity suite *fast* rather than eager-slow -- remains as follow-on. The LEVEL_4 high-precision suite is correct but eager-slow at depth 20 (the motivation for 3b) and runs in the stress tier only.

## Test Results
| Target | gcc | clang |
|---|---|---|
| el_math_trigonometry / exponent / hyperbolic (LEVEL_1) | PASS | PASS |
| transcendentals_highprecision LEVEL_4 path compiles | OK | OK |
| exp/sin/cos depth-20 digits, identities | 309-311, identities agree | (header-only, same) |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <N>`

Closes #1058
Relates to #1049, #1061

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved precision of exponential and trigonometric function calculations (exp, sin, cos, tan, and related functions) by refining internal computation methods to eliminate precision loss.
  * Enhanced validation testing for mathematical identity verification in high-precision arithmetic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->