### PR TITLE
feat(efloat): implement logarithmic suite (log2, log10, log1p)

### DIFF
--- a/elastic/efloat/math/math.cpp
+++ b/elastic/efloat/math/math.cpp
@@ -173,6 +173,19 @@ namespace {
 				if (reportTestCases) std::cout << "    FAIL: log(-1.0) did not set InvalidOperation\n";
 				++failures;
 			}
+
+			// 3e. Exceptional value: log(-inf) -> NaN + InvalidOperation (signbit check)
+			clear_efloat_exceptions();
+			efloat<4> neg_inf;
+			neg_inf.setinf(true);
+			if (!log(neg_inf).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: log(-inf) did not return NaN\n";
+				++failures;
+			}
+			if (!has_efloat_exception(ExceptionFlag::InvalidOperation)) {
+				if (reportTestCases) std::cout << "    FAIL: log(-inf) did not set InvalidOperation\n";
+				++failures;
+			}
 		}
 
 		// ---------------------------------------------------------------------
@@ -225,6 +238,19 @@ namespace {
 			}
 			if (!has_efloat_exception(ExceptionFlag::DivisionByZero)) {
 				if (reportTestCases) std::cout << "    FAIL: log1p(-1.0) did not set DivisionByZero\n";
+				++failures;
+			}
+
+			// 4f. log1p(-inf) -> NaN + InvalidOperation (extended signbit domain check)
+			clear_efloat_exceptions();
+			efloat<4> neg_inf;
+			neg_inf.setinf(true);
+			if (!log1p(neg_inf).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: log1p(-inf) did not return NaN\n";
+				++failures;
+			}
+			if (!has_efloat_exception(ExceptionFlag::InvalidOperation)) {
+				if (reportTestCases) std::cout << "    FAIL: log1p(-inf) did not set InvalidOperation\n";
 				++failures;
 			}
 		}

--- a/elastic/efloat/math/math.cpp
+++ b/elastic/efloat/math/math.cpp
@@ -4,6 +4,7 @@
 //   - Tier 1: Bootstrap Square Root (sqrt)
 //   - Tier 1: Natural Logarithm (log)
 //   - Tier 1: Exponential (exp)
+//   - Logarithmic Suite: log2, log10, log1p (Issue #1108)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -174,6 +175,60 @@ namespace {
 			}
 		}
 
+		// ---------------------------------------------------------------------
+		// 4. Logarithmic Suite Validation (log2, log10, log1p)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying Logarithmic Suite (log2, log10, log1p)...\n";
+		{
+			clear_efloat_exceptions();
+
+			// 4a. log2(4.0) == 2.0
+			efloat<8> four(4.0);
+			if (!IsClose(log2(four), 2.0)) {
+				if (reportTestCases) std::cout << "    FAIL: log2(4.0) is not 2.0\n";
+				++failures;
+			}
+
+			// 4b. log10(100.0) == 2.0
+			efloat<8> hundred(100.0);
+			if (!IsClose(log10(hundred), 2.0)) {
+				if (reportTestCases) std::cout << "    FAIL: log10(100.0) is not 2.0\n";
+				++failures;
+			}
+
+			// 4c. log1p(1e-12) avoids catastrophic cancellation as x -> 0
+			efloat<8> small;
+			parse("0.000000000001", small); // 10^-12
+			double expected_log1p = std::log1p(1e-12);
+			if (!IsClose(log1p(small), expected_log1p, 1e-25)) {
+				if (reportTestCases) std::cout << "    FAIL: log1p(10^-12) is inaccurate. Result: " << double(log1p(small)) << "\n";
+				++failures;
+			}
+
+			// 4d. log1p(-2.0) -> NaN + InvalidOperation
+			efloat<4> neg_two(-2.0);
+			if (!log1p(neg_two).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: log1p(-2.0) did not return NaN\n";
+				++failures;
+			}
+			if (!has_efloat_exception(ExceptionFlag::InvalidOperation)) {
+				if (reportTestCases) std::cout << "    FAIL: log1p(-2.0) did not set InvalidOperation\n";
+				++failures;
+			}
+
+			// 4e. log1p(-1.0) -> -Inf + DivisionByZero
+			efloat<4> neg_one(-1.0);
+			efloat<4> res_log1p = log1p(neg_one);
+			if (!res_log1p.isinf() || res_log1p.sign() != -1) {
+				if (reportTestCases) std::cout << "    FAIL: log1p(-1.0) did not return -Inf\n";
+				++failures;
+			}
+			if (!has_efloat_exception(ExceptionFlag::DivisionByZero)) {
+				if (reportTestCases) std::cout << "    FAIL: log1p(-1.0) did not set DivisionByZero\n";
+				++failures;
+			}
+		}
+
 		clear_efloat_exceptions();
 		return failures;
 	}
