### PR TITLE
feat(efloat): BBP pi identity-verification demonstration (#1099)

### DIFF
--- a/applications/precision/adaptive/README.md
+++ b/applications/precision/adaptive/README.md
@@ -10,6 +10,7 @@ is the working precision.
 | `catastrophic_cancellation` | `(1-cos x)/x^2` for small `x`: `double` cancels to 0, `efloat` returns 1/2 (#1096) |
 | `ill_conditioned_systems`   | Hilbert-matrix solve: `double` error ~100% at n=12, `efloat` is exact (#1097) |
 | `high_precision_fractals`   | Mandelbrot deep zoom: `double` pixelates, `efloat` resolves the detail (#1098) |
+| `mathematical_identities`   | BBP series for pi: `double` stalls at ~15 digits, `efloat` verifies ~150 (#1099) |
 
 ## High-precision fractal visualization
 

--- a/applications/precision/adaptive/mathematical_identities.cpp
+++ b/applications/precision/adaptive/mathematical_identities.cpp
@@ -26,12 +26,11 @@
 template<typename Real>
 Real bbp_pi(int terms) {
 	Real sum(0.0);
-	Real inv16(1.0);                     // 16^-n, updated each term
+	Real inv16(1.0);  // 16^-n, updated each term
 	for (int n = 0; n < terms; ++n) {
-		Real term = Real(4.0) / Real(static_cast<double>(8 * n + 1))
-		          - Real(2.0) / Real(static_cast<double>(8 * n + 4))
-		          - Real(1.0) / Real(static_cast<double>(8 * n + 5))
-		          - Real(1.0) / Real(static_cast<double>(8 * n + 6));
+		Real term = Real(4.0) / Real(static_cast<double>(8 * n + 1)) -
+		            Real(2.0) / Real(static_cast<double>(8 * n + 4)) -
+		            Real(1.0) / Real(static_cast<double>(8 * n + 5)) - Real(1.0) / Real(static_cast<double>(8 * n + 6));
 		sum   = sum + term * inv16;
 		inv16 = inv16 / Real(16.0);
 	}
@@ -39,23 +38,23 @@ Real bbp_pi(int terms) {
 }
 
 namespace {
-	using efloat512 = sw::universal::efloat<16>;   // 16 limbs * 32 = 512 bits (~154 digits)
+using efloat512 = sw::universal::efloat<16>;  // 16 limbs * 32 = 512 bits (~154 digits)
 
-	// Decimal digits to which `value` matches the oracle pi (the higher, the better).
-	int agreement_digits(const efloat512& value, const efloat512& oracle) {
-		efloat512 d = value - oracle;
-		d.setsign(false);
-		if (d.iszero()) return 154;                 // limited by the 512-bit oracle
-		int digits = static_cast<int>(-static_cast<double>(d.scale()) * 0.301029995663981);
-		return digits < 0 ? 0 : digits;
-	}
+// Decimal digits to which `value` matches the oracle pi (the higher, the better).
+int agreement_digits(const efloat512& value, const efloat512& oracle) {
+	efloat512 d = value - oracle;
+	d.setsign(false);
+	if (d.iszero())
+		return 154;  // limited by the 512-bit oracle
+	int digits = static_cast<int>(-static_cast<double>(d.scale()) * 0.301029995663981);
+	return digits < 0 ? 0 : digits;
+}
 }
 
-int main()
-try {
+int main() try {
 	using namespace sw::universal;
 
-	const efloat512 oracle = efloat_pi<16>();       // independent reference (~154 digits at 512 bits)
+	const efloat512 oracle = efloat_pi<16>();  // independent reference (~154 digits at 512 bits)
 
 	std::cout << "Verifying the BBP series for pi:\n";
 	std::cout << "  pi = sum 1/16^n ( 4/(8n+1) - 2/(8n+4) - 1/(8n+5) - 1/(8n+6) )\n";
@@ -66,7 +65,7 @@ try {
 	// -------------------------------------------------------------------------
 	{
 		const int terms = 150;
-		efloat512 dsum(double(bbp_pi<double>(terms)));      // double result, lifted for comparison
+		efloat512 dsum(double(bbp_pi<double>(terms)));  // double result, lifted for comparison
 		efloat512 esum = bbp_pi<efloat512>(terms);
 		std::cout << "After " << terms << " terms:\n";
 		std::cout << "  double : matches pi to ~" << agreement_digits(dsum, oracle)
@@ -78,16 +77,13 @@ try {
 	// -------------------------------------------------------------------------
 	// Convergence table: efloat gains ~1.2 digits/term; double is pinned at ~15.
 	// -------------------------------------------------------------------------
-	std::cout << "  " << std::left
-	          << std::setw(8)  << "terms"
-	          << std::setw(22) << "double agree (digits)"
+	std::cout << "  " << std::left << std::setw(8) << "terms" << std::setw(22) << "double agree (digits)"
 	          << "efloat agree (digits)\n";
 	std::cout << "  " << std::string(52, '-') << "\n";
 	for (int terms = 20; terms <= 150; terms += 20) {
 		efloat512 dsum(double(bbp_pi<double>(terms)));
 		efloat512 esum = bbp_pi<efloat512>(terms);
-		std::cout << "  " << std::left << std::setw(8) << terms
-		          << std::setw(22) << agreement_digits(dsum, oracle)
+		std::cout << "  " << std::left << std::setw(8) << terms << std::setw(22) << agreement_digits(dsum, oracle)
 		          << agreement_digits(esum, oracle) << "\n";
 	}
 
@@ -95,16 +91,13 @@ try {
 	std::cout << "to well over 100 digits -- useful as an oracle for checking numerical algorithms.\n";
 
 	return EXIT_SUCCESS;
-}
-catch (const char* msg) {
+} catch (const char* msg) {
 	std::cerr << "Caught exception: " << msg << std::endl;
 	return EXIT_FAILURE;
-}
-catch (const std::exception& e) {
+} catch (const std::exception& e) {
 	std::cerr << "Caught exception: " << e.what() << std::endl;
 	return EXIT_FAILURE;
-}
-catch (...) {
+} catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }

--- a/applications/precision/adaptive/mathematical_identities.cpp
+++ b/applications/precision/adaptive/mathematical_identities.cpp
@@ -1,0 +1,110 @@
+// mathematical_identities.cpp: verify the BBP series for pi with double vs efloat (issue #1099)
+//
+// The Bailey-Borwein-Plouffe (BBP) formula
+//
+//   pi = sum_{n>=0} 1/16^n ( 4/(8n+1) - 2/(8n+4) - 1/(8n+5) - 1/(8n+6) )
+//
+// converges at ~1.2 decimal digits per term. Evaluating it in double bottoms out
+// at ~15-16 digits (double's ceiling); the SAME templated summation in efloat
+// keeps gaining digits with each term. Both are checked against an independent
+// oracle -- efloat_pi(), a stored ~1000-digit constant -- so this program
+// numerically verifies the identity and shows how far each type can confirm it.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <iomanip>
+#include <universal/number/efloat/efloat.hpp>
+
+// Sum the first `terms` terms of the BBP series for pi. Same code on double and
+// efloat; the running 1/16^n factor is carried as a reciprocal to avoid growth.
+template<typename Real>
+Real bbp_pi(int terms) {
+	Real sum(0.0);
+	Real inv16(1.0);                     // 16^-n, updated each term
+	for (int n = 0; n < terms; ++n) {
+		Real term = Real(4.0) / Real(static_cast<double>(8 * n + 1))
+		          - Real(2.0) / Real(static_cast<double>(8 * n + 4))
+		          - Real(1.0) / Real(static_cast<double>(8 * n + 5))
+		          - Real(1.0) / Real(static_cast<double>(8 * n + 6));
+		sum   = sum + term * inv16;
+		inv16 = inv16 / Real(16.0);
+	}
+	return sum;
+}
+
+namespace {
+	using efloat512 = sw::universal::efloat<16>;   // 16 limbs * 32 = 512 bits (~154 digits)
+
+	// Decimal digits to which `value` matches the oracle pi (the higher, the better).
+	int agreement_digits(const efloat512& value, const efloat512& oracle) {
+		efloat512 d = value - oracle;
+		d.setsign(false);
+		if (d.iszero()) return 154;                 // limited by the 512-bit oracle
+		int digits = static_cast<int>(-static_cast<double>(d.scale()) * 0.301029995663981);
+		return digits < 0 ? 0 : digits;
+	}
+}
+
+int main()
+try {
+	using namespace sw::universal;
+
+	const efloat512 oracle = efloat_pi<16>();       // independent reference (~154 digits at 512 bits)
+
+	std::cout << "Verifying the BBP series for pi:\n";
+	std::cout << "  pi = sum 1/16^n ( 4/(8n+1) - 2/(8n+4) - 1/(8n+5) - 1/(8n+6) )\n";
+	std::cout << "Both types run the SAME summation; each is checked against the efloat_pi() oracle.\n\n";
+
+	// -------------------------------------------------------------------------
+	// double vs efloat at a healthy term count.
+	// -------------------------------------------------------------------------
+	{
+		const int terms = 150;
+		efloat512 dsum(double(bbp_pi<double>(terms)));      // double result, lifted for comparison
+		efloat512 esum = bbp_pi<efloat512>(terms);
+		std::cout << "After " << terms << " terms:\n";
+		std::cout << "  double : matches pi to ~" << agreement_digits(dsum, oracle)
+		          << " digits   <- double's ceiling (it cannot represent pi more precisely)\n";
+		std::cout << "  efloat : matches pi to ~" << agreement_digits(esum, oracle)
+		          << " digits   <- 512-bit summation keeps verifying further\n\n";
+	}
+
+	// -------------------------------------------------------------------------
+	// Convergence table: efloat gains ~1.2 digits/term; double is pinned at ~15.
+	// -------------------------------------------------------------------------
+	std::cout << "  " << std::left
+	          << std::setw(8)  << "terms"
+	          << std::setw(22) << "double agree (digits)"
+	          << "efloat agree (digits)\n";
+	std::cout << "  " << std::string(52, '-') << "\n";
+	for (int terms = 20; terms <= 150; terms += 20) {
+		efloat512 dsum(double(bbp_pi<double>(terms)));
+		efloat512 esum = bbp_pi<efloat512>(terms);
+		std::cout << "  " << std::left << std::setw(8) << terms
+		          << std::setw(22) << agreement_digits(dsum, oracle)
+		          << agreement_digits(esum, oracle) << "\n";
+	}
+
+	std::cout << "\nSame identity, same code: double stalls at ~15 digits while efloat verifies pi\n";
+	std::cout << "to well over 100 digits -- useful as an oracle for checking numerical algorithms.\n";
+
+	return EXIT_SUCCESS;
+}
+catch (const char* msg) {
+	std::cerr << "Caught exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Numerically verifies the **Bailey-Borwein-Plouffe (BBP)** series for pi with the same templated summation on `double` vs `efloat<16>` (512-bit), each checked against an independent oracle -- `efloat_pi()`, the stored ~1000-digit constant (#1142).

`pi = sum 1/16^n ( 4/(8n+1) - 2/(8n+4) - 1/(8n+5) - 1/(8n+6) )`

## What it shows (actual output)
```
After 150 terms:
  double : matches pi to ~15 digits   <- double's ceiling
  efloat : matches pi to ~152 digits  <- 512-bit summation keeps verifying further

  terms   double agree (digits) efloat agree (digits)
  ----------------------------------------------------
  20      15                    27
  40      15                    52
  60      15                    76
  80      15                    100
  100     15                    125
  120     15                    149
  140     15                    152
```
`double` is pinned at ~15 digits no matter how many terms; `efloat` gains ~1.2 digits/term (textbook BBP convergence), verifying the identity to well over 100 digits.

## Changes
- `applications/precision/adaptive/mathematical_identities.cpp` (new).
- `applications/precision/adaptive/README.md` -- new demo row.
- **No CMake change** -- the `adaptive` glob (#1096) builds `adaptive_mathematical_identities`.

## Test Results
| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| adaptive_mathematical_identities | OK | OK | OK | OK |

gcc 13.3.0, clang 18.1.3.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1099

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new adaptive-precision demonstration that verifies π using the Bailey–Borwein–Plouffe (BBP) series.
  - Compares standard double-precision results with extended-precision calculations, highlighting accuracy beyond approximately 15 decimal digits.
  - Includes a convergence table showing precision improvements across increasing calculation lengths.

- **Documentation**
  - Added the demonstration to the adaptive-precision examples list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->