### PR TITLE
feat(elreal): class facade -- plug-in arithmetic number system + lazy API (#1079)

### DIFF
--- a/elastic/elreal/CMakeLists.txt
+++ b/elastic/elreal/CMakeLists.txt
@@ -9,6 +9,7 @@
 # Phase 7 (#931): math suite (7.2 sqrt/hypot, ...).
 # Phase 8+ (#932-#933): real-FP conversion, evaluation.
 
+file (GLOB API_SRCS         "./api/*.cpp")
 file (GLOB BLOCK_SRCS       "./block/*.cpp")
 file (GLOB ZBCL_SRCS        "./zbcl/*.cpp")
 file (GLOB BLOCK_EFT_SRCS   "./block_eft/*.cpp")
@@ -16,6 +17,7 @@ file (GLOB ARITHMETIC_SRCS  "./arithmetic/*.cpp")
 file (GLOB SUMMATION_SRCS   "./summation/*.cpp")
 file (GLOB MATH_SRCS        "./math/*.cpp")
 
+compile_all("true" "el_api"        "Number Systems/elastic/floating-point/binary/elreal/api"        "${API_SRCS}")
 compile_all("true" "el_block"      "Number Systems/elastic/floating-point/binary/elreal/block"      "${BLOCK_SRCS}")
 compile_all("true" "el_zbcl"       "Number Systems/elastic/floating-point/binary/elreal/zbcl"       "${ZBCL_SRCS}")
 compile_all("true" "el_block_eft"  "Number Systems/elastic/floating-point/binary/elreal/block_eft"  "${BLOCK_EFT_SRCS}")

--- a/elastic/elreal/api/api.cpp
+++ b/elastic/elreal/api/api.cpp
@@ -1,0 +1,112 @@
+// api.cpp: usage patterns for the elreal class facade (#1079 Phase 1).
+//
+// elreal<FpType> is a plug-in arithmetic number system over the McCleeary LFPERA
+// lazy block co-list (ZBCL): standard native ctors / conversions / operators, plus
+// a lazy state-machine extension (runtime precision, incremental refine, raw stream).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/traits/elreal_traits.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+using namespace sw::universal;
+
+// a generic kernel: elreal must drop into templated numeric code like any other type
+template <typename Real>
+Real poly(const Real& x) { return x * x * x - Real(2) * x + Real(1); }   // x^3 - 2x + 1
+
+int check(const char* tag, double got, double want, double tol) {
+    if (std::fabs(got - want) > tol) {
+        std::cout << "  FAIL " << tag << ": " << got << " != " << want << '\n';
+        return 1;
+    }
+    return 0;
+}
+
+// (1) construction + native conversion
+int verify_construction() {
+    int n = 0;
+    elreal<double> a;            n += (a.iszero() ? 0 : 1);          // default = 0
+    elreal<double> b = 3.0;      n += check("ctor(3.0)", double(b), 3.0, 1e-12);
+    elreal<double> c = 42;       n += check("ctor(int)", double(c), 42.0, 1e-12);
+    elreal<double> d(b);         n += check("copy", double(d), 3.0, 1e-12);
+    n += (is_elreal<elreal<double>> ? 0 : 1);
+    return n;
+}
+
+// (2) lazy arithmetic + boundary conversion
+int verify_arithmetic() {
+    int n = 0;
+    elreal<double> a = 3.0, b = 7.0;
+    n += check("3+7",  double(a + b), 10.0, 1e-12);
+    n += check("3-7",  double(a - b), -4.0, 1e-12);
+    n += check("3*7",  double(a * b), 21.0, 1e-12);
+    n += check("3/7",  double(a / b), 3.0 / 7.0, 1e-12);
+    n += check("-3",   double(-a), -3.0, 1e-12);
+    n += check("abs",  double(abs(-a)), 3.0, 1e-12);
+    n += check("poly(2)", double(poly(elreal<double>(2.0))), 5.0, 1e-12);   // plug-in kernel
+    return n;
+}
+
+// (3) depth-bounded comparison (exact on terminating ratios)
+int verify_logic() {
+    int n = 0;
+    elreal<double> a = 3.0, b = 7.0, one = 1.0;
+    n += ((a / b) < one ? 0 : 1);     // 3/7 < 1
+    n += ((b / b) == one ? 0 : 1);    // 7/7 == 1 exactly
+    n += (a != b ? 0 : 1);
+    n += (b > a ? 0 : 1);
+    return n;
+}
+
+// (4) lazy API / state-machine extension
+int verify_lazy_api() {
+    int n = 0;
+    elreal<double> q = elreal<double>(1.0) / elreal<double>(3.0);    // 1/3, irrational stream
+    n += (q.limbs(3).size() == 3 ? 0 : 1);                          // pull 3 limbs
+    q.refine(16);
+    n += (q.precision() == 16 ? 0 : 1);                            // incremental refine
+    n += check("1/3 approx@16", q.approx<double>(16), 1.0 / 3.0, 1e-12);
+    n += (q.stream().is_empty() ? 1 : 0);                          // raw state machine handle
+    {   // scoped precision override
+        elreal_precision_guard g(20);
+        elreal<double> z;
+        n += (z.precision() == 20 ? 0 : 1);
+    }
+    elreal<double> z2;
+    n += (z2.precision() == 8 ? 0 : 1);                            // restored
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal class facade (plug-in + lazy API) (#1079)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_construction();
+    nrOfFailedTestCases += verify_arithmetic();
+    nrOfFailedTestCases += verify_logic();
+    nrOfFailedTestCases += verify_lazy_api();
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/api/api.cpp
+++ b/elastic/elreal/api/api.cpp
@@ -58,14 +58,24 @@ int verify_arithmetic() {
     return n;
 }
 
-// (3) depth-bounded comparison (exact on terminating ratios)
+// (3) depth-bounded comparison. The operands are COMPUTED (irrational quotients /
+// exact ratios) rather than literal-initialised, so each comparison is a genuine
+// runtime exercise of the operator -- ordering on the nonzero leading limb, and
+// exact equality on a terminating ratio.
 int verify_logic() {
     int n = 0;
-    elreal<double> a = 3.0, b = 7.0, one = 1.0;
-    n += ((a / b) < one ? 0 : 1);     // 3/7 < 1
-    n += ((b / b) == one ? 0 : 1);    // 7/7 == 1 exactly
-    n += (a != b ? 0 : 1);
-    n += (b > a ? 0 : 1);
+    elreal<double> third = elreal<double>(1.0) / elreal<double>(3.0);   // 0.3333...
+    elreal<double> half  = elreal<double>(1.0) / elreal<double>(2.0);   // 0.5
+    elreal<double> one   = 1.0;
+    n += (third <  half  ? 0 : 1);    // 1/3 < 1/2
+    n += (half  >  third ? 0 : 1);    // 1/2 > 1/3
+    n += (third != half  ? 0 : 1);
+    n += (third <= half  ? 0 : 1);
+    n += (half  >= third ? 0 : 1);
+    n += (third <  one   ? 0 : 1);    // 1/3 < 1
+    // exact equality on a terminating ratio: 7/7 == 1 to any precision.
+    elreal<double> seven = elreal<double>(7.0);
+    n += ((seven / seven) == one ? 0 : 1);
     return n;
 }
 

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -52,3 +52,7 @@
 #include <universal/number/elreal/math/exponent.hpp>
 #include <universal/number/elreal/math/hyperbolic.hpp>
 #include <universal/number/elreal/math/trigonometry.hpp>
+// The elreal class facade: a plug-in arithmetic number system over the ZBCL
+// machinery above (lazy operators, runtime precision, depth-bounded compare).
+#include <universal/number/elreal/elreal_impl.hpp>
+#include <universal/number/elreal/manipulators.hpp>

--- a/include/sw/universal/number/elreal/elreal_fwd.hpp
+++ b/include/sw/universal/number/elreal/elreal_fwd.hpp
@@ -17,4 +17,15 @@ struct block;
 template <typename FpType>
 class ZBCL;
 
+// The elreal class facade (plug-in arithmetic number system over ZBCL).
+template <typename FpType>
+class elreal;
+
+template <typename FpType> elreal<FpType> abs(const elreal<FpType>&);
+template <typename FpType> elreal<FpType> fabs(const elreal<FpType>&);
+
+// Standard host aliases.
+using elreal64 = elreal<double>;
+using elreal32 = elreal<float>;
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -1,0 +1,223 @@
+#pragma once
+// elreal_impl.hpp: the elreal class facade -- a plug-in arithmetic number system
+// over the McCleeary LFPERA lazy block co-list (ZBCL).
+//
+// elreal<FpType> wraps a ZBCL<FpType> (a lazy, memoised, pull-driven stream of
+// blocks) and presents the standard Universal plug-in interface (native ctors,
+// conversions, arithmetic + logic operators) so it drops into templated kernels
+// like any other number type. Unlike the eager ereal (Priest/Shewchuk expansion),
+// elreal is LAZY: arithmetic operators store unforced streams and evaluation
+// happens only at a boundary (conversion / comparison / I/O / explicit approx),
+// to a runtime-controlled precision (_depth). Because the underlying ZBCL memoises
+// its tail thunks, refining to a deeper precision REUSES the work already pulled --
+// the incremental-precision edge over the eager elastic types.
+//
+// elreal is an ELASTIC type: it holds a ZBCL (shared_ptr) and is therefore NOT
+// trivially copyable (the #925 hardware-shareable triviality rule applies to the
+// static `block`, not to this elastic facade -- same as ereal/einteger/edecimal).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>
+#include <string>
+#include <vector>
+#include <type_traits>
+
+#include <universal/number/shared/specific_value_encoding.hpp>
+
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/exceptions.hpp>
+#include <universal/number/elreal/block.hpp>
+#include <universal/number/elreal/zbcl.hpp>
+#include <universal/number/elreal/zbcl_helpers.hpp>     // from_native, to_double_approx
+#include <universal/number/elreal/threeAdd.hpp>         // add
+#include <universal/number/elreal/negate.hpp>           // negate
+#include <universal/number/elreal/online_multiply.hpp>  // mul_online
+#include <universal/number/elreal/online_divide.hpp>    // div_online
+
+namespace sw { namespace universal {
+
+// elreal default precision (in blocks). One block ~ k bits ~ 16 decimal digits for
+// a double host; the default is the pull depth used by boundary operations
+// (conversion / comparison / I/O) unless overridden per-object via precision(). It
+// is a thread-local default so an enclosing scope can change it (see
+// elreal_precision_guard) without recompiling the type.
+inline std::size_t& elreal_default_precision() {
+    static thread_local std::size_t depth = 8;   // ~128 decimal digits on a double host
+    return depth;
+}
+
+// RAII scoped override of the default precision.
+struct elreal_precision_guard {
+    std::size_t saved;
+    explicit elreal_precision_guard(std::size_t d) : saved(elreal_default_precision()) {
+        elreal_default_precision() = d;
+    }
+    ~elreal_precision_guard() { elreal_default_precision() = saved; }
+};
+
+template <typename FpType = double>
+class elreal {
+public:
+    using value_type = FpType;
+    using block_type = block<FpType>;
+    using stream_type = ZBCL<FpType>;
+
+    // --- construction --------------------------------------------------------
+    elreal() : _value{}, _depth(elreal_default_precision()) {}   // 0 (empty stream)
+    elreal(const elreal&) = default;
+    elreal(elreal&&) noexcept = default;
+    elreal& operator=(const elreal&) = default;
+    elreal& operator=(elreal&&) noexcept = default;
+
+    // wrap an existing lazy stream (advanced / internal)
+    explicit elreal(stream_type v, std::size_t depth = elreal_default_precision())
+        : _value(std::move(v)), _depth(depth) {}
+
+    // native conversions (exact for integers < 2^53; from_native for floats)
+    elreal(signed char iv)        { *this = static_cast<double>(iv); }
+    elreal(short iv)              { *this = static_cast<double>(iv); }
+    elreal(int iv)               { *this = static_cast<double>(iv); }
+    elreal(long iv)              { *this = static_cast<double>(iv); }
+    elreal(long long iv)         { *this = static_cast<double>(iv); }
+    elreal(unsigned char iv)     { *this = static_cast<double>(iv); }
+    elreal(unsigned short iv)    { *this = static_cast<double>(iv); }
+    elreal(unsigned int iv)      { *this = static_cast<double>(iv); }
+    elreal(unsigned long iv)     { *this = static_cast<double>(iv); }
+    elreal(unsigned long long iv){ *this = static_cast<double>(iv); }
+    elreal(float iv)             { *this = static_cast<double>(iv); }
+    elreal(double iv)            { *this = iv; }
+
+    elreal& operator=(double rhs) {
+        _value = from_native<FpType>(rhs);
+        _depth = elreal_default_precision();
+        return *this;
+    }
+    elreal& operator=(float rhs)       { return *this = static_cast<double>(rhs); }
+    elreal& operator=(int rhs)         { return *this = static_cast<double>(rhs); }
+    elreal& operator=(long long rhs)   { return *this = static_cast<double>(rhs); }
+
+    // SpecificValue: elreal is an exact FINITE real; non-finite codes map to 0 for
+    // plug-in compatibility (a dedicated non-finite state is a later design item).
+    elreal(const SpecificValue code) : _value{}, _depth(elreal_default_precision()) {
+        switch (code) {
+            case SpecificValue::maxpos:  *this =  1.0e308; break;
+            case SpecificValue::maxneg:  *this = -1.0e308; break;
+            case SpecificValue::minpos:  *this =  1.0e-307; break;
+            case SpecificValue::minneg:  *this = -1.0e-307; break;
+            default:                     _value = stream_type{}; break;  // zero / nan / inf
+        }
+    }
+
+    // --- conversions (boundary: forces evaluation to _depth) -----------------
+    explicit operator double()      const noexcept { return to_double_approx(_value, _depth); }
+    explicit operator float()       const noexcept { return static_cast<float>(static_cast<double>(*this)); }
+    explicit operator long double() const noexcept { return static_cast<long double>(static_cast<double>(*this)); }
+
+    // --- arithmetic (LAZY: store unforced streams) ---------------------------
+    elreal operator-() const { return elreal(negate(_value), _depth); }
+
+    elreal& operator+=(const elreal& rhs) {
+        _value = add(_value, rhs._value);
+        _depth = _depth > rhs._depth ? _depth : rhs._depth;
+        return *this;
+    }
+    elreal& operator-=(const elreal& rhs) { return *this += (-rhs); }
+    elreal& operator*=(const elreal& rhs) {
+        _value = mul_online(_value, rhs._value);
+        _depth = _depth > rhs._depth ? _depth : rhs._depth;
+        return *this;
+    }
+    elreal& operator/=(const elreal& rhs) {
+        _value = div_online(_value, rhs._value);
+        _depth = _depth > rhs._depth ? _depth : rhs._depth;
+        return *this;
+    }
+
+    // --- lazy API / state-machine extension ----------------------------------
+    // precision(): the per-object default pull depth for boundary ops.
+    std::size_t precision() const noexcept { return _depth; }
+    elreal& precision(std::size_t d) noexcept { _depth = d; return *this; }
+
+    // limbs(n): pull the first n blocks (reuses memoised work on repeat/deeper calls).
+    std::vector<block_type> limbs(std::size_t n) const { return _value.take(n); }
+
+    // approx<T>(depth): materialise the value to `depth` blocks as a native T.
+    template <typename T = double>
+    T approx(std::size_t depth) const { return to_double_approx(_value, depth); }
+
+    // refine(depth): raise the default pull depth; the next boundary op pulls deeper,
+    // reusing everything already memoised. The incremental-precision primitive.
+    elreal& refine(std::size_t depth) noexcept { if (depth > _depth) _depth = depth; return *this; }
+
+    // stream(): the raw lazy state machine (advanced).
+    const stream_type& stream() const noexcept { return _value; }
+
+    bool iszero() const noexcept { return _value.is_empty(); }
+
+private:
+    stream_type _value;    // lazy, memoised block co-list
+    std::size_t _depth;    // default pull depth for boundary operations
+};
+
+// =============================================================================
+// free arithmetic operators (lazy)
+// =============================================================================
+template <typename FpType>
+inline elreal<FpType> operator+(const elreal<FpType>& a, const elreal<FpType>& b) { elreal<FpType> r(a); r += b; return r; }
+template <typename FpType>
+inline elreal<FpType> operator-(const elreal<FpType>& a, const elreal<FpType>& b) { elreal<FpType> r(a); r -= b; return r; }
+template <typename FpType>
+inline elreal<FpType> operator*(const elreal<FpType>& a, const elreal<FpType>& b) { elreal<FpType> r(a); r *= b; return r; }
+template <typename FpType>
+inline elreal<FpType> operator/(const elreal<FpType>& a, const elreal<FpType>& b) { elreal<FpType> r(a); r /= b; return r; }
+
+// mixed with double
+template <typename FpType> inline elreal<FpType> operator+(const elreal<FpType>& a, double b) { return a + elreal<FpType>(b); }
+template <typename FpType> inline elreal<FpType> operator-(const elreal<FpType>& a, double b) { return a - elreal<FpType>(b); }
+template <typename FpType> inline elreal<FpType> operator*(const elreal<FpType>& a, double b) { return a * elreal<FpType>(b); }
+template <typename FpType> inline elreal<FpType> operator/(const elreal<FpType>& a, double b) { return a / elreal<FpType>(b); }
+template <typename FpType> inline elreal<FpType> operator+(double a, const elreal<FpType>& b) { return elreal<FpType>(a) + b; }
+template <typename FpType> inline elreal<FpType> operator-(double a, const elreal<FpType>& b) { return elreal<FpType>(a) - b; }
+template <typename FpType> inline elreal<FpType> operator*(double a, const elreal<FpType>& b) { return elreal<FpType>(a) * b; }
+template <typename FpType> inline elreal<FpType> operator/(double a, const elreal<FpType>& b) { return elreal<FpType>(a) / b; }
+
+// =============================================================================
+// logic operators (DEPTH-BOUNDED: compare a-b to the deeper of the two depths;
+// equal-to-precision when no nonzero limb appears within that window). Exact
+// ordering when the difference's leading block is nonzero. Exact equality of two
+// distinct irrationals is undecidable -- this is a precision-bounded comparison.
+// =============================================================================
+template <typename FpType>
+inline int elreal_cmp(const elreal<FpType>& a, const elreal<FpType>& b) {
+    const std::size_t d = a.precision() > b.precision() ? a.precision() : b.precision();
+    ZBCL<FpType> diff = add(a.stream(), negate(b.stream()));
+    for (const auto& blk : diff.take(d + 1)) {
+        if (!blk.is_zero_block()) return blk.sign();   // first nonzero limb decides
+    }
+    return 0;   // no nonzero limb within d -> equal to precision
+}
+template <typename FpType> inline bool operator==(const elreal<FpType>& a, const elreal<FpType>& b) { return elreal_cmp(a, b) == 0; }
+template <typename FpType> inline bool operator!=(const elreal<FpType>& a, const elreal<FpType>& b) { return !(a == b); }
+template <typename FpType> inline bool operator< (const elreal<FpType>& a, const elreal<FpType>& b) { return elreal_cmp(a, b) <  0; }
+template <typename FpType> inline bool operator> (const elreal<FpType>& a, const elreal<FpType>& b) { return elreal_cmp(a, b) >  0; }
+template <typename FpType> inline bool operator<=(const elreal<FpType>& a, const elreal<FpType>& b) { return elreal_cmp(a, b) <= 0; }
+template <typename FpType> inline bool operator>=(const elreal<FpType>& a, const elreal<FpType>& b) { return elreal_cmp(a, b) >= 0; }
+template <typename FpType> inline bool operator==(const elreal<FpType>& a, double b) { return a == elreal<FpType>(b); }
+template <typename FpType> inline bool operator!=(const elreal<FpType>& a, double b) { return !(a == elreal<FpType>(b)); }
+template <typename FpType> inline bool operator< (const elreal<FpType>& a, double b) { return a <  elreal<FpType>(b); }
+template <typename FpType> inline bool operator> (const elreal<FpType>& a, double b) { return a >  elreal<FpType>(b); }
+
+// abs / fabs
+template <typename FpType>
+inline elreal<FpType> abs(const elreal<FpType>& a) {
+    // sign from the leading (most significant) block
+    auto bl = a.stream().take(1);
+    bool neg = !bl.empty() && bl.front().sign() < 0;
+    return neg ? -a : a;
+}
+template <typename FpType> inline elreal<FpType> fabs(const elreal<FpType>& a) { return abs(a); }
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -49,12 +49,18 @@ inline std::size_t& elreal_default_precision() {
     return depth;
 }
 
-// RAII scoped override of the default precision.
+// RAII scoped override of the default precision. Non-copyable/non-movable: it
+// restores shared thread-local state on destruction, so a copy/move would let a
+// stale instance clobber the active scope.
 struct elreal_precision_guard {
     std::size_t saved;
     explicit elreal_precision_guard(std::size_t d) : saved(elreal_default_precision()) {
         elreal_default_precision() = d;
     }
+    elreal_precision_guard(const elreal_precision_guard&) = delete;
+    elreal_precision_guard& operator=(const elreal_precision_guard&) = delete;
+    elreal_precision_guard(elreal_precision_guard&&) = delete;
+    elreal_precision_guard& operator=(elreal_precision_guard&&) = delete;
     ~elreal_precision_guard() { elreal_default_precision() = saved; }
 };
 

--- a/include/sw/universal/number/elreal/manipulators.hpp
+++ b/include/sw/universal/number/elreal/manipulators.hpp
@@ -1,0 +1,31 @@
+#pragma once
+// manipulators.hpp: type identifier and stream output for elreal.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <iostream>
+#include <string>
+#include <typeinfo>
+
+#include <universal/number/elreal/elreal_fwd.hpp>
+
+namespace sw { namespace universal {
+
+// type_tag: a human-readable identifier for the elreal type (host + default depth).
+template <typename FpType>
+inline std::string type_tag(const elreal<FpType>& = {}) {
+    std::string host = "double";
+    if (sizeof(FpType) == sizeof(float))  host = "float";
+    return std::string("elreal<") + host + ">";
+}
+
+// stream output: print the value at its current precision as a double approximation.
+// (A full high-precision decimal printer is a later manipulators item.)
+template <typename FpType>
+inline std::ostream& operator<<(std::ostream& ostr, const elreal<FpType>& v) {
+    return ostr << static_cast<double>(v);
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/traits/elreal_traits.hpp
+++ b/include/sw/universal/traits/elreal_traits.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <type_traits>
 #include <universal/traits/integral_constant.hpp>
 #include <universal/number/elreal/elreal_fwd.hpp>
 

--- a/include/sw/universal/traits/elreal_traits.hpp
+++ b/include/sw/universal/traits/elreal_traits.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// elreal_traits.hpp : traits for the McCleeary LFPERA lazy exact-real number system
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/traits/integral_constant.hpp>
+#include <universal/number/elreal/elreal_fwd.hpp>
+
+namespace sw { namespace universal {
+
+	// trait to identify elreal types
+	template<typename _Ty>
+	struct is_elreal_trait
+		: false_type
+	{
+	};
+
+	template<typename FpType>
+	struct is_elreal_trait< sw::universal::elreal<FpType> >
+		: true_type
+	{
+	};
+
+	template<typename _Ty>
+	constexpr bool is_elreal = is_elreal_trait<_Ty>::value;
+
+	template<typename _Ty, typename Type = void>
+	using enable_if_elreal = std::enable_if_t<is_elreal<_Ty>, Type>;
+
+}} // namespace sw::universal


### PR DESCRIPTION
Gives `elreal` (McCleeary LFPERA lazy exact-real) the standard Universal facade -- a `class elreal` -- so it drops into templated kernels like every other number system, while exposing a **lazy state-machine API** (the incremental-precision edge over the eager elastic types). Tracking + phase scoring in **#1079**.

This PR accumulates the phases; **Phase 1 (facade scaffold) is here**.

## Phase 1 (this commit)
`class elreal<FpType=double>` wrapping a lazy `ZBCL<FpType>`:
- **Facade** (mirrors `ereal_impl.hpp`): native ctors / conversions / `SpecificValue`; lazy `+ - * /` and compound assigns (store unforced `add`/`mul_online`/`div_online`); depth-bounded `== < ...`; `abs/fabs`; free operators.
- **Lazy state-machine API**: `precision()`/`precision(d)` + thread-local default + RAII `elreal_precision_guard`; `limbs(n)` / `approx<T>(depth)` / `refine(depth)` (reuses memoised work) / `stream()`.
- New files: `elreal_impl.hpp`, `manipulators.hpp`, `traits/elreal_traits.hpp`; updated `elreal_fwd.hpp` + umbrella + aliases (`elreal64`/`elreal32`); `elastic/elreal/api/api.cpp` wired into CMake.

`elreal` is **elastic** (holds a `ZBCL`/shared_ptr -> not trivially copyable; the #925 triviality rule is for the static `block`).

## Design decisions (settled, see #1079)
- Precision = runtime member + thread-local scoped default.
- Operators = fully lazy, force at boundaries.
- Comparison = depth-bounded (exact on a nonzero leading limb).

## Test Results
| Target | gcc | clang |
|---|---|---|
| el_api_api (plug-in kernel + lazy API) | PASS | PASS |

## Remaining phases (#1079)
2: lazy API hardening (memoisation regression test) - 3: numeric_limits / attributes / full manipulators - 4: math facade (mathlib) - 5: conversions/logic/arithmetic suites + non-finite policy + CI.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Phases 2-5 land on this branch
- [ ] Promote to ready when complete

Relates to #1079, #923

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new lazy exact-real number type supporting arithmetic, unary negation, magnitude (`abs`/`fabs`), and depth-bounded conversions/comparisons.
  * Added precision control via a guard and thread-local default precision, plus streaming output for the new type.
  * Added forward declarations, `elreal32`/`elreal64` aliases, and type-trait detection for the new type.
* **Tests**
  * Added a verification entry point covering construction, native conversions, lazy operations, comparison semantics, and precision-guard behavior.
* **Chores**
  * Updated build wiring to compile the API verification component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->