### PR TITLE
fix(bfloat16): round float conversion to nearest-even (RNE) instead of truncating

### DIFF
--- a/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
@@ -61,9 +61,26 @@ class bfloat16 {
 		typename = typename std::enable_if< std::is_floating_point<Real>::value, Real >::type>
 	BIT_CAST_CONSTEXPR bfloat16& convert_ieee754(Real rhs) noexcept {
 		// Down-cast wider floats to single precision first; bfloat16 is
-		// defined relative to the 32-bit IEEE-754 layout.
+		// defined relative to the 32-bit IEEE-754 layout. bfloat16 keeps the
+		// top 16 bits (sign + 8 exponent + 7 fraction) and must round the
+		// discarded low 16 bits to nearest, ties-to-even (RNE), matching the
+		// hardware behavior of Google TPUs and Intel. See issue #1133.
 		float f = static_cast<float>(rhs);
 		uint32_t bits = sw::bit_cast<uint32_t>(f);
+		// A float NaN whose payload lives only in the low 16 bits would, after
+		// truncation or rounding, collapse to +/-inf. Preserve NaN by forcing a
+		// quiet-NaN fraction bit while keeping the sign and exponent.
+		if ((bits & 0x7FFFFFFFu) > 0x7F800000u) {
+			_bits = static_cast<uint16_t>((bits >> 16) | 0x0040u);
+			return *this;
+		}
+		// RNE via magic rounding bias: adding (0x7FFF + lsb) rounds the retained
+		// field up on more-than-half, leaves it on less-than-half, and on an
+		// exact-half tie rounds toward the even significand (lsb == 0). A carry
+		// out of the fraction propagates correctly into the exponent, and a
+		// value within half a ulp of the range limit rounds to inf as expected.
+		uint32_t lsb = (bits >> 16) & 1u;
+		bits += 0x7FFFu + lsb;
 		_bits = static_cast<uint16_t>(bits >> 16);
 		return *this;
 	}

--- a/include/sw/universal/number/bfloat16/numeric_limits.hpp
+++ b/include/sw/universal/number/bfloat16/numeric_limits.hpp
@@ -68,7 +68,7 @@ public:
 	static constexpr bool is_modulo = false;
 	static constexpr bool traps = false;
 	static constexpr bool tinyness_before = false;
-	static constexpr float_round_style round_style = round_toward_zero;
+	static constexpr float_round_style round_style = round_to_nearest;
 };
 
 }

