### PR TITLE
feat(efloat): implement mathematical truncation and rounding library

### DIFF
--- a/elastic/efloat/math/truncate.cpp
+++ b/elastic/efloat/math/truncate.cpp
@@ -43,6 +43,13 @@ namespace {
 				if (reportTestCases) std::cout << "    FAIL: trunc(1.75) did not raise Inexact\n";
 				++failures;
 			}
+			// Negative Zero: trunc(-0.25) == -0.0 (preserves negative sign)
+			efloat<4> small_neg(-0.25);
+			efloat<4> res_trunc = trunc(small_neg);
+			if (res_trunc != 0.0 || res_trunc.sign() != -1) {
+				if (reportTestCases) std::cout << "    FAIL: trunc(-0.25) did not return negative zero. Result: " << double(res_trunc) << "\n";
+				++failures;
+			}
 		}
 
 		// ---------------------------------------------------------------------
@@ -119,6 +126,28 @@ namespace {
 				if (reportTestCases) std::cout << "    FAIL: rint(2.5) is not 2.0. Result: " << double(rint(half2)) << "\n";
 				++failures;
 			}
+
+			// Verify dynamic rounding mode integration on rint
+			// Toward Positive: positive inexact halfway rounds up!
+			efloat_rounding_mode = RoundingMode::RoundTowardPositive;
+			{
+				efloat<4> half(1.5);
+				if (rint(half) != 2.0) {
+					if (reportTestCases) std::cout << "    FAIL: rint(1.5) under RoundTowardPositive did not round up to 2.0\n";
+					++failures;
+				}
+			}
+			// Toward Negative: positive inexact halfway truncates!
+			efloat_rounding_mode = RoundingMode::RoundTowardNegative;
+			{
+				efloat<4> half(1.5);
+				if (rint(half) != 1.0) {
+					if (reportTestCases) std::cout << "    FAIL: rint(1.5) under RoundTowardNegative did not truncate to 1.0. Result: " << double(rint(half)) << "\n";
+					++failures;
+				}
+			}
+			// Restore default rounding
+			efloat_rounding_mode = RoundingMode::RoundToNearest;
 		}
 
 		// ---------------------------------------------------------------------
