### PR TITLE
fix(elreal): drop trailing subnormal limbs in zbcl_from_blocks

### DIFF
--- a/include/sw/universal/number/elreal/sum.hpp
+++ b/include/sw/universal/number/elreal/sum.hpp
@@ -78,10 +78,23 @@
 namespace sw { namespace universal {
 
 // Build a ZBCL from a finite, already-0-overlap block list, dropping trailing
-// zero blocks (which do not change the value).
+// zero blocks (which do not change the value) and trailing subnormal limbs.
+//
+// A subnormal block cannot satisfy the k-gap 0-overlap invariant
+// (block::is_normalised: "0-overlap accounting assumes the leading bit is
+// set"). On a narrow host (bfloat16 k=7, fp16 k=11) a deep expansion can bottom
+// out at the denormal floor and leave a trailing subnormal limb whose gap to
+// its head is below k; carrying it into the ZBCL trips the 0-overlap assert in
+// ZBCL::tail() downstream. mul_scalar / online_divide / online_multiply already
+// drop non-normalised blocks at their producers; this centralises the same
+// guard for every block-list producer (add / multiply / divide / sum). Trailing
+// removal is sufficient and value-preserving: the list is priestRenorm'd
+// (descending exponent), so subnormal limbs sit strictly below every normalised
+// limb and dropping them never removes a value above the floor. is_normalised()
+// is false for zero blocks too, so this subsumes the previous zero-drop.
 template <typename FpType>
 inline ZBCL<FpType> zbcl_from_blocks(std::vector<block<FpType>> blocks) {
-    while (!blocks.empty() && blocks.back().is_zero_block()) blocks.pop_back();
+    while (!blocks.empty() && !blocks.back().is_normalised()) blocks.pop_back();
     ZBCL<FpType> out{};
     for (std::size_t i = blocks.size(); i-- > 0;) {
         out = ZBCL<FpType>::cons(blocks[i], out);


### PR DESCRIPTION
## Summary
On a narrow host (`bfloat16` k=7, `fp16` k=11) a deep `ZBCL` expansion can bottom out at the denormal floor and leave a **trailing subnormal limb** whose exponent gap to its head is below `k`. `zbcl_from_blocks()` only stripped trailing *zero* blocks, so the subnormal limb was carried into the ZBCL, and forcing the tail that holds it tripped the 0-overlap debug assert in `ZBCL::tail()`.

## Root cause
A subnormal block cannot satisfy the k-gap 0-overlap invariant. `block::is_normalised()` documents this directly: *"Subnormals fail this predicate; McCleeary blocks must avoid them because 0-overlap accounting assumes the leading bit is set."* The streaming producers (`mul_scalar`, `online_divide`, `online_multiply`) already drop non-normalised blocks, but `zbcl_from_blocks` -- the block-list -> ZBCL choke point for `add`/`multiply`/`divide`/`sum` -- did not.

## Fix
`zbcl_from_blocks()` now drops trailing **non-normalised** blocks (subsumes the existing zero-block drop, since `is_normalised()` is false for zero blocks too). Trailing removal is value-preserving: the list is `priestRenorm`'d (descending exponent), so subnormal limbs sit strictly below every normalised limb.

## How it surfaced
Latent, pre-existing fragility, masked while `bfloat16` conversion truncated. The RNE-conversion fix (#1133) changes the deep `sqrt` expansion so the exact denormal-floor configuration is reached, exposing the assert:
```
OVERLAP: head exp=-121  tail.head exp=-127  k=7   (bfloat16 emin=-126, so -127 is subnormal)
```
`el_math_sqrt` aborted under Debug/ASan with `FpType=bfloat16`. The numerical result was already correct -- only the invariant assert fired.

## Changes
- `include/sw/universal/number/elreal/sum.hpp` -- `zbcl_from_blocks` drops trailing subnormal limbs.

## Test Results
- **All 42 elreal regression tests pass on gcc 13.3.0 and clang 18.1.3** (default bfloat16 + fix) -- no regression.
- `el_math_sqrt` passes with RNE bfloat16 (from #1133) on both compilers -- the fix resolves the assert.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Sanitizers pass (this is the job #1133 tripped)
- [ ] Promote to ready when satisfied

Resolves #1135

Generated with [Claude Code](https://claude.com/claude-code)