@@ -195,7 +250,7 @@ namespace {
 int main() try {
 	using namespace sw::universal;
 
-	std::string test_suite          = "efloat Tier-1 mathematical functions";
+	std::string test_suite          = "efloat mathematical functions library";
 	std::string test_tag            = "math";
 	bool        reportTestCases     = true;
 	int         nrOfFailedTestCases = 0;

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -331,10 +331,11 @@ public:
 		if (_limb.size() == 1 && _limb[0] == 0x80000000) {
 			unsigned target_prec = _precision_limbs;
 			int64_t old_exp = _exponent;
+			bool original_sign = _sign;
 			*this = rhs;
 			_precision_limbs = target_prec;
 			_exponent += old_exp;
-			_sign = (_sign != rhs._sign);
+			_sign = (original_sign != rhs._sign);
 			return *this;
 		}
 

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -561,6 +561,14 @@ public:
 		}
 	}
 
+	static constexpr int compare_limbs(const std::vector<uint32_t>& a, const std::vector<uint32_t>& b) noexcept {
+		for (size_t i = 0; i < a.size(); ++i) {
+			if (a[i] > b[i]) return 1;
+			if (b[i] > a[i]) return -1;
+		}
+		return 0;
+	}
+
 protected:
 	FloatingPointState    _state;    // exceptional state
 	bool                  _sign;     // sign of the number: -1 if true, +1 if false, zero is positive
@@ -754,14 +762,6 @@ protected:
 				}
 			}
 		}
-	}
-
-	static constexpr int compare_limbs(const std::vector<uint32_t>& a, const std::vector<uint32_t>& b) noexcept {
-		for (size_t i = 0; i < a.size(); ++i) {
-			if (a[i] > b[i]) return 1;
-			if (b[i] > a[i]) return -1;
-		}
-		return 0;
 	}
 
 
@@ -1442,8 +1442,39 @@ constexpr bool operator!=(const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) 
 	return !operator==(lhs, rhs);
 }
 template<unsigned nlimbs>
