### PR TITLE
perf(elreal): Abel-summed euler_gamma A-accumulation (~2.3-3.1x) (#1061 Phase 3b)

### DIFF
--- a/docs/design/elreal-euler-gamma.md
+++ b/docs/design/elreal-euler-gamma.md
@@ -1,0 +1,182 @@
+# elreal: computing Euler's gamma (Brent-McMillan B1 and the Abel reduction)
+
+## TL;DR
+
+Every other named constant in the `elreal` math suite (pi, e, ln2, ln10, phi,
+the sqrt radicals) has a rapidly-converging *elementary* series -- a Machin atan
+sum, an artanh sum, a Taylor exp, a Newton sqrt -- so each is just a streaming
+`infsum` over a significance-windowed term co-list (see
+`elreal-online-convergence.md`).
+
+The Euler-Mascheroni constant `gamma = 0.5772156649...` has **no** such series.
+It needs a real algorithm. `euler_gamma_zbcl` uses **Brent-McMillan B1**, whose
+cost is dominated by an `A(n) = sum_k w_k H_k` accumulation. This note records
+that algorithm and the **Abel reduction** (#1061 Phase 3b, PR #1088) that removed
+the harmonic numbers and the per-term full multiply from that accumulation,
+making it ~2.3-3.1x faster while staying value-identical to 305 decimal digits.
+It also records why a *true* asymptotic speedup (binary splitting) was deferred.
+
+## Why gamma is special
+
+`gamma = lim_{m->inf} (H_m - ln m)`, where `H_m = sum_{j=1}^m 1/j`. That defining
+limit converges like `1/m` -- useless for high precision. There is no known
+elementary fast series for gamma, unlike pi or e. The standard high-precision
+route is Brent-McMillan (1980), derived from the modified Bessel functions
+`I_0`, `K_0`.
+
+## Brent-McMillan B1
+
+For an integer parameter `n`,
+
+```
+gamma = A(n) / B(n) - ln(n) + O(pi * exp(-4n))
+```
+
+with
+
+```
+w_k  = (n^k / k!)^2                      (the common weight)
+B(n) = sum_{k>=0} w_k                     (~ I_0(2n)-like)
+A(n) = sum_{k>=0} w_k * H_k,   H_0 = 0,   H_k = H_{k-1} + 1/k
+```
+
+The truncation error is `~ pi * exp(-4n)`, so for `D` correct decimal digits pick
+`n >= D * ln(10) / 4`. In `euler_gamma_zbcl`, `n` is derived from the requested
+working depth (`n ~ targetDigits * ln(10)/4 + slack`).
+
+### Host-range constraint
+
+The intermediate `w_k = (n^k/k!)^2` peaks near `k = n` at magnitude `~ exp(2n)`.
+`n` grows with the requested precision, so the block significand has to carry that
+magnitude. A NARROW-exponent host (float, bfloat16; max `~10^38`) overflows once
+`n` exceeds `~44`. **High-precision gamma is therefore a double-host generator;**
+on narrow hosts keep the depth shallow (`n` below the overflow). This is the same
+constraint noted for the eager generator (#1053).
+
+### The peak, analytically
+
+The windowing (below) needs the peak exponent of `w_k`. Rather than run a whole
+recurrence just to find it (a redundant pass, removed in #1087), it is known by
+Stirling: at `k = n`, `n^n/n! ~ e^n / sqrt(2*pi*n)`, so
+
+```
+log2(w_n) ~ 2n*log2(e) - log2(2*pi*n)
+```
+
+accurate to ~1 bit -- far inside the windowing slack (see below).
+
+## Computing A and B in the ZBCL framework
+
+`w_k` follows a cheap scalar recurrence: `w_k = w_{k-1} * n^2 / k^2`. Each step is
+a single-block scalar multiply (`* n^2`) and a single-block scalar divide
+(`/ k^2`) on the ZBCL.
+
+`B(n)` is a plain streaming sum of the `w_k`, accumulated with `priestRenorm` and
+capped to the working depth (`cap = wdepth + 2` blocks): terms more than `cap`
+limbs below the running peak are negligible for the `O(1)` ratio `A/B`.
+
+**Windowing.** Only the `~sqrt(n)` terms near the peak contribute to the leading
+blocks; the tiny early terms and the decaying tail are skipped by pulling each
+contribution only down to a significance floor
+
+```
+aFloor = peakExp - cap * k    (k = block bit-width)
+```
+
+(`take_while_above`). This keeps the per-term work bounded.
+
+### The A-sum was the cost
+
+The naive `A(n) = sum_k w_k H_k` requires, per term:
+
+- maintaining the harmonic number `H_k` as a multi-block ZBCL (`H_k = H_{k-1} + 1/k`), and
+- a **full ZBCL x ZBCL multiply** `mul_online(w_k, H_k)`.
+
+That full multiply, over `~n` terms each at working depth, is the dominant cost of
+the whole constant (e.g. ~11 s at depth 16 before this change).
+
+## The Abel reduction
+
+Abel summation (summation by parts) rewrites the weighted sum exactly. With
+`B_k = sum_{j<=k} w_j` the partial sums and `tail_k = sum_{j>k} w_j = B - B_k`:
+
+```
+A = sum_{k>=0} w_k H_k = sum_{k>=0} tail_k / (k+1)
+```
+
+### Derivation
+
+`H_k = sum_{j=1}^{k} 1/j`, so by swapping the order of summation
+
+```
+A = sum_{k} w_k sum_{j=1}^{k} 1/j
+  = sum_{j>=1} (1/j) sum_{k>=j} w_k
+  = sum_{j>=1} (1/j) * tail_{j-1}
+  = sum_{m>=0} tail_m / (m+1)          (m = j-1)
+```
+
+Spot check (`K = 2`): `A = w_1 H_1 + w_2 H_2 = w_1 + 1.5 w_2`. The RHS is
+`tail_0/1 + tail_1/2 + tail_2/3 = (w_1+w_2) + w_2/2 + 0 = w_1 + 1.5 w_2`. Match.
+
+### Why it is faster
+
+The harmonic numbers vanish entirely, and the per-term **full multiply** becomes a
+per-term **single-block scalar division** `tail_k / (k+1)` -- the fast
+`twoDivZBCL` path. Concretely:
+
+- **Pass A** runs the `w_k` recurrence and sums `B = sum w_k`.
+- **Pass B** walks the *same* recurrence keeping a running
+  `tail = B - B_k` (forward subtraction `tail_k = tail_{k-1} - w_k`) and folds the
+  scalar quotient `tail_k/(k+1)` into `A`.
+
+A full multiply (`O(M(wdepth))`) per term is replaced by an add and a scalar
+divide (`O(wdepth)`) per term.
+
+### The one numerical subtlety
+
+`A = H_K*B - sum_k B_k/(k+1)` is the *naive* Abel form and is unusable: both
+terms grow like `B * ln K` and catastrophically cancel. The **convergent** form
+above (`sum tail_k/(k+1)`, all terms positive) avoids that.
+
+It has one residual cancellation: forming `tail_k = tail_{k-1} - w_k` to the right
+of the peak, where `w_k` dominates the remaining tail, loses bits. But those
+`tail_k` are themselves small contributors there, so the absolute error is bounded
+by roughly one ULP of the peak -- comfortably inside the `cap`-block guard
+(`cap*k - wbits` spare bits). This is not assumed; it is **verified** against the
+oracle.
+
+## Validation
+
+The exact-dyadic oracle (`verification/elreal_reference_digits.hpp`) compares the
+generated constant against a 320-digit mpmath reference. With the Abel reduction,
+`euler_gamma_zbcl<double>(20)` agrees to **305 digits** (threshold `>= 300`) on
+both gcc and clang -- identical to the prior implementation.
+
+> Gotcha: that 320-digit check lives in
+> `elastic/elreal/math/constants_highprecision.cpp` behind `#if REGRESSION_LEVEL_4`.
+> A default (`LEVEL_1`) build compiles it out and the test passes as a no-op. To
+> actually exercise it, build with `-DREGRESSION_LEVEL_4=1` (or the
+> `UNIVERSAL_BUILD_REGRESSION_LEVEL_4` CMake option).
+
+## What is NOT done: binary splitting
+
+The Abel reduction is a constant-factor win; Brent-McMillan is still inherently
+`O(n)` term-products, and `n ~ D`, so the cost is still `~O(D * M(D))`.
+
+The asymptotically-best approach is **binary splitting**: the `B` and `A` sums are
+holonomic, so a balanced `P/Q/B/T` recursion over the index range -- accumulating
+exact big-integer numerators/denominators and dividing once at the end -- computes
+gamma in `~O(M(D) log^2 D)`. That was deliberately deferred: it requires pulling
+arbitrary-precision integers (`einteger`) into the elreal math layer (which has no
+such dependency today), a new `einteger -> ZBCL` block-decomposition bridge, and a
+harmonic-aware splitting tuple, with no existing binary-splitting precedent in the
+repository to model on. It is tracked as a separate, larger effort.
+
+## References
+
+- R. P. Brent and E. M. McMillan, "Some new algorithms for high-precision
+  computation of Euler's constant", Math. Comp. 34 (1980), 305-312.
+- Abel summation (summation by parts), standard.
+- `elreal-online-convergence.md` -- the streaming `infsum` series framework the
+  other constants use.
+- `include/sw/universal/number/elreal/math/constants.hpp` -- `euler_gamma_zbcl`.

--- a/include/sw/universal/number/elreal/math/constants.hpp
+++ b/include/sw/universal/number/elreal/math/constants.hpp
@@ -222,36 +222,50 @@ inline ZBCL<FpType> euler_gamma_zbcl(std::size_t depth = 16) {
         acc = priestRenorm(pool);
         if (acc.size() > cap) acc.resize(cap);
     };
-    // The A-accumulation windows each product w_k*H_k to A's significance band, so the
-    // tiny early terms and the decaying tail are skipped -- only the ~sqrt(n) terms near
-    // the peak of w_k = (n^k/k!)^2 are multiplied in full. The peak (near k=n) is known
-    // analytically by Stirling: log2(w_n) ~ 2n*log2(e) - log2(2*pi*n), accurate to ~1 bit.
-    // A keeps cap (=wdepth+2) blocks below the peak, i.e. ~cap*k - wbits bits of slack, so
-    // the ~1-bit Stirling error is far inside the margin -- this replaces a full redundant
-    // peak-finding recurrence pass with an O(1) estimate. (#1061 Phase 3b)
+    // A(n) = sum_k w_k H_k is computed by ABEL SUMMATION as A = sum_{k>=0} tail_k/(k+1)
+    // with tail_k = sum_{j>k} w_j = B - B_k. This is all-positive accumulation that needs
+    // NO harmonic numbers and NO full per-term multiply: each term is a single-block scalar
+    // division tail_k/(k+1) (fast) in place of mul_online(w_k, H_k) (full ZBCL x ZBCL).
+    // (Algebraically: sum w_k H_k = sum_{k} (sum_{j>k} w_j)/(k+1); validated to 320 digits.)
+    //
+    // Windowing peak: w_k=(n^k/k!)^2 peaks near k=n at log2(w_n) ~ 2n*log2(e) - log2(2*pi*n)
+    // (Stirling, ~1-bit accurate). A keeps cap (=wdepth+2) blocks below it; the tail
+    // subtraction's cancellation right of the peak (where its terms are negligible) stays
+    // inside that guard. The analytic peak replaces a redundant peak-finding pass. (#1061 Ph3b)
     const double npd = static_cast<double>(n);
     const int peakExp = std::max(0, static_cast<int>(std::llround(
         2.0 * npd * 1.4426950408889634 - std::log2(6.283185307179586 * npd))));
-    // A keeps ~cap blocks below its peak (~peakExp); a product whose blocks all sit below
-    // that floor contributes nothing, so pull each w_k*H_k only down to it. aFloor sits a
-    // touch below A's true floor (A.peak = peakExp + scale(H_k)), so nothing is lost.
     const int aFloor = peakExp - static_cast<int>(cap) * block<FpType>::k;
 
-    // Pass 2: accumulate A(n) = sum w_k H_k, B(n) = sum w_k, H_k = H_{k-1} + 1/k.
+    // Pass A: B(n) = sum_k w_k,  w_k = w_{k-1} * n^2/k^2.
     ZBCL<FpType> w = one;
-    std::vector<B> Hblocks, Bblocks = w.take(cap), Ablocks;
+    std::vector<B> Bblocks = w.take(cap);
     for (std::size_t k = 1; ; ++k) {
         w = div(mul_scalar(B{ static_cast<FpType>(n2), 0 }, w, wdepth),
-                from_native<FpType>(static_cast<double>(k) * static_cast<double>(k)), wdepth); // *n^2/k^2
+                from_native<FpType>(static_cast<double>(k) * static_cast<double>(k)), wdepth);
         if (w.is_empty()) break;
-        fold(Hblocks, div(one, from_native<FpType>(static_cast<double>(k)), wdepth), wdepth);   // H_k += 1/k
-        ZBCL<FpType> Hk = zbcl_from_blocks<FpType>(Hblocks);
         fold(Bblocks, w, cap);
-        fold(Ablocks, detail::take_while_above(mul_online(w, Hk), aFloor), cap);                // w_k * H_k, windowed
         if (k > static_cast<std::size_t>(n) &&
             static_cast<int>(w.head().exponent()) < peakExp - wbits - 8) break;
     }
-    ZBCL<FpType> ratio = div(zbcl_from_blocks<FpType>(Ablocks), zbcl_from_blocks<FpType>(Bblocks), wdepth);
+    const ZBCL<FpType> Bfull = zbcl_from_blocks<FpType>(Bblocks);
+
+    // Pass B: A(n) = sum_{k>=0} tail_k/(k+1), tail_k = B - B_k (forward subtraction of w_k).
+    ZBCL<FpType> tail = add(Bfull, negate(one));                          // tail_0 = B - w_0
+    std::vector<B> Ablocks;
+    fold(Ablocks, detail::take_while_above(tail, aFloor), cap);           // k=0: tail_0 / 1
+    w = one;
+    for (std::size_t k = 1; ; ++k) {
+        w = div(mul_scalar(B{ static_cast<FpType>(n2), 0 }, w, wdepth),
+                from_native<FpType>(static_cast<double>(k) * static_cast<double>(k)), wdepth);
+        if (w.is_empty()) break;
+        tail = add(tail, negate(w));                                      // tail_k = tail_{k-1} - w_k
+        fold(Ablocks, detail::take_while_above(
+                 div(tail, from_native<FpType>(static_cast<double>(k + 1)), wdepth), aFloor), cap);
+        if (k > static_cast<std::size_t>(n) &&
+            static_cast<int>(w.head().exponent()) < peakExp - wbits - 8) break;
+    }
+    ZBCL<FpType> ratio = div(zbcl_from_blocks<FpType>(Ablocks), Bfull, wdepth);
     // ln(n) = e*ln2 + 2*artanh((m-1)/(m+1)), m = n / 2^e in [1,2). Pass `depth` (NOT
     // wdepth): the helpers add their own kSeriesGuard, and ln2_zbcl=artanh(1/3) is
     // costly over-deep.

--- a/include/sw/universal/number/elreal/math/constants.hpp
+++ b/include/sw/universal/number/elreal/math/constants.hpp
@@ -193,16 +193,17 @@ inline ZBCL<FpType> phi_zbcl(std::size_t depth = 16) {
 //   B(n) = sum_{k>=0} (n^k/k!)^2,  A(n) = sum_{k>=0} (n^k/k!)^2 * H_k,  H_0 = 0,
 //   |error| ~ pi*exp(-4n)  ->  n >= D*ln(10)/4 for D digits.
 // The Euler-Mascheroni constant has no rapidly-converging elementary series, so
-// (unlike pi/e/ln2) it needs a real algorithm. The per-term work is dominated by
-// the product w_k * H_k; the long tail of terms contributes only a few limbs each.
+// (unlike pi/e/ln2) it needs a real algorithm. The A(n) = sum_k w_k H_k sum is
+// computed by Abel summation (sum tail_k/(k+1)) -- no harmonic numbers, no per-term
+// full multiply. Full derivation, the cancellation analysis, and the deferred
+// binary-splitting alternative are in docs/design/elreal-euler-gamma.md (#1061 Ph3b).
 //
 // HOST RANGE: the intermediate w_k = (n^k/k!)^2 peaks at ~exp(2n) near k=n. n grows
 // with the requested precision (n ~ D*ln(10)/4), and the block significand carries
 // that magnitude, so a NARROW-exponent host (float/bfloat16, max ~10^38) overflows
 // once n exceeds ~44 (a few blocks of depth). High-precision euler_gamma is therefore
 // a double-host generator; on narrow hosts keep depth shallow (n below the overflow).
-// Validated to 307 digits on double (#1053); eager like the other constants -- the
-// online-ops speedup for the whole series layer is #1061 Phase 3.
+// Validated to 305 digits on double vs the 320-digit reference (#1053, REGRESSION_LEVEL_4).
 template <typename FpType>
 inline ZBCL<FpType> euler_gamma_zbcl(std::size_t depth = 16) {
     using B = block<FpType>;


### PR DESCRIPTION
## Summary
The Brent-McMillan B1 `A(n) = sum_k w_k H_k` was the residual cost in `euler_gamma`:
a full per-term ZBCL x ZBCL multiply `mul_online(w_k, H_k)` plus per-term harmonic
maintenance. Replace it with **Abel summation**:

```
sum_k w_k H_k  ==  sum_{k>=0} tail_k/(k+1),   tail_k = sum_{j>k} w_j = B - B_k
```

(verified algebraically). All-positive accumulation that needs **no harmonic numbers**
and **no full multiply**:
- **Pass A** sums `B = sum w_k` (the w recurrence).
- **Pass B** walks the same recurrence keeping `tail = B - B_k` (forward subtraction)
  and folds the **single-block scalar division** `tail_k/(k+1)` into A.

The tail-subtraction's cancellation right of the w-peak (where its terms are
negligible) stays inside the cap-block guard -- confirmed by the 320-digit oracle.

This is a constant-factor win in the existing ZBCL framework (no einteger dependency).
Brent-McMillan is still inherently O(n) products; the asymptotic win (binary-splitting
einteger P/Q/B/T) is left as a separate, larger effort.

## Results
| depth | before | after | speedup |
|------:|-------:|------:|--------:|
| 8 | 4408 ms | 1890 ms | ~2.3x |
| 16 | 10986 ms | 3578 ms | ~3.1x |

## Validation
- **euler_gamma: 305 digits** vs the 320-digit mpmath reference (REGRESSION_LEVEL_4)
  on **gcc + clang** (>= 300 threshold).
- Full elreal ctest **42/42** on gcc + clang; cppcheck + ASCII clean.

## Changes
- `include/sw/universal/number/elreal/math/constants.hpp` -- `euler_gamma_zbcl`
  A-accumulation rewritten (two passes, Abel sum); harmonic machinery removed.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Relates to #1061

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the computation strategy for a key mathematical constant (Euler’s gamma) in the universal number library by using a more efficient summation-by-parts/Abel approach, reducing per-term work while preserving precision.
- **Documentation**
  - Added detailed design notes explaining the updated calculation method, numerical considerations, and validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->