### PR TITLE
feat(efloat): implement decimal operator<< / to_string (was a 'TBD' stub) (#1150)

### DIFF
--- a/elastic/efloat/conversion/to_string.cpp
+++ b/elastic/efloat/conversion/to_string.cpp
@@ -117,6 +117,33 @@ int VerifyEfloatToString(bool reportTestCases) {
 				std::cout << "    FAIL: fixed -3.25 -> " << os2.str() << "\n";
 			++failures;
 		}
+		// fixed format must ROUND (not truncate) and a sub-1 value must emit exactly `precision` decimals
+		std::ostringstream os3;
+		os3 << std::fixed << std::setprecision(4) << E(2.0 / 3.0);  // 0.66666... -> 0.6667
+		if (os3.str() != "0.6667") {
+			if (reportTestCases)
+				std::cout << "    FAIL: fixed 2/3 @4 -> " << os3.str() << " (want 0.6667)\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 6. large exponent (efloat's range far exceeds double's, so 4-digit
+	//    exponents are reachable -- e.g. 1e1000)
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying large exponents...\n";
+	{
+		E big;
+		big.set_precision(400);
+		parse<16384>("1e1000", big);
+		std::ostringstream os;
+		os << std::scientific << std::setprecision(3) << big;
+		if (os.str().find("e+1000") == std::string::npos) {
+			if (reportTestCases)
+				std::cout << "    FAIL: 1e1000 -> " << os.str() << " (want ...e+1000)\n";
+			++failures;
+		}
 	}
 
 	// ---------------------------------------------------------------------

--- a/elastic/efloat/conversion/to_string.cpp
+++ b/elastic/efloat/conversion/to_string.cpp
@@ -1,0 +1,202 @@
+// to_string.cpp: regression tests for efloat decimal output (operator<< / to_string).
+//
+// Before #1150, operator<< emitted the literal "TBD" for every finite value.
+// It now produces a correctly-rounded decimal string at arbitrary precision.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template<unsigned nlimbs>
+std::string sci(const sw::universal::efloat<nlimbs>& v, int prec) {
+	std::ostringstream os;
+	os << std::scientific << std::setprecision(prec) << v;
+	return os.str();
+}
+
+int VerifyEfloatToString(bool reportTestCases) {
+	using namespace sw::universal;
+	using E      = efloat<16>;  // 512 bits
+	int failures = 0;
+
+	// ---------------------------------------------------------------------
+	// 1. no more "TBD"; basic scientific values match std for double-range
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying basic decimal output...\n";
+	{
+		if (sci(E(1.5), 6).find("TBD") != std::string::npos) {
+			if (reportTestCases)
+				std::cout << "    FAIL: still prints TBD\n";
+			++failures;
+		}
+		for (double d : {1.5, -3.25, 1234.5678, 2.0 / 3.0, 0.1, 1e-9}) {
+			std::ostringstream es;
+			es << std::scientific << std::setprecision(14) << E(d);
+			std::ostringstream ds;
+			ds << std::scientific << std::setprecision(14) << d;
+			if (es.str() != ds.str()) {
+				if (reportTestCases)
+					std::cout << "    FAIL: " << d << " efloat=" << es.str() << " std=" << ds.str() << "\n";
+				++failures;
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. high precision: to_string of pi matches the efloat_pi oracle after
+	//    parsing back (round-trip) to well beyond double precision
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying high-precision round-trip...\n";
+	{
+		for (int prec : {20, 50, 100}) {
+			std::string str = sci(efloat_pi<16>(), prec);
+			E           rt;
+			rt.set_precision(600);
+			parse<16384>(str, rt);
+			E d = rt - efloat_pi<16>();
+			d.setsign(false);
+			int64_t sc = d.iszero() ? -100000 : d.scale();
+			// prec decimal digits ~ prec*3.32 bits of agreement; require prec-2 digits
+			int64_t want = -static_cast<int64_t>((prec - 2) * 3.321928);
+			if (sc > want) {
+				if (reportTestCases)
+					std::cout << "    FAIL: pi@" << prec << " round-trip scale=" << sc << " (want <=" << want << ")\n";
+				++failures;
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 3. round-trip of arbitrary finite values: parse(to_string(x)) ~= x
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying round-trip of finite values...\n";
+	{
+		for (double d : {1.5, -3.25, 2.0 / 3.0, 6.022e23, -1e-15}) {
+			E x(d);
+			E rt;
+			rt.set_precision(120);
+			parse<16384>(sci(x, 30), rt);
+			if (std::abs(double(rt) - d) > std::abs(d) * 1e-14 + 1e-300) {
+				if (reportTestCases)
+					std::cout << "    FAIL: round-trip " << d << " -> " << double(rt) << "\n";
+				++failures;
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 4. fixed format
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying fixed format...\n";
+	{
+		std::ostringstream os;
+		os << std::fixed << std::setprecision(4) << E(1.5);
+		if (os.str() != "1.5000") {
+			if (reportTestCases)
+				std::cout << "    FAIL: fixed 1.5 -> " << os.str() << "\n";
+			++failures;
+		}
+		std::ostringstream os2;
+		os2 << std::fixed << std::setprecision(2) << E(-3.25);
+		if (os2.str() != "-3.25") {
+			if (reportTestCases)
+				std::cout << "    FAIL: fixed -3.25 -> " << os2.str() << "\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 5. special values (including the -inf sign, which isneg() misses)
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying special values...\n";
+	{
+		auto out = [](const E& v) {
+			std::ostringstream o;
+			o << v;
+			return o.str();
+		};
+		E pinf;
+		pinf.setinf(false);
+		E ninf;
+		ninf.setinf(true);
+		E nan;
+		nan.setnan();
+		if (out(pinf) != "inf") {
+			if (reportTestCases)
+				std::cout << "    FAIL: +inf -> " << out(pinf) << "\n";
+			++failures;
+		}
+		if (out(ninf) != "-inf") {
+			if (reportTestCases)
+				std::cout << "    FAIL: -inf -> " << out(ninf) << "\n";
+			++failures;
+		}
+		if (out(nan) != "nan") {
+			if (reportTestCases)
+				std::cout << "    FAIL: nan -> " << out(nan) << "\n";
+			++failures;
+		}
+		std::ostringstream z;
+		z << std::scientific << std::setprecision(3) << E(0.0);
+		if (z.str() != "0.000e+00") {
+			if (reportTestCases)
+				std::cout << "    FAIL: zero -> " << z.str() << "\n";
+			++failures;
+		}
+	}
+
+	return failures;
+}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat decimal output (operator<<) library";
+	std::string test_tag            = "to_string";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatToString(reportTestCases), "efloat", "to_string");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+} catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+} catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -1708,14 +1708,13 @@ inline efloat<nlimbs> operator/(double lhs, const efloat<nlimbs>& rhs) {
 
 namespace efloat_detail {
 
-	// append a 2-or-3 digit signed decimal exponent
+	// append a signed decimal exponent, minimum 2 digits (efloat's exponent range
+	// far exceeds double's, so 4+ digit exponents are reachable -- e.g. 1e1000).
 	inline void append_exponent(std::string& str, int e) {
 		str += (e < 0 ? '-' : '+');
-		e = (e < 0) ? -e : e;
-		int k;
-		if (e >= 100) { k = e / 100; str += static_cast<char>('0' + k); e -= 100 * k; }
-		k = e / 10; str += static_cast<char>('0' + k); e -= 10 * k;
-		str += static_cast<char>('0' + e);
+		std::string digits = std::to_string((e < 0) ? -e : e);
+		if (digits.size() < 2) digits.insert(0, 2u - digits.size(), '0');
+		str += digits;
 	}
 
 	// round the digit string in place, propagating a carry; bump *decimalPoint on overflow
@@ -1841,9 +1840,11 @@ std::string to_string(const efloat<nlimbs>& value, std::streamsize precision, st
 			else {
 				std::vector<char> t;
 				if (fixed) {
+					// compute extra guard digits (nrDigitsForFixedFormat) for accuracy,
+					// but round and print exactly nrDigits (= integerDigits + precision).
 					t.resize(static_cast<size_t>(nrDigitsForFixedFormat + 1));
 					efloat_detail::to_digits(value, t, e, nrDigitsForFixedFormat);
-					efloat_detail::round_string(t, nrDigitsForFixedFormat + 1, &integerDigits);
+					efloat_detail::round_string(t, nrDigits + 1, &integerDigits);
 					if (integerDigits > 0) {
 						int i;
 						for (i = 0; i < integerDigits; ++i) s += t[static_cast<unsigned>(i)];
@@ -1855,7 +1856,7 @@ std::string to_string(const efloat<nlimbs>& value, std::streamsize precision, st
 					else {
 						s += "0.";
 						if (integerDigits < 0) s.append(static_cast<size_t>(-integerDigits), '0');
-						for (int i = 0; i < nrDigitsForFixedFormat; ++i) s += t[static_cast<unsigned>(i)];
+						for (int i = 0; i < nrDigits; ++i) s += t[static_cast<unsigned>(i)];
 					}
 				}
 				else {

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -1433,31 +1433,26 @@ bool parse(const std::string& txt, efloat<nlimbs>& value) {
 }
 
 // generate an efloat format ASCII format
+// forward reference: full decimal formatter, defined after the arithmetic
+// operators it relies on (see below).
+template<unsigned nlimbs>
+std::string to_string(const efloat<nlimbs>& value, std::streamsize precision, std::streamsize width,
+                      bool fixed, bool scientific, bool internal, bool left, bool showpos,
+                      bool uppercase, char fill);
+
 template<unsigned nlimbs>
 inline std::ostream& operator<<(std::ostream& ostr, const efloat<nlimbs>& rhs) {
-	// to make certain that setw and left/right operators work properly
-	// we need to transform the efloat into a string
-	std::stringstream ss;
-
-	if (rhs.isinf()) {
-		ss << (rhs.sign() == -1 ? "-inf" : "+inf");
-	}
-	else if (rhs.isqnan()) {
-		ss << "nan(qnan)";
-	}
-	else if (rhs.issnan()) {
-		ss << "nan(snan)";
-	}
-	else {
-		std::streamsize prec = ostr.precision();
-		std::streamsize width = ostr.width();
-		std::ios_base::fmtflags ff;
-		ff = ostr.flags();
-		ss.flags(ff);
-		ss << std::setw(width) << std::setprecision(prec) << "TBD";
-	}
-
-	return ostr << ss.str();
+	std::ios_base::fmtflags fmt = ostr.flags();
+	std::streamsize precision   = ostr.precision();
+	std::streamsize width       = ostr.width();
+	char fillChar               = ostr.fill();
+	bool showpos    = (fmt & std::ios_base::showpos)    != 0;
+	bool uppercase  = (fmt & std::ios_base::uppercase)  != 0;
+	bool fixed      = (fmt & std::ios_base::fixed)      != 0;
+	bool scientific = (fmt & std::ios_base::scientific) != 0;
+	bool internal   = (fmt & std::ios_base::internal)   != 0;
+	bool left       = (fmt & std::ios_base::left)       != 0;
+	return ostr << to_string(rhs, precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
 }
 
 // read an ASCII efloat format
@@ -1701,6 +1696,193 @@ inline efloat<nlimbs> operator*(double lhs, const efloat<nlimbs>& rhs) {
 template<unsigned nlimbs>
 inline efloat<nlimbs> operator/(double lhs, const efloat<nlimbs>& rhs) {
 	return operator/(efloat<nlimbs>(lhs), rhs);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// decimal formatting (binary -> decimal string at arbitrary precision)
+///
+/// Ported from ereal's to_string/to_digits: digits are extracted one at a time
+/// using efloat's OWN arithmetic (scale to [1,10) via *10 / /10, then repeatedly
+/// take floor and multiply by 10). Accuracy is limited by the operand's working
+/// precision. (issue #1150)
+
+namespace efloat_detail {
+
+	// append a 2-or-3 digit signed decimal exponent
+	inline void append_exponent(std::string& str, int e) {
+		str += (e < 0 ? '-' : '+');
+		e = (e < 0) ? -e : e;
+		int k;
+		if (e >= 100) { k = e / 100; str += static_cast<char>('0' + k); e -= 100 * k; }
+		k = e / 10; str += static_cast<char>('0' + k); e -= 10 * k;
+		str += static_cast<char>('0' + e);
+	}
+
+	// round the digit string in place, propagating a carry; bump *decimalPoint on overflow
+	inline void round_string(std::vector<char>& s, int precision, int* decimalPoint) {
+		int lastDigit = precision - 1;
+		if (s[static_cast<unsigned>(lastDigit)] >= '5') {
+			int i = precision - 2;
+			s[static_cast<unsigned>(i)]++;
+			while (i > 0 && s[static_cast<unsigned>(i)] > '9') {
+				s[static_cast<unsigned>(i)] -= 10;
+				s[static_cast<unsigned>(--i)]++;
+			}
+		}
+		if (s[0] > '9') {
+			for (int i = precision - 1; i >= 2; --i) s[static_cast<unsigned>(i)] = s[static_cast<unsigned>(i - 1)];
+			s[0u] = '1';
+			s[1u] = '0';
+			(*decimalPoint)++;
+		}
+	}
+
+	// generate `precision`+1 decimal digits of |value| into s, with the decimal
+	// exponent returned in `exponent` (value ~= 0.s[0]s[1]... * 10^(exponent+1),
+	// i.e. s[0] is the leading significant digit at 10^exponent).
+	template<unsigned nlimbs>
+	void to_digits(const efloat<nlimbs>& value, std::vector<char>& s, int& exponent, int precision) {
+		constexpr double log10_2 = 0.301029995663981;
+		if (value.iszero()) {
+			exponent = 0;
+			for (int i = 0; i < precision; ++i) s[static_cast<unsigned>(i)] = '0';
+			return;
+		}
+
+		// estimate the power-of-ten exponent from the binary scale, then correct
+		int e = static_cast<int>(log10_2 * static_cast<double>(value.scale()));
+
+		efloat<nlimbs> r(value); r.setsign(false);   // |value|
+		const efloat<nlimbs> ten(10.0), one(1.0);
+		if (e < 0)      { for (int k = 0; k < -e; ++k) r = r * ten; }
+		else if (e > 0) { for (int k = 0; k <  e; ++k) r = r / ten; }
+		if (r >= ten)     { r = r / ten; ++e; }
+		else if (r < one) { r = r * ten; --e; }
+
+		const int nrDigits = precision + 1;
+		for (int i = 0; i < nrDigits; ++i) {
+			if (r.iszero()) { for (int j = i; j < nrDigits; ++j) s[static_cast<unsigned>(j)] = '0'; break; }
+			int digit = static_cast<int>(double(r));           // r in [0,10): leading digit
+			r = r - efloat<nlimbs>(static_cast<double>(digit));
+			r = r * ten;
+			s[static_cast<unsigned>(i)] = static_cast<char>(digit + '0');
+		}
+
+		// repair any digit that fell just outside [0,9] from rounding
+		for (int i = nrDigits - 1; i > 0; --i) {
+			if (s[static_cast<unsigned>(i)] < '0')      { s[static_cast<unsigned>(i - 1)]--; s[static_cast<unsigned>(i)] += 10; }
+			else if (s[static_cast<unsigned>(i)] > '9') { s[static_cast<unsigned>(i - 1)]++; s[static_cast<unsigned>(i)] -= 10; }
+		}
+
+		// round to `precision` digits, propagate carry
+		int lastDigit = nrDigits - 1;
+		if (s[static_cast<unsigned>(lastDigit)] >= '5') {
+			int i = nrDigits - 2;
+			s[static_cast<unsigned>(i)]++;
+			while (i > 0 && s[static_cast<unsigned>(i)] > '9') {
+				s[static_cast<unsigned>(i)] -= 10;
+				s[static_cast<unsigned>(--i)]++;
+			}
+		}
+		if (s[0] > '9') {   // carry made the leading digit 10 -> shift
+			++e;
+			for (int i = precision; i >= 2; --i) s[static_cast<unsigned>(i)] = s[static_cast<unsigned>(i - 1)];
+			s[0u] = '1';
+			s[1u] = '0';
+		}
+		s[static_cast<unsigned>(precision)] = 0;
+		exponent = e;
+	}
+
+}  // namespace efloat_detail
+
+template<unsigned nlimbs>
+std::string to_string(const efloat<nlimbs>& value, std::streamsize precision, std::streamsize width,
+                      bool fixed, bool scientific, bool internal, bool left, bool showpos,
+                      bool uppercase, char fill) {
+	std::string s;
+	if (fixed && scientific) fixed = false;   // scientific takes precedence
+	if (precision < 0) precision = 6;         // default stream precision
+
+	bool negative = (value.sign() == -1);   // sign(), not isneg(): isneg() is false for -inf
+	int  e = 0;
+
+	if (value.isnan()) {
+		s = uppercase ? "NAN" : "nan";
+		negative = false;
+	}
+	else {
+		if (negative) s += '-'; else if (showpos) s += '+';
+
+		if (value.isinf()) {
+			s += uppercase ? "INF" : "inf";
+		}
+		else if (value.iszero()) {
+			s += '0';
+			if (precision > 0) { s += '.'; s.append(static_cast<unsigned>(precision), '0'); }
+			if (!fixed) s += (uppercase ? "E+00" : "e+00");
+		}
+		else {
+			int powerOfTenScale = static_cast<int>(std::floor(static_cast<double>(value.scale()) * 0.301029995663981));
+			int integerDigits   = (fixed ? (powerOfTenScale + 1) : 1);
+			int nrDigits        = integerDigits + static_cast<int>(precision);
+
+			int minBuffer = static_cast<int>(nlimbs) * 16;
+			int nrDigitsForFixedFormat = fixed ? std::max(minBuffer, nrDigits) : nrDigits;
+
+			double fullMagnitude = std::fabs(static_cast<double>(value));
+			if (fixed && (precision == 0) && (fullMagnitude < 1.0)) {
+				s += (fullMagnitude >= 0.5) ? '1' : '0';
+			}
+			else if (fixed && nrDigits <= 0) {
+				s += '0';
+				if (precision > 0) { s += '.'; s.append(static_cast<unsigned>(precision), '0'); }
+			}
+			else {
+				std::vector<char> t;
+				if (fixed) {
+					t.resize(static_cast<size_t>(nrDigitsForFixedFormat + 1));
+					efloat_detail::to_digits(value, t, e, nrDigitsForFixedFormat);
+					efloat_detail::round_string(t, nrDigitsForFixedFormat + 1, &integerDigits);
+					if (integerDigits > 0) {
+						int i;
+						for (i = 0; i < integerDigits; ++i) s += t[static_cast<unsigned>(i)];
+						if (precision > 0) {
+							s += '.';
+							for (int j = 0; j < static_cast<int>(precision); ++j, ++i) s += t[static_cast<unsigned>(i)];
+						}
+					}
+					else {
+						s += "0.";
+						if (integerDigits < 0) s.append(static_cast<size_t>(-integerDigits), '0');
+						for (int i = 0; i < nrDigitsForFixedFormat; ++i) s += t[static_cast<unsigned>(i)];
+					}
+				}
+				else {
+					t.resize(static_cast<size_t>(nrDigits + 1));
+					efloat_detail::to_digits(value, t, e, nrDigits);
+					s += t[0ull];
+					if (precision > 0) s += '.';
+					for (int i = 1; i <= static_cast<int>(precision); ++i) s += t[static_cast<unsigned>(i)];
+				}
+			}
+
+			if (!fixed) { s += (uppercase ? 'E' : 'e'); efloat_detail::append_exponent(s, e); }
+		}
+	}
+
+	// width / fill padding
+	size_t strLength = s.length();
+	if (width > 0 && strLength < static_cast<size_t>(width)) {
+		size_t pad = static_cast<size_t>(width) - strLength;
+		if (internal) {
+			const bool hasSign = !s.empty() && (s[0] == '-' || s[0] == '+');
+			s.insert(hasSign ? std::string::size_type(1) : std::string::size_type(0), pad, fill);
+		}
+		else if (left) s.append(pad, fill);
+		else s.insert(std::string::size_type(0), pad, fill);
+	}
+	return s;
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -1804,11 +1804,9 @@ std::string to_string(const efloat<nlimbs>& value, std::streamsize precision, st
 	if (precision < 0) precision = 6;         // default stream precision
 
 	bool negative = (value.sign() == -1);   // sign(), not isneg(): isneg() is false for -inf
-	int  e = 0;
 
 	if (value.isnan()) {
 		s = uppercase ? "NAN" : "nan";
-		negative = false;
 	}
 	else {
 		if (negative) s += '-'; else if (showpos) s += '+';
@@ -1822,6 +1820,7 @@ std::string to_string(const efloat<nlimbs>& value, std::streamsize precision, st
 			if (!fixed) s += (uppercase ? "E+00" : "e+00");
 		}
 		else {
+			int e               = 0;   // decimal exponent, filled in by to_digits below
 			int powerOfTenScale = static_cast<int>(std::floor(static_cast<double>(value.scale()) * 0.301029995663981));
 			int integerDigits   = (fixed ? (powerOfTenScale + 1) : 1);
 			int nrDigits        = integerDigits + static_cast<int>(precision);


### PR DESCRIPTION
## Summary
`efloat`'s stream output emitted the literal **`TBD`** for every finite value (only `inf`/`nan`/`zero` worked, `efloat_impl.hpp:1457`). Implemented an arbitrary-precision binary->decimal formatter so `efloat` values print their actual digits.

## Approach
Ported `to_string` + `to_digits` from `ereal`: digits are extracted using `efloat`'s **own arithmetic** -- estimate the power-of-ten from `scale()`, scale the magnitude into `[1,10)` (`*10` / `/10`), then repeatedly take the leading digit and multiply by 10, with round-to-nearest and carry propagation. Honors the stream's `precision`/`width` and `fixed`/`scientific`/`showpos`/`uppercase`/`internal`/`left` flags; `operator<<` now extracts the flags and delegates (same structure as `ereal`'s).

Two details:
- Sign uses `sign() == -1`, not `isneg()` (which is false for `-inf`), so `-inf` prints correctly.
- The formatter is defined after the arithmetic operators it uses (forward-declared before `operator<<`).

Accuracy is bounded by the operand's working precision.

## Example
```
pi (50 digits): 3.14159265358979323846264338327950288419716939937511e+00
0.1 (30 digits): 1.000000000000000055511151231258e-01   (true binary value of double 0.1)
fixed 1.5 (prec 4): 1.5000
-inf / nan / 0: -inf nan 0.0000e+00
```

## Changes
- `include/sw/universal/number/efloat/efloat_impl.hpp` -- `to_string`/`to_digits`/`round_string`/`append_exponent`; `operator<<` delegates.
- `elastic/efloat/conversion/to_string.cpp` (new) -- no-TBD, std match for double-range scientific, high-precision round-trip (pi to 20/50/100 digits vs the `efloat_pi` oracle), finite round-trips, fixed format, special values (incl. `-inf`).

## Notes
- `efloat_impl.hpp` is a large file that predates clang-format; only my additions are new -- reformatting the whole file (~1100 lines) is out of scope here.
- Unblocks the adaptive-precision demos printing high-precision digits directly instead of via `double()` casts.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_to_string (new) | OK | PASS | OK | PASS |
| efloat_math / exponent / constants / api (regression) | OK | PASS | -- | -- |

gcc 13.3.0, clang 18.1.3.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1150

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete decimal output formatting for `efloat` values.
  * Supports fixed and scientific notation, precision, width, fill characters, alignment, signs, and uppercase exponents.
  * Correctly formats zero, infinity, negative infinity, and NaN.
  * Improves high-precision decimal output and round-trip accuracy.

* **Bug Fixes**
  * Replaced placeholder `"TBD"` output for finite values with meaningful formatted decimals.

* **Tests**
  * Added regression coverage for precision, rounding, special values, and stream formatting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->