### PR TITLE
feat(elreal): math facade -- functions + constants (#1079 Phase 4)

### DIFF
--- a/elastic/elreal/api/math.cpp
+++ b/elastic/elreal/api/math.cpp
@@ -1,0 +1,123 @@
+// math.cpp: the elreal-class math facade -- functions and constants (#1079 Phase 4).
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+using namespace sw::universal;
+using Real = elreal<double>;
+
+// close enough at host-double resolution: the facade refines well past 53 bits,
+// so a correctly-wired function must agree with the std:: reference to ~1 ulp.
+bool near(const Real& v, double ref, double tol = 1.0e-12) {
+    return std::fabs(static_cast<double>(v) - ref) <= tol * (1.0 + std::fabs(ref));
+}
+
+// (1) named constants resolve to their reference values.
+// elreal_e() and elreal_euler_gamma() are exercised by the math/constants suite,
+// not here: they still route through the eager e_zbcl / euler_gamma_zbcl factories
+// (the online conversion is #1061 Phase 3b), and at ~10-16 s each they would
+// dominate this fast-tier wiring test. The wrappers are one-liners identical to
+// the ones below, so these checks already cover the constant-wrapping pattern;
+// the e value itself is verified through exp(1) in verify_unary().
+int verify_constants() {
+    int n = 0;
+    if (!near(elreal_pi(),      3.14159265358979324))  ++n;
+    if (!near(elreal_ln2(),     0.69314718055994531))  ++n;
+    if (!near(elreal_ln10(),    2.30258509299404568))  ++n;
+    if (!near(elreal_sqrt2(),   1.41421356237309505))  ++n;
+    if (!near(elreal_sqrt3(),   1.73205080756887729))  ++n;
+    if (!near(elreal_sqrt5(),   2.23606797749978969))  ++n;
+    if (!near(elreal_phi(),     1.61803398874989485))  ++n;
+    if (!near(elreal_log2_10(), 3.32192809488736235))  ++n;
+    return n;
+}
+
+// (2) unary functions wrap the ZBCL versions and thread precision
+int verify_unary() {
+    int n = 0;
+    // sqrt: value and the squaring identity
+    Real two = Real(1.0) + Real(1.0);
+    if (!near(sqrt(two), 1.41421356237309505)) ++n;
+    if (!near(sqrt(two) * sqrt(two), 2.0))     ++n;
+    // exp / log are inverses; exp(1) == e; log(e) == 1
+    Real one = two / two;
+    if (!near(log(exp(one)), 1.0))            ++n;
+    if (!near(exp(one), 2.71828182845904524)) ++n;   // exp(1) == e (fast online path)
+    // trig: Pythagorean identity and a known angle (pi/6 -> 1/2)
+    Real x = one / (one + two);                 // 1/3, an unremarkable interior angle
+    if (!near(sin(x) * sin(x) + cos(x) * cos(x), 1.0)) ++n;
+    Real pi6 = elreal_pi() / (two + two + two); // pi/6
+    if (!near(sin(pi6), 0.5)) ++n;
+    // inverse trig: 4 atan(1) == pi
+    if (!near(atan(one) * (two + two), 3.14159265358979324)) ++n;
+    // hyperbolic identity: cosh^2 - sinh^2 == 1
+    if (!near(cosh(x) * cosh(x) - sinh(x) * sinh(x), 1.0)) ++n;
+    if (!near(tanh(x), std::tanh(1.0 / 3.0)))               ++n;
+    return n;
+}
+
+// (3) binary functions
+int verify_binary() {
+    int n = 0;
+    Real two = Real(1.0) + Real(1.0);
+    // pow(2, 10) == 1024 (exact integer power)
+    if (!near(pow(two, two * (two + two + (two / two))), 1024.0)) ++n;   // 2^10
+    // pow(x, 1/2) == sqrt(x)
+    Real x = two + two + two;                   // 6
+    if (!near(pow(x, Real(1.0) / two), std::sqrt(6.0))) ++n;
+    // hypot(3, 4) == 5
+    Real three = two + (two / two);
+    Real four  = two + two;
+    if (!near(hypot(three, four), 5.0)) ++n;
+    return n;
+}
+
+// (4) precision threads through the facade: a deeper operand yields a deeper result
+int verify_precision_threading() {
+    int n = 0;
+    elreal_precision_guard g(6);
+    Real two = Real(1.0) + Real(1.0);
+    Real r = sqrt(two);
+    if (r.precision() != 6) ++n;                  // result carries the operand's depth
+    if (r.limbs(r.precision()).size() < 2) ++n;   // sqrt(2) is irrational -> multi-block
+    return n;
+}
+
+} // anonymous
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal math facade: functions + constants (#1079 Phase 4)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+    // bound the working precision so the transcendental series stay quick while
+    // still resolving past host-double (this is the facade wiring test, not a
+    // precision sweep -- the ZBCL math is validated to hundreds of digits by the
+    // math/* suites).
+    elreal_precision_guard g(2);
+
+    nrOfFailedTestCases += verify_constants();
+    nrOfFailedTestCases += verify_unary();
+    nrOfFailedTestCases += verify_binary();
+    nrOfFailedTestCases += verify_precision_threading();
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/api/math.cpp
+++ b/elastic/elreal/api/math.cpp
@@ -6,6 +6,9 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
 #include <cmath>
+#include <cstdlib>      // EXIT_SUCCESS / EXIT_FAILURE
+#include <exception>    // std::exception
+#include <iostream>     // std::cerr / std::endl
 #include <string>
 
 #include <universal/number/elreal/elreal.hpp>

--- a/include/sw/universal/number/elreal/elreal.hpp
+++ b/include/sw/universal/number/elreal/elreal.hpp
@@ -45,16 +45,13 @@
 #include <universal/number/elreal/negate.hpp>
 #include <universal/number/elreal/multiply.hpp>
 #include <universal/number/elreal/divide.hpp>
-// Phase 7 (#931): math suite
-#include <universal/number/elreal/math/sqrt.hpp>
-#include <universal/number/elreal/math/hypot.hpp>
-#include <universal/number/elreal/math/constants.hpp>
-#include <universal/number/elreal/math/exponent.hpp>
-#include <universal/number/elreal/math/hyperbolic.hpp>
-#include <universal/number/elreal/math/trigonometry.hpp>
 // The elreal class facade: a plug-in arithmetic number system over the ZBCL
 // machinery above (lazy operators, runtime precision, depth-bounded compare).
 #include <universal/number/elreal/elreal_impl.hpp>
 #include <universal/number/elreal/numeric_limits.hpp>
 #include <universal/number/elreal/attributes.hpp>
 #include <universal/number/elreal/manipulators.hpp>
+// Phase 7 (#931) math suite, lifted to class elreal by the facade. mathlib.hpp
+// pulls in the ZBCL-level math/*.hpp (sqrt/hypot/exp/log/trig/hyperbolic/
+// constants) and wraps each at the elreal class level (#1079 Phase 4).
+#include <universal/number/elreal/mathlib.hpp>

--- a/include/sw/universal/number/elreal/mathlib.hpp
+++ b/include/sw/universal/number/elreal/mathlib.hpp
@@ -1,0 +1,82 @@
+#pragma once
+// mathlib.hpp: the elreal-class math facade.
+//
+// The math/*.hpp headers implement LFPERA sqrt / exp / log / trig / hyperbolic
+// and the named constants on the raw lazy ZBCL<FpType> co-list. This facade
+// lifts them to the class elreal so they participate in plug-in/templated kernels
+// like every other Universal number system's mathlib.
+//
+// Precision policy (matches the lazy operators in elreal_impl.hpp):
+//   - unary functions refine to the operand's runtime precision()
+//   - binary functions refine to the deeper of the two operands
+//   - named constants refine to the scoped default precision and carry it forward
+// All results stay lazy: the wrapped ZBCL is only forced at a boundary
+// (conversion / comparison / I/O), exactly as for the arithmetic operators.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>
+
+#include <universal/number/elreal/elreal_fwd.hpp>
+#include <universal/number/elreal/elreal_impl.hpp>
+#include <universal/number/elreal/math/sqrt.hpp>
+#include <universal/number/elreal/math/hypot.hpp>
+#include <universal/number/elreal/math/exponent.hpp>
+#include <universal/number/elreal/math/hyperbolic.hpp>
+#include <universal/number/elreal/math/trigonometry.hpp>
+#include <universal/number/elreal/math/constants.hpp>
+
+namespace sw { namespace universal {
+
+// ---------------------------------------------------------------------------
+// unary functions -- refine to the operand's runtime precision.
+// Each forwards to the ZBCL overload of the same name (resolved by argument
+// type: stream() yields a ZBCL<FpType>, so the two-argument ZBCL overload is
+// selected, never this single-argument elreal one).
+// ---------------------------------------------------------------------------
+template <typename FpType> inline elreal<FpType> sqrt(const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(sqrt(x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> exp (const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(exp (x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> log (const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(log (x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> sin (const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(sin (x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> cos (const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(cos (x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> tan (const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(tan (x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> asin(const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(asin(x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> acos(const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(acos(x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> atan(const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(atan(x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> sinh(const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(sinh(x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> cosh(const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(cosh(x.stream(), d), d); }
+template <typename FpType> inline elreal<FpType> tanh(const elreal<FpType>& x) { const std::size_t d = x.precision(); return elreal<FpType>(tanh(x.stream(), d), d); }
+
+// ---------------------------------------------------------------------------
+// binary functions -- refine to the deeper of the two operands.
+// ---------------------------------------------------------------------------
+template <typename FpType>
+inline elreal<FpType> pow(const elreal<FpType>& x, const elreal<FpType>& y) {
+    const std::size_t d = x.precision() > y.precision() ? x.precision() : y.precision();
+    return elreal<FpType>(pow(x.stream(), y.stream(), d), d);
+}
+template <typename FpType>
+inline elreal<FpType> hypot(const elreal<FpType>& x, const elreal<FpType>& y) {
+    const std::size_t d = x.precision() > y.precision() ? x.precision() : y.precision();
+    return elreal<FpType>(hypot(x.stream(), y.stream(), d), d);
+}
+
+// ---------------------------------------------------------------------------
+// named constants -- elreal at the ZBCL factory's tuned series depth; the
+// returned object reads at the scoped default precision. FpType defaults to
+// double (elreal64); supply it explicitly for other hosts, e.g. elreal_pi<float>().
+// ---------------------------------------------------------------------------
+template <typename FpType = double> inline elreal<FpType> elreal_e()           { return elreal<FpType>(e_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_pi()          { return elreal<FpType>(pi_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_ln2()         { return elreal<FpType>(ln2_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_ln10()        { return elreal<FpType>(ln10_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_log2_10()     { return elreal<FpType>(log2_10_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt2()       { return elreal<FpType>(sqrt2_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt3()       { return elreal<FpType>(sqrt3_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt5()       { return elreal<FpType>(sqrt5_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_phi()         { return elreal<FpType>(phi_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_euler_gamma() { return elreal<FpType>(euler_gamma_zbcl<FpType>()); }
+
+}} // namespace sw::universal


### PR DESCRIPTION
## Summary
Phase 4 of the elreal class facade (#1079): `mathlib.hpp` lifts the ZBCL-level
LFPERA math (`math/*.hpp`) to **class elreal**, so the standard functions and
named constants drop into templated / plug-in kernels like every other Universal
number system's mathlib.

- **Unary** (refine to the operand's `precision()`): `sqrt exp log sin cos tan
  asin acos atan sinh cosh tanh` -- each forwards to the same-named ZBCL overload
  via `stream()` and re-wraps the result. Stays lazy (forced only at a boundary).
- **Binary** (refine to the deeper operand): `pow`, `hypot`.
- **Constants** (`elreal` at the factory's tuned depth; `FpType` defaults to
  double): `elreal_pi/e/ln2/ln10/log2_10/sqrt2/sqrt3/sqrt5/phi/euler_gamma`.
- Umbrella now pulls the math suite in via `mathlib.hpp` (which includes the
  `math/*.hpp` headers) instead of including them directly.

## Changes
- `include/sw/universal/number/elreal/mathlib.hpp` -- NEW (the facade)
- `include/sw/universal/number/elreal/elreal.hpp` -- umbrella wiring
- `elastic/elreal/api/math.cpp` -- NEW test

## Test Results
| Target | gcc build | gcc test | clang build | clang test | gcc Debug+assert |
|--------|-----------|----------|-------------|------------|------------------|
| el_api_math | OK | PASS (9s) | OK | PASS | PASS (10s) |

Identities: `sqrt(2)^2=2`, `log(exp x)=x`, `exp(1)=e`, `sin^2+cos^2=1`,
`4 atan(1)=pi`, `cosh^2-sinh^2=1`, `pow(2,10)=1024`, `hypot(3,4)=5`, precision
threading. cppcheck + ASCII clean.

**Note:** the test skips `elreal_e()` / `elreal_euler_gamma()` (still the eager
`e_zbcl` / `euler_gamma_zbcl` path, ~10-16 s each -- online conversion is tracked
by #1061 Phase 3b); the `e` value is checked via `exp(1)`. The wrappers are
one-line-identical to the tested constants.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Relates to #1079

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an elreal math facade with standard functions (sqrt, exp/log, trigonometric, hyperbolic) and binary operations (pow, hypot) that automatically refine output precision based on inputs
  * Added named mathematical constants (π, e, ln2, ln10, √2, √3, √5, φ, γ)
* **Bug Fixes**
  * None
* **Tests**
  * Added a validation test program to compare elreal math results against reference double values, including precision checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->