### PR TITLE
feat(efloat): catastrophic cancellation demonstration (#1096)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1406,6 +1406,7 @@ add_subdirectory("applications/performance/stream")
 add_subdirectory("applications/performance/weather")
 add_subdirectory("applications/performance/ir")
 
+add_subdirectory("applications/precision/adaptive")
 add_subdirectory("applications/precision/constants")
 add_subdirectory("applications/precision/floating-point")
 add_subdirectory("applications/precision/math")

--- a/applications/precision/adaptive/CMakeLists.txt
+++ b/applications/precision/adaptive/CMakeLists.txt
@@ -1,0 +1,3 @@
+file (GLOB SOURCES "./*.cpp")
+
+compile_all("true" "adaptive" "Applications/Precision/Adaptive Precision" "${SOURCES}")

--- a/applications/precision/adaptive/catastrophic_cancellation.cpp
+++ b/applications/precision/adaptive/catastrophic_cancellation.cpp
@@ -1,0 +1,114 @@
+// catastrophic_cancellation.cpp: demonstrate how efloat's adaptive precision
+//                                defeats catastrophic cancellation (issue #1096)
+//
+// f(x) = (1 - cos x) / x^2   is numerically UNSTABLE for small x: cos x is very
+// close to 1, so (1 - cos x) loses almost all its significant digits in fixed-
+// precision double. The mathematically equivalent
+//
+//   g(x) = 2 * sin(x/2)^2 / x^2
+//
+// is STABLE (no subtraction of nearly-equal quantities). Both tend to 1/2 as
+// x -> 0. Written as a single templated kernel, the same code runs on `double`
+// and on `efloat`; with enough working precision `efloat` gets the right answer
+// even from the unstable formula.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <iostream>
+#include <iomanip>
+#include <string>
+#include <universal/number/efloat/efloat.hpp>
+
+// Unstable form: subtracts two nearly-equal quantities for small x.
+template<typename Real>
+Real f_unstable(const Real& x) {
+	using namespace sw::universal;
+	using std::cos;
+	return (Real(1.0) - cos(x)) / (x * x);
+}
+
+// Stable form: no cancellation. Algebraically identical to f.
+template<typename Real>
+Real g_stable(const Real& x) {
+	using namespace sw::universal;
+	using std::sin;
+	Real s = sin(x / Real(2.0));
+	return (Real(2.0) * s * s) / (x * x);
+}
+
+int main()
+try {
+	using namespace sw::universal;
+	using efloat256 = efloat<8>;   // 8 limbs * 32 = 256 bits of working precision
+
+	std::cout << "Catastrophic cancellation: f(x) = (1 - cos x) / x^2   (unstable)\n";
+	std::cout << "                     vs    g(x) = 2 sin^2(x/2) / x^2   (stable)\n";
+	std::cout << "Both tend to 1/2 as x -> 0.  efloat working precision: 256 bits (~77 digits)\n\n";
+
+	// -------------------------------------------------------------------------
+	// The four results the issue asks for, at x = 1e-10.
+	// double and efloat start from the SAME x, so the only difference is the
+	// arithmetic precision.
+	// -------------------------------------------------------------------------
+	const double x0 = 1e-10;
+	efloat256 xe(x0);
+
+	std::cout << std::setprecision(17);
+	std::cout << "At x = " << x0 << ":\n";
+	std::cout << "  double  f(x) = " << std::setw(22) << f_unstable(x0) << "   <- catastrophic cancellation\n";
+	std::cout << "  double  g(x) = " << std::setw(22) << g_stable(x0)   << "   <- double's correct reference\n";
+	std::cout << "  efloat  f(x) = " << std::setw(22) << double(f_unstable(xe)) << "   <- correct, from the UNSTABLE formula\n";
+	std::cout << "  efloat  g(x) = " << std::setw(22) << double(g_stable(xe))   << "\n";
+	{
+		efloat256 diff = f_unstable(xe) - g_stable(xe);
+		diff.setsign(false);
+		long long bits = diff.iszero() ? 256 : -static_cast<long long>(diff.scale());
+		std::cout << "  efloat f and g agree to ~" << bits << " bits (~" << (bits * 3) / 10 << " digits)\n\n";
+	}
+
+	// -------------------------------------------------------------------------
+	// Breakdown table: as x shrinks, double f(x) progressively loses digits and
+	// finally collapses to 0, while efloat f(x) stays accurate. The reference is
+	// the stable efloat g(x).
+	// -------------------------------------------------------------------------
+	std::cout << "  " << std::left
+	          << std::setw(10) << "x"
+	          << std::setw(24) << "double f(x)"
+	          << std::setw(24) << "efloat f(x)  (accurate)"
+	          << "double f rel.error\n";
+	std::cout << "  " << std::string(72, '-') << "\n";
+	const double xs[] = { 1e-2, 1e-4, 1e-6, 1e-8, 1e-10, 1e-12, 1e-14 };
+	for (double x : xs) {
+		efloat256 xe2(x);
+		double df = f_unstable(x);
+		efloat256 ef = f_unstable(xe2);
+		efloat256 ref = g_stable(xe2);         // stable, high-precision reference
+		double eref = double(ref);
+		double relerr = (eref != 0.0) ? std::abs(df - eref) / std::abs(eref) : std::abs(df);
+		std::cout << "  " << std::left  << std::setw(10) << std::scientific << std::setprecision(0) << x
+		          << std::right << std::fixed << std::setprecision(15)
+		          << std::setw(22) << df << "  "
+		          << std::setw(22) << double(ef) << "  "
+		          << std::scientific << std::setprecision(2) << std::setw(10) << relerr << "\n";
+	}
+
+	std::cout << "\nThe unstable formula is fine in efloat because 256-bit arithmetic keeps the\n";
+	std::cout << "tiny (1 - cos x) term that double rounds away. Same code, two number types.\n";
+
+	return EXIT_SUCCESS;
+}
+catch (const char* msg) {
+	std::cerr << "Caught exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Adds a demonstration of how `efloat`'s adaptive precision defeats **catastrophic cancellation** -- the first efloat application example, and the natural capstone to the efloat math-library arc (trig #1137, constants #1142, sqrt #1143, parse #1141).

Same templated kernel runs on `double` and `efloat`:
- unstable `f(x) = (1 - cos x)/x^2` (for small x, `cos x ~ 1`, so `1 - cos x` loses its significant digits)
- stable `g(x) = 2 sin^2(x/2)/x^2` (algebraically identical, no cancellation)

## What it shows (actual output)
```
At x = 1e-10:
  double  f(x) =                      0   <- catastrophic cancellation
  double  g(x) =                    0.5   <- double's correct reference
  efloat  f(x) =                    0.5   <- correct, from the UNSTABLE formula
  efloat  g(x) =                    0.5
  efloat f and g agree to ~192 bits (~57 digits)

  x         double f(x)             efloat f(x)  (accurate) double f rel.error
  ------------------------------------------------------------------------
  1e-02          0.499995833347366       0.499995833347222    2.88e-13
  1e-04          0.499999996961265       0.499999999583333    5.24e-09
  1e-06          0.500044450291171       0.499999999999958    8.89e-05
  1e-08          0.000000000000000       0.500000000000000    1.00e+00
  1e-10          0.000000000000000       0.500000000000000    1.00e+00
  ...
```
`double f` degrades from ~3e-13 relative error to **100% wrong**; `efloat<8>` (256-bit) `f` stays at 0.5 from the same unstable formula.

## Changes
- `applications/precision/adaptive/catastrophic_cancellation.cpp` (new) -- the demo (templated `f`/`g`, single-point report + breakdown table).
- `applications/precision/adaptive/CMakeLists.txt` (new) -- mirrors the sibling precision examples; target `adaptive_catastrophic_cancellation`.
- `CMakeLists.txt` -- `add_subdirectory("applications/precision/adaptive")` in the applications block.

## Notes
- efloat's `operator<<` is still a TBD stub, so values print via `double()` casts and high-precision agreement is shown via the scale metric -- sufficient to make the point without depending on the streaming path. (A full-precision `operator<<` would be a nice separate enhancement.)

## Test Results
| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| adaptive_catastrophic_cancellation | OK | OK | OK | OK |

gcc 13.3.0, clang 18.1.3.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1096

Generated with [Claude Code](https://claude.com/claude-code)