### PR TITLE
feat(efloat): implement math/trigonometry.hpp (sin, cos, tan, asin, acos, atan, atan2)

### DIFF
--- a/elastic/efloat/math/trigonometry.cpp
+++ b/elastic/efloat/math/trigonometry.cpp
@@ -113,9 +113,11 @@ namespace {
 			if (!IsClose(atan(efloat<8>(-1.0)), -PI / 4.0))          { if (reportTestCases) std::cout << "    FAIL: atan(-1) != -pi/4\n"; ++failures; }
 			if (!IsClose(atan(efloat<8>(3.0)), std::atan(3.0)))      { if (reportTestCases) std::cout << "    FAIL: atan(3) inaccurate (|x|>1)\n"; ++failures; }
 			if (!IsClose(atan(efloat<8>(0.75)), std::atan(0.75)))    { if (reportTestCases) std::cout << "    FAIL: atan(0.75) inaccurate (addition formula)\n"; ++failures; }
-			// atan(+inf) == pi/2
+			// atan(+/-inf) == +/- pi/2
 			efloat<8> pinf; pinf.setinf(false);
-			if (!IsClose(atan(pinf), PI / 2.0))                     { if (reportTestCases) std::cout << "    FAIL: atan(+inf) != pi/2\n"; ++failures; }
+			efloat<8> ninf; ninf.setinf(true);
+			if (!IsClose(atan(pinf),  PI / 2.0))                    { if (reportTestCases) std::cout << "    FAIL: atan(+inf) != pi/2\n"; ++failures; }
+			if (!IsClose(atan(ninf), -PI / 2.0))                    { if (reportTestCases) std::cout << "    FAIL: atan(-inf) != -pi/2\n"; ++failures; }
 		}
 
 		// ---------------------------------------------------------------------
@@ -129,6 +131,18 @@ namespace {
 			if (!IsClose(atan2(efloat<8>(-1.0), efloat<8>(1.0)),  -PI / 4.0))        { if (reportTestCases) std::cout << "    FAIL: atan2(-1,1)\n"; ++failures; }  // QIV
 			if (!IsClose(atan2(efloat<8>(1.0),  efloat<8>(0.0)),  PI / 2.0))         { if (reportTestCases) std::cout << "    FAIL: atan2(1,0)\n"; ++failures; }
 			if (!IsClose(atan2(efloat<8>(0.0),  efloat<8>(-1.0)), PI))               { if (reportTestCases) std::cout << "    FAIL: atan2(0,-1)\n"; ++failures; }
+			// both arguments infinite -> diagonal directions (+/- pi/4, +/- 3pi/4)
+			{
+				efloat<8> pinf; pinf.setinf(false);
+				efloat<8> ninf; ninf.setinf(true);
+				if (!IsClose(atan2(pinf, pinf),        PI / 4.0))       { if (reportTestCases) std::cout << "    FAIL: atan2(+inf,+inf) != pi/4\n"; ++failures; }
+				if (!IsClose(atan2(pinf, ninf),  3.0 * PI / 4.0))       { if (reportTestCases) std::cout << "    FAIL: atan2(+inf,-inf) != 3pi/4\n"; ++failures; }
+				if (!IsClose(atan2(ninf, pinf),       -PI / 4.0))       { if (reportTestCases) std::cout << "    FAIL: atan2(-inf,+inf) != -pi/4\n"; ++failures; }
+				if (!IsClose(atan2(ninf, ninf), -3.0 * PI / 4.0))       { if (reportTestCases) std::cout << "    FAIL: atan2(-inf,-inf) != -3pi/4\n"; ++failures; }
+				// single infinite argument (negative operands exercise the sign()-vs-isneg() fix)
+				if (!IsClose(atan2(efloat<8>(1.0), ninf),  PI))          { if (reportTestCases) std::cout << "    FAIL: atan2(1,-inf) != pi\n"; ++failures; }
+				if (!IsClose(atan2(ninf, efloat<8>(1.0)), -PI / 2.0))    { if (reportTestCases) std::cout << "    FAIL: atan2(-inf,1) != -pi/2\n"; ++failures; }
+			}
 		}
 
 		// ---------------------------------------------------------------------