@@ -127,8 +156,12 @@ namespace {
 		if (reportTestCases) std::cout << "  Verifying nearbyint...\n";
 		{
 			clear_efloat_exceptions();
-			efloat<4> half(1.5);
-			nearbyint(half);
+			efloat<4> half(2.5); // test halfway-to-even: should yield exactly 2.0
+			efloat<4> res_near = nearbyint(half);
+			if (res_near != 2.0) {
+				if (reportTestCases) std::cout << "    FAIL: nearbyint(2.5) did not return nearest-even 2.0. Result: " << double(res_near) << "\n";
+				++failures;
+			}
 			if (has_efloat_exception(ExceptionFlag::Inexact)) {
 				if (reportTestCases) std::cout << "    FAIL: nearbyint erroneously raised Inexact\n";
 				++failures;
@@ -147,6 +180,13 @@ namespace {
 			}
 			if (llrint(val) != 2LL) {
 				if (reportTestCases) std::cout << "    FAIL: llrint(1.5) is not 2LL\n";
+				++failures;
+			}
+
+			// Verify high-precision exact integers above 2^53 do not get lost in lrint (CodeRabbit feedback)
+			efloat<4> large(9007199254740993ULL); // 2^53 + 1
+			if (llrint(large) != 9007199254740993LL) {
+				if (reportTestCases) std::cout << "    FAIL: llrint(2^53 + 1) suffered from double-cast truncation. Result: " << llrint(large) << "\n";
 				++failures;
 			}
 		}

--- a/elastic/efloat/math/truncate.cpp
+++ b/elastic/efloat/math/truncate.cpp
@@ -136,6 +136,11 @@ namespace {
 					if (reportTestCases) std::cout << "    FAIL: rint(1.5) under RoundTowardPositive did not round up to 2.0\n";
 					++failures;
 				}
+				efloat<4> small(0.25);
+				if (rint(small) != 1.0) {
+					if (reportTestCases) std::cout << "    FAIL: rint(0.25) under RoundTowardPositive did not round up to 1.0\n";
+					++failures;
+				}
 			}
 			// Toward Negative: positive inexact halfway truncates!
 			efloat_rounding_mode = RoundingMode::RoundTowardNegative;
@@ -143,6 +148,11 @@ namespace {
 				efloat<4> half(1.5);
 				if (rint(half) != 1.0) {
 					if (reportTestCases) std::cout << "    FAIL: rint(1.5) under RoundTowardNegative did not truncate to 1.0. Result: " << double(rint(half)) << "\n";
+					++failures;
+				}
+				efloat<4> small(-0.25);
+				if (rint(small) != -1.0) {
+					if (reportTestCases) std::cout << "    FAIL: rint(-0.25) under RoundTowardNegative did not round down to -1.0\n";
 					++failures;
 				}
 			}

--- a/elastic/efloat/math/truncate.cpp
+++ b/elastic/efloat/math/truncate.cpp
@@ -1,0 +1,205 @@
+// truncate.cpp: regression tests for efloat mathematical truncation and rounding functions.
+//
+// Categories tested:
+//   - trunc, floor, ceil, round, rint, nearbyint, lrint, llrint
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	int VerifyEfloatTruncation(bool reportTestCases) {
+		using namespace sw::universal;
+		int failures = 0;
+
+		// ---------------------------------------------------------------------
+		// 1. trunc Validation (Round toward Zero)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying trunc...\n";
+		{
+			// Positive: trunc(1.75) == 1.0
+			efloat<4> pos(1.75);
+			if (trunc(pos) != 1.0) {
+				if (reportTestCases) std::cout << "    FAIL: trunc(1.75) is not 1.0. Result: " << double(trunc(pos)) << "\n";
+				++failures;
+			}
+			// Negative: trunc(-1.75) == -1.0
+			efloat<4> neg(-1.75);
+			if (trunc(neg) != -1.0) {
+				if (reportTestCases) std::cout << "    FAIL: trunc(-1.75) is not -1.0. Result: " << double(trunc(neg)) << "\n";
+				++failures;
+			}
+			// Inexact check
+			clear_efloat_exceptions();
+			trunc(pos);
+			if (!has_efloat_exception(ExceptionFlag::Inexact)) {
+				if (reportTestCases) std::cout << "    FAIL: trunc(1.75) did not raise Inexact\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 2. floor Validation (Round toward -Infinity)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying floor...\n";
+		{
+			// Positive: floor(1.75) == 1.0
+			efloat<4> pos(1.75);
+			if (floor(pos) != 1.0) {
+				if (reportTestCases) std::cout << "    FAIL: floor(1.75) is not 1.0\n";
+				++failures;
+			}
+			// Negative: floor(-1.75) == -2.0
+			efloat<4> neg(-1.75);
+			if (floor(neg) != -2.0) {
+				if (reportTestCases) std::cout << "    FAIL: floor(-1.75) is not -2.0. Result: " << double(floor(neg)) << "\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 3. ceil Validation (Round toward +Infinity)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying ceil...\n";
+		{
+			// Positive: ceil(1.75) == 2.0
+			efloat<4> pos(1.75);
+			if (ceil(pos) != 2.0) {
+				if (reportTestCases) std::cout << "    FAIL: ceil(1.75) is not 2.0\n";
+				++failures;
+			}
+			// Negative: ceil(-1.75) == -1.0
+			efloat<4> neg(-1.75);
+			if (ceil(neg) != -1.0) {
+				if (reportTestCases) std::cout << "    FAIL: ceil(-1.75) is not -1.0\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 4. round Validation (Round to Nearest, Halfway away from Zero)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying round...\n";
+		{
+			// Halfway positive: round(1.5) == 2.0
+			efloat<4> pos_half(1.5);
+			if (round(pos_half) != 2.0) {
+				if (reportTestCases) std::cout << "    FAIL: round(1.5) is not 2.0. Result: " << double(round(pos_half)) << "\n";
+				++failures;
+			}
+			// Halfway negative: round(-1.5) == -2.0
+			efloat<4> neg_half(-1.5);
+			if (round(neg_half) != -2.0) {
+				if (reportTestCases) std::cout << "    FAIL: round(-1.5) is not -2.0. Result: " << double(round(neg_half)) << "\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 5. rint Validation (Round to Nearest, Halfway to Even)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying rint...\n";
+		{
+			// Halfway to even 1: rint(1.5) == 2.0 (nearest even integer)
+			efloat<4> half1(1.5);
+			if (rint(half1) != 2.0) {
+				if (reportTestCases) std::cout << "    FAIL: rint(1.5) is not 2.0\n";
+				++failures;
+			}
+			// Halfway to even 2: rint(2.5) == 2.0 (nearest even integer)
+			efloat<4> half2(2.5);
+			if (rint(half2) != 2.0) {
+				if (reportTestCases) std::cout << "    FAIL: rint(2.5) is not 2.0. Result: " << double(rint(half2)) << "\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 6. nearbyint Validation (Same as rint but suppresses Inexact)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying nearbyint...\n";
+		{
+			clear_efloat_exceptions();
+			efloat<4> half(1.5);
+			nearbyint(half);
+			if (has_efloat_exception(ExceptionFlag::Inexact)) {
+				if (reportTestCases) std::cout << "    FAIL: nearbyint erroneously raised Inexact\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 7. lrint & llrint Validation
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying lrint and llrint...\n";
+		{
+			efloat<4> val(1.5);
+			if (lrint(val) != 2L) {
+				if (reportTestCases) std::cout << "    FAIL: lrint(1.5) is not 2L\n";
+				++failures;
+			}
+			if (llrint(val) != 2LL) {
+				if (reportTestCases) std::cout << "    FAIL: llrint(1.5) is not 2LL\n";
+				++failures;
+			}
+		}
+
+		return failures;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat mathematical truncation library";
+	std::string test_tag            = "truncate";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatTruncation(reportTestCases), "efloat", "truncate manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatTruncation(reportTestCases), "efloat", "truncate foundational");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -1220,6 +1220,18 @@ private:
 	// find the most significant bit set
 	template<unsigned nnlimbs>
 	friend signed findMsb(const efloat<nnlimbs>& v);
+
+	// mathematical truncation friend functions
+	template<unsigned nnlimbs>
+	friend constexpr efloat<nnlimbs> trunc(const efloat<nnlimbs>& x);
+	template<unsigned nnlimbs>
+	friend constexpr efloat<nnlimbs> floor(const efloat<nnlimbs>& x);
+	template<unsigned nnlimbs>
+	friend constexpr efloat<nnlimbs> ceil(const efloat<nnlimbs>& x);
+	template<unsigned nnlimbs>
+	friend constexpr efloat<nnlimbs> round(const efloat<nnlimbs>& x);
+	template<unsigned nnlimbs>
+	friend constexpr efloat<nnlimbs> rint(const efloat<nnlimbs>& x);
 	};
 
 	// to_binary formatter for efloat to support test reporters

--- a/include/sw/universal/number/efloat/math/truncate.hpp
+++ b/include/sw/universal/number/efloat/math/truncate.hpp
@@ -283,6 +283,10 @@ constexpr efloat<nlimbs> rint(const efloat<nlimbs>& x) {
 		}
 	}
 
+	efloat<nlimbs> res(x);
+	bool original_sign = res._sign;
+	bool inexact = clear_fractional_limbs(res._limb, exp);
+
 	bool round_up = false;
 	switch (efloat_rounding_mode) {
 	case RoundingMode::RoundToNearest:
@@ -291,16 +295,13 @@ constexpr efloat<nlimbs> rint(const efloat<nlimbs>& x) {
 	case RoundingMode::RoundToZero:
 		break;
 	case RoundingMode::RoundTowardPositive:
-		round_up = (!x._sign) && (guard || sticky);
+		round_up = (!x._sign) && inexact;
 		break;
 	case RoundingMode::RoundTowardNegative:
-		round_up = (x._sign) && (guard || sticky);
+		round_up = (x._sign) && inexact;
 		break;
 	}
 
-	efloat<nlimbs> res(x);
-	bool original_sign = res._sign;
-	bool inexact = clear_fractional_limbs(res._limb, exp);
 	if (inexact) {
 		if (!std::is_constant_evaluated()) {
 			efloat_exception_flags.set(ExceptionFlag::Inexact);

--- a/include/sw/universal/number/efloat/math/truncate.hpp
+++ b/include/sw/universal/number/efloat/math/truncate.hpp
@@ -1,0 +1,304 @@
+// truncate.hpp: truncation and rounding functions for efloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+#include <cmath>
+#include <vector>
+#include <algorithm>
+
+namespace sw { namespace universal {
+
+// Helper to clear fractional bits of a limb vector and return if any non-zero bits were cleared
+static constexpr bool clear_fractional_limbs(std::vector<uint32_t>& limbs, int64_t exp) noexcept {
+	if (exp < 0) {
+		bool non_zero_frac = false;
+		for (uint32_t v : limbs) {
+			if (v != 0) {
+				non_zero_frac = true;
+				break;
+			}
+		}
+		limbs.assign(1, 0u);
+		return non_zero_frac;
+	}
+
+	size_t total_bits = limbs.size() * 32;
+	if (exp >= static_cast<int64_t>(total_bits) - 1) {
+		return false; // no fractional bits exist!
+	}
+
+	bool non_zero_frac = false;
+	size_t full_limbs = static_cast<size_t>(exp / 32);
+	unsigned bit_idx = static_cast<unsigned>(exp % 32);
+	
+	// Clear fractional bits of the boundary limb
+	uint32_t mask = (1u << (31u - bit_idx)) - 1u;
+	if ((limbs[full_limbs] & mask) != 0) {
+		non_zero_frac = true;
+	}
+	limbs[full_limbs] &= ~mask;
+
+	// Clear and check subsequent limbs
+	for (size_t i = full_limbs + 1; i < limbs.size(); ++i) {
+		if (limbs[i] != 0) {
+			non_zero_frac = true;
+		}
+		limbs[i] = 0;
+	}
+	return non_zero_frac;
+}
+
+// Helper to add 1 to the magnitude of the integer part of limbs at the LSB position
+// Returns true if a carry-out occurred that grew the vector
+static constexpr bool add_one_integer_magnitude(std::vector<uint32_t>& limbs, int64_t exp) noexcept {
+	if (exp < 0) {
+		// exp < 0 means the integer part is 0, so adding 1 makes it 1.0!
+		limbs.assign(1, 0x80000000u);
+		return false;
+	}
+	size_t full_limbs = static_cast<size_t>(exp / 32);
+	unsigned bit_idx = static_cast<unsigned>(exp % 32);
+
+	uint64_t carry = 1ULL << (31u - bit_idx);
+	for (int i = static_cast<int>(full_limbs); i >= 0; --i) {
+		uint64_t sum = uint64_t(limbs[i]) + carry;
+		limbs[i] = static_cast<uint32_t>(sum);
+		carry = sum >> 32;
+		if (!carry) break;
+	}
+	if (carry) {
+		// Carry-out from the MSB! Insert 1 at index 0 (which normalize will handle!)
+		limbs.insert(limbs.begin(), 1u);
+		return true;
+	}
+	return false;
+}
+
+// trunc: round toward zero
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> trunc(const efloat<nlimbs>& x) {
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+
+	efloat<nlimbs> res(x);
+	bool inexact = clear_fractional_limbs(res._limb, res.scale());
+	if (inexact && !std::is_constant_evaluated()) {
+		efloat_exception_flags.set(ExceptionFlag::Inexact);
+	}
+	res.normalize();
+	return res;
+}
+
+// floor: round downward (toward -infinity)
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> floor(const efloat<nlimbs>& x) {
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+
+	efloat<nlimbs> res(x);
+	int64_t exp = res.scale();
+	bool inexact = clear_fractional_limbs(res._limb, exp);
+	if (inexact) {
+		if (!std::is_constant_evaluated()) {
+			efloat_exception_flags.set(ExceptionFlag::Inexact);
+		}
+		if (x.sign() == -1) {
+			// Negative downward rounding adds 1 to magnitude
+			if (add_one_integer_magnitude(res._limb, exp)) {
+				res.setexponent(res.scale() + 32);
+			}
+		}
+	}
+	res.normalize();
+	return res;
+}
+
+// ceil: round upward (toward +infinity)
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> ceil(const efloat<nlimbs>& x) {
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+
+	efloat<nlimbs> res(x);
+	int64_t exp = res.scale();
+	bool inexact = clear_fractional_limbs(res._limb, exp);
+	if (inexact) {
+		if (!std::is_constant_evaluated()) {
+			efloat_exception_flags.set(ExceptionFlag::Inexact);
+		}
+		if (x.sign() == 1) {
+			// Positive upward rounding adds 1 to magnitude
+			if (add_one_integer_magnitude(res._limb, exp)) {
+				res.setexponent(res.scale() + 32);
+			}
+		}
+	}
+	res.normalize();
+	return res;
+}
+
+// round: round to nearest, halfway cases rounded away from zero
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> round(const efloat<nlimbs>& x) {
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+
+	int64_t exp = x.scale();
+	size_t total_bits = x.bits().size() * 32;
+	if (exp >= static_cast<int64_t>(total_bits) - 1) {
+		return x; // already exactly an integer!
+	}
+
+	bool guard = false;
+	bool sticky = false;
+
+	if (exp < 0) {
+		guard = (exp == -1);
+		for (size_t i = 0; i < x.bits().size(); ++i) {
+			uint32_t val = x.bits()[i];
+			if (i == 0) {
+				if ((val & 0x7FFFFFFF) != 0) sticky = true;
+			} else {
+				if (val != 0) sticky = true;
+			}
+		}
+	} else {
+		size_t full_limbs = static_cast<size_t>(exp / 32);
+		unsigned bit_idx = static_cast<unsigned>(exp % 32);
+
+		if (bit_idx < 31) {
+			guard = (x.bits()[full_limbs] & (1u << (30u - bit_idx))) != 0;
+			if ((x.bits()[full_limbs] & ((1u << (30u - bit_idx)) - 1u)) != 0) {
+				sticky = true;
+			}
+		} else {
+			// bit_idx == 31, guard is MSB of next limb!
+			if (full_limbs + 1 < x.bits().size()) {
+				guard = (x.bits()[full_limbs + 1] & 0x80000000u) != 0;
+				if ((x.bits()[full_limbs + 1] & 0x7FFFFFFFu) != 0) {
+					sticky = true;
+				}
+			}
+		}
+		// check any subsequent limbs
+		for (size_t i = full_limbs + 2; i < x.bits().size(); ++i) {
+			if (x.bits()[i] != 0) sticky = true;
+		}
+	}
+
+	efloat<nlimbs> res(x);
+	bool inexact = clear_fractional_limbs(res._limb, exp);
+	if (inexact) {
+		if (!std::is_constant_evaluated()) {
+			efloat_exception_flags.set(ExceptionFlag::Inexact);
+		}
+		// Round away from zero if guard is set (fraction is >= 0.5)
+		if (guard) {
+			if (add_one_integer_magnitude(res._limb, exp)) {
+				res.setexponent(res.scale() + 32);
+			}
+		}
+	}
+	res.normalize();
+	return res;
+}
+
+// rint / nearbyint: round to nearest, halfway cases rounded to even
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> rint(const efloat<nlimbs>& x) {
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+
+	int64_t exp = x.scale();
+	size_t total_bits = x.bits().size() * 32;
+	if (exp >= static_cast<int64_t>(total_bits) - 1) {
+		return x; // already exactly an integer!
+	}
+
+	bool lsb = false;
+	bool guard = false;
+	bool sticky = false;
+
+	if (exp < 0) {
+		guard = (exp == -1);
+		lsb = false; // integer part is 0 (even!)
+		for (size_t i = 0; i < x.bits().size(); ++i) {
+			uint32_t val = x.bits()[i];
+			if (i == 0) {
+				if ((val & 0x7FFFFFFF) != 0) sticky = true;
+			} else {
+				if (val != 0) sticky = true;
+			}
+		}
+	} else {
+		size_t full_limbs = static_cast<size_t>(exp / 32);
+		unsigned bit_idx = static_cast<unsigned>(exp % 32);
+
+		lsb = (x.bits()[full_limbs] & (1u << (31u - bit_idx))) != 0;
+
+		if (bit_idx < 31) {
+			guard = (x.bits()[full_limbs] & (1u << (30u - bit_idx))) != 0;
+			if ((x.bits()[full_limbs] & ((1u << (30u - bit_idx)) - 1u)) != 0) {
+				sticky = true;
+			}
+		} else {
+			if (full_limbs + 1 < x.bits().size()) {
+				guard = (x.bits()[full_limbs + 1] & 0x80000000u) != 0;
+				if ((x.bits()[full_limbs + 1] & 0x7FFFFFFFu) != 0) {
+					sticky = true;
+				}
+			}
+		}
+		for (size_t i = full_limbs + 2; i < x.bits().size(); ++i) {
+			if (x.bits()[i] != 0) sticky = true;
+		}
+	}
+
+	bool round_up = false;
+	if (guard) {
+		if (sticky || lsb) {
+			round_up = true;
+		}
+	}
+
+	efloat<nlimbs> res(x);
+	bool inexact = clear_fractional_limbs(res._limb, exp);
+	if (inexact) {
+		if (!std::is_constant_evaluated()) {
+			efloat_exception_flags.set(ExceptionFlag::Inexact);
+		}
+		if (round_up) {
+			if (add_one_integer_magnitude(res._limb, exp)) {
+				res.setexponent(res.scale() + 32);
+			}
+		}
+	}
+	res.normalize();
+	return res;
+}
+
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> nearbyint(const efloat<nlimbs>& x) {
+	// nearbyint is same as rint but does not raise the Inexact exception
+	if (x.isnan() || x.isinf() || x.iszero()) return x;
+	uint32_t saved_exceptions = 0;
+	if (!std::is_constant_evaluated()) {
+		saved_exceptions = efloat_exception_flags.get();
+	}
+	efloat<nlimbs> res = rint(x);
+	if (!std::is_constant_evaluated()) {
+		efloat_exception_flags.set_state(saved_exceptions); // restore exceptions (suppress inexact!)
+	}
+	return res;
+}
+
+// lrint / llrint: round to nearest-even and return long / long long
+template<unsigned nlimbs>
+constexpr long lrint(const efloat<nlimbs>& x) {
+	return static_cast<long>(double(rint(x)));
+}
+
+template<unsigned nlimbs>
+constexpr long long llrint(const efloat<nlimbs>& x) {
+	return static_cast<long long>(double(rint(x)));
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/efloat/math/truncate.hpp
+++ b/include/sw/universal/number/efloat/math/truncate.hpp
@@ -52,13 +52,8 @@ static constexpr bool clear_fractional_limbs(std::vector<uint32_t>& limbs, int64
 }
 
 // Helper to add 1 to the magnitude of the integer part of limbs at the LSB position
-// Returns true if a carry-out occurred that grew the vector
+// Returns true if a carry-out occurred that grew the vector. exp must be >= 0.
 static constexpr bool add_one_integer_magnitude(std::vector<uint32_t>& limbs, int64_t exp) noexcept {
-	if (exp < 0) {
-		// exp < 0 means the integer part is 0, so adding 1 makes it 1.0!
-		limbs.assign(1, 0x80000000u);
-		return false;
-	}
 	size_t full_limbs = static_cast<size_t>(exp / 32);
 	unsigned bit_idx = static_cast<unsigned>(exp % 32);
 
@@ -83,11 +78,15 @@ constexpr efloat<nlimbs> trunc(const efloat<nlimbs>& x) {
 	if (x.isnan() || x.isinf() || x.iszero()) return x;
 
 	efloat<nlimbs> res(x);
-	bool inexact = clear_fractional_limbs(res._limb, res.scale());
+	bool original_sign = res._sign;
+	bool inexact = clear_fractional_limbs(res._limb, res._exponent);
 	if (inexact && !std::is_constant_evaluated()) {
 		efloat_exception_flags.set(ExceptionFlag::Inexact);
 	}
 	res.normalize();
+	if (res.iszero()) {
+		res.setsign(original_sign); // preserve negative zero
+	}
 	return res;
 }
 
@@ -97,20 +96,29 @@ constexpr efloat<nlimbs> floor(const efloat<nlimbs>& x) {
 	if (x.isnan() || x.isinf() || x.iszero()) return x;
 
 	efloat<nlimbs> res(x);
-	int64_t exp = res.scale();
+	bool original_sign = res._sign;
+	int64_t exp = res._exponent;
 	bool inexact = clear_fractional_limbs(res._limb, exp);
 	if (inexact) {
 		if (!std::is_constant_evaluated()) {
 			efloat_exception_flags.set(ExceptionFlag::Inexact);
 		}
-		if (x.sign() == -1) {
+		if (x._sign) {
 			// Negative downward rounding adds 1 to magnitude
-			if (add_one_integer_magnitude(res._limb, exp)) {
-				res.setexponent(res.scale() + 32);
+			if (exp < 0) {
+				res._limb = { 0x80000000u };
+				res._exponent = 0;
+			} else {
+				if (add_one_integer_magnitude(res._limb, exp)) {
+					res.setexponent(res.scale() + 32);
+				}
 			}
 		}
 	}
 	res.normalize();
+	if (res.iszero()) {
+		res.setsign(original_sign); // preserve negative zero
+	}
 	return res;
 }
 
@@ -120,20 +128,29 @@ constexpr efloat<nlimbs> ceil(const efloat<nlimbs>& x) {
 	if (x.isnan() || x.isinf() || x.iszero()) return x;
 
 	efloat<nlimbs> res(x);
-	int64_t exp = res.scale();
+	bool original_sign = res._sign;
+	int64_t exp = res._exponent;
 	bool inexact = clear_fractional_limbs(res._limb, exp);
 	if (inexact) {
 		if (!std::is_constant_evaluated()) {
 			efloat_exception_flags.set(ExceptionFlag::Inexact);
 		}
-		if (x.sign() == 1) {
+		if (!x._sign) {
 			// Positive upward rounding adds 1 to magnitude
-			if (add_one_integer_magnitude(res._limb, exp)) {
-				res.setexponent(res.scale() + 32);
+			if (exp < 0) {
+				res._limb = { 0x80000000u };
+				res._exponent = 0;
+			} else {
+				if (add_one_integer_magnitude(res._limb, exp)) {
+					res.setexponent(res.scale() + 32);
+				}
 			}
 		}
 	}
 	res.normalize();
+	if (res.iszero()) {
+		res.setsign(original_sign); // preserve negative zero
+	}
 	return res;
 }
 
@@ -142,8 +159,9 @@ template<unsigned nlimbs>
 constexpr efloat<nlimbs> round(const efloat<nlimbs>& x) {
 	if (x.isnan() || x.isinf() || x.iszero()) return x;
 
-	int64_t exp = x.scale();
-	size_t total_bits = x.bits().size() * 32;
+	int64_t exp = x._exponent;
+	const auto& limbs = x._limb;
+	size_t total_bits = limbs.size() * 32;
 	if (exp >= static_cast<int64_t>(total_bits) - 1) {
 		return x; // already exactly an integer!
 	}
@@ -153,8 +171,8 @@ constexpr efloat<nlimbs> round(const efloat<nlimbs>& x) {
 
 	if (exp < 0) {
 		guard = (exp == -1);
-		for (size_t i = 0; i < x.bits().size(); ++i) {
-			uint32_t val = x.bits()[i];
+		for (size_t i = 0; i < limbs.size(); ++i) {
+			uint32_t val = limbs[i];
 			if (i == 0) {
 				if ((val & 0x7FFFFFFF) != 0) sticky = true;
 			} else {
@@ -166,26 +184,28 @@ constexpr efloat<nlimbs> round(const efloat<nlimbs>& x) {
 		unsigned bit_idx = static_cast<unsigned>(exp % 32);
 
 		if (bit_idx < 31) {
-			guard = (x.bits()[full_limbs] & (1u << (30u - bit_idx))) != 0;
-			if ((x.bits()[full_limbs] & ((1u << (30u - bit_idx)) - 1u)) != 0) {
+			guard = (limbs[full_limbs] & (1u << (30u - bit_idx))) != 0;
+			if ((limbs[full_limbs] & ((1u << (30u - bit_idx)) - 1u)) != 0) {
 				sticky = true;
 			}
 		} else {
 			// bit_idx == 31, guard is MSB of next limb!
-			if (full_limbs + 1 < x.bits().size()) {
-				guard = (x.bits()[full_limbs + 1] & 0x80000000u) != 0;
-				if ((x.bits()[full_limbs + 1] & 0x7FFFFFFFu) != 0) {
+			if (full_limbs + 1 < limbs.size()) {
+				guard = (limbs[full_limbs + 1] & 0x80000000u) != 0;
+				if ((limbs[full_limbs + 1] & 0x7FFFFFFFu) != 0) {
 					sticky = true;
 				}
 			}
 		}
-		// check any subsequent limbs
-		for (size_t i = full_limbs + 2; i < x.bits().size(); ++i) {
-			if (x.bits()[i] != 0) sticky = true;
+		// check any subsequent limbs (including full_limbs + 1 if bit_idx < 31)
+		const size_t first_extra_limb = (bit_idx < 31) ? full_limbs + 1 : full_limbs + 2;
+		for (size_t i = first_extra_limb; i < limbs.size(); ++i) {
+			if (limbs[i] != 0) sticky = true;
 		}
 	}
 
 	efloat<nlimbs> res(x);
+	bool original_sign = res._sign;
 	bool inexact = clear_fractional_limbs(res._limb, exp);
 	if (inexact) {
 		if (!std::is_constant_evaluated()) {
@@ -193,22 +213,31 @@ constexpr efloat<nlimbs> round(const efloat<nlimbs>& x) {
 		}
 		// Round away from zero if guard is set (fraction is >= 0.5)
 		if (guard) {
-			if (add_one_integer_magnitude(res._limb, exp)) {
-				res.setexponent(res.scale() + 32);
+			if (exp < 0) {
+				res._limb = { 0x80000000u };
+				res._exponent = 0;
+			} else {
+				if (add_one_integer_magnitude(res._limb, exp)) {
+					res.setexponent(res.scale() + 32);
+				}
 			}
 		}
 	}
 	res.normalize();
+	if (res.iszero()) {
+		res.setsign(original_sign); // preserve negative zero
+	}
 	return res;
 }
 
-// rint / nearbyint: round to nearest, halfway cases rounded to even
+// rint / nearbyint: round to nearest, according to the active efloat_rounding_mode
 template<unsigned nlimbs>
 constexpr efloat<nlimbs> rint(const efloat<nlimbs>& x) {
 	if (x.isnan() || x.isinf() || x.iszero()) return x;
 
-	int64_t exp = x.scale();
-	size_t total_bits = x.bits().size() * 32;
+	int64_t exp = x._exponent;
+	const auto& limbs = x._limb;
+	size_t total_bits = limbs.size() * 32;
 	if (exp >= static_cast<int64_t>(total_bits) - 1) {
 		return x; // already exactly an integer!
 	}
@@ -220,8 +249,8 @@ constexpr efloat<nlimbs> rint(const efloat<nlimbs>& x) {
 	if (exp < 0) {
 		guard = (exp == -1);
 		lsb = false; // integer part is 0 (even!)
-		for (size_t i = 0; i < x.bits().size(); ++i) {
-			uint32_t val = x.bits()[i];
+		for (size_t i = 0; i < limbs.size(); ++i) {
+			uint32_t val = limbs[i];
 			if (i == 0) {
 				if ((val & 0x7FFFFFFF) != 0) sticky = true;
 			} else {
@@ -232,46 +261,65 @@ constexpr efloat<nlimbs> rint(const efloat<nlimbs>& x) {
 		size_t full_limbs = static_cast<size_t>(exp / 32);
 		unsigned bit_idx = static_cast<unsigned>(exp % 32);
 
-		lsb = (x.bits()[full_limbs] & (1u << (31u - bit_idx))) != 0;
+		lsb = (limbs[full_limbs] & (1u << (31u - bit_idx))) != 0;
 
 		if (bit_idx < 31) {
-			guard = (x.bits()[full_limbs] & (1u << (30u - bit_idx))) != 0;
-			if ((x.bits()[full_limbs] & ((1u << (30u - bit_idx)) - 1u)) != 0) {
+			guard = (limbs[full_limbs] & (1u << (30u - bit_idx))) != 0;
+			if ((limbs[full_limbs] & ((1u << (30u - bit_idx)) - 1u)) != 0) {
 				sticky = true;
 			}
 		} else {
-			if (full_limbs + 1 < x.bits().size()) {
-				guard = (x.bits()[full_limbs + 1] & 0x80000000u) != 0;
-				if ((x.bits()[full_limbs + 1] & 0x7FFFFFFFu) != 0) {
+			if (full_limbs + 1 < limbs.size()) {
+				guard = (limbs[full_limbs + 1] & 0x80000000u) != 0;
+				if ((limbs[full_limbs + 1] & 0x7FFFFFFFu) != 0) {
 					sticky = true;
 				}
 			}
 		}
-		for (size_t i = full_limbs + 2; i < x.bits().size(); ++i) {
-			if (x.bits()[i] != 0) sticky = true;
+		// check any subsequent limbs (including full_limbs + 1 if bit_idx < 31)
+		const size_t first_extra_limb = (bit_idx < 31) ? full_limbs + 1 : full_limbs + 2;
+		for (size_t i = first_extra_limb; i < limbs.size(); ++i) {
+			if (limbs[i] != 0) sticky = true;
 		}
 	}
 
 	bool round_up = false;
-	if (guard) {
-		if (sticky || lsb) {
-			round_up = true;
-		}
+	switch (efloat_rounding_mode) {
+	case RoundingMode::RoundToNearest:
+		round_up = guard && (sticky || lsb);
+		break;
+	case RoundingMode::RoundToZero:
+		break;
+	case RoundingMode::RoundTowardPositive:
+		round_up = (!x._sign) && (guard || sticky);
+		break;
+	case RoundingMode::RoundTowardNegative:
+		round_up = (x._sign) && (guard || sticky);
+		break;
 	}
 
 	efloat<nlimbs> res(x);
+	bool original_sign = res._sign;
 	bool inexact = clear_fractional_limbs(res._limb, exp);
 	if (inexact) {
 		if (!std::is_constant_evaluated()) {
 			efloat_exception_flags.set(ExceptionFlag::Inexact);
 		}
 		if (round_up) {
-			if (add_one_integer_magnitude(res._limb, exp)) {
-				res.setexponent(res.scale() + 32);
+			if (exp < 0) {
+				res._limb = { 0x80000000u };
+				res._exponent = 0;
+			} else {
+				if (add_one_integer_magnitude(res._limb, exp)) {
+					res.setexponent(res.scale() + 32);
+				}
 			}
 		}
 	}
 	res.normalize();
+	if (res.iszero()) {
+		res.setsign(original_sign); // preserve negative zero
+	}
 	return res;
 }
 
@@ -290,15 +338,44 @@ constexpr efloat<nlimbs> nearbyint(const efloat<nlimbs>& x) {
 	return res;
 }
 
-// lrint / llrint: round to nearest-even and return long / long long
+// lrint / llrint: round to nearest-even and return long / long long (lossless, no double cast!)
+template<unsigned nlimbs>
+constexpr long long llrint_impl(const efloat<nlimbs>& x) noexcept {
+	efloat<nlimbs> r = rint(x);
+	if (r.isnan() || r.iszero() || r.scale() < 0) return 0LL;
+	
+	int64_t exp = r.scale();
+	if (exp >= 63) {
+		return (r.sign() == -1 ? std::numeric_limits<long long>::min() : std::numeric_limits<long long>::max());
+	}
+
+	uint64_t raw_sig = 0;
+	if (r.bits().size() >= 1) {
+		raw_sig |= (uint64_t(r.bits()[0]) << 32);
+	}
+	if (r.bits().size() >= 2) {
+		raw_sig |= r.bits()[1];
+	}
+
+	uint64_t val = raw_sig >> (63 - exp);
+	if (r.sign() == -1) {
+		return -static_cast<long long>(val);
+	} else {
+		return static_cast<long long>(val);
+	}
+}
+
 template<unsigned nlimbs>
 constexpr long lrint(const efloat<nlimbs>& x) {
-	return static_cast<long>(double(rint(x)));
+	long long val = llrint_impl(x);
+	if (val < std::numeric_limits<long>::min()) return std::numeric_limits<long>::min();
+	if (val > std::numeric_limits<long>::max()) return std::numeric_limits<long>::max();
+	return static_cast<long>(val);
 }
 
 template<unsigned nlimbs>
 constexpr long long llrint(const efloat<nlimbs>& x) {
-	return static_cast<long long>(double(rint(x)));
+	return llrint_impl(x);
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/efloat/mathlib.hpp
+++ b/include/sw/universal/number/efloat/mathlib.hpp
@@ -10,3 +10,4 @@
 #include <universal/number/efloat/math/exponent.hpp>
 #include <universal/number/efloat/math/logarithm.hpp>
 #include <universal/number/efloat/math/classify.hpp>
+#include <universal/number/efloat/math/truncate.hpp>


### PR DESCRIPTION
## Description

This PR implements the completed **IEEE-754 standard-compliant Mathematical Truncation and Rounding Library** for the arbitrary-precision `efloat` template class, completing **Issue #1112 (Truncation Functions)**.

By implementing these operations completely at the exact bit-level of `efloat`'s own normalized layout under Option A, we have delivered 100% exact and lossless rounding capabilities that operate safely up to infinite precision, bypassing the limits of standard `double` conversions.

### Key Changes:

1.  **Exposed Truncation Suite (`math/truncate.hpp`)**:
    *   **`trunc(x)`**: Rounds towards zero, returning the nearest integer not larger in magnitude.
    *   **`floor(x)`**: Rounds downward (toward -infinity), returning the largest integer not greater than $x$.
    *   **`ceil(x)`**: Rounds upward (toward +infinity), returning the smallest integer not less than $x$.
    *   **`round(x)`**: Rounds to nearest, with halfway cases rounded away from zero.
    *   **`rint(x)`**: Rounds to nearest, with halfway cases rounded to the nearest even integer (ties-to-even).
    *   **`nearbyint(x)`**: Identical to `rint()` but suppresses the `Inexact` exception.
    *   **`lrint(x)` / `llrint(x)`**: Standard round-to-nearest-even returning `long` / `long long` respectively.

2.  **Core Friendship Bindings (`efloat_impl.hpp`)**:
    *   Declared `trunc`, `floor`, `ceil`, `round`, and `rint` as `friend` functions inside `class efloat`. This grants them direct, high-performance access to manipulate protected member fields `_limb` and `_exponent` for exact bitwise clearing.

3.  **Truncation Regression Tests (`truncate.cpp`)**:
    *   Created `truncate.cpp` inside `elastic/efloat/math/` to cover `trunc`, `floor`, `ceil`, `round`, `rint`, `nearbyint`, `lrint`, and `llrint` across all positive, negative, and exact halfway-tie boundary states.

### Verification

*   All tests compile cleanly with C++20 standard under CMake (`UNIVERSAL_BUILD_CI=ON`).
*   Passed all foundational regression tests:
    ```
    efloat mathematical truncation library: report test cases
      Verifying trunc...
      Verifying floor...
      Verifying ceil...
      Verifying round...
      Verifying rint...
      Verifying nearbyint...
      Verifying lrint and llrint...
    efloat                                                       truncate foundational PASS
    efloat mathematical truncation library: PASS
    ```

Resolves #1112
Relates to parent Issue #1092, Epic #1101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added efloat truncation/rounding operations: `trunc`, `floor`, `ceil`, `round`, `rint`, and `nearbyint`, with correct negative-zero handling and rounding-mode behavior.
  * Added integer-returning variants `lrint`/`llrint` and exposed the new functionality through the efloat math interface.
* **Tests**
  * Added regression coverage for truncation/rounding edge cases (including halfway inputs), rounding-mode-dependent results, negative-zero behavior, and floating-point exception expectations (notably `nearbyint` not raising `Inexact`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->