### PR TITLE
chore(efloat): clang-format the adaptive-precision demo sources

### DIFF
--- a/applications/precision/adaptive/catastrophic_cancellation.cpp
+++ b/applications/precision/adaptive/catastrophic_cancellation.cpp
@@ -39,10 +39,9 @@ Real g_stable(const Real& x) {
 	return (Real(2.0) * s * s) / (x * x);
 }
 
-int main()
-try {
+int main() try {
 	using namespace sw::universal;
-	using efloat256 = efloat<8>;   // 8 limbs * 32 = 256 bits of working precision
+	using efloat256 = efloat<8>;  // 8 limbs * 32 = 256 bits of working precision
 
 	std::cout << "Catastrophic cancellation: f(x) = (1 - cos x) / x^2   (unstable)\n";
 	std::cout << "                     vs    g(x) = 2 sin^2(x/2) / x^2   (stable)\n";
@@ -54,14 +53,15 @@ try {
 	// arithmetic precision.
 	// -------------------------------------------------------------------------
 	const double x0 = 1e-10;
-	efloat256 xe(x0);
+	efloat256    xe(x0);
 
 	std::cout << std::setprecision(17);
 	std::cout << "At x = " << x0 << ":\n";
 	std::cout << "  double  f(x) = " << std::setw(22) << f_unstable(x0) << "   <- catastrophic cancellation\n";
-	std::cout << "  double  g(x) = " << std::setw(22) << g_stable(x0)   << "   <- double's correct reference\n";
-	std::cout << "  efloat  f(x) = " << std::setw(22) << double(f_unstable(xe)) << "   <- correct, from the UNSTABLE formula\n";
-	std::cout << "  efloat  g(x) = " << std::setw(22) << double(g_stable(xe))   << "\n";
+	std::cout << "  double  g(x) = " << std::setw(22) << g_stable(x0) << "   <- double's correct reference\n";
+	std::cout << "  efloat  f(x) = " << std::setw(22) << double(f_unstable(xe))
+	          << "   <- correct, from the UNSTABLE formula\n";
+	std::cout << "  efloat  g(x) = " << std::setw(22) << double(g_stable(xe)) << "\n";
 	{
 		efloat256 diff = f_unstable(xe) - g_stable(xe);
 		diff.setsign(false);
@@ -74,41 +74,33 @@ try {
 	// finally collapses to 0, while efloat f(x) stays accurate. The reference is
 	// the stable efloat g(x).
 	// -------------------------------------------------------------------------
-	std::cout << "  " << std::left
-	          << std::setw(10) << "x"
-	          << std::setw(24) << "double f(x)"
-	          << std::setw(24) << "efloat f(x)  (accurate)"
-	          << "double f rel.error\n";
+	std::cout << "  " << std::left << std::setw(10) << "x" << std::setw(24) << "double f(x)" << std::setw(24)
+	          << "efloat f(x)  (accurate)" << "double f rel.error\n";
 	std::cout << "  " << std::string(72, '-') << "\n";
-	const double xs[] = { 1e-2, 1e-4, 1e-6, 1e-8, 1e-10, 1e-12, 1e-14 };
+	const double xs[] = {1e-2, 1e-4, 1e-6, 1e-8, 1e-10, 1e-12, 1e-14};
 	for (double x : xs) {
 		efloat256 xe2(x);
-		double df = f_unstable(x);
-		efloat256 ef = f_unstable(xe2);
-		efloat256 ref = g_stable(xe2);         // stable, high-precision reference
-		double eref = double(ref);
-		double relerr = (eref != 0.0) ? std::abs(df - eref) / std::abs(eref) : std::abs(df);
-		std::cout << "  " << std::left  << std::setw(10) << std::scientific << std::setprecision(0) << x
-		          << std::right << std::fixed << std::setprecision(15)
-		          << std::setw(22) << df << "  "
-		          << std::setw(22) << double(ef) << "  "
-		          << std::scientific << std::setprecision(2) << std::setw(10) << relerr << "\n";
+		double    df     = f_unstable(x);
+		efloat256 ef     = f_unstable(xe2);
+		efloat256 ref    = g_stable(xe2);  // stable, high-precision reference
+		double    eref   = double(ref);
+		double    relerr = (eref != 0.0) ? std::abs(df - eref) / std::abs(eref) : std::abs(df);
+		std::cout << "  " << std::left << std::setw(10) << std::scientific << std::setprecision(0) << x << std::right
+		          << std::fixed << std::setprecision(15) << std::setw(22) << df << "  " << std::setw(22) << double(ef)
+		          << "  " << std::scientific << std::setprecision(2) << std::setw(10) << relerr << "\n";
 	}
 
 	std::cout << "\nThe unstable formula is fine in efloat because 256-bit arithmetic keeps the\n";
 	std::cout << "tiny (1 - cos x) term that double rounds away. Same code, two number types.\n";
 
 	return EXIT_SUCCESS;
-}
-catch (const char* msg) {
+} catch (const char* msg) {
 	std::cerr << "Caught exception: " << msg << std::endl;
 	return EXIT_FAILURE;
-}
-catch (const std::exception& e) {
+} catch (const std::exception& e) {
 	std::cerr << "Caught exception: " << e.what() << std::endl;
 	return EXIT_FAILURE;
-}
-catch (...) {
+} catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }

--- a/applications/precision/adaptive/high_precision_fractals.cpp
+++ b/applications/precision/adaptive/high_precision_fractals.cpp
@@ -29,14 +29,14 @@
 // under-resolves. Keep the image modest so it renders quickly; scale IMG_W /
 // IMG_H / MAXITER up for a higher-resolution picture (see the README).
 namespace {
-	constexpr int    IMG_W    = 80;
-	constexpr int    IMG_H    = 80;
-	constexpr int    MAXITER  = 1000;
-	constexpr double CENTER_X = -0.7269;
-	constexpr double CENTER_Y =  0.1889;
-	constexpr double VIEW_W   =  3e-15;   // width of the view window in the complex plane
-	                                      // (dx ~ 0.34 ulp: double collapses ~2/3 of the
-	                                      //  columns into blocks; efloat resolves them all)
+constexpr int    IMG_W    = 80;
+constexpr int    IMG_H    = 80;
+constexpr int    MAXITER  = 1000;
+constexpr double CENTER_X = -0.7269;
+constexpr double CENTER_Y = 0.1889;
+constexpr double VIEW_W   = 3e-15;  // width of the view window in the complex plane
+                                    // (dx ~ 0.34 ulp: double collapses ~2/3 of the
+                                    //  columns into blocks; efloat resolves them all)
 }
 
 // Escape time of z_{n+1} = z_n^2 + c (z_0 = 0). Same code for double and efloat.
@@ -46,24 +46,25 @@ int escape_time(const Real& cr, const Real& ci, int maxit) {
 	for (int i = 0; i < maxit; ++i) {
 		Real zr2 = zr * zr;
 		Real zi2 = zi * zi;
-		if (zr2 + zi2 > Real(4.0)) return i;     // escaped -- compare in Real, no double rounding
+		if (zr2 + zi2 > Real(4.0))
+			return i;  // escaped -- compare in Real, no double rounding
 		Real t = zr2 - zi2 + cr;
-		zi = Real(2.0) * zr * zi + ci;
-		zr = t;
+		zi     = Real(2.0) * zr * zi + ci;
+		zr     = t;
 	}
-	return maxit;                                // assumed in-set
+	return maxit;  // assumed in-set
 }
 
 // Render the escape-time grid at the fixed view, computing pixel coordinates in
 // the working type Real (double: quantized; efloat: exact).
 template<typename Real>
 std::vector<int> render() {
-	const Real cx(CENTER_X), cy(CENTER_Y), dx(VIEW_W / IMG_W);
+	const Real       cx(CENTER_X), cy(CENTER_Y), dx(VIEW_W / IMG_W);
 	std::vector<int> grid(static_cast<std::size_t>(IMG_W) * IMG_H);
 	for (int py = 0; py < IMG_H; ++py) {
 		for (int px = 0; px < IMG_W; ++px) {
-			Real cr = cx + Real(static_cast<double>(px - IMG_W / 2)) * dx;
-			Real ci = cy + Real(static_cast<double>(py - IMG_H / 2)) * dx;
+			Real cr                                         = cx + Real(static_cast<double>(px - IMG_W / 2)) * dx;
+			Real ci                                         = cy + Real(static_cast<double>(py - IMG_H / 2)) * dx;
 			grid[static_cast<std::size_t>(py) * IMG_W + px] = escape_time<Real>(cr, ci, MAXITER);
 		}
 	}
@@ -74,27 +75,26 @@ std::vector<int> render() {
 // classic smooth Mandelbrot palette keyed on the escape count.
 void write_ppm(const std::string& path, const std::vector<int>& grid) {
 	std::ofstream f;
-	f.exceptions(std::ios::failbit | std::ios::badbit);   // I/O errors propagate to main's catch
+	f.exceptions(std::ios::failbit | std::ios::badbit);  // I/O errors propagate to main's catch
 	f.open(path, std::ios::binary);
 	f << "P6\n" << IMG_W << ' ' << IMG_H << "\n255\n";
 	for (int v : grid) {
-		unsigned char rgb[3] = { 0, 0, 0 };
+		unsigned char rgb[3] = {0, 0, 0};
 		if (v < MAXITER) {
 			double t = static_cast<double>(v) / MAXITER;
-			rgb[0] = static_cast<unsigned char>(9.0  * (1 - t) * t * t * t * 255.0);
-			rgb[1] = static_cast<unsigned char>(15.0 * (1 - t) * (1 - t) * t * t * 255.0);
-			rgb[2] = static_cast<unsigned char>(8.5  * (1 - t) * (1 - t) * (1 - t) * t * 255.0);
+			rgb[0]   = static_cast<unsigned char>(9.0 * (1 - t) * t * t * t * 255.0);
+			rgb[1]   = static_cast<unsigned char>(15.0 * (1 - t) * (1 - t) * t * t * 255.0);
+			rgb[2]   = static_cast<unsigned char>(8.5 * (1 - t) * (1 - t) * (1 - t) * t * 255.0);
 		}
 		f.write(reinterpret_cast<const char*>(rgb), 3);
 	}
 }
 
-int main()
-try {
+int main() try {
 	using namespace sw::universal;
-	using efloat256 = efloat<8>;   // 8 limbs * 32 = 256 bits
+	using efloat256 = efloat<8>;  // 8 limbs * 32 = 256 bits
 
-	const double dx    = VIEW_W / IMG_W;
+	const double dx = VIEW_W / IMG_W;
 	// ulp of the x-coordinate (near CENTER_X ~ -0.73, binade [0.5,1) -> exponent -1).
 	// CENTER_Y ~ 0.19 sits in a smaller binade, so its ulp is smaller and the y
 	// coordinates stay distinct: only the x coordinates collapse (vertical bands).
@@ -104,8 +104,8 @@ try {
 	std::cout << std::setprecision(15);
 	std::cout << "  center = (" << CENTER_X << ", " << CENTER_Y << ")\n";
 	std::cout << std::scientific << std::setprecision(3);
-	std::cout << "  view width = " << VIEW_W << "   image = " << IMG_W << " x " << IMG_H
-	          << "   maxiter = " << MAXITER << "\n";
+	std::cout << "  view width = " << VIEW_W << "   image = " << IMG_W << " x " << IMG_H << "   maxiter = " << MAXITER
+	          << "\n";
 	std::cout << "  pixel spacing dx = " << dx << "   double ulp at CENTER_X = " << ulp_x
 	          << "   dx/ulp = " << std::fixed << std::setprecision(2) << (dx / ulp_x) << "\n";
 	std::cout << "  (dx < ulp means adjacent x coordinates collapse: double renders vertical bands)\n\n";
@@ -116,7 +116,8 @@ try {
 	// How badly does the double render disagree with the efloat oracle?
 	int diff = 0, emin = MAXITER, emax = 0;
 	for (std::size_t i = 0; i < gd.size(); ++i) {
-		if (gd[i] != ge[i]) ++diff;
+		if (gd[i] != ge[i])
+			++diff;
 		emin = std::min(emin, ge[i]);
 		emax = std::max(emax, ge[i]);
 	}
@@ -126,24 +127,20 @@ try {
 
 	std::cout << "  efloat (oracle) escape range: [" << emin << ", " << emax << "]"
 	          << (emin != emax ? "  <- real fractal structure\n" : "  (uniform)\n");
-	std::cout << "  pixels where double disagrees with efloat: " << diff << " / " << gd.size()
-	          << std::fixed << std::setprecision(1)
-	          << "  (" << (100.0 * diff / gd.size()) << "%)\n\n";
+	std::cout << "  pixels where double disagrees with efloat: " << diff << " / " << gd.size() << std::fixed
+	          << std::setprecision(1) << "  (" << (100.0 * diff / gd.size()) << "%)\n\n";
 	std::cout << "  wrote mandelbrot_double.ppm and mandelbrot_efloat.ppm\n";
 	std::cout << "  The double image is corrupted by coordinate quantization at this zoom;\n";
 	std::cout << "  the efloat image is correct. Same escape-time kernel, two number types.\n";
 
 	return EXIT_SUCCESS;
-}
-catch (const char* msg) {
+} catch (const char* msg) {
 	std::cerr << "Caught exception: " << msg << std::endl;
 	return EXIT_FAILURE;
-}
-catch (const std::exception& e) {
+} catch (const std::exception& e) {
 	std::cerr << "Caught exception: " << e.what() << std::endl;
 	return EXIT_FAILURE;
-}
-catch (...) {
+} catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }

--- a/applications/precision/adaptive/ill_conditioned_systems.cpp
+++ b/applications/precision/adaptive/ill_conditioned_systems.cpp
@@ -40,7 +40,8 @@ Real hilbert_solve_relerr(int n) {
 	Vector b(n, Real(0.0));
 	for (int i = 0; i < n; ++i) {
 		Real s(0.0);
-		for (int j = 0; j < n; ++j) s = s + H[i][j] * x[j];
+		for (int j = 0; j < n; ++j)
+			s = s + H[i][j] * x[j];
 		b[i] = s;
 	}
 
@@ -48,17 +49,21 @@ Real hilbert_solve_relerr(int n) {
 	Matrix A = H;
 	Vector c = b;
 	for (int k = 0; k < n; ++k) {
-		int    piv  = k;
-		Real   best = abs(A[k][k]);
+		int  piv  = k;
+		Real best = abs(A[k][k]);
 		for (int i = k + 1; i < n; ++i) {
 			Real v = abs(A[i][k]);
-			if (v > best) { best = v; piv = i; }
+			if (v > best) {
+				best = v;
+				piv  = i;
+			}
 		}
 		std::swap(A[k], A[piv]);
 		std::swap(c[k], c[piv]);
 		for (int i = k + 1; i < n; ++i) {
 			Real factor = A[i][k] / A[k][k];
-			for (int j = k; j < n; ++j) A[i][j] = A[i][j] - factor * A[k][j];
+			for (int j = k; j < n; ++j)
+				A[i][j] = A[i][j] - factor * A[k][j];
 			c[i] = c[i] - factor * c[k];
 		}
 	}
@@ -67,7 +72,8 @@ Real hilbert_solve_relerr(int n) {
 	Vector xhat(n, Real(0.0));
 	for (int i = n - 1; i >= 0; --i) {
 		Real s = c[i];
-		for (int j = i + 1; j < n; ++j) s = s - A[i][j] * xhat[j];
+		for (int j = i + 1; j < n; ++j)
+			s = s - A[i][j] * xhat[j];
 		xhat[i] = s / A[i][i];
 	}
 
@@ -75,16 +81,15 @@ Real hilbert_solve_relerr(int n) {
 	Real num(0.0), den(0.0);
 	for (int i = 0; i < n; ++i) {
 		Real e = xhat[i] - x[i];
-		num = num + e * e;
-		den = den + x[i] * x[i];
+		num    = num + e * e;
+		den    = den + x[i] * x[i];
 	}
 	return sqrt(num) / sqrt(den);
 }
 
-int main()
-try {
+int main() try {
 	using namespace sw::universal;
-	using efloat512 = efloat<16>;   // 16 limbs * 32 = 512 bits (~154 digits)
+	using efloat512 = efloat<16>;  // 16 limbs * 32 = 512 bits (~154 digits)
 
 	std::cout << "Ill-conditioned linear system: Hilbert matrix H(i,j) = 1/(i+j-1)\n";
 	std::cout << "Exact solution x = [1, 1, ..., 1];  b = Hx;  solve Hx_hat = b (Gaussian elim).\n";
@@ -94,12 +99,12 @@ try {
 	// Primary result at n = 12 (condition number ~1e16, at double's limit).
 	// -------------------------------------------------------------------------
 	{
-		const int n = 12;
+		const int n  = 12;
 		double    de = double(hilbert_solve_relerr<double>(n));
 		efloat512 ee = hilbert_solve_relerr<efloat512>(n);
 		std::cout << std::scientific << std::setprecision(3);
 		std::cout << "At n = " << n << ":\n";
-		std::cout << "  double  relative error = " << de       << "   <- solution is essentially garbage\n";
+		std::cout << "  double  relative error = " << de << "   <- solution is essentially garbage\n";
 		std::cout << "  efloat  relative error = " << double(ee) << "   <- oracle: x recovered almost exactly\n\n";
 	}
 
@@ -107,9 +112,7 @@ try {
 	// Breakdown across n: double degrades toward O(1) error as conditioning
 	// outruns 53-bit precision; efloat stays near machine-zero for 512 bits.
 	// -------------------------------------------------------------------------
-	std::cout << "  " << std::left
-	          << std::setw(6)  << "n"
-	          << std::setw(22) << "double rel.error"
+	std::cout << "  " << std::left << std::setw(6) << "n" << std::setw(22) << "double rel.error"
 	          << "efloat<512b> rel.error\n";
 	std::cout << "  " << std::string(50, '-') << "\n";
 	std::cout << std::right << std::scientific << std::setprecision(3);
@@ -117,8 +120,7 @@ try {
 	for (int n = 4; n <= 14; n += 2) {
 		double    de = double(hilbert_solve_relerr<double>(n));
 		efloat512 ee = hilbert_solve_relerr<efloat512>(n);
-		std::cout << "  " << std::left << std::setw(6) << n << std::right
-		          << std::setw(18) << de << "    "
+		std::cout << "  " << std::left << std::setw(6) << n << std::right << std::setw(18) << de << "    "
 		          << std::setw(18) << double(ee) << "\n";
 	}
 
@@ -127,16 +129,13 @@ try {
 	std::cout << "a high-precision oracle for verifying the double solver's accuracy.\n";
 
 	return EXIT_SUCCESS;
-}
-catch (const char* msg) {
+} catch (const char* msg) {
 	std::cerr << "Caught exception: " << msg << std::endl;
 	return EXIT_FAILURE;
-}
-catch (const std::exception& e) {
+} catch (const std::exception& e) {
 	std::cerr << "Caught exception: " << e.what() << std::endl;
 	return EXIT_FAILURE;
-}
-catch (...) {
+} catch (...) {
 	std::cerr << "Caught unknown exception" << std::endl;
 	return EXIT_FAILURE;
 }


### PR DESCRIPTION
## Summary
Formatting-only cleanup (#1152): the first three `applications/precision/adaptive/` demos predate clang-format and were not conformant with the project `.clang-format`. Ran the project formatter on them.

## Changes
- `catastrophic_cancellation.cpp` (#1096)
- `ill_conditioned_systems.cpp` (#1097)
- `high_precision_fractals.cpp` (#1098)

(`mathematical_identities.cpp` and `polynomial_roots.cpp` were already conformant.) All five `adaptive/` sources now pass `clang-format --dry-run` cleanly.

## Notes
- Formatting-only, no behavior change. The project `.clang-format` enables `AlignConsecutiveAssignments`, so the project formatter is authoritative.
- All three still build and run on gcc 13.3.0 and clang 18.1.3.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1152

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted precision-adaptive example output for clearer alignment and readability.
  * Improved formatting of numerical calculations, tables, console messages, and error-handling blocks.
  * Preserved existing computations, workflows, and results across all examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->