### PR TITLE
fix(efloat): make sqrt()/cbrt() precision-adaptive (were capped at ~97 digits)

### DIFF
--- a/elastic/efloat/math/sqrt_precision.cpp
+++ b/elastic/efloat/math/sqrt_precision.cpp
@@ -1,0 +1,127 @@
+// sqrt_precision.cpp: regression tests for efloat sqrt()/cbrt() accuracy scaling.
+//
+// Guards issue #1140: sqrt/cbrt used a fixed 7 Newton iterations from a ~1-bit
+// exponent-only seed, freezing accuracy at ~323 bits (~97 digits) regardless of
+// get_precision(). The iteration count is now precision-adaptive, so accuracy
+// must scale with the working precision.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	// |a - b| binary scale (very negative == agreement to many bits; -1e6 == exact)
+	template<unsigned nlimbs>
+	int64_t err_scale(sw::universal::efloat<nlimbs> a, const sw::universal::efloat<nlimbs>& b) {
+		a = a - b; a.setsign(false);
+		return a.iszero() ? -1000000 : a.scale();
+	}
+
+	int VerifyEfloatSqrtPrecision(bool reportTestCases) {
+		using namespace sw::universal;
+		int failures = 0;
+
+		// ---------------------------------------------------------------------
+		// 1. Basic values
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying basic sqrt/cbrt/hypot values...\n";
+		{
+			if (std::abs(double(sqrt(efloat<8>(4.0)))  - 2.0) > 1e-13) { if (reportTestCases) std::cout << "    FAIL: sqrt(4)!=2\n"; ++failures; }
+			if (std::abs(double(sqrt(efloat<8>(2.0)))  - std::sqrt(2.0)) > 1e-13) { if (reportTestCases) std::cout << "    FAIL: sqrt(2)\n"; ++failures; }
+			if (std::abs(double(cbrt(efloat<8>(27.0))) - 3.0) > 1e-13) { if (reportTestCases) std::cout << "    FAIL: cbrt(27)!=3\n"; ++failures; }
+			if (std::abs(double(cbrt(efloat<8>(-8.0))) + 2.0) > 1e-13) { if (reportTestCases) std::cout << "    FAIL: cbrt(-8)!=-2\n"; ++failures; }
+			if (std::abs(double(hypot(efloat<8>(3.0), efloat<8>(4.0))) - 5.0) > 1e-13) { if (reportTestCases) std::cout << "    FAIL: hypot(3,4)!=5\n"; ++failures; }
+		}
+
+		// ---------------------------------------------------------------------
+		// 2. Accuracy scales with precision (the #1140 guard).
+		//    At capacity B bits, |sqrt(2)^2 - 2| must fall well below 2^-300
+		//    (the old cap) -- we require agreement to at least B-8 bits.
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying sqrt accuracy scales with precision...\n";
+		{
+			// efloat<16> -> 512-bit capacity; require > 300-bit agreement (old cap was ~323)
+			{
+				efloat<16> two(2.0);
+				efloat<16> r = sqrt(two);
+				int64_t sc = err_scale<16>(r * r, two);
+				if (sc > -500) { if (reportTestCases) std::cout << "    FAIL: sqrt@512 only " << -sc << " bits (want > 500)\n"; ++failures; }
+			}
+			// efloat<64> -> 2048-bit capacity; must far exceed the ~323-bit old cap
+			{
+				efloat<64> two(2.0);
+				efloat<64> r = sqrt(two);
+				int64_t sc = err_scale<64>(r * r, two);
+				if (sc > -2000) { if (reportTestCases) std::cout << "    FAIL: sqrt@2048 only " << -sc << " bits (want > 2000; old cap ~323)\n"; ++failures; }
+			}
+			// cbrt at 2048-bit capacity
+			{
+				efloat<64> two(2.0);
+				efloat<64> r = cbrt(two);
+				int64_t sc = err_scale<64>(r * r * r, two);
+				if (sc > -2000) { if (reportTestCases) std::cout << "    FAIL: cbrt@2048 only " << -sc << " bits (want > 2000)\n"; ++failures; }
+			}
+		}
+
+		// ---------------------------------------------------------------------
+		// 3. Special values
+		// ---------------------------------------------------------------------
+		if (reportTestCases) std::cout << "  Verifying sqrt special values...\n";
+		{
+			if (!sqrt(efloat<8>(0.0)).iszero())      { if (reportTestCases) std::cout << "    FAIL: sqrt(0)\n"; ++failures; }
+			if (!sqrt(efloat<8>(-1.0)).isnan())      { if (reportTestCases) std::cout << "    FAIL: sqrt(-1) not NaN\n"; ++failures; }
+			efloat<8> inf; inf.setinf(false);
+			if (!sqrt(inf).isinf())                  { if (reportTestCases) std::cout << "    FAIL: sqrt(inf)\n"; ++failures; }
+			efloat<8> nan; nan.setnan();
+			if (!sqrt(nan).isnan())                  { if (reportTestCases) std::cout << "    FAIL: sqrt(nan)\n"; ++failures; }
+		}
+
+		return failures;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat sqrt precision library";
+	std::string test_tag            = "sqrt-precision";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatSqrtPrecision(reportTestCases), "efloat", "sqrt precision");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/math/sqrt.hpp
+++ b/include/sw/universal/number/efloat/math/sqrt.hpp
@@ -31,9 +31,24 @@ constexpr efloat<nlimbs> sqrt(const efloat<nlimbs>& a) {
 
 	efloat<nlimbs> half(0.5);
 
-	// Newton iterations (7 iterations converge up to 2048 bits!)
-	for (int i = 0; i < 7; ++i) {
+	// Newton's iteration x <- (x + a/x)/2 doubles the number of correct bits
+	// each step. The exponent-only seed above is accurate to ~1 bit (it keeps
+	// efloat's unbounded exponent range but carries no mantissa information), so
+	// the iteration count must scale with the working precision: ~ceil(log2(P))
+	// doublings plus a few guard steps. A fixed 7 iterations previously capped
+	// accuracy at ~97 digits regardless of get_precision() (issue #1140). The
+	// convergence break stops as soon as the update falls below the working
+	// precision, so high-precision operands do not pay for the guard steps.
+	// The working precision is the max feeding the arithmetic: the operand's
+	// precision or the seed/default precision (~nlimbs*32), whichever is larger.
+	const unsigned prec = (a.get_precision() > nlimbs * 32u) ? a.get_precision() : nlimbs * 32u;
+	int max_iters = 6;
+	for (unsigned p = prec; p > 1u; p >>= 1) ++max_iters;   // ceil(log2(prec)) + 6
+	for (int i = 0; i < max_iters; ++i) {
+		efloat<nlimbs> prev(x);
 		x = half * (x + a / x);
+		efloat<nlimbs> d(x - prev); d.setsign(false);
+		if (d.iszero() || (!x.iszero() && d.scale() < x.scale() - static_cast<int64_t>(prec))) break;
 	}
 	return x;
 }
@@ -57,9 +72,18 @@ constexpr efloat<nlimbs> cbrt(const efloat<nlimbs>& a) {
 	efloat<nlimbs> one_third = efloat<nlimbs>(1.0) / efloat<nlimbs>(3.0);
 	efloat<nlimbs> two(2.0);
 
-	// Newton iterations for y^3 - abs_a = 0: y_next = 1/3 * (2 * y + abs_a / y^2)
-	for (int i = 0; i < 7; ++i) {
+	// Newton iterations for y^3 - abs_a = 0: y_next = 1/3 * (2 * y + abs_a / y^2).
+	// Precision-adaptive iteration count with a convergence break, for the same
+	// reason as sqrt above (issue #1140): the ~1-bit exponent-only seed needs
+	// ~ceil(log2(precision)) doublings to reach full precision.
+	const unsigned prec = (abs_a.get_precision() > nlimbs * 32u) ? abs_a.get_precision() : nlimbs * 32u;
+	int max_iters = 6;
+	for (unsigned p = prec; p > 1u; p >>= 1) ++max_iters;
+	for (int i = 0; i < max_iters; ++i) {
+		efloat<nlimbs> prev(y);
 		y = one_third * (two * y + abs_a / (y * y));
+		efloat<nlimbs> d(y - prev); d.setsign(false);
+		if (d.iszero() || (!y.iszero() && d.scale() < y.scale() - static_cast<int64_t>(prec))) break;
 	}
 
 	if (is_neg) {


### PR DESCRIPTION
## Summary
`efloat` `sqrt()` and `cbrt()` ran a **fixed 7 Newton iterations**, freezing accuracy at **~323 bits (~97 digits)** regardless of `get_precision()` (issue #1140).

## Root cause
The header comment claimed *"7 iterations converge up to 2048 bits"* -- but that assumes a ~52-bit seed. The actual initial guess is **exponent-only** (`2^(scale/2)`, mantissa `1.0`), accurate to ~1 bit. That seed is deliberate: it preserves efloat's unbounded exponent range (a `double`-based seed would overflow for large scales). But from a 1-bit seed, Newton's quadratic convergence reaches only ~2^7 = ~128 bits in 7 steps -- hence the cap.

(For contrast, efloat's `+ - * /` are correct to 3400+ bits, so the limitation was specific to these fixed-iteration kernels.)

## Fix
Keep the unbounded-range seed, but **scale the iteration count with the working precision**: `~ceil(log2(P))` doublings plus guard steps, where `P` is the max precision feeding the arithmetic (operand precision or the seed/default, whichever is larger). A **convergence break** stops as soon as the update falls below `P`, so high-precision operands don't pay for the guard steps. Same fix applied to `cbrt`.

## Changes
- `include/sw/universal/number/efloat/math/sqrt.hpp` -- precision-adaptive iteration count + convergence break in `sqrt` and `cbrt`.
- `elastic/efloat/math/sqrt_precision.cpp` (new) -- regression test (target `efloat_sqrt_precision`).

## Verification
`|sqrt(2)^2 - 2|` and `|cbrt(2)^3 - 2|` now converge to the type's **full precision** (exact at `efloat<128>`), versus ~`2^-323` before:

| capacity | old accuracy | new accuracy |
|----------|-------------|--------------|
| efloat<16> (512b) | ~323 bits | > 500 bits |
| efloat<64> (2048b) | ~323 bits | full (~2046 bits) |
| efloat<128> (4096b) | ~323 bits | exact |

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_sqrt_precision (new) | OK | PASS | OK | PASS |
| efloat_math / pow / fractional / minmax / ... (regression) | OK | PASS | -- | -- |

gcc 13.3.0, clang 18.1.3.

## Notes
- Enables native high-precision `sqrt`-based computation -- e.g. `phi = (1+sqrt(5))/2` and Gauss-Legendre `pi` -- the native-computation alternative considered for the #1139 constants.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1140

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of `sqrt` and `cbrt` across varying `efloat` precision levels.
  - Iterations now adapt to the requested precision and stop early when further refinement is no longer meaningful.
- **Tests**
  - Added a new regression test program covering `sqrt`, `cbrt`, and `hypot`, including basic correctness, precision-scaling behavior, convergence checks, and special-value handling (zero, negative, infinities, and NaNs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->