### PR TITLE
feat(elreal): numeric_limits + attributes + manipulators (#1079 Phase 3)

### DIFF
--- a/elastic/elreal/api/attributes.cpp
+++ b/elastic/elreal/api/attributes.cpp
@@ -19,27 +19,34 @@ using namespace sw::universal;
 using Real = elreal<double>;
 
 // (1) numeric_limits specialisation
+//
+// The compile-time-constant fields are checked with static_assert (the idiomatic
+// test for constexpr members; it also avoids cppcheck knownConditionTrueFalse on
+// the folded comparisons). Only the runtime value factories are checked at runtime.
 int verify_numeric_limits() {
-    int n = 0;
     using lim = std::numeric_limits<Real>;
-    if (!lim::is_specialized) ++n;
-    if (!lim::is_signed) ++n;
-    if (lim::is_integer) ++n;
-    if (lim::is_exact) ++n;
-    if (lim::radix != 2) ++n;
-    // finite-only: no NaN / Inf
-    if (lim::has_infinity) ++n;
-    if (lim::has_quiet_NaN) ++n;
-    if (lim::is_bounded) ++n;                       // unbounded exponent
-    // precision reported against the nominal default (8 blocks * 53 bits)
-    if (lim::digits != static_cast<int>(kElrealDefaultPrecision) * std::numeric_limits<double>::digits) ++n;
-    if (lim::digits10 <= 0) ++n;
+    static_assert(lim::is_specialized,  "elreal numeric_limits must be specialized");
+    static_assert(lim::is_signed,       "elreal is signed");
+    static_assert(!lim::is_integer,     "elreal is not an integer type");
+    static_assert(!lim::is_exact,       "elreal materialises to host blocks (not exact)");
+    static_assert(lim::radix == 2,      "elreal radix is 2");
+    static_assert(!lim::has_infinity,   "elreal is finite-only");
+    static_assert(!lim::has_quiet_NaN,  "elreal is finite-only");
+    static_assert(!lim::is_bounded,     "elreal has an unbounded exponent");
+    // precision reported against the nominal default (kElrealDefaultPrecision blocks).
+    static_assert(lim::digits == static_cast<int>(kElrealDefaultPrecision) * std::numeric_limits<double>::digits,
+                  "elreal digits = default precision * host digits");
+    static_assert(lim::digits10 > 0, "elreal digits10 is positive");
+
+    int n = 0;
     // value factories produce sane magnitudes
     if (!(double(lim::max()) > 0.0)) ++n;
     if (!(double(lim::min()) > 0.0)) ++n;
     if (!(double(lim::lowest()) < 0.0)) ++n;
     if (!(double(lim::epsilon()) > 0.0 && double(lim::epsilon()) < 1.0)) ++n;
     if (double(lim::infinity()) != 0.0) ++n;        // finite-only -> 0
+    // denorm_absent contract: denorm_min() == min()
+    if (double(lim::denorm_min()) != double(lim::min())) ++n;
     return n;
 }
 
@@ -71,8 +78,9 @@ int verify_manipulators() {
     if (comps.find("0.125") == std::string::npos) ++n;
     std::string bin = to_binary(q);
     if (bin.empty() || bin == "0") ++n;
+    // 0.125 = 1 * 2^-3  ->  triple (sign, scale, significand) = (+, -3, 1)
     std::string tri = to_triple(q);
-    if (tri.front() != '(') ++n;
+    if (tri != "(+, -3, 1)") ++n;
 
     // operator<< then operator>> round-trips a double-representable value
     std::stringstream ss;

--- a/elastic/elreal/api/attributes.cpp
+++ b/elastic/elreal/api/attributes.cpp
@@ -1,0 +1,110 @@
+// attributes.cpp: numeric_limits, attributes, and manipulators for elreal (#1079 Phase 3).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+using namespace sw::universal;
+using Real = elreal<double>;
+
+// (1) numeric_limits specialisation
+int verify_numeric_limits() {
+    int n = 0;
+    using lim = std::numeric_limits<Real>;
+    if (!lim::is_specialized) ++n;
+    if (!lim::is_signed) ++n;
+    if (lim::is_integer) ++n;
+    if (lim::is_exact) ++n;
+    if (lim::radix != 2) ++n;
+    // finite-only: no NaN / Inf
+    if (lim::has_infinity) ++n;
+    if (lim::has_quiet_NaN) ++n;
+    if (lim::is_bounded) ++n;                       // unbounded exponent
+    // precision reported against the nominal default (8 blocks * 53 bits)
+    if (lim::digits != static_cast<int>(kElrealDefaultPrecision) * std::numeric_limits<double>::digits) ++n;
+    if (lim::digits10 <= 0) ++n;
+    // value factories produce sane magnitudes
+    if (!(double(lim::max()) > 0.0)) ++n;
+    if (!(double(lim::min()) > 0.0)) ++n;
+    if (!(double(lim::lowest()) < 0.0)) ++n;
+    if (!(double(lim::epsilon()) > 0.0 && double(lim::epsilon()) < 1.0)) ++n;
+    if (double(lim::infinity()) != 0.0) ++n;        // finite-only -> 0
+    return n;
+}
+
+// (2) attributes: sign / scale / significand
+int verify_attributes() {
+    int n = 0;
+    Real pos = 6.0, neg = -6.0, zero;
+    if (sign(pos) != 1) ++n;
+    if (sign(neg) != -1) ++n;
+    if (sign(zero) != 1) ++n;                       // +1 for zero
+    // 6.0 = 1.5 * 2^2 -> scale 2, significand ~1.5
+    if (scale(pos) != 2) ++n;
+    if (std::fabs(significand<double>(pos) - 1.5) > 1e-12) ++n;
+    if (scale(zero) != 0) ++n;
+    if (significand<double>(zero) != 0.0) ++n;
+    // sign attribute matches isneg()
+    if (neg.isneg() != true || pos.isneg() != false) ++n;
+    return n;
+}
+
+// (3) manipulators: type_tag / to_components / to_binary / to_triple / I/O
+int verify_manipulators() {
+    int n = 0;
+    if (type_tag(Real{}) != "elreal<double>") ++n;
+    if (type_tag(elreal<float>{}) != "elreal<float>") ++n;
+
+    Real q = Real(1.0) / Real(8.0);                 // 0.125 = exactly one block
+    std::string comps = to_components(q);
+    if (comps.find("0.125") == std::string::npos) ++n;
+    std::string bin = to_binary(q);
+    if (bin.empty() || bin == "0") ++n;
+    std::string tri = to_triple(q);
+    if (tri.front() != '(') ++n;
+
+    // operator<< then operator>> round-trips a double-representable value
+    std::stringstream ss;
+    ss << Real(0.25);
+    Real back;
+    ss >> back;
+    if (std::fabs(double(back) - 0.25) > 1e-15) ++n;
+
+    // zero renders cleanly
+    if (to_components(Real{}) != "( 0 )") ++n;
+    if (to_binary(Real{}) != "0") ++n;
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal numeric_limits / attributes / manipulators (#1079 Phase 3)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    nrOfFailedTestCases += verify_numeric_limits();
+    nrOfFailedTestCases += verify_attributes();
+    nrOfFailedTestCases += verify_manipulators();
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/attributes.hpp
+++ b/include/sw/universal/number/elreal/attributes.hpp
@@ -1,0 +1,36 @@
+#pragma once
+// attributes.hpp: free functions to query elreal value attributes.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <cstdint>
+#include <type_traits>
+
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/elreal_impl.hpp>
+
+namespace sw { namespace universal {
+
+// sign(v): -1 if v < 0, +1 otherwise (+1 for zero).
+template <typename FpType>
+inline int sign(const elreal<FpType>& v) { return v.sign(); }
+
+// scale(v): the value's binary exponent E (the leading block's combined exponent);
+// 0 for zero. value(v) ~ significand * 2^scale.
+template <typename FpType>
+inline int64_t scale(const elreal<FpType>& v) { return static_cast<int64_t>(v.scale()); }
+
+// significand(v): the normalised significand in [1,2) (sign applied), so that
+// v ~ significand * 2^scale. Defined as v / 2^scale, taken from the host
+// approximation; returns 0 for zero.
+template <typename FpType, typename Real = double,
+          typename = std::enable_if_t<std::is_floating_point<Real>::value, Real>>
+inline Real significand(const elreal<FpType>& v) {
+    if (v.iszero()) return Real{0};
+    return static_cast<Real>(std::ldexp(v.template approx<Real>(2), -v.scale()));
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -55,4 +55,6 @@
 // The elreal class facade: a plug-in arithmetic number system over the ZBCL
 // machinery above (lazy operators, runtime precision, depth-bounded compare).
 #include <universal/number/elreal/elreal_impl.hpp>
+#include <universal/number/elreal/numeric_limits.hpp>
+#include <universal/number/elreal/attributes.hpp>
 #include <universal/number/elreal/manipulators.hpp>

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -21,6 +21,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <type_traits>
@@ -183,9 +184,13 @@ public:
         auto bl = _value.take(1);
         return (!bl.empty() && bl.front().sign() < 0) ? -1 : 1;
     }
-    int scale() const noexcept {
+    // int64_t (not int): elreal carries an unbounded integer<256> exponent, so a
+    // narrow int cast could overflow. The host-FP attribute surface this feeds
+    // (ldexp / significand) is bounded by FpType's exponent range, for which int64_t
+    // has vast headroom; the full-width exponent stays reachable via block::exponent().
+    int64_t scale() const noexcept {
         auto bl = _value.take(1);
-        return bl.empty() ? 0 : static_cast<int>(bl.front().exponent());
+        return bl.empty() ? 0 : static_cast<int64_t>(bl.front().exponent());
     }
 
 private:

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -44,8 +44,13 @@ namespace sw { namespace universal {
 // (conversion / comparison / I/O) unless overridden per-object via precision(). It
 // is a thread-local default so an enclosing scope can change it (see
 // elreal_precision_guard) without recompiling the type.
+// The compile-time nominal default precision (in blocks). numeric_limits reports
+// its precision-dependent fields against this; the runtime default below is seeded
+// from it and may be changed per-scope (elreal_precision_guard).
+inline constexpr std::size_t kElrealDefaultPrecision = 8;   // ~128 decimal digits on a double host
+
 inline std::size_t& elreal_default_precision() {
-    static thread_local std::size_t depth = 8;   // ~128 decimal digits on a double host
+    static thread_local std::size_t depth = kElrealDefaultPrecision;
     return depth;
 }
 
@@ -169,6 +174,19 @@ public:
     const stream_type& stream() const noexcept { return _value; }
 
     bool iszero() const noexcept { return _value.is_empty(); }
+    bool isneg()  const noexcept { return sign() < 0; }
+
+    // sign(): -1 if negative, +1 otherwise (the most significant block's sign;
+    // +1 for zero). scale(): the value's binary exponent (the leading block's
+    // combined exponent E = scale_of_v + exp; 0 for zero).
+    int sign() const noexcept {
+        auto bl = _value.take(1);
+        return (!bl.empty() && bl.front().sign() < 0) ? -1 : 1;
+    }
+    int scale() const noexcept {
+        auto bl = _value.take(1);
+        return bl.empty() ? 0 : static_cast<int>(bl.front().exponent());
+    }
 
 private:
     stream_type _value;    // lazy, memoised block co-list

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -20,8 +20,10 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <numeric>
 #include <string>
 #include <vector>
 #include <type_traits>
@@ -162,9 +164,9 @@ public:
     template <typename T = double>
     T approx(std::size_t depth) const {
         static_assert(std::is_floating_point_v<T>, "elreal::approx<T> requires a native floating-point T");
-        T acc = T{0};
-        for (const auto& b : _value.take(depth)) acc += b.template value_as<T>();
-        return acc;
+        const auto blocks = _value.take(depth);
+        return std::accumulate(blocks.begin(), blocks.end(), T{0},
+            [](T acc, const auto& b) { return acc + b.template value_as<T>(); });
     }
 
     // refine(depth): raise the default pull depth; the next boundary op pulls deeper,
@@ -230,10 +232,11 @@ template <typename FpType>
 inline int elreal_cmp(const elreal<FpType>& a, const elreal<FpType>& b) {
     const std::size_t d = a.precision() > b.precision() ? a.precision() : b.precision();
     ZBCL<FpType> diff = add(a.stream(), negate(b.stream()));
-    for (const auto& blk : diff.take(d + 1)) {
-        if (!blk.is_zero_block()) return blk.sign();   // first nonzero limb decides
-    }
-    return 0;   // no nonzero limb within d -> equal to precision
+    const auto blocks = diff.take(d + 1);
+    // first nonzero limb decides the ordering; none within d -> equal to precision
+    const auto it = std::find_if(blocks.begin(), blocks.end(),
+        [](const auto& blk) { return !blk.is_zero_block(); });
+    return it != blocks.end() ? it->sign() : 0;
 }
 template <typename FpType> inline bool operator==(const elreal<FpType>& a, const elreal<FpType>& b) { return elreal_cmp(a, b) == 0; }
 template <typename FpType> inline bool operator!=(const elreal<FpType>& a, const elreal<FpType>& b) { return !(a == b); }

--- a/include/sw/universal/number/elreal/manipulators.hpp
+++ b/include/sw/universal/number/elreal/manipulators.hpp
@@ -1,31 +1,82 @@
 #pragma once
-// manipulators.hpp: type identifier and stream output for elreal.
+// manipulators.hpp: type identification, rendering, and stream I/O for elreal.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <iostream>
+#include <iomanip>
+#include <sstream>
 #include <string>
-#include <typeinfo>
+#include <vector>
 
 #include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/elreal_impl.hpp>
+#include <universal/number/elreal/block_manipulators.hpp>   // to_binary(block) / to_hex(block)
+#include <universal/traits/elreal_traits.hpp>
 
 namespace sw { namespace universal {
 
-// type_tag: a human-readable identifier for the elreal type (host + default depth).
+// type_tag: a human-readable identifier (host type).
 template <typename FpType>
 inline std::string type_tag(const elreal<FpType>& = {}) {
     std::string host = "double";
-    if (sizeof(FpType) == sizeof(float))  host = "float";
+    if (sizeof(FpType) == sizeof(float)) host = "float";
     return std::string("elreal<") + host + ">";
 }
 
-// stream output: print the value at its current precision as a double approximation.
-// (A full high-precision decimal printer is a later manipulators item.)
+// to_components: the block expansion v ~ sum_i (block_i), each block's value, at the
+// value's current precision. A non-empty stream renders down to precision() blocks.
+template <typename FpType>
+inline std::string to_components(const elreal<FpType>& v) {
+    std::stringstream s;
+    auto blocks = v.limbs(v.precision());
+    s << "( ";
+    for (std::size_t i = 0; i < blocks.size(); ++i) {
+        s << std::setprecision(17) << blocks[i].template value_as<double>();
+        if (i + 1 < blocks.size()) s << ", ";
+    }
+    if (blocks.empty()) s << "0";
+    s << " )";
+    return s.str();
+}
+
+// to_binary: the leading (and, if multi-block, trailing) block in binary.
+template <typename FpType>
+inline std::string to_binary(const elreal<FpType>& v, bool nibbleMarker = false) {
+    std::stringstream s;
+    auto blocks = v.limbs(v.precision());
+    if (blocks.empty()) { s << "0"; return s.str(); }
+    s << to_binary(blocks.front(), nibbleMarker);
+    if (blocks.size() > 1) s << " ... " << to_binary(blocks.back(), nibbleMarker);
+    return s.str();
+}
+
+// to_triple: (sign, scale, significand) of the value.
+template <typename FpType>
+inline std::string to_triple(const elreal<FpType>& v) {
+    std::stringstream s;
+    s << (v.isneg() ? "(-, " : "(+, ") << v.scale() << ", "
+      << std::setprecision(17) << static_cast<double>(v) << ')';
+    return s.str();
+}
+
+// stream output: the value at its current precision as a host-double approximation.
+// (A full high-precision decimal printer is tracked as later manipulators work.)
 template <typename FpType>
 inline std::ostream& operator<<(std::ostream& ostr, const elreal<FpType>& v) {
     return ostr << static_cast<double>(v);
+}
+
+// stream input: parse a host-double literal into an elreal (exact for values a
+// double represents exactly; otherwise the nearest double).
+template <typename FpType>
+inline std::istream& operator>>(std::istream& istr, elreal<FpType>& v) {
+    double d{};
+    istr >> d;
+    if (!istr.fail()) v = d;
+    return istr;
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/elreal/manipulators.hpp
+++ b/include/sw/universal/number/elreal/manipulators.hpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 #include <sstream>
@@ -53,12 +55,16 @@ inline std::string to_binary(const elreal<FpType>& v, bool nibbleMarker = false)
     return s.str();
 }
 
-// to_triple: (sign, scale, significand) of the value.
+// to_triple: (sign, scale, significand) of the value, so that
+// value ~ (sign) significand * 2^scale with significand in [1,2) (0 for zero).
 template <typename FpType>
 inline std::string to_triple(const elreal<FpType>& v) {
     std::stringstream s;
-    s << (v.isneg() ? "(-, " : "(+, ") << v.scale() << ", "
-      << std::setprecision(17) << static_cast<double>(v) << ')';
+    const int64_t e = v.scale();
+    const double  m = v.iszero() ? 0.0
+                    : std::ldexp(v.template approx<double>(2), -static_cast<int>(e));
+    s << (v.isneg() ? "(-, " : "(+, ") << e << ", "
+      << std::setprecision(17) << m << ')';
     return s.str();
 }
 

--- a/include/sw/universal/number/elreal/numeric_limits.hpp
+++ b/include/sw/universal/number/elreal/numeric_limits.hpp
@@ -35,7 +35,9 @@ public:
     // smallest increment from 1.0 at the nominal default precision (~2^-digits).
     static ElrealType epsilon()     { return ElrealType(std::ldexp(1.0, -digits)); }
     static ElrealType round_error() { return ElrealType(0.5); }
-    static ElrealType denorm_min()  { return ElrealType(std::numeric_limits<FpType>::denorm_min()); }
+    // has_denorm = denorm_absent, so the C++20 contract requires denorm_min() to
+    // return the minimum positive NORMALISED value, i.e. min().
+    static ElrealType denorm_min()  { return min(); }
     // finite-only: no infinity / NaN -> the factories return 0.
     static ElrealType infinity()      { return ElrealType(); }
     static ElrealType quiet_NaN()     { return ElrealType(); }

--- a/include/sw/universal/number/elreal/numeric_limits.hpp
+++ b/include/sw/universal/number/elreal/numeric_limits.hpp
@@ -1,0 +1,73 @@
+#pragma once
+// numeric_limits.hpp: std::numeric_limits specialisation for elreal.
+//
+// elreal is a LAZY, unbounded-exponent exact-finite real: it has no fixed digit
+// count (precision is pull-driven at runtime) and no NaN/Inf (the McCleeary LFPERA
+// model is exact-finite). The precision-dependent fields (digits/epsilon) are
+// therefore reported against the COMPILE-TIME nominal default precision
+// (kElrealDefaultPrecision blocks); the runtime precision can differ -- query an
+// object's precision() for its actual pull depth. The non-finite predicates are
+// false and the corresponding factories return 0.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <limits>
+
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/elreal_impl.hpp>
+
+namespace std {
+
+template <typename FpType>
+class numeric_limits< sw::universal::elreal<FpType> > {
+public:
+    using ElrealType = sw::universal::elreal<FpType>;
+    static constexpr bool is_specialized = true;
+
+    // value range follows the host FpType (values materialise to host blocks); the
+    // EXPONENT is effectively unbounded (integer<256>), hence is_bounded = false.
+    static ElrealType min()    { return ElrealType(std::numeric_limits<FpType>::min()); }
+    static ElrealType max()    { return ElrealType(std::numeric_limits<FpType>::max()); }
+    static ElrealType lowest() { return ElrealType(std::numeric_limits<FpType>::lowest()); }
+    // smallest increment from 1.0 at the nominal default precision (~2^-digits).
+    static ElrealType epsilon()     { return ElrealType(std::ldexp(1.0, -digits)); }
+    static ElrealType round_error() { return ElrealType(0.5); }
+    static ElrealType denorm_min()  { return ElrealType(std::numeric_limits<FpType>::denorm_min()); }
+    // finite-only: no infinity / NaN -> the factories return 0.
+    static ElrealType infinity()      { return ElrealType(); }
+    static ElrealType quiet_NaN()     { return ElrealType(); }
+    static ElrealType signaling_NaN() { return ElrealType(); }
+
+    // precision-dependent: reported against the nominal default precision (blocks).
+    static constexpr int  digits        = static_cast<int>(sw::universal::kElrealDefaultPrecision)
+                                          * std::numeric_limits<FpType>::digits;
+    static constexpr int  digits10      = static_cast<int>(digits * 0.30103);
+    static constexpr int  max_digits10  = digits10 + 2;
+    static constexpr bool is_signed     = true;
+    static constexpr bool is_integer    = false;
+    static constexpr bool is_exact      = false;
+    static constexpr int  radix         = 2;
+
+    static constexpr int  min_exponent   = std::numeric_limits<FpType>::min_exponent;
+    static constexpr int  min_exponent10 = std::numeric_limits<FpType>::min_exponent10;
+    static constexpr int  max_exponent   = std::numeric_limits<FpType>::max_exponent;
+    static constexpr int  max_exponent10 = std::numeric_limits<FpType>::max_exponent10;
+
+    static constexpr bool has_infinity              = false;
+    static constexpr bool has_quiet_NaN             = false;
+    static constexpr bool has_signaling_NaN         = false;
+    static constexpr float_denorm_style has_denorm  = denorm_absent;
+    static constexpr bool has_denorm_loss           = false;
+
+    static constexpr bool is_iec559        = false;
+    static constexpr bool is_bounded       = false;   // unbounded exponent
+    static constexpr bool is_modulo        = false;
+    static constexpr bool traps            = false;
+    static constexpr bool tinyness_before  = false;
+    static constexpr float_round_style round_style = round_toward_zero;
+};
+
+} // namespace std


### PR DESCRIPTION
## Summary
Phase 3 of the elreal class facade (#1079): the standard **query / render**
surface that every Universal number system exposes.

- `std::numeric_limits<elreal<FpType>>` -- precision-parametrised, **finite-only**
  (the two settled policy questions): non-finite predicates are false and the
  factories return 0; `is_bounded = false` (unbounded integer<256> exponent);
  precision-dependent fields reported against the compile-time nominal default
  (`kElrealDefaultPrecision` blocks), object runtime `precision()` may differ.
- `attributes.hpp` -- `sign(v)`, `scale(v)`, `significand<Real>(v)`.
- `manipulators.hpp` (expanded) -- `type_tag`, `to_components`, `to_binary`,
  `to_triple`, `operator<<`, `operator>>`.
- `elreal_impl.hpp` -- extract `kElrealDefaultPrecision`; add `sign()/scale()/isneg()`.

**Deferred** (as in `ereal`, where they are `tbd` stubs): `to_hex` and a full
high-precision decimal printer (needs the dyadic->decimal machinery) -- tracked
for a manipulators follow-up.

## Changes
- `include/sw/universal/number/elreal/numeric_limits.hpp` -- NEW
- `include/sw/universal/number/elreal/attributes.hpp` -- NEW
- `include/sw/universal/number/elreal/manipulators.hpp` -- expanded
- `include/sw/universal/number/elreal/elreal_impl.hpp` -- constant + accessors
- `include/sw/universal/number/elreal/elreal.hpp` -- umbrella wiring
- `elastic/elreal/api/attributes.cpp` -- NEW test

## Test Results
| Target | gcc build | gcc test | clang build | clang test | gcc Debug+assert |
|--------|-----------|----------|-------------|------------|------------------|
| el_api_attributes | OK | PASS | OK | PASS | PASS |
| el_api_api (regr) | OK | PASS | OK | PASS | - |
| el_api_lazy (regr) | OK | PASS | OK | PASS | - |

Broader elreal math/arith targets still build; cppcheck clean; ASCII clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Relates to #1079

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new inspection APIs for elreal values: `sign()`, `scale()`, and `significand()`.
  * Added additional string formatting helpers: `to_components()`, `to_binary()`, and `to_triple()`.
  * Added stream input support via `operator>>` (parses from a host `double`-formatted input).
  * Added a `std::numeric_limits` specialization for elreal.
* **Tests**
  * Added a dedicated test program covering numeric limits behavior, value attributes, manipulators, and stream round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->