--- a/elastic/efloat/math/trigonometry.cpp
+++ b/elastic/efloat/math/trigonometry.cpp
@@ -1,0 +1,210 @@
+// trigonometry.cpp: regression tests for efloat trigonometric functions.
+//
+// Categories tested:
+//   - sin, cos, tan
+//   - asin, acos, atan, atan2
+//   - argument reduction, identities, special values (Issue #1115)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	// Helper to check if two values are close
+	template<unsigned nlimbs>
+	bool IsClose(const sw::universal::efloat<nlimbs>& a, double target_val, double tolerance = 1e-12) {
+		double diff = std::abs(double(a) - target_val);
+		return diff <= tolerance;
+	}
+
+	int VerifyEfloatTrigonometry(bool reportTestCases) {
+		using namespace sw::universal;
+		int failures = 0;
+
+		const double PI = std::acos(-1.0);
+
+		// ---------------------------------------------------------------------
+		// 1. sine (sin)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying sine (sin)...\n";
+		{
+			clear_efloat_exceptions();
+
+			if (sin(efloat<8>(0.0)) != 0.0)                           { if (reportTestCases) std::cout << "    FAIL: sin(0) != 0\n"; ++failures; }
+			if (!IsClose(sin(efloat<8>(PI / 2.0)),  1.0))             { if (reportTestCases) std::cout << "    FAIL: sin(pi/2) != 1\n"; ++failures; }
+			if (!IsClose(sin(efloat<8>(PI / 6.0)),  0.5))             { if (reportTestCases) std::cout << "    FAIL: sin(pi/6) != 0.5\n"; ++failures; }
+			if (!IsClose(sin(efloat<8>(1.0)), std::sin(1.0)))         { if (reportTestCases) std::cout << "    FAIL: sin(1) inaccurate\n"; ++failures; }
+			if (!IsClose(sin(efloat<8>(-1.0)), std::sin(-1.0)))       { if (reportTestCases) std::cout << "    FAIL: sin(-1) inaccurate\n"; ++failures; }
+			// argument reduction: sin(10*pi + pi/6) == sin(pi/6) == 0.5
+			if (!IsClose(sin(efloat<8>(10.0 * PI + PI / 6.0)), 0.5, 1e-10)) { if (reportTestCases) std::cout << "    FAIL: sin argument reduction\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 2. cosine (cos)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying cosine (cos)...\n";
+		{
+			if (cos(efloat<8>(0.0)) != 1.0)                          { if (reportTestCases) std::cout << "    FAIL: cos(0) != 1\n"; ++failures; }
+			if (!IsClose(cos(efloat<8>(PI / 3.0)), 0.5))             { if (reportTestCases) std::cout << "    FAIL: cos(pi/3) != 0.5\n"; ++failures; }
+			if (!IsClose(cos(efloat<8>(PI)), -1.0))                  { if (reportTestCases) std::cout << "    FAIL: cos(pi) != -1\n"; ++failures; }
+			if (!IsClose(cos(efloat<8>(2.0)), std::cos(2.0)))        { if (reportTestCases) std::cout << "    FAIL: cos(2) inaccurate\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 3. Pythagorean identity sin^2 + cos^2 == 1 (internal consistency)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying sin^2 + cos^2 == 1...\n";
+		{
+			efloat<8> x(0.7);
+			efloat<8> s = sin(x), c = cos(x);
+			efloat<8> id = s * s + c * c;
+			if (!IsClose(id, 1.0, 1e-14))                            { if (reportTestCases) std::cout << "    FAIL: sin^2+cos^2 != 1, got " << double(id) << "\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 4. tangent (tan)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying tangent (tan)...\n";
+		{
+			if (tan(efloat<8>(0.0)) != 0.0)                          { if (reportTestCases) std::cout << "    FAIL: tan(0) != 0\n"; ++failures; }
+			if (!IsClose(tan(efloat<8>(PI / 4.0)), 1.0))             { if (reportTestCases) std::cout << "    FAIL: tan(pi/4) != 1\n"; ++failures; }
+			if (!IsClose(tan(efloat<8>(0.5)), std::tan(0.5)))        { if (reportTestCases) std::cout << "    FAIL: tan(0.5) inaccurate\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 5. arcsine (asin)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying arcsine (asin)...\n";
+		{
+			if (asin(efloat<8>(0.0)) != 0.0)                         { if (reportTestCases) std::cout << "    FAIL: asin(0) != 0\n"; ++failures; }
+			if (!IsClose(asin(efloat<8>(1.0)), PI / 2.0))            { if (reportTestCases) std::cout << "    FAIL: asin(1) != pi/2\n"; ++failures; }
+			if (!IsClose(asin(efloat<8>(0.5)), PI / 6.0))            { if (reportTestCases) std::cout << "    FAIL: asin(0.5) != pi/6\n"; ++failures; }
+			if (!IsClose(asin(efloat<8>(-0.5)), -PI / 6.0))          { if (reportTestCases) std::cout << "    FAIL: asin(-0.5) != -pi/6\n"; ++failures; }
+			if (!IsClose(asin(efloat<8>(0.9)), std::asin(0.9), 1e-10)) { if (reportTestCases) std::cout << "    FAIL: asin(0.9) inaccurate (reduction)\n"; ++failures; }
+			// domain: |x| > 1 -> NaN
+			if (!asin(efloat<8>(2.0)).isnan())                      { if (reportTestCases) std::cout << "    FAIL: asin(2) not NaN\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 6. arccosine (acos)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying arccosine (acos)...\n";
+		{
+			if (!IsClose(acos(efloat<8>(1.0)), 0.0))                 { if (reportTestCases) std::cout << "    FAIL: acos(1) != 0\n"; ++failures; }
+			if (!IsClose(acos(efloat<8>(0.0)), PI / 2.0))            { if (reportTestCases) std::cout << "    FAIL: acos(0) != pi/2\n"; ++failures; }
+			if (!IsClose(acos(efloat<8>(-1.0)), PI))                 { if (reportTestCases) std::cout << "    FAIL: acos(-1) != pi\n"; ++failures; }
+			if (!acos(efloat<8>(2.0)).isnan())                      { if (reportTestCases) std::cout << "    FAIL: acos(2) not NaN\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 7. arctangent (atan)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying arctangent (atan)...\n";
+		{
+			if (atan(efloat<8>(0.0)) != 0.0)                         { if (reportTestCases) std::cout << "    FAIL: atan(0) != 0\n"; ++failures; }
+			if (!IsClose(atan(efloat<8>(1.0)), PI / 4.0))            { if (reportTestCases) std::cout << "    FAIL: atan(1) != pi/4\n"; ++failures; }
+			if (!IsClose(atan(efloat<8>(-1.0)), -PI / 4.0))          { if (reportTestCases) std::cout << "    FAIL: atan(-1) != -pi/4\n"; ++failures; }
+			if (!IsClose(atan(efloat<8>(3.0)), std::atan(3.0)))      { if (reportTestCases) std::cout << "    FAIL: atan(3) inaccurate (|x|>1)\n"; ++failures; }
+			if (!IsClose(atan(efloat<8>(0.75)), std::atan(0.75)))    { if (reportTestCases) std::cout << "    FAIL: atan(0.75) inaccurate (addition formula)\n"; ++failures; }
+			// atan(+inf) == pi/2
+			efloat<8> pinf; pinf.setinf(false);
+			if (!IsClose(atan(pinf), PI / 2.0))                     { if (reportTestCases) std::cout << "    FAIL: atan(+inf) != pi/2\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 8. atan2 (all quadrants)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying atan2 (quadrants)...\n";
+		{
+			if (!IsClose(atan2(efloat<8>(1.0),  efloat<8>(1.0)),  PI / 4.0))         { if (reportTestCases) std::cout << "    FAIL: atan2(1,1)\n"; ++failures; }   // QI
+			if (!IsClose(atan2(efloat<8>(1.0),  efloat<8>(-1.0)), 3.0 * PI / 4.0))   { if (reportTestCases) std::cout << "    FAIL: atan2(1,-1)\n"; ++failures; }  // QII
+			if (!IsClose(atan2(efloat<8>(-1.0), efloat<8>(-1.0)), -3.0 * PI / 4.0))  { if (reportTestCases) std::cout << "    FAIL: atan2(-1,-1)\n"; ++failures; } // QIII
+			if (!IsClose(atan2(efloat<8>(-1.0), efloat<8>(1.0)),  -PI / 4.0))        { if (reportTestCases) std::cout << "    FAIL: atan2(-1,1)\n"; ++failures; }  // QIV
+			if (!IsClose(atan2(efloat<8>(1.0),  efloat<8>(0.0)),  PI / 2.0))         { if (reportTestCases) std::cout << "    FAIL: atan2(1,0)\n"; ++failures; }
+			if (!IsClose(atan2(efloat<8>(0.0),  efloat<8>(-1.0)), PI))               { if (reportTestCases) std::cout << "    FAIL: atan2(0,-1)\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 9. round-trip: asin(sin(x)) == x, atan(tan(x)) == x  (x in principal range)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying inverse round-trips...\n";
+		{
+			efloat<8> x(0.3);
+			if (!IsClose(asin(sin(x)), 0.3, 1e-12))                 { if (reportTestCases) std::cout << "    FAIL: asin(sin(0.3)) != 0.3\n"; ++failures; }
+			if (!IsClose(atan(tan(x)), 0.3, 1e-12))                 { if (reportTestCases) std::cout << "    FAIL: atan(tan(0.3)) != 0.3\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 10. special values (NaN / Inf propagation)
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying special values...\n";
+		{
+			efloat<4> nan; nan.setnan();
+			if (!sin(nan).isnan())  { if (reportTestCases) std::cout << "    FAIL: sin(nan) not NaN\n"; ++failures; }
+			if (!cos(nan).isnan())  { if (reportTestCases) std::cout << "    FAIL: cos(nan) not NaN\n"; ++failures; }
+			if (!atan(nan).isnan()) { if (reportTestCases) std::cout << "    FAIL: atan(nan) not NaN\n"; ++failures; }
+
+			efloat<4> inf; inf.setinf(false);
+			if (!sin(inf).isnan())  { if (reportTestCases) std::cout << "    FAIL: sin(+inf) not NaN\n"; ++failures; }
+			if (!cos(inf).isnan())  { if (reportTestCases) std::cout << "    FAIL: cos(+inf) not NaN\n"; ++failures; }
+		}
+
+		return failures;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat mathematical trigonometry library";
+	std::string test_tag            = "trigonometry";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatTrigonometry(reportTestCases), "efloat", "trigonometry manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatTrigonometry(reportTestCases), "efloat", "trigonometry foundational");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/math/trigonometry.hpp
+++ b/include/sw/universal/number/efloat/math/trigonometry.hpp
@@ -1,0 +1,284 @@
+// trigonometry.hpp: trigonometric and inverse trigonometric functions for efloat
+//                   (sin, cos, tan, asin, acos, atan, atan2)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+#include <cmath>
+
+namespace sw { namespace universal {
+
+// ----------------------------------------------------------------------------
+// High-precision constants
+//
+// Constants are seeded from a ~62-digit decimal literal via efloat's arbitrary-
+// precision decimal-to-binary parse() (the same idiom exp()/log() use for ln2).
+// pi/2 and pi/4 are derived by exact multiplication by 0.5 / 0.25 (both exactly
+// representable), so only pi and atan(1/2) need a literal.
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> efloat_pi() {
+	efloat<nlimbs> pi;
+	parse("3.14159265358979323846264338327950288419716939937510582097494459", pi);
+	return pi;
+}
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> efloat_pi_2() {
+	return efloat_pi<nlimbs>() * efloat<nlimbs>(0.5);
+}
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> efloat_pi_4() {
+	return efloat_pi<nlimbs>() * efloat<nlimbs>(0.25);
+}
+
+// ----------------------------------------------------------------------------
+// sin: sine, computed by argument reduction to [-pi, pi] + Taylor series
+//   sin(x) = x - x^3/3! + x^5/5! - ...   term_n = -term_{n-1} * x^2 / ((2n)(2n+1))
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> sin(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) return x;               // sin(+/-0) = +/-0
+	if (x.isinf()) {
+		efloat<nlimbs> nan; nan.setnan();
+		if (!std::is_constant_evaluated()) efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+
+	efloat<nlimbs> pi = efloat_pi<nlimbs>();
+	efloat<nlimbs> two_pi = pi * efloat<nlimbs>(2.0);
+
+	// reduce to [-pi, pi]:  r = x - round(x / 2pi) * 2pi
+	efloat<nlimbs> k = round(x / two_pi);
+	efloat<nlimbs> r = x - k * two_pi;
+
+	// Taylor series
+	efloat<nlimbs> neg_r2 = r * r; neg_r2.setsign(true);   // -r^2 (r^2 >= 0)
+	efloat<nlimbs> term = r;
+	efloat<nlimbs> sum  = r;
+	for (unsigned n = 1; n < 1000; ++n) {
+		efloat<nlimbs> denom = efloat<nlimbs>(static_cast<double>(2 * n)) * efloat<nlimbs>(static_cast<double>(2 * n + 1));
+		term = term * neg_r2 / denom;
+		if (term.iszero()) break;
+		sum += term;
+		if (!sum.iszero() && term.scale() < sum.scale() - static_cast<int64_t>(sum.get_precision())) break;
+	}
+	return sum;
+}
+
+// ----------------------------------------------------------------------------
+// cos: cosine, argument reduction to [-pi, pi] + Taylor series
+//   cos(x) = 1 - x^2/2! + x^4/4! - ...   term_n = -term_{n-1} * x^2 / ((2n-1)(2n))
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> cos(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) return efloat<nlimbs>(1.0);
+	if (x.isinf()) {
+		efloat<nlimbs> nan; nan.setnan();
+		if (!std::is_constant_evaluated()) efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+
+	efloat<nlimbs> pi = efloat_pi<nlimbs>();
+	efloat<nlimbs> two_pi = pi * efloat<nlimbs>(2.0);
+
+	efloat<nlimbs> k = round(x / two_pi);
+	efloat<nlimbs> r = x - k * two_pi;
+
+	efloat<nlimbs> neg_r2 = r * r; neg_r2.setsign(true);   // -r^2
+	efloat<nlimbs> term(1.0);
+	efloat<nlimbs> sum(1.0);
+	for (unsigned n = 1; n < 1000; ++n) {
+		efloat<nlimbs> denom = efloat<nlimbs>(static_cast<double>(2 * n - 1)) * efloat<nlimbs>(static_cast<double>(2 * n));
+		term = term * neg_r2 / denom;
+		if (term.iszero()) break;
+		sum += term;
+		if (!sum.iszero() && term.scale() < sum.scale() - static_cast<int64_t>(sum.get_precision())) break;
+	}
+	return sum;
+}
+
+// ----------------------------------------------------------------------------
+// tan: tan(x) = sin(x) / cos(x)
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> tan(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) return x;
+	if (x.isinf()) {
+		efloat<nlimbs> nan; nan.setnan();
+		if (!std::is_constant_evaluated()) efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+	efloat<nlimbs> s = sin(x);
+	efloat<nlimbs> c = cos(x);
+	if (c.iszero()) {                        // odd multiple of pi/2: pole
+		efloat<nlimbs> inf; inf.setinf(s.isneg());
+		if (!std::is_constant_evaluated()) efloat_exception_flags.set(ExceptionFlag::DivisionByZero);
+		return inf;
+	}
+	return s / c;
+}
+
+// ----------------------------------------------------------------------------
+// atan: inverse tangent
+//   |x| == 1        -> +/- pi/4
+//   |x| >  1        -> sign * (pi/2 - atan(1/|x|))
+//   |x| >  1/2      -> atan(1/2) + atan((|x|-1/2)/(1+|x|/2))   (addition formula)
+//   else Taylor:  atan(x) = x - x^3/3 + x^5/5 - ...
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> atan(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) return x;
+	if (x.isinf()) {                         // atan(+/-inf) = +/- pi/2
+		efloat<nlimbs> h = efloat_pi_2<nlimbs>();
+		h.setsign(x.isneg());
+		return h;
+	}
+
+	bool negative = x.isneg();
+	efloat<nlimbs> ax(x); ax.setsign(false);  // |x|  (abs() free fn is a stub -- do it manually)
+	efloat<nlimbs> one(1.0);
+
+	efloat<nlimbs> result;
+	if (ax == one) {
+		result = efloat_pi_4<nlimbs>();
+	}
+	else if (ax > one) {
+		result = efloat_pi_2<nlimbs>() - atan(one / ax);
+	}
+	else {
+		efloat<nlimbs> half(0.5);
+		efloat<nlimbs> reduced = ax;
+		bool used_addition = false;
+		if (ax > half) {
+			// atan(x) = atan(1/2) + atan((x - 1/2)/(1 + x/2)),  reduced arg < ~0.32
+			efloat<nlimbs> num = ax - half;
+			efloat<nlimbs> den = one + ax * half;
+			reduced = num / den;
+			used_addition = true;
+		}
+		// Taylor series for |reduced| < ~0.5
+		efloat<nlimbs> neg_r2 = reduced * reduced; neg_r2.setsign(true);  // -reduced^2
+		efloat<nlimbs> power = reduced;    // reduced^(2n+1)
+		efloat<nlimbs> series = reduced;
+		for (unsigned n = 1; n < 2000; ++n) {
+			power = power * neg_r2;                                        // alternates sign
+			efloat<nlimbs> t = power / efloat<nlimbs>(static_cast<double>(2 * n + 1));
+			if (t.iszero()) break;
+			series += t;
+			if (!series.iszero() && t.scale() < series.scale() - static_cast<int64_t>(series.get_precision())) break;
+		}
+		if (used_addition) {
+			efloat<nlimbs> atan_half;
+			parse("0.46364760900080611621425623146121440202853705428612026381093309", atan_half);
+			result = atan_half + series;
+		}
+		else {
+			result = series;
+		}
+	}
+	if (negative) result = efloat<nlimbs>(0.0) - result;
+	return result;
+}
+
+// ----------------------------------------------------------------------------
+// asin: inverse sine
+//   |x| > 1 -> NaN;  x == +/-1 -> +/- pi/2
+//   |x| > 0.8 -> sign * (pi/2 - asin(sqrt(1 - x^2)))   (reduce toward 0)
+//   else Taylor:  asin(x) = x + (1/2)x^3/3 + (1*3/2*4)x^5/5 + ...
+//                 term_n = term_{n-1} * x^2 * (2n-1)^2 / ((2n)(2n+1))
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> asin(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	if (x.iszero()) return x;
+
+	bool negative = x.isneg();
+	efloat<nlimbs> ax(x); ax.setsign(false);  // |x|
+	efloat<nlimbs> one(1.0);
+
+	if (ax > one) {                           // domain error
+		efloat<nlimbs> nan; nan.setnan();
+		if (!std::is_constant_evaluated()) efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+	efloat<nlimbs> result;
+	if (ax == one) {
+		result = efloat_pi_2<nlimbs>();
+	}
+	else if (ax > efloat<nlimbs>(0.8)) {
+		// asin(x) = pi/2 - asin(sqrt(1 - x^2))   (on |x|)
+		efloat<nlimbs> t = sqrt(one - ax * ax);
+		result = efloat_pi_2<nlimbs>() - asin(t);
+	}
+	else {
+		efloat<nlimbs> x2 = ax * ax;
+		efloat<nlimbs> term = ax;             // (2n-1)!!/(2n)!! * x^(2n+1) accumulator, term_0 = x
+		efloat<nlimbs> sum  = ax;
+		for (unsigned n = 1; n < 4000; ++n) {
+			efloat<nlimbs> odd = efloat<nlimbs>(static_cast<double>(2 * n - 1));
+			efloat<nlimbs> num = odd * odd;   // (2n-1)^2
+			efloat<nlimbs> den = efloat<nlimbs>(static_cast<double>(2 * n)) * efloat<nlimbs>(static_cast<double>(2 * n + 1));
+			term = term * x2 * num / den;
+			if (term.iszero()) break;
+			sum += term;
+			if (!sum.iszero() && term.scale() < sum.scale() - static_cast<int64_t>(sum.get_precision())) break;
+		}
+		result = sum;
+	}
+	if (negative) result = efloat<nlimbs>(0.0) - result;
+	return result;
+}
+
+// ----------------------------------------------------------------------------
+// acos: acos(x) = pi/2 - asin(x);  |x| > 1 -> NaN
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> acos(const efloat<nlimbs>& x) {
+	if (x.isnan()) return x;
+	efloat<nlimbs> ax(x); ax.setsign(false);
+	if (ax > efloat<nlimbs>(1.0)) {           // domain error
+		efloat<nlimbs> nan; nan.setnan();
+		if (!std::is_constant_evaluated()) efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+	return efloat_pi_2<nlimbs>() - asin(x);
+}
+
+// ----------------------------------------------------------------------------
+// atan2: full-quadrant arctangent of y/x
+// ----------------------------------------------------------------------------
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> atan2(const efloat<nlimbs>& y, const efloat<nlimbs>& x) {
+	if (y.isnan() || x.isnan()) {
+		efloat<nlimbs> nan; nan.setnan();
+		return nan;
+	}
+	efloat<nlimbs> pi   = efloat_pi<nlimbs>();
+	efloat<nlimbs> pi_2 = efloat_pi_2<nlimbs>();
+
+	if (x.iszero()) {
+		if (y.iszero()) return efloat<nlimbs>(0.0);    // atan2(0,0): convention 0
+		efloat<nlimbs> h(pi_2); h.setsign(y.isneg());  // +/- pi/2
+		return h;
+	}
+	if (y.iszero()) {
+		if (x.isneg()) return pi;                      // atan2(+0, -x) = pi
+		return efloat<nlimbs>(0.0);                     // atan2(+0, +x) = 0
+	}
+
+	efloat<nlimbs> angle = atan(y / x);
+	if (x.isneg()) {
+		// quadrant II / III correction
+		if (y.isneg()) angle = angle - pi;              // QIII: result in (-pi, -pi/2)
+		else           angle = angle + pi;              // QII:  result in ( pi/2, pi)
+	}
+	return angle;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/efloat/math/trigonometry.hpp
+++ b/include/sw/universal/number/efloat/math/trigonometry.hpp
@@ -136,7 +136,7 @@ constexpr efloat<nlimbs> atan(const efloat<nlimbs>& x) {
 	if (x.iszero()) return x;
 	if (x.isinf()) {                         // atan(+/-inf) = +/- pi/2
 		efloat<nlimbs> h = efloat_pi_2<nlimbs>();
-		h.setsign(x.isneg());
+		h.setsign(x.sign() == -1);           // isneg() is false for inf (state != Normal)
 		return h;
 	}
 
@@ -262,21 +262,37 @@ constexpr efloat<nlimbs> atan2(const efloat<nlimbs>& y, const efloat<nlimbs>& x)
 	efloat<nlimbs> pi   = efloat_pi<nlimbs>();
 	efloat<nlimbs> pi_2 = efloat_pi_2<nlimbs>();
 
+	// Sign checks below use sign() == -1, not isneg(): isneg() is false for an
+	// infinity (its state is Infinite, not Normal), and atan2 arguments may be
+	// infinite in every branch. sign() reads the stored sign bit directly, so
+	// it is correct for both normal and infinite operands (and equivalent to
+	// isneg() for finite normals).
+	const bool y_neg = (y.sign() == -1);
+	const bool x_neg = (x.sign() == -1);
+
+	// both infinite: y/x is indeterminate, but atan2 is defined on the
+	// diagonal directions -> +/- pi/4 (x > 0) or +/- 3pi/4 (x < 0).
+	if (y.isinf() && x.isinf()) {
+		efloat<nlimbs> angle = x_neg ? (pi - efloat_pi_4<nlimbs>()) : efloat_pi_4<nlimbs>();
+		angle.setsign(y_neg);
+		return angle;
+	}
+
 	if (x.iszero()) {
 		if (y.iszero()) return efloat<nlimbs>(0.0);    // atan2(0,0): convention 0
-		efloat<nlimbs> h(pi_2); h.setsign(y.isneg());  // +/- pi/2
+		efloat<nlimbs> h(pi_2); h.setsign(y_neg);      // +/- pi/2
 		return h;
 	}
 	if (y.iszero()) {
-		if (x.isneg()) return pi;                      // atan2(+0, -x) = pi
+		if (x_neg) return pi;                          // atan2(+0, -x) = pi
 		return efloat<nlimbs>(0.0);                     // atan2(+0, +x) = 0
 	}
 
 	efloat<nlimbs> angle = atan(y / x);
-	if (x.isneg()) {
+	if (x_neg) {
 		// quadrant II / III correction
-		if (y.isneg()) angle = angle - pi;              // QIII: result in (-pi, -pi/2)
-		else           angle = angle + pi;              // QII:  result in ( pi/2, pi)
+		if (y_neg) angle = angle - pi;                  // QIII: result in (-pi, -pi/2)
+		else       angle = angle + pi;                  // QII:  result in ( pi/2, pi)
 	}
 	return angle;
 }

--- a/include/sw/universal/number/efloat/mathlib.hpp
+++ b/include/sw/universal/number/efloat/mathlib.hpp
@@ -11,6 +11,7 @@
 #include <universal/number/efloat/math/logarithm.hpp>
 #include <universal/number/efloat/math/classify.hpp>
 #include <universal/number/efloat/math/truncate.hpp>
+#include <universal/number/efloat/math/trigonometry.hpp>
 #include <universal/number/efloat/math/pow.hpp>
 #include <universal/number/efloat/math/fractional.hpp>
 #include <universal/number/efloat/math/minmax.hpp>


### PR DESCRIPTION
## Summary
Implements `efloat/math/trigonometry.hpp` for the arbitrary-precision `efloat` template, the last missing piece of the efloat mathematical library (parent #1092). These are **native arbitrary-precision** implementations (argument reduction + series), not double-delegating shims.

## Changes
- `include/sw/universal/number/efloat/math/trigonometry.hpp` (new) -- `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2` in `sw::universal`, plus internal `efloat_pi`/`efloat_pi_2`/`efloat_pi_4` helpers.
- `include/sw/universal/number/efloat/mathlib.hpp` -- include the new header after `truncate.hpp` (trig needs `round()`).
- `elastic/efloat/math/trigonometry.cpp` (new) -- regression test (auto-globbed as target `efloat_trigonometry`).

## Algorithm
- **sin/cos**: reduce to `[-pi, pi]` via `r = x - round(x/2pi)*2pi`, then Taylor series with the precision-aware `term.scale() < sum.scale() - get_precision()` terminator (same idiom as `expm1`/`log1p`).
- **tan** = sin/cos, signed-infinity at the pole (`cos == 0`).
- **atan**: `|x|==1 -> pi/4`; `|x|>1 -> pi/2 - atan(1/|x|)`; `0.5<|x|<=1 ->` addition formula `atan(1/2) + atan((|x|-1/2)/(1+|x|/2))`; else Taylor -- keeps the reduced argument small so the series converges fast (no slow Leibniz tail near 1).
- **asin**: domain `|x|>1 -> NaN`; `|x|>0.8 -> pi/2 - asin(sqrt(1-x^2))`; else Taylor.
- **acos** = `pi/2 - asin`.
- **atan2**: full-quadrant, using the efloat pi constants (**not** bare `double` literals -- avoids the double-contamination bug present in `ereal`'s `atan2`).

## Notes / follow-ups
- High-precision pi is seeded via `parse()` of a ~62-digit literal (the same idiom `exp`/`log` use for `ln2`); `pi/2`, `pi/4` derived by exact multiplication. Accuracy is therefore capped at ~62 digits like the existing `ln2`/`ln10` constants -- fine for the standard efloat configs; a longer literal or a native pi computation can lift that in a later PR.
- The free `abs()`/`fabs()` function in `efloat_impl.hpp` is a **pre-existing stub** that returns its argument unchanged; this code takes absolute values via the `setsign(false)` idiom the other efloat math headers already use. Worth a separate fix.
- Unblocks the efloat demonstration issues that need trig (#1096 catastrophic cancellation, #1099 identities).

## Test Results (built with `-I include/sw`, `-std=c++20`, `-DREGRESSION_LEVEL_1=1`)
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_trigonometry (new) | OK | PASS | OK | PASS |
| efloat_math (regression) | OK | PASS | -- | -- |
| efloat_exponent (regression) | OK | PASS | -- | -- |
| efloat_pow (regression) | OK | PASS | -- | -- |

gcc 13.3.0, clang 18.1.3. Coverage: values, identities (`sin^2+cos^2==1`), argument reduction, inverse round-trips, all four `atan2` quadrants, domain errors (`asin`/`acos` of `|x|>1`), NaN/Inf special values.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #1115

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trigonometric and inverse-trigonometric functions for efloat values, including `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, and `atan2`.
  * Added high-precision constants for π, π/2, and π/4.
  * Added handling for special values, including zero, infinity, and NaN inputs.

* **Tests**
  * Added regression coverage for trigonometric accuracy, identities, argument reduction, round trips, and special-value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->