### PR TITLE
feat(efloat): high-precision Mandelbrot deep-zoom demonstration (#1098)

### DIFF
--- a/applications/precision/adaptive/README.md
+++ b/applications/precision/adaptive/README.md
@@ -1,0 +1,69 @@
+# Adaptive-precision demonstrations (`efloat`)
+
+Small, self-contained programs that show where fixed-precision `double` breaks
+down and adaptive-precision `efloat` keeps computing correctly. Each runs the
+**same templated kernel** on both `double` and `efloat` -- the only difference
+is the working precision.
+
+| Program | What it shows |
+|---------|---------------|
+| `catastrophic_cancellation` | `(1-cos x)/x^2` for small `x`: `double` cancels to 0, `efloat` returns 1/2 (#1096) |
+| `ill_conditioned_systems`   | Hilbert-matrix solve: `double` error ~100% at n=12, `efloat` is exact (#1097) |
+| `high_precision_fractals`   | Mandelbrot deep zoom: `double` pixelates, `efloat` resolves the detail (#1098) |
+
+## High-precision fractal visualization
+
+`high_precision_fractals.cpp` renders a deep-zoom view of the Mandelbrot set
+(`z_{n+1} = z_n^2 + c`) around a spiral in the seahorse-valley neighbourhood.
+
+At the chosen zoom the pixel spacing (`dx ~ 3.75e-17`) is a fraction of a
+`double` ulp (`~1.11e-16`) at these coordinates, so **`double` cannot give
+adjacent pixels distinct coordinates**: about two thirds of the columns (and
+rows) collapse onto their neighbour, and the image degrades into blocky,
+streaked bands. The `efloat` (256-bit) render computes every pixel's coordinate
+exactly and reveals the true fractal structure.
+
+### Build and run
+
+Configure with applications enabled, then run the target:
+
+```bash
+cmake -DUNIVERSAL_BUILD_APPLICATIONS=ON ..
+make adaptive_high_precision_fractals
+./applications/precision/adaptive/adaptive_high_precision_fractals
+```
+
+It prints a quantitative summary and writes two images in the current directory:
+
+- `mandelbrot_double.ppm` -- the `double` render (blocky / corrupted)
+- `mandelbrot_efloat.ppm` -- the `efloat` render (correct)
+
+View them with any image viewer, or convert to PNG:
+
+```bash
+# ImageMagick
+convert mandelbrot_efloat.ppm mandelbrot_efloat.png
+# or Python / Pillow
+python3 -c "from PIL import Image; Image.open('mandelbrot_efloat.ppm').save('mandelbrot_efloat.png')"
+```
+
+### Expected output
+
+```
+  pixel spacing dx = 3.750e-17   double ulp here = 1.110e-16   dx/ulp = 0.34
+  efloat (oracle) escape range: [295, 1000]  <- real fractal structure
+  pixels where double disagrees with efloat: 4835 / 6400  (75.5%)
+```
+
+About **75% of pixels** in the `double` image are wrong relative to the `efloat`
+oracle. Side by side, the `efloat` image shows coherent fractal filaments while
+the `double` image is broken into horizontal blocks where the coordinates
+collapsed.
+
+### Tuning
+
+The view is controlled by the constants at the top of the source
+(`CENTER_X`, `CENTER_Y`, `VIEW_W`, `IMG_W`, `IMG_H`, `MAXITER`). The defaults
+keep the render fast (~2 s for the `efloat` pass); raise `IMG_W` / `IMG_H` /
+`MAXITER` for a higher-resolution picture (the `efloat` render time grows
+roughly linearly with the pixel count and iteration budget).

--- a/applications/precision/adaptive/README.md
+++ b/applications/precision/adaptive/README.md
@@ -16,12 +16,14 @@ is the working precision.
 `high_precision_fractals.cpp` renders a deep-zoom view of the Mandelbrot set
 (`z_{n+1} = z_n^2 + c`) around a spiral in the seahorse-valley neighbourhood.
 
-At the chosen zoom the pixel spacing (`dx ~ 3.75e-17`) is a fraction of a
-`double` ulp (`~1.11e-16`) at these coordinates, so **`double` cannot give
-adjacent pixels distinct coordinates**: about two thirds of the columns (and
-rows) collapse onto their neighbour, and the image degrades into blocky,
-streaked bands. The `efloat` (256-bit) render computes every pixel's coordinate
-exactly and reveals the true fractal structure.
+At the chosen zoom the pixel spacing is `dx ~ 3.75e-17`. That is only about
+`0.34` of a `double` ulp at `CENTER_X ~ -0.73` (ulp `~1.11e-16`), so **`double`
+cannot give adjacent columns distinct x coordinates** -- about two thirds of the
+columns collapse onto their neighbour and the image degrades into blocky
+vertical bands. (`CENTER_Y ~ 0.19` sits in a smaller binade, ulp `~2.78e-17`, so
+`dx` is `~1.35` ulp there and the y coordinates stay distinct -- the collapse is
+x-only.) The `efloat` (256-bit) render computes every pixel's coordinate exactly
+and reveals the true fractal structure.
 
 ### Build and run
 
@@ -49,15 +51,15 @@ python3 -c "from PIL import Image; Image.open('mandelbrot_efloat.ppm').save('man
 
 ### Expected output
 
-```
-  pixel spacing dx = 3.750e-17   double ulp here = 1.110e-16   dx/ulp = 0.34
+```text
+  pixel spacing dx = 3.750e-17   double ulp at CENTER_X = 1.110e-16   dx/ulp = 0.34
   efloat (oracle) escape range: [295, 1000]  <- real fractal structure
   pixels where double disagrees with efloat: 4835 / 6400  (75.5%)
 ```
 
 About **75% of pixels** in the `double` image are wrong relative to the `efloat`
 oracle. Side by side, the `efloat` image shows coherent fractal filaments while
-the `double` image is broken into horizontal blocks where the coordinates
+the `double` image is broken into vertical bands where the x coordinates
 collapsed.
 
 ### Tuning

--- a/applications/precision/adaptive/high_precision_fractals.cpp
+++ b/applications/precision/adaptive/high_precision_fractals.cpp
@@ -1,0 +1,141 @@
+// high_precision_fractals.cpp: deep-zoom Mandelbrot in double vs efloat (issue #1098)
+//
+// The Mandelbrot iteration z_{n+1} = z_n^2 + c is rendered for a deep-zoom view
+// whose pixel spacing (~1.25e-16) is at the resolution limit of double: adjacent
+// pixel coordinates are only ~1 ulp apart, so double quantizes the view and its
+// escape-time image is corrupted. The SAME templated kernel run with efloat
+// (256-bit) coordinates resolves the view correctly and serves as the oracle.
+//
+// Both renders are written as binary PPM (P6). A quantitative summary prints how
+// far double falls below the needed resolution and how many pixels the double
+// image gets wrong relative to the efloat oracle.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+#include <universal/number/efloat/efloat.hpp>
+
+// View: a spiral in the "seahorse valley" neighbourhood, zoomed until double
+// under-resolves. Keep the image modest so it renders quickly; scale IMG_W /
+// IMG_H / MAXITER up for a higher-resolution picture (see the README).
+namespace {
+	constexpr int    IMG_W    = 80;
+	constexpr int    IMG_H    = 80;
+	constexpr int    MAXITER  = 1000;
+	constexpr double CENTER_X = -0.7269;
+	constexpr double CENTER_Y =  0.1889;
+	constexpr double VIEW_W   =  3e-15;   // width of the view window in the complex plane
+	                                      // (dx ~ 0.34 ulp: double collapses ~2/3 of the
+	                                      //  columns into blocks; efloat resolves them all)
+}
+
+// Escape time of z_{n+1} = z_n^2 + c (z_0 = 0). Same code for double and efloat.
+template<typename Real>
+int escape_time(const Real& cr, const Real& ci, int maxit) {
+	Real zr(0.0), zi(0.0);
+	for (int i = 0; i < maxit; ++i) {
+		Real zr2 = zr * zr;
+		Real zi2 = zi * zi;
+		if (double(zr2 + zi2) > 4.0) return i;   // escaped
+		Real t = zr2 - zi2 + cr;
+		zi = Real(2.0) * zr * zi + ci;
+		zr = t;
+	}
+	return maxit;                                // assumed in-set
+}
+
+// Render the escape-time grid at the fixed view, computing pixel coordinates in
+// the working type Real (double: quantized; efloat: exact).
+template<typename Real>
+std::vector<int> render() {
+	const Real cx(CENTER_X), cy(CENTER_Y), dx(VIEW_W / IMG_W);
+	std::vector<int> grid(static_cast<std::size_t>(IMG_W) * IMG_H);
+	for (int py = 0; py < IMG_H; ++py) {
+		for (int px = 0; px < IMG_W; ++px) {
+			Real cr = cx + Real(static_cast<double>(px - IMG_W / 2)) * dx;
+			Real ci = cy + Real(static_cast<double>(py - IMG_H / 2)) * dx;
+			grid[static_cast<std::size_t>(py) * IMG_W + px] = escape_time<Real>(cr, ci, MAXITER);
+		}
+	}
+	return grid;
+}
+
+// Write a binary PPM (P6). In-set pixels are black; escaped pixels use the
+// classic smooth Mandelbrot palette keyed on the escape count.
+void write_ppm(const std::string& path, const std::vector<int>& grid) {
+	std::ofstream f(path, std::ios::binary);
+	f << "P6\n" << IMG_W << ' ' << IMG_H << "\n255\n";
+	for (int v : grid) {
+		unsigned char rgb[3] = { 0, 0, 0 };
+		if (v < MAXITER) {
+			double t = static_cast<double>(v) / MAXITER;
+			rgb[0] = static_cast<unsigned char>(9.0  * (1 - t) * t * t * t * 255.0);
+			rgb[1] = static_cast<unsigned char>(15.0 * (1 - t) * (1 - t) * t * t * 255.0);
+			rgb[2] = static_cast<unsigned char>(8.5  * (1 - t) * (1 - t) * (1 - t) * t * 255.0);
+		}
+		f.write(reinterpret_cast<const char*>(rgb), 3);
+	}
+}
+
+int main()
+try {
+	using namespace sw::universal;
+	using efloat256 = efloat<8>;   // 8 limbs * 32 = 256 bits
+
+	const double dx  = VIEW_W / IMG_W;
+	const double ulp = std::ldexp(1.0, -53);     // ulp near |c| ~ 0.75 (exponent -1)
+
+	std::cout << "Deep-zoom Mandelbrot: double vs efloat (256-bit) coordinates\n";
+	std::cout << std::setprecision(15);
+	std::cout << "  center = (" << CENTER_X << ", " << CENTER_Y << ")\n";
+	std::cout << std::scientific << std::setprecision(3);
+	std::cout << "  view width = " << VIEW_W << "   image = " << IMG_W << " x " << IMG_H
+	          << "   maxiter = " << MAXITER << "\n";
+	std::cout << "  pixel spacing dx = " << dx << "   double ulp here = " << ulp
+	          << "   dx/ulp = " << std::fixed << std::setprecision(2) << (dx / ulp) << "\n";
+	std::cout << "  (dx/ulp near 1 means adjacent pixels are ~1 ulp apart: double cannot resolve them)\n\n";
+
+	std::vector<int> gd = render<double>();
+	std::vector<int> ge = render<efloat256>();
+
+	// How badly does the double render disagree with the efloat oracle?
+	int diff = 0, emin = MAXITER, emax = 0;
+	for (std::size_t i = 0; i < gd.size(); ++i) {
+		if (gd[i] != ge[i]) ++diff;
+		emin = std::min(emin, ge[i]);
+		emax = std::max(emax, ge[i]);
+	}
+
+	write_ppm("mandelbrot_double.ppm", gd);
+	write_ppm("mandelbrot_efloat.ppm", ge);
+
+	std::cout << "  efloat (oracle) escape range: [" << emin << ", " << emax << "]"
+	          << (emin != emax ? "  <- real fractal structure\n" : "  (uniform)\n");
+	std::cout << "  pixels where double disagrees with efloat: " << diff << " / " << gd.size()
+	          << std::fixed << std::setprecision(1)
+	          << "  (" << (100.0 * diff / gd.size()) << "%)\n\n";
+	std::cout << "  wrote mandelbrot_double.ppm and mandelbrot_efloat.ppm\n";
+	std::cout << "  The double image is corrupted by coordinate quantization at this zoom;\n";
+	std::cout << "  the efloat image is correct. Same escape-time kernel, two number types.\n";
+
+	return EXIT_SUCCESS;
+}
+catch (const char* msg) {
+	std::cerr << "Caught exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/applications/precision/adaptive/high_precision_fractals.cpp
+++ b/applications/precision/adaptive/high_precision_fractals.cpp
@@ -14,7 +14,10 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <algorithm>
 #include <cmath>
+#include <cstdlib>
+#include <exception>
 #include <vector>
 #include <string>
 #include <fstream>
@@ -43,7 +46,7 @@ int escape_time(const Real& cr, const Real& ci, int maxit) {
 	for (int i = 0; i < maxit; ++i) {
 		Real zr2 = zr * zr;
 		Real zi2 = zi * zi;
-		if (double(zr2 + zi2) > 4.0) return i;   // escaped
+		if (zr2 + zi2 > Real(4.0)) return i;     // escaped -- compare in Real, no double rounding
 		Real t = zr2 - zi2 + cr;
 		zi = Real(2.0) * zr * zi + ci;
 		zr = t;
@@ -70,7 +73,9 @@ std::vector<int> render() {
 // Write a binary PPM (P6). In-set pixels are black; escaped pixels use the
 // classic smooth Mandelbrot palette keyed on the escape count.
 void write_ppm(const std::string& path, const std::vector<int>& grid) {
-	std::ofstream f(path, std::ios::binary);
+	std::ofstream f;
+	f.exceptions(std::ios::failbit | std::ios::badbit);   // I/O errors propagate to main's catch
+	f.open(path, std::ios::binary);
 	f << "P6\n" << IMG_W << ' ' << IMG_H << "\n255\n";
 	for (int v : grid) {
 		unsigned char rgb[3] = { 0, 0, 0 };
@@ -89,8 +94,11 @@ try {
 	using namespace sw::universal;
 	using efloat256 = efloat<8>;   // 8 limbs * 32 = 256 bits
 
-	const double dx  = VIEW_W / IMG_W;
-	const double ulp = std::ldexp(1.0, -53);     // ulp near |c| ~ 0.75 (exponent -1)
+	const double dx    = VIEW_W / IMG_W;
+	// ulp of the x-coordinate (near CENTER_X ~ -0.73, binade [0.5,1) -> exponent -1).
+	// CENTER_Y ~ 0.19 sits in a smaller binade, so its ulp is smaller and the y
+	// coordinates stay distinct: only the x coordinates collapse (vertical bands).
+	const double ulp_x = std::ldexp(1.0, std::ilogb(std::fabs(CENTER_X)) - 52);
 
 	std::cout << "Deep-zoom Mandelbrot: double vs efloat (256-bit) coordinates\n";
 	std::cout << std::setprecision(15);
@@ -98,9 +106,9 @@ try {
 	std::cout << std::scientific << std::setprecision(3);
 	std::cout << "  view width = " << VIEW_W << "   image = " << IMG_W << " x " << IMG_H
 	          << "   maxiter = " << MAXITER << "\n";
-	std::cout << "  pixel spacing dx = " << dx << "   double ulp here = " << ulp
-	          << "   dx/ulp = " << std::fixed << std::setprecision(2) << (dx / ulp) << "\n";
-	std::cout << "  (dx/ulp near 1 means adjacent pixels are ~1 ulp apart: double cannot resolve them)\n\n";
+	std::cout << "  pixel spacing dx = " << dx << "   double ulp at CENTER_X = " << ulp_x
+	          << "   dx/ulp = " << std::fixed << std::setprecision(2) << (dx / ulp_x) << "\n";
+	std::cout << "  (dx < ulp means adjacent x coordinates collapse: double renders vertical bands)\n\n";
 
 	std::vector<int> gd = render<double>();
 	std::vector<int> ge = render<efloat256>();


### PR DESCRIPTION
## Summary
Renders a **deep-zoom Mandelbrot** view with the same templated escape-time kernel on `double` vs `efloat<8>` (256-bit) coordinates. At the chosen zoom `double` cannot resolve adjacent pixels and the image corrupts into blocks; `efloat` resolves the true structure.

## The failure, quantified and visualized
At the view's pixel spacing `dx ~ 3.75e-17` (only `0.34` of a `double` ulp at these coordinates), ~2/3 of the columns/rows collapse onto their neighbour:
```
  pixel spacing dx = 3.750e-17   double ulp here = 1.110e-16   dx/ulp = 0.34
  efloat (oracle) escape range: [295, 1000]  <- real fractal structure
  pixels where double disagrees with efloat: 4835 / 6400  (75.5%)
```
**~75% of `double` pixels are wrong** vs the `efloat` oracle. Rendered side by side, the `efloat` image shows coherent fractal filaments while the `double` image is broken into horizontal blocks where the coordinates collapsed. (Verified by rendering both PPMs to PNG and inspecting.)

## Changes
- `applications/precision/adaptive/high_precision_fractals.cpp` (new) -- templated escape-time kernel, double + efloat renders, quantitative summary, writes `mandelbrot_double.ppm` / `mandelbrot_efloat.ppm` (binary P6).
- `applications/precision/adaptive/README.md` (new) -- how to run, expected output, viewing/conversion, tuning (required by the acceptance criteria; also documents the two sibling demos).
- **No CMake change** -- the `applications/precision/adaptive` glob (#1096) auto-builds `adaptive_high_precision_fractals`.

## Design notes
- Iterates on real/imag `efloat` parts directly, avoiding `std::complex<efloat>` (UB for non-standard element types).
- Default view renders in ~2 s (the `efloat` pass); constants at the top of the file scale the resolution up.

## Test Results
| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| adaptive_high_precision_fractals | OK | OK | OK | OK |

gcc 13.3.0, clang 18.1.3.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1098

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a high-precision Mandelbrot deep-zoom demonstration comparing standard and adaptive-precision calculations.
  * The demo generates viewable image files for both precision modes and reports pixel differences, escape-time ranges, and numerical diagnostics.
  * Added error handling for failed executions.

* **Documentation**
  * Added setup, build, and run instructions for the demonstration.
  * Documented generated image outputs, visualization guidance, expected results, and adjustable rendering parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->