### PR TITLE
refactor(efloat): efloat_constants make_constant delegates to parse<16384> (#1151)

### DIFF
--- a/include/sw/universal/number/efloat/math/constants/efloat_constants.hpp
+++ b/include/sw/universal/number/efloat/math/constants/efloat_constants.hpp
@@ -12,16 +12,15 @@
 // to ~1000 decimal digits, well beyond the ~315-digit ceiling of the
 // multi-component ereal/elreal constants (issue #1139).
 //
-// Construction bypasses efloat::parse() (which caps at the 2040-bit d2b default,
-// issue #1141) and calls decimal_to_binary::convert<BigBits> directly with a
-// large budget: the internal reduction shifts the digit-integer left by
-// ~(target + 3*ndigits) bits, so BigBits must be well above that -- 16384 bits
-// covers a 1000-digit literal at ~3300-bit target. This does NOT change the
-// shared d2b default budget that other number systems rely on.
+// Construction uses efloat's BigBits-templated parse() (#1141) with a large
+// budget: the d2b reduction shifts the digit-integer left by ~(target +
+// 3*ndigits) bits, so the budget must be well above that -- 16384 bits covers a
+// 1000-digit literal at ~3300-bit target. Passing the budget explicitly does NOT
+// change the shared d2b default that other number systems rely on.
 #pragma once
+#include <string>
 #include <string_view>
 #include <algorithm>
-#include <universal/utility/decimal_to_binary.hpp>
 
 namespace sw { namespace universal {
 
@@ -44,49 +43,17 @@ namespace efloat_detail {
 	inline constexpr unsigned constant_big_bits = 16384u;
 
 	// make_constant<nlimbs>(decimal): parse a decimal literal into an efloat at
-	// min(nlimbs*32, constant_literal_bits) bits, exactly, via a wide d2b
-	// convert. Mirrors efloat::parse()'s round + MSB-first limb packing, but at
-	// constant_big_bits so it is correct past the 2040-bit parse() ceiling.
+	// min(nlimbs*32, constant_literal_bits) bits, exactly. Delegates to efloat's
+	// BigBits-templated parse() (#1141): sizing the working precision first, then
+	// calling parse<constant_big_bits> gives an exact conversion well past the
+	// 2040-bit default d2b ceiling -- the wide budget covers the digit-integer's
+	// 5^|E| growth for a ~1000-digit literal. Invalid input -> NaN.
 	template<unsigned nlimbs>
 	inline efloat<nlimbs> make_constant(std::string_view decimal) {
-		namespace d2b = sw::universal::decimal_to_binary;
 		efloat<nlimbs> value;
-		value.clear();
-
 		const unsigned target_bits = std::min(nlimbs * 32u, constant_literal_bits);
-
-		auto r = d2b::convert<constant_big_bits>(decimal, target_bits);
-		if (!r.valid) { value.setnan(); return value; }
-		if (r.is_zero) { value.setzero(); if (r.negative) value.setsign(true); return value; }
-
-		auto          mantissa     = r.mantissa;
-		std::int64_t  binary_scale = r.binary_scale;
-		// round-to-nearest-even using d2b's guard/sticky
-		const bool round_up = r.guard_bit && (r.sticky_bit || mantissa.at(0));
-		if (round_up) {
-			mantissa += d2b::big_integer<constant_big_bits>(1);
-			if (mantissa.at(target_bits)) { mantissa >>= 1; ++binary_scale; }
-		}
-
-		value.setsign(r.negative);
-		value.setexponent(binary_scale);
-
-		// pack MSB-first into uint32 limbs (same convention as efloat::parse)
-		const unsigned full_limbs = target_bits / 32u;
-		const unsigned leftover   = target_bits % 32u;
-		for (unsigned i = 0; i < full_limbs; ++i) {
-			std::uint32_t v = 0;
-			const unsigned base = target_bits - 32u * (i + 1u);
-			for (unsigned b = 0; b < 32u; ++b) if (mantissa.at(base + b)) v |= (1u << b);
-			value.setlimb(i, v);
-		}
-		if (leftover > 0u) {
-			std::uint32_t v = 0;
-			for (unsigned b = 0; b < leftover; ++b)
-				if (mantissa.at(b)) v |= (1u << (32u - leftover + b));
-			value.setlimb(full_limbs, v);
-		}
 		value.set_precision(target_bits);
+		if (!parse<constant_big_bits>(std::string(decimal), value)) value.setnan();
 		return value;
 	}
 


### PR DESCRIPTION
## Summary
`efloat_detail::make_constant()` in `efloat_constants.hpp` carried a bespoke copy of `efloat::parse()`'s decimal path -- a direct `decimal_to_binary::convert<16384>` plus round + MSB-first limb packing. It was written that way in #1142 because `parse()` was then capped at the 2040-bit d2b default and returned garbage above it.

That limitation was removed in #1144: `parse` is now templated on `BigBits` (default unchanged) with overflow-safe target sizing. So `make_constant` now simply sizes the working precision and calls `parse<constant_big_bits>`:

```cpp
template<unsigned nlimbs>
inline efloat<nlimbs> make_constant(std::string_view decimal) {
    efloat<nlimbs> value;
    const unsigned target_bits = std::min(nlimbs * 32u, constant_literal_bits);
    value.set_precision(target_bits);
    if (!parse<constant_big_bits>(std::string(decimal), value)) value.setnan();
    return value;
}
```

## Changes
- `include/sw/universal/number/efloat/math/constants/efloat_constants.hpp` -- `make_constant` delegates to `parse<16384>` (drops ~35 lines of duplicated convert/round/pack); invalid input still yields NaN; dropped the now-unused `decimal_to_binary` include, added `<string>`; refreshed the header comment. Net -33 lines.

## Verification
`efloat_pi/e/phi` values are **unchanged**:
- constants regression passes at **level 1** (~308 digits) and **LEVEL_4** (~1000 digits) on gcc + clang;
- the `make_constant` error paths (invalid -> NaN, `"0.0"` -> zero) still pass;
- the trigonometry suite (which consumes `efloat_pi`) still passes.

## Note
The generated ~1000-digit string literals in this file are not clang-format conformant (clang-format would wrap them), but that is pre-existing generator output and out of scope here.

## Test plan
- [x] Fast CI passes (gcc + clang CI_LITE)
- [x] Promote to ready when satisfied

Resolves #1151

Generated with [Claude Code](https://claude.com/claude-code)