--- a/static/float/bfloat16/conversion/round_to_nearest_even.cpp
+++ b/static/float/bfloat16/conversion/round_to_nearest_even.cpp
@@ -1,0 +1,116 @@
+// round_to_nearest_even.cpp: regression tests for RNE rounding when converting
+//                            a native IEEE-754 float/double into a bfloat16 (#1133)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under
+// an MIT Open Source license.
+//
+// Before #1133, bfloat16 conversion truncated the low 16 bits of the float
+// representation (round-toward-zero). Google TPUs and Intel use round-to-
+// nearest, ties-to-even (RNE). These tests pin the RNE behavior, including the
+// exact-halfway tie-to-even boundary and preservation of inf/nan/zero.
+
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <iostream>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+namespace {
+
+// build a float from a raw 32-bit IEEE-754 pattern
+float f32(std::uint32_t bits) { return sw::bit_cast<float>(bits); }
+
+}  // namespace
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite   = "bfloat16 round-to-nearest-even conversion (#1133)";
+	bool reportTestCases     = false;
+	int  nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// helper: convert a value, compare the resulting float to an expected float
+	auto expect = [&](double input, float expected, const char* label) {
+		bfloat16 b(input);
+		float got = float(b);
+		if (got != expected) {
+			++nrOfFailedTestCases;
+			if (reportTestCases) {
+				std::cout << "  FAIL " << label << ": " << input
+				          << " -> " << got << " (" << to_binary(b) << ")"
+				          << " expected " << expected << '\n';
+			}
+		}
+	};
+
+	// ----- the exact case from issue #1133 -----
+	{
+		int start = nrOfFailedTestCases;
+		// 0.2691408770292272 -> float bits 0x3E89CCD5; dropped bits 0xCCD5 > half,
+		// so RNE rounds UP to 0x3E8A (0.26953125). Truncation gave 0.267578125.
+		expect(0.2691408770292272, 0.26953125f, "issue-1133 round up");
+		// and assert it is NOT the truncated value
+		if (float(bfloat16(0.2691408770292272)) == 0.267578125f) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 issue-1133 case\n";
+	}
+
+	// ----- more-than-half rounds up, less-than-half stays -----
+	{
+		int start = nrOfFailedTestCases;
+		// base 1.0 == 0x3F800000; next bfloat16 up is 0x3F81 == 1.0078125
+		expect(f32(0x3F80C000u), 1.0078125f, "guard+sticky rounds up");   // dropped 0xC000 > half
+		expect(f32(0x3F804000u), 1.0f,        "below half truncates");    // dropped 0x4000 < half
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 up/down rounding\n";
+	}
+
+	// ----- exact-half ties round to even -----
+	{
+		int start = nrOfFailedTestCases;
+		// dropped bits exactly 0x8000, retained lsb == 0 (even) -> stays 1.0
+		expect(f32(0x3F808000u), 1.0f,        "tie to even (lsb=0) stays");
+		// dropped bits exactly 0x8000, retained lsb == 1 (odd)  -> rounds up to 0x3F82 == 1.015625
+		expect(f32(0x3F818000u), 1.015625f,   "tie to even (lsb=1) rounds up");
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 tie-to-even\n";
+	}
+
+	// ----- special values survive rounding -----
+	{
+		int start = nrOfFailedTestCases;
+		if (!bfloat16(f32(0x7F800000u)).isinf()) ++nrOfFailedTestCases;            // +inf
+		if (!bfloat16(f32(0xFF800000u)).isinf()) ++nrOfFailedTestCases;            // -inf
+		if (!bfloat16(f32(0x7FC00000u)).isnan()) ++nrOfFailedTestCases;            // qnan
+		// NaN whose payload is only in the low 16 bits must NOT collapse to inf
+		if (!bfloat16(f32(0x7F800001u)).isnan()) ++nrOfFailedTestCases;
+		if (!bfloat16(0.0).iszero())             ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 special-value preservation\n";
+	}
+
+	// ----- round_style advertises round_to_nearest -----
+	{
+		int start = nrOfFailedTestCases;
+		if (std::numeric_limits<bfloat16>::round_style != std::round_to_nearest) ++nrOfFailedTestCases;
+		if (nrOfFailedTestCases - start > 0) std::cout << "FAIL: bfloat16 round_style\n";
+	}
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
- `bfloat16`'s float/double conversion was **truncating** (round-toward-zero): `convert_ieee754()` did a bare `bits >> 16`, dropping the low 16 bits of the IEEE-754 float with no rounding.
- Google TPUs and Intel round float->bfloat16 to **nearest, ties-to-even (RNE)**. This PR implements RNE.

## Root cause
`include/sw/universal/number/bfloat16/bfloat16_impl.hpp` kept the upper 16 bits of the source float verbatim. For the issue's value `0.2691408770292272` (float bits `0x3E89CCD5`), the dropped bits `0xCCD5` are more than half a ulp, so RNE must round **up**:
- truncation -> `0.267578125`
- RNE (correct) -> `0.26953125`

## Changes
- `include/sw/universal/number/bfloat16/bfloat16_impl.hpp` -- RNE via the standard magic rounding bias `0x7FFF + lsb_of_retained_field` before the shift, plus a NaN guard so a float NaN whose payload lives only in the low 16 bits does not collapse to +/-inf. Carry into the exponent and round-to-inf at the range limit both fall out correctly.
- `include/sw/universal/number/bfloat16/numeric_limits.hpp` -- `round_style` now `round_to_nearest` (was `round_toward_zero`).
- `static/float/bfloat16/conversion/round_to_nearest_even.cpp` -- new regression test: the issue case, more-than-half/less-than-half rounding, exact-half tie-to-even (lsb=0 stays, lsb=1 rounds up), and inf/nan/zero preservation.

## Test Results (built with `-I include/sw`, `-std=c++20`)
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| bfloat16_round_to_nearest_even (new) | OK | PASS | OK | PASS |
| bfloat16_string_parse | OK | PASS | OK | PASS |
| bfloat16_arithmetic | OK | PASS | OK | PASS |
| bfloat16_api | OK | PASS | OK | PASS |

gcc 13.3.0, clang 18.1.3.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #1133

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bfloat16 down-conversion accuracy, using round-to-nearest, ties-to-even behavior.
  - Fixed halfway/tie rounding so results match expected bfloat16 rounding semantics.
  - Preserved NaNs (including payloads) and continued correct handling of zeros and infinities.
- **Compatibility**
  - Updated bfloat16 rounding metadata to report round-to-nearest behavior.
- **Tests**
  - Added regression coverage to validate round-to-nearest-even conversions and special-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->