-constexpr bool operator< (const efloat<nlimbs>& /* lhs */, const efloat<nlimbs>& /* rhs */) noexcept {
-	return false; // lhs and rhs are the same
+constexpr bool operator< (const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {
+	if (lhs.isnan() || rhs.isnan()) return false;
+	if (lhs.iszero() && rhs.iszero()) return false;
+
+	int lhs_sign = lhs.sign();
+	int rhs_sign = rhs.sign();
+	if (lhs_sign != rhs_sign) {
+		return lhs_sign == -1;
+	}
+
+	// Signs are equal. Compare absolute magnitudes.
+	int abs_cmp = 0;
+	if (lhs.isinf()) {
+		if (rhs.isinf()) abs_cmp = 0;
+		else abs_cmp = 1;
+	} else if (rhs.isinf()) {
+		abs_cmp = -1;
+	} else {
+		if (lhs.scale() < rhs.scale()) {
+			abs_cmp = -1;
+		} else if (lhs.scale() > rhs.scale()) {
+			abs_cmp = 1;
+		} else {
+			// exponents are equal, compare limbs
+			abs_cmp = efloat<nlimbs>::compare_limbs(lhs.bits(), rhs.bits());
+		}
+	}
+
+	if (lhs_sign == -1) {
+		return abs_cmp > 0; // for negative, larger absolute magnitude is smaller
+	} else {
+		return abs_cmp < 0; // for positive, smaller absolute magnitude is smaller
+	}
 }
 template<unsigned nlimbs>
 constexpr bool operator> (const efloat<nlimbs>& lhs, const efloat<nlimbs>& rhs) noexcept {

--- a/include/sw/universal/number/efloat/math/logarithm.hpp
+++ b/include/sw/universal/number/efloat/math/logarithm.hpp
@@ -23,7 +23,8 @@ constexpr efloat<nlimbs> log(const efloat<nlimbs>& x) {
 		}
 		return neg_inf;
 	}
-	if (x.isneg()) {
+	// Signbit check captures both negative normal values and negative infinity
+	if (x.sign() == -1) {
 		efloat<nlimbs> nan;
 		nan.setnan();
 		if (!std::is_constant_evaluated()) {
@@ -61,7 +62,7 @@ constexpr efloat<nlimbs> log2(const efloat<nlimbs>& x) {
 		}
 		return neg_inf;
 	}
-	if (x.isneg()) {
+	if (x.sign() == -1) {
 		efloat<nlimbs> nan;
 		nan.setnan();
 		if (!std::is_constant_evaluated()) {
@@ -89,7 +90,7 @@ constexpr efloat<nlimbs> log10(const efloat<nlimbs>& x) {
 		}
 		return neg_inf;
 	}
-	if (x.isneg()) {
+	if (x.sign() == -1) {
 		efloat<nlimbs> nan;
 		nan.setnan();
 		if (!std::is_constant_evaluated()) {
@@ -127,7 +128,7 @@ constexpr efloat<nlimbs> log1p(const efloat<nlimbs>& x) {
 		return neg_inf;
 	}
 	if (x.isinf()) {
-		if (x.isneg()) {
+		if (x.sign() == -1) {
 			efloat<nlimbs> nan;
 			nan.setnan();
 			if (!std::is_constant_evaluated()) {
@@ -138,18 +139,22 @@ constexpr efloat<nlimbs> log1p(const efloat<nlimbs>& x) {
 		return x;
 	}
 
-	double x_dbl = double(x);
-	if (std::abs(x_dbl) < 0.375) {
+	// Precision-safe range check completely in efloat space (avoids double underflows)
+	if (abs(x) < efloat<nlimbs>(0.375)) {
 		// Taylor series for log(1 + x) prevents cancellation as x -> 0
 		efloat<nlimbs> sum(0.0);
 		efloat<nlimbs> term(x);
 		efloat<nlimbs> x_pow(x);
 
 		sum += term;
-		for (unsigned n = 2; n < 100; ++n) {
+		for (unsigned n = 2; n < 200; ++n) {
 			x_pow = x_pow * x;
 			term = x_pow / efloat<nlimbs>(n);
-			if (term.iszero()) break;
+			
+			// Dynamic precision-safe termination: stops when next term cannot affect the sum
+			if (term.iszero() || term.scale() < sum.scale() - static_cast<int64_t>(sum.get_precision())) {
+				break;
+			}
 			if (n % 2 == 0) {
 				sum -= term;
 			} else {

--- a/include/sw/universal/number/efloat/math/logarithm.hpp
+++ b/include/sw/universal/number/efloat/math/logarithm.hpp
@@ -48,4 +48,118 @@ constexpr efloat<nlimbs> log(const efloat<nlimbs>& x) {
 	return y;
 }
 
+// Logarithm base 2 function for efloat
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> log2(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) {
+		efloat<nlimbs> neg_inf;
+		neg_inf.setinf(true);
+		if (!std::is_constant_evaluated()) {
+			neg_inf.set_precision(x.get_precision());
+			efloat_exception_flags.set(ExceptionFlag::DivisionByZero);
+		}
+		return neg_inf;
+	}
+	if (x.isneg()) {
+		efloat<nlimbs> nan;
+		nan.setnan();
+		if (!std::is_constant_evaluated()) {
+			efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		}
+		return nan;
+	}
+	if (x.isinf()) return x;
+
+	efloat<nlimbs> ln2;
+	parse("0.69314718055994530941723212145817656807550013436025525412068", ln2);
+	return log(x) / ln2;
+}
+
+// Logarithm base 10 function for efloat
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> log10(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) {
+		efloat<nlimbs> neg_inf;
+		neg_inf.setinf(true);
+		if (!std::is_constant_evaluated()) {
+			neg_inf.set_precision(x.get_precision());
+			efloat_exception_flags.set(ExceptionFlag::DivisionByZero);
+		}
+		return neg_inf;
+	}
+	if (x.isneg()) {
+		efloat<nlimbs> nan;
+		nan.setnan();
+		if (!std::is_constant_evaluated()) {
+			efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		}
+		return nan;
+	}
+	if (x.isinf()) return x;
+
+	efloat<nlimbs> ln10;
+	parse("2.3025850929940456840179914546843642076011014886287729760333", ln10);
+	return log(x) / ln10;
+}
+
+// Natural logarithm of 1 + x function for efloat
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> log1p(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) return x;
+	if (x < efloat<nlimbs>(-1.0)) {
+		efloat<nlimbs> nan;
+		nan.setnan();
+		if (!std::is_constant_evaluated()) {
+			efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		}
+		return nan;
+	}
+	if (x == efloat<nlimbs>(-1.0)) {
+		efloat<nlimbs> neg_inf;
+		neg_inf.setinf(true);
+		if (!std::is_constant_evaluated()) {
+			neg_inf.set_precision(x.get_precision());
+			efloat_exception_flags.set(ExceptionFlag::DivisionByZero);
+		}
+		return neg_inf;
+	}
+	if (x.isinf()) {
+		if (x.isneg()) {
+			efloat<nlimbs> nan;
+			nan.setnan();
+			if (!std::is_constant_evaluated()) {
+				efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+			}
+			return nan;
+		}
+		return x;
+	}
+
+	double x_dbl = double(x);
+	if (std::abs(x_dbl) < 0.375) {
+		// Taylor series for log(1 + x) prevents cancellation as x -> 0
+		efloat<nlimbs> sum(0.0);
+		efloat<nlimbs> term(x);
+		efloat<nlimbs> x_pow(x);
+
+		sum += term;
+		for (unsigned n = 2; n < 100; ++n) {
+			x_pow = x_pow * x;
+			term = x_pow / efloat<nlimbs>(n);
+			if (term.iszero()) break;
+			if (n % 2 == 0) {
+				sum -= term;
+			} else {
+				sum += term;
+			}
+		}
+		return sum;
+	} else {
+		return log(efloat<nlimbs>(1.0) + x);
+	}
+}
+
 }} // namespace sw::universal


### PR DESCRIPTION
## Description

This PR implements the completed **IEEE-754 standard-compliant Logarithmic Functions Suite** for the arbitrary-precision `efloat` template class, completing **Issue #1108 (Logarithmic Functions)**.

By leveraging our robust natural `log()`, we have completed standard math libraries for base-2, base-10, and cancellation-free small-fraction natural logarithms.

### Key Changes:

1.  **Exposed Logarithmic Suite (`math/logarithm.hpp`)**:
    *   **`log2(x)`**: Implemented logarithm base 2: $\log_2(x) = \ln(x) / \ln(2)$ utilizing high-precision `ln2`.
    *   **`log10(x)`**: Implemented logarithm base 10: $\log_{10}(x) = \ln(x) / \ln(10)$ utilizing high-precision `ln10` ($2.3025850929940...$).
    *   **`log1p(x)`**: Implemented the natural logarithm of $1 + x$ which is critical for preventing catastrophic cancellation errors as $x \to 0$. For small $x$ ($|x| < 0.375$), it is evaluated using Taylor series expansion: $\sum (-1)^{n-1} x^n / n$. Otherwise, it falls back to `log(1.0 + x)`.

2.  **Core Power-of-2 Sign Clobbering Fix (`efloat_impl.hpp`)**:
    *   **The Bug**: Discovered that inside `operator*=`, the second power-of-2 bypass block (when `*this` is a power of 2) was copy-assigning `*this = rhs;` before executing the sign XOR calculation `_sign = (_sign != rhs._sign);`. Since `_sign` was already copied from `rhs`, this evaluated to `rhs._sign != rhs._sign` which is always `false` (positive), making the product of a power of 2 by *any* signed number erroneously positive! This broke Taylor series convergence when `r` was negative.
    *   **The Fix**: Saved the original sign into a local boolean `bool original_sign = _sign;` before the copy-assignment and evaluated the XOR using the original sign: `_sign = (original_sign != rhs._sign);`.

3.  **Expanded Math Regression Tests (`math.cpp`)**:
    *   Expanded `math.cpp` inside `elastic/efloat/math/` to cover:
        *   **`log2`**: `log2(4.0) == 2.0`.
        *   **`log10`**: `log10(100.0) == 2.0`.
        *   **`log1p`**: `log1p(1e-12)` (avoids cancellation as $x \to 0$), negative bounds `log1p(-2.0) == NaN` (`InvalidOperation`), and division limits `log1p(-1.0) == -Inf` (`DivisionByZero`).

### Verification

*   All tests compile cleanly with C++20 standard under CMake (`UNIVERSAL_BUILD_CI=ON`).
*   Passed all foundational regression tests:
    ```
    efloat mathematical functions library: report test cases
      Verifying Square Root (sqrt)...
      Verifying Exponential (exp)...
      Verifying Logarithm (log)...
      Verifying Logarithmic Suite (log2, log10, log1p)...
    efloat                                                       math foundational PASS
    efloat mathematical functions library: PASS
    ```

Resolves #1108
Relates to parent Issue #1092, Epic #1101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `log2`, `log10`, and `log1p` on efloat values, including improved handling for edge cases like zero, negative inputs, and infinities.
  * `log1p` now uses a more accurate approach for values near zero to reduce precision loss.

* **Bug Fixes**
  * Corrected sign handling in multiplication for a special fast-path case, improving result accuracy.
  * Expanded regression coverage for mathematical functions, including checks for expected exceptional behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->