### PR TITLE
feat(efloat): implement mathematical square root, cube root, and hypotenuse library

### DIFF
--- a/elastic/efloat/math/math.cpp
+++ b/elastic/efloat/math/math.cpp
@@ -72,6 +72,60 @@ namespace {
 				if (reportTestCases) std::cout << "    FAIL: sqrt(-1.0) did not set InvalidOperation\n";
 				++failures;
 			}
+
+			// 1d. Exceptional value: sqrt(-inf) -> NaN + InvalidOperation
+			efloat<4> neg_inf; neg_inf.setinf(true);
+			clear_efloat_exceptions();
+			efloat<4> res_neg_inf = sqrt(neg_inf);
+			if (!res_neg_inf.isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: sqrt(-inf) did not return NaN\n";
+				++failures;
+			}
+			if (!has_efloat_exception(ExceptionFlag::InvalidOperation)) {
+				if (reportTestCases) std::cout << "    FAIL: sqrt(-inf) did not set InvalidOperation\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 1e. Cube Root (cbrt) Validation
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying Cube Root (cbrt)...\n";
+		{
+			efloat<4> eight(8.0);
+			if (!IsClose(cbrt(eight), 2.0)) {
+				if (reportTestCases) std::cout << "    FAIL: cbrt(8.0) is not 2.0. Result: " << double(cbrt(eight)) << "\n";
+				++failures;
+			}
+			efloat<4> neg_eight(-8.0);
+			if (!IsClose(cbrt(neg_eight), -2.0)) {
+				if (reportTestCases) std::cout << "    FAIL: cbrt(-8.0) is not -2.0. Result: " << double(cbrt(neg_eight)) << "\n";
+				++failures;
+			}
+			efloat<4> zero_val(0.0);
+			if (cbrt(zero_val) != 0.0) {
+				if (reportTestCases) std::cout << "    FAIL: cbrt(0.0) is not 0.0\n";
+				++failures;
+			}
+			efloat<8> cbrt_two(2.0);
+			double expected_cbrt2 = std::cbrt(2.0);
+			if (!IsClose(cbrt(cbrt_two), expected_cbrt2)) {
+				if (reportTestCases) std::cout << "    FAIL: cbrt(2.0) is inaccurate. Result: " << double(cbrt(cbrt_two)) << "\n";
+				++failures;
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 1f. Hypotenuse (hypot) Validation
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying Hypotenuse (hypot)...\n";
+		{
+			efloat<4> three(3.0);
+			efloat<4> four_val(4.0);
+			if (hypot(three, four_val) != 5.0) {
+				if (reportTestCases) std::cout << "    FAIL: hypot(3.0, 4.0) is not 5.0. Result: " << double(hypot(three, four_val)) << "\n";
+				++failures;
+			}
 		}
 
 		// ---------------------------------------------------------------------

--- a/elastic/efloat/math/math.cpp
+++ b/elastic/efloat/math/math.cpp
@@ -110,8 +110,12 @@ namespace {
 			efloat<8> cbrt_two(2.0);
 			efloat<8> y_cbrt = cbrt(cbrt_two);
 			// Validate higher-precision cbrt(2.0) via an efloat-space round-trip check (CodeRabbit feedback)
-			if (!IsClose(y_cbrt * y_cbrt * y_cbrt, 2.0)) {
-				if (reportTestCases) std::cout << "    FAIL: cbrt(2.0) roundtrip failed. Result cubed: " << double(y_cbrt * y_cbrt * y_cbrt) << "\n";
+			efloat<8> cubed = y_cbrt * y_cbrt * y_cbrt;
+			efloat<8> diff = (cubed < efloat<8>(2.0)) ? (efloat<8>(2.0) - cubed) : (cubed - efloat<8>(2.0));
+			efloat<8> tol(1.0);
+			tol.setexponent(-200); // 256-bit efloat space tolerance (approx. 1e-60!)
+			if (diff > tol) {
+				if (reportTestCases) std::cout << "    FAIL: cbrt(2.0) roundtrip failed. Result cubed: " << double(cubed) << "\n";
 				++failures;
 			}
 		}
@@ -131,11 +135,13 @@ namespace {
 			// Validate IEEE-754: Infinity suppresses NaN inside hypot (CodeRabbit feedback)
 			efloat<4> nan; nan.setnan();
 			efloat<4> inf; inf.setinf(false);
-			if (!hypot(nan, inf).isinf()) {
+			efloat<4> nan_inf_res = hypot(nan, inf);
+			if (!nan_inf_res.isinf() || nan_inf_res.sign() != 1) {
 				if (reportTestCases) std::cout << "    FAIL: hypot(NaN, +inf) did not return +Inf\n";
 				++failures;
 			}
-			if (!hypot(inf, nan).isinf()) {
+			efloat<4> inf_nan_res = hypot(inf, nan);
+			if (!inf_nan_res.isinf() || inf_nan_res.sign() != 1) {
 				if (reportTestCases) std::cout << "    FAIL: hypot(+inf, NaN) did not return +Inf\n";
 				++failures;
 			}

--- a/elastic/efloat/math/math.cpp
+++ b/elastic/efloat/math/math.cpp
@@ -108,9 +108,10 @@ namespace {
 				++failures;
 			}
 			efloat<8> cbrt_two(2.0);
-			double expected_cbrt2 = std::cbrt(2.0);
-			if (!IsClose(cbrt(cbrt_two), expected_cbrt2)) {
-				if (reportTestCases) std::cout << "    FAIL: cbrt(2.0) is inaccurate. Result: " << double(cbrt(cbrt_two)) << "\n";
+			efloat<8> y_cbrt = cbrt(cbrt_two);
+			// Validate higher-precision cbrt(2.0) via an efloat-space round-trip check (CodeRabbit feedback)
+			if (!IsClose(y_cbrt * y_cbrt * y_cbrt, 2.0)) {
+				if (reportTestCases) std::cout << "    FAIL: cbrt(2.0) roundtrip failed. Result cubed: " << double(y_cbrt * y_cbrt * y_cbrt) << "\n";
 				++failures;
 			}
 		}
@@ -124,6 +125,18 @@ namespace {
 			efloat<4> four_val(4.0);
 			if (hypot(three, four_val) != 5.0) {
 				if (reportTestCases) std::cout << "    FAIL: hypot(3.0, 4.0) is not 5.0. Result: " << double(hypot(three, four_val)) << "\n";
+				++failures;
+			}
+
+			// Validate IEEE-754: Infinity suppresses NaN inside hypot (CodeRabbit feedback)
+			efloat<4> nan; nan.setnan();
+			efloat<4> inf; inf.setinf(false);
+			if (!hypot(nan, inf).isinf()) {
+				if (reportTestCases) std::cout << "    FAIL: hypot(NaN, +inf) did not return +Inf\n";
+				++failures;
+			}
+			if (!hypot(inf, nan).isinf()) {
+				if (reportTestCases) std::cout << "    FAIL: hypot(+inf, NaN) did not return +Inf\n";
 				++failures;
 			}
 		}

--- a/elastic/efloat/math/minmax.cpp
+++ b/elastic/efloat/math/minmax.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <limits>
 #include <universal/number/efloat/efloat.hpp>
+#include <universal/number/efloat/math/minmax.hpp>
 #include <universal/verification/test_suite.hpp>
 
 namespace {
@@ -70,6 +71,12 @@ namespace {
 				++failures;
 			}
 
+			// fmax(NaN, NaN) is NaN
+			if (!fmax(nan, nan).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: fmax(NaN, NaN) did not return NaN\n";
+				++failures;
+			}
+
 			// IEEE-754 signed-zero tie-breaking (CodeRabbit feedback)
 			efloat<4> pos_zero(0.0);
 			efloat<4> neg_zero(-0.0);
@@ -121,8 +128,12 @@ namespace {
 			}
 
 			// fdim NaN propagation (CodeRabbit feedback)
-			if (!fdim(x, nan).isnan() || !fdim(nan, y).isnan()) {
-				if (reportTestCases) std::cout << "    FAIL: fdim did not propagate NaN\n";
+			if (!fdim(x, nan).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: fdim(5.5, NaN) did not return NaN\n";
+				++failures;
+			}
+			if (!fdim(nan, y).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL: fdim(NaN, 2.0) did not return NaN\n";
 				++failures;
 			}
 		}

--- a/include/sw/universal/number/efloat/math/sqrt.hpp
+++ b/include/sw/universal/number/efloat/math/sqrt.hpp
@@ -1,4 +1,4 @@
-// sqrt.hpp: square root function for efloat
+// sqrt.hpp: square root, cube root, and hypotenuse functions for efloat
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -13,7 +13,7 @@ namespace sw { namespace universal {
 template<unsigned nlimbs>
 constexpr efloat<nlimbs> sqrt(const efloat<nlimbs>& a) {
 	if (a.iszero()) return a;
-	if (a.isneg()) {
+	if (a.sign() == -1) {
 		efloat<nlimbs> nan;
 		nan.setnan();
 		if (!std::is_constant_evaluated()) {
@@ -36,6 +36,63 @@ constexpr efloat<nlimbs> sqrt(const efloat<nlimbs>& a) {
 		x = half * (x + a / x);
 	}
 	return x;
+}
+
+// cbrt: cube root function for efloat using Newton's method
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> cbrt(const efloat<nlimbs>& a) {
+	if (a.iszero() || a.isinf() || a.isnan()) return a;
+
+	// standard cbrt(-x) == -cbrt(x)
+	bool is_neg = (a.sign() == -1);
+	efloat<nlimbs> abs_a(a);
+	abs_a.setsign(false);
+
+	// Initial guess: y0 = 1.0 * 2^(scale / 3)
+	efloat<nlimbs> y;
+	y.clear();
+	y.setexponent(abs_a.scale() / 3);
+	y.setlimb(0, 0x80000000);
+
+	efloat<nlimbs> one_third = efloat<nlimbs>(1.0) / efloat<nlimbs>(3.0);
+	efloat<nlimbs> two(2.0);
+
+	// Newton iterations for y^3 - abs_a = 0: y_next = 1/3 * (2 * y + abs_a / y^2)
+	for (int i = 0; i < 7; ++i) {
+		y = one_third * (two * y + abs_a / (y * y));
+	}
+
+	if (is_neg) {
+		y.setsign(true);
+	}
+	return y;
+}
+
+// hypot: hypotenuse function sqrt(x^2 + y^2) with scale-based overflow prevention
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> hypot(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	if (x.isnan() || y.isnan()) {
+		efloat<nlimbs> nan; nan.setnan();
+		return nan;
+	}
+	if (x.isinf() || y.isinf()) {
+		efloat<nlimbs> inf; inf.setinf(false);
+		return inf;
+	}
+
+	efloat<nlimbs> abs_x(x); abs_x.setsign(false);
+	efloat<nlimbs> abs_y(y); abs_y.setsign(false);
+
+	// Scale by max to prevent intermediate underflow/overflow
+	efloat<nlimbs> max_val = (abs_x < abs_y) ? abs_y : abs_x;
+	efloat<nlimbs> min_val = (abs_x < abs_y) ? abs_x : abs_y;
+
+	if (max_val.iszero()) {
+		return efloat<nlimbs>(0.0);
+	}
+
+	efloat<nlimbs> r = min_val / max_val;
+	return max_val * sqrt(efloat<nlimbs>(1.0) + r * r);
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/efloat/math/sqrt.hpp
+++ b/include/sw/universal/number/efloat/math/sqrt.hpp
@@ -71,13 +71,14 @@ constexpr efloat<nlimbs> cbrt(const efloat<nlimbs>& a) {
 // hypot: hypotenuse function sqrt(x^2 + y^2) with scale-based overflow prevention
 template<unsigned nlimbs>
 constexpr efloat<nlimbs> hypot(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
-	if (x.isnan() || y.isnan()) {
-		efloat<nlimbs> nan; nan.setnan();
-		return nan;
-	}
+	// IEEE-754: Infinity suppresses NaN inside hypot! Infinity check must run first.
 	if (x.isinf() || y.isinf()) {
 		efloat<nlimbs> inf; inf.setinf(false);
 		return inf;
+	}
+	if (x.isnan() || y.isnan()) {
+		efloat<nlimbs> nan; nan.setnan();
+		return nan;
 	}
 
 	efloat<nlimbs> abs_x(x); abs_x.setsign(false);


### PR DESCRIPTION
## Description

This PR implements the completed **IEEE-754 standard-compliant Mathematical Square Root, Cube Root, and Hypotenuse Library** for the arbitrary-precision `efloat` template class, completing **Issue #1118 (Square Root Functions)**.

By implementing standard Newton-Raphson cube root solver (`cbrt`) and scaling-robust hypotenuse calculations (`hypot`), we deliver clean, constexpr-compatible, high-precision root interfaces.

### Key Changes:

1.  **Standard Sqrt Exceptions Fix (`math/sqrt.hpp`)**:
    *   Replaced `a.isneg()` with `a.sign() == -1` to correctly capture and handle negative infinity, ensuring `sqrt(-inf)` returns `NaN` with `InvalidOperation` instead of falling through to return `-inf`.

2.  **Exposed Cube Root (`cbrt`)**:
    *   Implements the standard cube root function for negative, positive, and zero arguments completely in `efloat` space using Newton's method on $y^3 - \text{abs}(a) = 0$ with scale-derived initial guess and 7 quadratic iterations. Sign is preserved as `cbrt(-x) == -cbrt(x)`.

3.  **Exposed Hypotenuse (`hypot`)**:
    *   Implements standard $\text{hypot}(x, y) = \sqrt{x^2 + y^2}$. Employs scale-based division by max ($a \sqrt{1 + (b/a)^2}$) to robustly eliminate intermediate overflow and underflow, handling zeros, infinities, and NaNs in strict compliance with IEEE-754.

4.  **Math Regression Tests (`math.cpp`)**:
    *   Added regressions inside `elastic/efloat/math/math.cpp` verifying standard exception state propagation for `sqrt(-inf)`, exact/inexact results for `cbrt` (8.0, -8.0, 0.0, 2.0), and Pythagorean identities for `hypot(3.0, 4.0) == 5.0`.

### Verification

*   All tests compile cleanly with C++20 standard under CMake (`UNIVERSAL_BUILD_CI=ON`).
*   Passed all foundational regression tests:
    ```
    efloat mathematical functions library: report test cases
      Verifying Square Root (sqrt)...
      Verifying Cube Root (cbrt)...
      Verifying Hypotenuse (hypot)...
      Verifying Exponential (exp)...
      Verifying Logarithm (log)...
      Verifying Logarithmic Suite (log2, log10, log1p)...
    efloat                                                       math foundational PASS
    efloat mathematical functions library: PASS
    ```

Resolves #1118
Relates to parent Issue #1092, Epic #1101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cube-root (`cbrt`) and hypotenuse (`hypot`) support for `efloat` math.
* **Bug Fixes**
  * Improved `sqrt` handling for negative infinity to correctly surface the invalid operation result.
* **Tests**
  * Expanded regression coverage for cube root, hypotenuse, and square root, including edge cases for `NaN`, `Infinity`, and signed-zero behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->