### PR TITLE
feat(efloat): implement mathematical minimum, maximum, and difference library

### DIFF
--- a/elastic/efloat/math/minmax.cpp
+++ b/elastic/efloat/math/minmax.cpp
@@ -1,0 +1,146 @@
+// minmax.cpp: regression tests for efloat mathematical minimum, maximum, and difference functions.
+//
+// Categories tested:
+//   - min, max, fmin, fmax, fdim
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	int VerifyEfloatMinmax(bool reportTestCases) {
+		using namespace sw::universal;
+		int failures = 0;
+
+		// ---------------------------------------------------------------------
+		// 1. min & max Validation
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying min and max...\n";
+		{
+			efloat<4> x(5.5);
+			efloat<4> y(2.0);
+			if (min(x, y) != 2.0) {
+				if (reportTestCases) std::cout << "    FAIL: min(5.5, 2.0) is not 2.0\n";
+				++failures;
+			}
+			if (max(x, y) != 5.5) {
+				if (reportTestCases) std::cout << "    FAIL: max(5.5, 2.0) is not 5.5\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 2. fmin & fmax NaN Suppression Validation
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying fmin and fmax (NaN-suppressing)...\n";
+		{
+			efloat<4> x(5.5);
+			efloat<4> nan; nan.setnan();
+
+			// fmin(5.5, NaN) == 5.5
+			if (fmin(x, nan) != 5.5) {
+				if (reportTestCases) std::cout << "    FAIL: fmin(5.5, NaN) is not 5.5\n";
+				++failures;
+			}
+			if (fmin(nan, x) != 5.5) {
+				if (reportTestCases) std::cout << "    FAIL: fmin(NaN, 5.5) is not 5.5\n";
+				++failures;
+			}
+
+			// fmax(5.5, NaN) == 5.5
+			if (fmax(x, nan) != 5.5) {
+				if (reportTestCases) std::cout << "    FAIL: fmax(5.5, NaN) is not 5.5\n";
+				++failures;
+			}
+			if (fmax(nan, x) != 5.5) {
+				if (reportTestCases) std::cout << "    FAIL: fmax(NaN, 5.5) is not 5.5\n";
+				++failures;
+			}
+
+			// fmin(NaN, NaN) is NaN
+			if (!fmin(nan, nan).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: fmin(NaN, NaN) did not return NaN\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 3. fdim Validation (Positive Difference)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying fdim (Positive Difference)...\n";
+		{
+			efloat<4> x(5.5);
+			efloat<4> y(2.0);
+
+			// fdim(5.5, 2.0) == 3.5
+			if (fdim(x, y) != 3.5) {
+				if (reportTestCases) std::cout << "    FAIL: fdim(5.5, 2.0) is not 3.5. Result: " << double(fdim(x, y)) << "\n";
+				++failures;
+			}
+
+			// fdim(2.0, 5.5) == 0.0
+			if (fdim(y, x) != 0.0) {
+				if (reportTestCases) std::cout << "    FAIL: fdim(2.0, 5.5) is not 0.0. Result: " << double(fdim(y, x)) << "\n";
+				++failures;
+			}
+		}
+
+		return failures;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat mathematical minmax library";
+	std::string test_tag            = "minmax";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatMinmax(reportTestCases), "efloat", "minmax manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatMinmax(reportTestCases), "efloat", "minmax foundational");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/elastic/efloat/math/minmax.cpp
+++ b/elastic/efloat/math/minmax.cpp
@@ -37,9 +37,9 @@ namespace {
 		}
 
 		// ---------------------------------------------------------------------
-		// 2. fmin & fmax NaN Suppression Validation
+		// 2. fmin & fmax NaN Suppression & Signed Zero Validation
 		// ---------------------------------------------------------------------
-		if (reportTestCases) std::cout << "  Verifying fmin and fmax (NaN-suppressing)...\n";
+		if (reportTestCases) std::cout << "  Verifying fmin and fmax...\n";
 		{
 			efloat<4> x(5.5);
 			efloat<4> nan; nan.setnan();
@@ -69,6 +69,34 @@ namespace {
 				if (reportTestCases) std::cout << "    FAIL: fmin(NaN, NaN) did not return NaN\n";
 				++failures;
 			}
+
+			// IEEE-754 signed-zero tie-breaking (CodeRabbit feedback)
+			efloat<4> pos_zero(0.0);
+			efloat<4> neg_zero(-0.0);
+
+			// fmin(-0.0, +0.0) -> -0.0
+			efloat<4> res_fmin1 = fmin(neg_zero, pos_zero);
+			if (res_fmin1 != 0.0 || res_fmin1.sign() != -1) {
+				if (reportTestCases) std::cout << "    FAIL: fmin(-0.0, +0.0) is not -0.0\n";
+				++failures;
+			}
+			efloat<4> res_fmin2 = fmin(pos_zero, neg_zero);
+			if (res_fmin2 != 0.0 || res_fmin2.sign() != -1) {
+				if (reportTestCases) std::cout << "    FAIL: fmin(+0.0, -0.0) is not -0.0\n";
+				++failures;
+			}
+
+			// fmax(-0.0, +0.0) -> +0.0
+			efloat<4> res_fmax1 = fmax(neg_zero, pos_zero);
+			if (res_fmax1 != 0.0 || res_fmax1.sign() != 1) {
+				if (reportTestCases) std::cout << "    FAIL: fmax(-0.0, +0.0) is not +0.0\n";
+				++failures;
+			}
+			efloat<4> res_fmax2 = fmax(pos_zero, neg_zero);
+			if (res_fmax2 != 0.0 || res_fmax2.sign() != 1) {
+				if (reportTestCases) std::cout << "    FAIL: fmax(+0.0, -0.0) is not +0.0\n";
+				++failures;
+			}
 		}
 
 		// ---------------------------------------------------------------------
@@ -78,6 +106,7 @@ namespace {
 		{
 			efloat<4> x(5.5);
 			efloat<4> y(2.0);
+			efloat<4> nan; nan.setnan();
 
 			// fdim(5.5, 2.0) == 3.5
 			if (fdim(x, y) != 3.5) {
@@ -88,6 +117,12 @@ namespace {
 			// fdim(2.0, 5.5) == 0.0
 			if (fdim(y, x) != 0.0) {
 				if (reportTestCases) std::cout << "    FAIL: fdim(2.0, 5.5) is not 0.0. Result: " << double(fdim(y, x)) << "\n";
+				++failures;
+			}
+
+			// fdim NaN propagation (CodeRabbit feedback)
+			if (!fdim(x, nan).isnan() || !fdim(nan, y).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: fdim did not propagate NaN\n";
 				++failures;
 			}
 		}

--- a/include/sw/universal/number/efloat/math/minmax.hpp
+++ b/include/sw/universal/number/efloat/math/minmax.hpp
@@ -27,6 +27,10 @@ template<unsigned nlimbs>
 constexpr efloat<nlimbs> fmin(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
 	if (x.isnan()) return y;
 	if (y.isnan()) return x;
+	if (x.iszero() && y.iszero()) {
+		// IEEE-754: fmin(-0.0, +0.0) must return -0.0
+		return (x.sign() == -1) ? x : y;
+	}
 	return (x < y) ? x : y;
 }
 
@@ -35,6 +39,10 @@ template<unsigned nlimbs>
 constexpr efloat<nlimbs> fmax(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
 	if (x.isnan()) return y;
 	if (y.isnan()) return x;
+	if (x.iszero() && y.iszero()) {
+		// IEEE-754: fmax(-0.0, +0.0) must return +0.0
+		return (x.sign() == 1) ? x : y;
+	}
 	return (x < y) ? y : x;
 }
 

--- a/include/sw/universal/number/efloat/math/minmax.hpp
+++ b/include/sw/universal/number/efloat/math/minmax.hpp
@@ -1,0 +1,52 @@
+// minmax.hpp: minimum, maximum, and positive difference functions for efloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+#include <cmath>
+#include <universal/number/efloat/math/classify.hpp>
+
+namespace sw { namespace universal {
+
+// min: returns the smaller of two efloat values
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> min(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	return (x < y) ? x : y;
+}
+
+// max: returns the larger of two efloat values
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> max(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	return (x < y) ? y : x;
+}
+
+// fmin: returns the smaller of two efloat values, suppressing NaN if only one is NaN
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> fmin(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	if (x.isnan()) return y;
+	if (y.isnan()) return x;
+	return (x < y) ? x : y;
+}
+
+// fmax: returns the larger of two efloat values, suppressing NaN if only one is NaN
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> fmax(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	if (x.isnan()) return y;
+	if (y.isnan()) return x;
+	return (x < y) ? y : x;
+}
+
+// fdim: returns the positive difference between x and y (x - y if x > y, +0.0 otherwise)
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> fdim(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	if (x.isnan() || y.isnan()) {
+		efloat<nlimbs> nan; nan.setnan();
+		return nan;
+	}
+	if (x > y) return x - y;
+	return efloat<nlimbs>(0.0);
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/efloat/mathlib.hpp
+++ b/include/sw/universal/number/efloat/mathlib.hpp
@@ -13,3 +13,4 @@
 #include <universal/number/efloat/math/truncate.hpp>
 #include <universal/number/efloat/math/pow.hpp>
 #include <universal/number/efloat/math/fractional.hpp>
+#include <universal/number/efloat/math/minmax.hpp>


### PR DESCRIPTION
## Description

This PR implements the completed **IEEE-754 standard-compliant Mathematical Minimum, Maximum, and Positive Difference Library** for the arbitrary-precision `efloat` template class, completing **Issue #1117 (Minimum, Maximum, and Difference Functions)**.

By implementing minimum and maximum operations completely inside `efloat`'s own space, we deliver clean, constexpr-compatible, standard-conforming queries.

### Key Changes:

1.  **Exposed Minimum, Maximum, and Difference Suite (`math/minmax.hpp`)**:
    *   **`min(x, y)`**: Returns the smaller of two efloat values.
    *   **`max(x, y)`**: Returns the larger of two efloat values.
    *   **`fmin(x, y)`**: NaN-suppressing minimum (returns the non-NaN value if only one of them is NaN, matching IEEE-754).
    *   **`fmax(x, y)`**: NaN-suppressing maximum (returns the non-NaN value if only one of them is NaN, matching IEEE-754).
    *   **`fdim(x, y)`**: Returns the positive difference $x - y$ if $x > y$, and $+0.0$ otherwise.

2.  **Registered Header (`mathlib.hpp`)**:
    *   Included `<universal/number/efloat/math/minmax.hpp>` inside our master efloat math library header.

3.  **Minmax Regression Tests (`minmax.cpp`)**:
    *   Created `minmax.cpp` inside `elastic/efloat/math/` to verify all minimum, maximum, and difference functions, testing standard boundary states and NaN suppression capabilities.

### Verification

*   All tests compile cleanly with C++20 standard under CMake (`UNIVERSAL_BUILD_CI=ON`).
*   Passed all foundational regression tests:
    ```
    efloat mathematical minmax library: report test cases
      Verifying min and max...
      Verifying fmin and fmax (NaN-suppressing)...
      Verifying fdim (Positive Difference)...
    efloat                                                       minmax foundational PASS
    efloat mathematical minmax library: PASS
    ```

Resolves #1117
Relates to parent Issue #1092, Epic #1101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new `efloat` `min`/`max` helpers, including NaN-aware `fmin`/`fmax` and IEEE-754 signed-zero tie-breaking behavior.
  * Added `fdim` support for positive-difference semantics with NaN propagation.
  * Updated the main `efloat` math include so these helpers are available via the common header.

* **Tests**
  * Added a regression test executable validating `min`/`max`, `fmin`/`fmax` NaN handling, signed-zero rules, and `fdim` behavior across configured regression levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->