### PR TITLE
feat(efloat): Wilkinson polynomial root-finding demonstration (#1100)

### DIFF
--- a/applications/precision/adaptive/README.md
+++ b/applications/precision/adaptive/README.md
@@ -11,6 +11,7 @@ is the working precision.
 | `ill_conditioned_systems`   | Hilbert-matrix solve: `double` error ~100% at n=12, `efloat` is exact (#1097) |
 | `high_precision_fractals`   | Mandelbrot deep zoom: `double` pixelates, `efloat` resolves the detail (#1098) |
 | `mathematical_identities`   | BBP series for pi: `double` stalls at ~15 digits, `efloat` verifies ~150 (#1099) |
+| `polynomial_roots`          | Wilkinson's polynomial: `double` roots drift off the integers, `efloat` recovers them (#1100) |
 
 ## High-precision fractal visualization
 
@@ -70,3 +71,36 @@ The view is controlled by the constants at the top of the source
 keep the render fast (~2 s for the `efloat` pass); raise `IMG_W` / `IMG_H` /
 `MAXITER` for a higher-resolution picture (the `efloat` render time grows
 roughly linearly with the pixel count and iteration budget).
+
+## Polynomial root finding (Wilkinson's polynomial)
+
+`polynomial_roots.cpp` finds the roots of **Wilkinson's polynomial**
+`W(x) = (x-1)(x-2)...(x-20)`, whose roots are obviously the integers 1..20.
+
+The catch is in the *coefficients*. Expanded into power form, `W` has enormous
+coefficients (up to ~1.4e19); several exceed `2^53`, so they cannot be stored
+exactly in `double`. Wilkinson's polynomial is the textbook example of a problem
+whose roots are **hypersensitive to coefficient perturbation** -- a tiny change
+in a coefficient moves the roots substantially (the middle roots most of all).
+
+The program expands `W` exactly in `efloat`, rounds the coefficients to `double`,
+and then runs the *same* Newton kernel from each true root location `i`, asking:
+is `i` still a root of the stored polynomial?
+
+- With **exact `efloat` coefficients**, yes -- Newton stays at `i`; every root is
+  recovered to full precision.
+- With **rounded `double` coefficients**, no -- the roots have moved, and Newton
+  drifts away from the integers by up to ~`1e-2` (worst for the middle roots
+  13..17), so `double` cannot recover the integer roots.
+
+### Build and run
+
+```bash
+cmake -DUNIVERSAL_BUILD_APPLICATIONS=ON ..
+make adaptive_polynomial_roots
+./applications/precision/adaptive/adaptive_polynomial_roots
+```
+
+The output prints the largest coefficient rounding error, then a table of all 20
+roots with the `double` and `efloat` results side by side and their distance from
+the true integer. `double`'s worst error is ~`1e-2`; `efloat`'s is `0`.

--- a/applications/precision/adaptive/polynomial_roots.cpp
+++ b/applications/precision/adaptive/polynomial_roots.cpp
@@ -1,0 +1,133 @@
+// polynomial_roots.cpp: Wilkinson's polynomial roots in double vs efloat (issue #1100)
+//
+// Wilkinson's polynomial W(x) = (x-1)(x-2)...(x-20) has the obvious roots
+// 1,2,...,20. Expanded into power form its coefficients are enormous (up to
+// ~1.4e19) and several exceed 2^53, so storing them as double perturbs them --
+// and the roots of W are famously hypersensitive to coefficient perturbation.
+//
+// This program expands W exactly in efloat, then asks the same question with the
+// SAME Newton kernel in each type: starting from each true root location i, is i
+// still a root of the stored polynomial? With exact efloat coefficients it is
+// (Newton stays at i); with rounded double coefficients it is not (Newton drifts
+// away), so double cannot recover the integer roots and efloat can.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>
+#include <cstdlib>
+#include <exception>
+#include <vector>
+#include <iostream>
+#include <iomanip>
+#include <universal/number/efloat/efloat.hpp>
+
+namespace {
+constexpr int DEGREE = 20;
+
+// Expand W(x) = prod_{i=1..DEGREE} (x - i) into coefficients c[k] of x^k.
+template<typename Real>
+std::vector<Real> expand_wilkinson() {
+	std::vector<Real> c(DEGREE + 1, Real(0.0));
+	c[0] = Real(1.0);
+	for (int i = 1; i <= DEGREE; ++i) {  // multiply the current polynomial by (x - i)
+		for (int k = DEGREE; k >= 1; --k)
+			c[k] = c[k - 1] - Real(static_cast<double>(i)) * c[k];
+		c[0] = Real(-static_cast<double>(i)) * c[0];
+	}
+	return c;
+}
+
+template<typename Real>
+Real poly(const std::vector<Real>& c, const Real& x) {  // Horner
+	Real p(0.0);
+	for (int k = DEGREE; k >= 0; --k)
+		p = p * x + c[k];
+	return p;
+}
+
+template<typename Real>
+Real dpoly(const std::vector<Real>& c, const Real& x) {  // Horner on the derivative
+	Real p(0.0);
+	for (int k = DEGREE; k >= 1; --k)
+		p = p * x + c[k] * Real(static_cast<double>(k));
+	return p;
+}
+
+// Newton's method from x0; refines a root of the stored polynomial.
+template<typename Real>
+Real newton(const std::vector<Real>& c, double x0, int iters) {
+	Real x(x0);
+	for (int i = 0; i < iters; ++i) {
+		Real d = dpoly(c, x);
+		if (double(d) == 0.0)
+			break;
+		x = x - poly(c, x) / d;
+	}
+	return x;
+}
+}  // namespace
+
+int main() try {
+	using namespace sw::universal;
+	using efloat512 = efloat<16>;  // 16 limbs * 32 = 512 bits
+
+	// Exact coefficients in efloat; the same values rounded to double.
+	std::vector<efloat512> ce = expand_wilkinson<efloat512>();
+	std::vector<double>    cd(ce.size());
+	for (std::size_t k = 0; k < ce.size(); ++k)
+		cd[k] = double(ce[k]);
+
+	std::cout << "Wilkinson's polynomial W(x) = (x-1)(x-2)...(x-" << DEGREE << "),  roots 1.." << DEGREE << "\n";
+	std::cout << "Expanded coefficients reach ~1.4e19; several exceed 2^53, so double cannot store them exactly.\n";
+
+	// Largest absolute error introduced by rounding a coefficient to double.
+	double worst  = 0.0;
+	int    worstk = 0;
+	for (int k = 0; k <= DEGREE; ++k) {
+		efloat512 e = ce[k] - efloat512(cd[k]);
+		e.setsign(false);
+		if (double(e) > worst) {
+			worst  = double(e);
+			worstk = k;
+		}
+	}
+	std::cout << std::scientific << std::setprecision(3);
+	std::cout << "  largest coefficient rounding error: the x^" << worstk << " coefficient is off by " << worst
+	          << " when stored as double\n\n";
+
+	// Same Newton kernel from each true root location i, in each type.
+	std::cout << "  " << std::left << std::setw(4) << "i" << std::setw(20) << "double root" << std::setw(13) << "|err|"
+	          << std::setw(20) << "efloat root" << "|err|\n";
+	std::cout << "  " << std::string(62, '-') << "\n";
+	double max_d = 0.0, max_e = 0.0;
+	for (int i = 1; i <= DEGREE; ++i) {
+		double    rd = double(newton<double>(cd, i, 100));
+		efloat512 re = newton<efloat512>(ce, i, 100);
+		double    ed = std::fabs(rd - i);
+		double    ee = std::fabs(double(re) - i);
+		max_d        = std::max(max_d, ed);
+		max_e        = std::max(max_e, ee);
+		std::cout << "  " << std::left << std::fixed << std::setprecision(9) << std::setw(4) << i << std::setw(20) << rd
+		          << std::scientific << std::setprecision(2) << std::setw(13) << ed << std::fixed
+		          << std::setprecision(9) << std::setw(20) << double(re) << std::scientific << std::setprecision(2)
+		          << ee << "\n";
+	}
+
+	std::cout << "\n  worst error over all 20 roots:  double = " << std::scientific << std::setprecision(3) << max_d
+	          << "   efloat = " << max_e << "\n";
+	std::cout << "  Rounding the coefficients to double moved the roots off the integers by up to ~"
+	          << std::setprecision(0) << max_d << "; efloat's exact coefficients keep every root at its integer.\n";
+
+	return EXIT_SUCCESS;
+} catch (const char* msg) {
+	std::cerr << "Caught exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+} catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+} catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Finds the roots of **Wilkinson's polynomial** `W(x) = (x-1)(x-2)...(x-20)` (roots 1..20) with the same Newton kernel on `double` vs `efloat<16>` (512-bit) -- the final demo in the `adaptive/` set.

## The problem, and what it shows (actual output)
Expanded, `W`'s coefficients reach ~1.4e19; several exceed `2^53`, so `double` can't store them exactly, and Wilkinson's roots are famously hypersensitive to coefficient perturbation.
```text
  largest coefficient rounding error: the x^3 coefficient is off by 5.120e+02 when stored as double

  i   double root         |err|        efloat root         |err|
  --------------------------------------------------------------
  ...
  13  12.995400697        4.60e-03     13.000000000        0.00e+00
  14  13.986903042        1.31e-02     14.000000000        0.00e+00
  15  14.992539774        7.46e-03     15.000000000        0.00e+00
  16  16.010063169        1.01e-02     16.000000000        0.00e+00
  17  16.995102392        4.90e-03     17.000000000        0.00e+00
  ...
  worst error over all 20 roots:  double = 1.310e-02   efloat = 0.000e+00
```
From each true root location `i`, `efloat`'s exact coefficients keep `i` a root (Newton stays, error 0); the rounded `double` coefficients have moved the roots off the integers by up to ~1.3e-2 (worst for the middle roots 13..17, the classic Wilkinson signature).

## Changes
- `applications/precision/adaptive/polynomial_roots.cpp` (new) -- exact efloat expansion, templated Newton kernel, coefficient-corruption metric + 20-root table.
- `applications/precision/adaptive/README.md` -- demo row + explanatory section (sensitivity + interpretation) per the acceptance criteria.
- **No CMake change** -- the `adaptive` glob (#1096) builds `adaptive_polynomial_roots`.

## Notes
- Avoids `std::complex<efloat>` (UB) by refining real roots with Newton from each integer.
- clang-format conformant (ran the project `.clang-format` up front).

## Test Results
| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| adaptive_polynomial_roots | OK | OK | OK | OK |

gcc 13.3.0, clang 18.1.3.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1100

Generated with [Claude Code](https://claude.com/claude-code)