### PR TITLE
feat(elreal): window euler_gamma's A-accumulation over online mul (#1061 Phase 3b)

### DIFF
--- a/include/sw/universal/number/elreal/math/constants.hpp
+++ b/include/sw/universal/number/elreal/math/constants.hpp
@@ -220,18 +220,39 @@ inline ZBCL<FpType> euler_gamma_zbcl(std::size_t depth = 16) {
         acc = priestRenorm(pool);
         if (acc.size() > cap) acc.resize(cap);
     };
+    // Pass 1: locate the GLOBAL peak exponent of w_k = (n^k/k!)^2 -- it grows to ~k=n
+    // then decays. The scalar w-recurrence is cheap; knowing the peak up front lets the
+    // A-accumulation window each product to A's significance band, so BOTH the tiny
+    // early terms and the decaying tail are skipped -- only the ~sqrt(n) terms near the
+    // peak are multiplied in full. (#1061 Phase 3b)
+    int peakExp = static_cast<int>(one.head().exponent());
+    {
+        ZBCL<FpType> w = one;
+        for (std::size_t k = 1; ; ++k) {
+            w = div(mul_scalar(B{ static_cast<FpType>(n2), 0 }, w, wdepth),
+                    from_native<FpType>(static_cast<double>(k) * static_cast<double>(k)), wdepth);
+            if (w.is_empty()) break;
+            peakExp = std::max(peakExp, static_cast<int>(w.head().exponent()));
+            if (k > static_cast<std::size_t>(n) &&
+                static_cast<int>(w.head().exponent()) < peakExp - wbits - 8) break;
+        }
+    }
+    // A keeps ~cap blocks below its peak (~peakExp); a product whose blocks all sit below
+    // that floor contributes nothing, so pull each w_k*H_k only down to it. aFloor sits a
+    // touch below A's true floor (A.peak = peakExp + scale(H_k)), so nothing is lost.
+    const int aFloor = peakExp - static_cast<int>(cap) * block<FpType>::k;
+
+    // Pass 2: accumulate A(n) = sum w_k H_k, B(n) = sum w_k, H_k = H_{k-1} + 1/k.
     ZBCL<FpType> w = one;
-    int peakExp = static_cast<int>(w.head().exponent());
     std::vector<B> Hblocks, Bblocks = w.take(cap), Ablocks;
     for (std::size_t k = 1; ; ++k) {
         w = div(mul_scalar(B{ static_cast<FpType>(n2), 0 }, w, wdepth),
                 from_native<FpType>(static_cast<double>(k) * static_cast<double>(k)), wdepth); // *n^2/k^2
         if (w.is_empty()) break;
-        peakExp = std::max(peakExp, static_cast<int>(w.head().exponent()));
         fold(Hblocks, div(one, from_native<FpType>(static_cast<double>(k)), wdepth), wdepth);   // H_k += 1/k
         ZBCL<FpType> Hk = zbcl_from_blocks<FpType>(Hblocks);
         fold(Bblocks, w, cap);
-        fold(Ablocks, mul(w, Hk, wdepth), cap);
+        fold(Ablocks, detail::take_while_above(mul_online(w, Hk), aFloor), cap);                // w_k * H_k, windowed
         if (k > static_cast<std::size_t>(n) &&
             static_cast<int>(w.head().exponent()) < peakExp - wbits - 8) break;
     }


### PR DESCRIPTION
## Summary
Last eager hot loop in #1061 Phase 3b. euler_gamma's Brent-McMillan inner loop spent nearly all its time in `fold(A, mul(w_k, H_k))` -- a full eager product per term (~2n terms).

Unlike a monotone series, `w_k = (n^k/k!)^2` **grows to a peak at k=n then decays**, so windowing against a *running* peak only helps the tail. **Two-pass instead:** a cheap scalar pre-pass finds the **global** peak exponent of w_k, then the accumulation pulls each `w_k*H_k` (now `mul_online`) only down to A's significance floor (`peakExp - cap*k`). Products entirely below that floor -- the tiny early terms **and** the decaying tail -- contribute nothing and are skipped; only the ~sqrt(n) terms near the peak are multiplied in full.

Builds on #1075's `take_while_above` + online mul/div. (The `ln(n)` half of the old #1053 cost wall -- ~107s of eager ln2 -- already vanished when `odd_power_series` went online in #1075.)

## Measured (double host), value-identical (matches `s_euler_gamma`)
| | before | after |
|---|---|---|
| depth 12 | 61s | **6.5s** (9.4x) |
| depth 20 | ~300s | **12.2s**, 305 digits |
| `constants_highprecision` LEVEL_4 | (euler_gamma ~minutes) | suite **PASSes in ~34s** |

## Changes
- `include/sw/universal/number/elreal/math/constants.hpp` -- two-pass euler_gamma: scalar peak-finding pre-pass + windowed `mul_online` A-accumulation.

## Test Results
| Target | gcc | clang | gcc Debug (asserts) |
|---|---|---|---|
| el_math_constants (LEVEL_1) | PASS | PASS | PASS |
| constants_highprecision (LEVEL_4) | PASS (34s) | (header-only) | - |

## Scope
With this, every elreal series/constant hot loop is online: `odd_power_series` (#1075), `exp`/`sin`/`cos` (#1077), euler_gamma (here). The scalar w-recurrence and B-fold stay eager (cheap). #1076 (sin/cos multi-block-argument precision) remains.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready: `gh pr ready <N>`

Relates to #1061, #1053

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined internal numerical computation strategy for mathematical constant calculations through optimized series accumulation techniques. Updated approach implements a multi-pass strategy with intelligent filtering to improve computational efficiency and numerical precision handling while maintaining full compatibility with existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->