### PR TITLE
feat(efloat): implement math/hyperbolic.hpp (sinh, cosh, tanh, asinh, acosh, atanh)

### DIFF
--- a/elastic/efloat/math/hyperbolic.cpp
+++ b/elastic/efloat/math/hyperbolic.cpp
@@ -327,39 +327,50 @@ int VerifyEfloatHyperbolic(bool reportTestCases) {
 			++failures;
 		}
 
-		// domain errors -> NaN
+		// domain errors -> NaN, and must raise InvalidOperation (an explicit objective)
 		clear_efloat_exceptions();
-		if (!acosh(efloat<8>(0.5)).isnan()) {
+		if (!acosh(efloat<8>(0.5)).isnan() || !has_efloat_exception(ExceptionFlag::InvalidOperation)) {
 			if (reportTestCases)
-				std::cout << "    FAIL: acosh(0.5) not NaN\n";
+				std::cout << "    FAIL: acosh(0.5) not NaN / no InvalidOperation\n";
 			++failures;
 		}
-		if (!acosh(ninf).isnan()) {
+		clear_efloat_exceptions();
+		if (!acosh(ninf).isnan() || !has_efloat_exception(ExceptionFlag::InvalidOperation)) {
 			if (reportTestCases)
-				std::cout << "    FAIL: acosh(-inf) not NaN\n";
+				std::cout << "    FAIL: acosh(-inf) not NaN / no InvalidOperation\n";
 			++failures;
 		}
-		if (!atanh(efloat<8>(2.0)).isnan()) {
+		clear_efloat_exceptions();
+		if (!atanh(efloat<8>(2.0)).isnan() || !has_efloat_exception(ExceptionFlag::InvalidOperation)) {
 			if (reportTestCases)
-				std::cout << "    FAIL: atanh(2) not NaN\n";
+				std::cout << "    FAIL: atanh(2) not NaN / no InvalidOperation\n";
 			++failures;
 		}
-		if (!atanh(pinf).isnan()) {
+		clear_efloat_exceptions();
+		if (!atanh(pinf).isnan() || !has_efloat_exception(ExceptionFlag::InvalidOperation)) {
 			if (reportTestCases)
-				std::cout << "    FAIL: atanh(+inf) not NaN\n";
+				std::cout << "    FAIL: atanh(+inf) not NaN / no InvalidOperation\n";
 			++failures;
 		}
 
-		// poles -> +/-inf
-		if (!atanh(efloat<8>(1.0)).isinf() || atanh(efloat<8>(1.0)).sign() != 1) {
-			if (reportTestCases)
-				std::cout << "    FAIL: atanh(1) != +inf\n";
-			++failures;
+		// poles -> +/-inf, and must raise DivisionByZero (an explicit objective)
+		clear_efloat_exceptions();
+		{
+			efloat<8> ap = atanh(efloat<8>(1.0));
+			if (!ap.isinf() || ap.sign() != 1 || !has_efloat_exception(ExceptionFlag::DivisionByZero)) {
+				if (reportTestCases)
+					std::cout << "    FAIL: atanh(1) != +inf / no DivisionByZero\n";
+				++failures;
+			}
 		}
-		if (!atanh(efloat<8>(-1.0)).isinf() || atanh(efloat<8>(-1.0)).sign() != -1) {
-			if (reportTestCases)
-				std::cout << "    FAIL: atanh(-1) != -inf\n";
-			++failures;
+		clear_efloat_exceptions();
+		{
+			efloat<8> an = atanh(efloat<8>(-1.0));
+			if (!an.isinf() || an.sign() != -1 || !has_efloat_exception(ExceptionFlag::DivisionByZero)) {
+				if (reportTestCases)
+					std::cout << "    FAIL: atanh(-1) != -inf / no DivisionByZero\n";
+				++failures;
+			}
 		}
 	}
 

--- a/elastic/efloat/math/hyperbolic.cpp
+++ b/elastic/efloat/math/hyperbolic.cpp
@@ -1,0 +1,416 @@
+// hyperbolic.cpp: regression tests for efloat hyperbolic functions.
+//
+// Categories tested:
+//   - sinh, cosh, tanh
+//   - asinh, acosh, atanh
+//   - identities, round-trips, special values, high-precision residuals (Issue #1114)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template<unsigned nlimbs>
+bool IsClose(const sw::universal::efloat<nlimbs>& a, double target_val, double tolerance = 1e-12) {
+	double diff = std::abs(double(a) - target_val);
+	return diff <= tolerance * (1.0 + std::abs(target_val));
+}
+
+// |a - b| as a binary scale; a very negative scale means agreement to that
+// many bits. Returns a large negative sentinel when the difference is zero.
+template<unsigned nlimbs>
+int64_t AgreementScale(const sw::universal::efloat<nlimbs>& a, const sw::universal::efloat<nlimbs>& b) {
+	using namespace sw::universal;
+	efloat<nlimbs> d = a - b;
+	d.setsign(false);
+	return d.iszero() ? -1000000 : d.scale();
+}
+
+int VerifyEfloatHyperbolic(bool reportTestCases) {
+	using namespace sw::universal;
+	int failures = 0;
+
+	// ---------------------------------------------------------------------
+	// 1. sinh
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying sinh...\n";
+	{
+		clear_efloat_exceptions();
+		if (sinh(efloat<8>(0.0)) != 0.0) {
+			if (reportTestCases)
+				std::cout << "    FAIL: sinh(0) != 0\n";
+			++failures;
+		}
+		if (!IsClose(sinh(efloat<8>(1.0)), std::sinh(1.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: sinh(1)\n";
+			++failures;
+		}
+		if (!IsClose(sinh(efloat<8>(-1.0)), std::sinh(-1.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: sinh(-1)\n";
+			++failures;
+		}
+		if (!IsClose(sinh(efloat<8>(3.5)), std::sinh(3.5))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: sinh(3.5)\n";
+			++failures;
+		}
+		// small argument (exercises the expm1 accurate path)
+		if (!IsClose(sinh(efloat<8>(1e-3)), std::sinh(1e-3))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: sinh(1e-3)\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. cosh
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying cosh...\n";
+	{
+		if (cosh(efloat<8>(0.0)) != 1.0) {
+			if (reportTestCases)
+				std::cout << "    FAIL: cosh(0) != 1\n";
+			++failures;
+		}
+		if (!IsClose(cosh(efloat<8>(1.0)), std::cosh(1.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: cosh(1)\n";
+			++failures;
+		}
+		if (!IsClose(cosh(efloat<8>(-2.0)), std::cosh(-2.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: cosh(-2)\n";
+			++failures;
+		}
+		if (!IsClose(cosh(efloat<8>(4.0)), std::cosh(4.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: cosh(4)\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 3. tanh
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying tanh...\n";
+	{
+		if (tanh(efloat<8>(0.0)) != 0.0) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh(0) != 0\n";
+			++failures;
+		}
+		if (!IsClose(tanh(efloat<8>(1.0)), std::tanh(1.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh(1)\n";
+			++failures;
+		}
+		if (!IsClose(tanh(efloat<8>(-0.5)), std::tanh(-0.5))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh(-0.5)\n";
+			++failures;
+		}
+		if (!IsClose(tanh(efloat<8>(1e-4)), std::tanh(1e-4))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh(1e-4)\n";
+			++failures;
+		}
+		// saturation for large argument
+		if (!IsClose(tanh(efloat<8>(40.0)), 1.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh(40) != 1\n";
+			++failures;
+		}
+		if (!IsClose(tanh(efloat<8>(-40.0)), -1.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh(-40) != -1\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 4. asinh / acosh / atanh
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying inverse hyperbolic...\n";
+	{
+		if (asinh(efloat<8>(0.0)) != 0.0) {
+			if (reportTestCases)
+				std::cout << "    FAIL: asinh(0) != 0\n";
+			++failures;
+		}
+		if (!IsClose(asinh(efloat<8>(1.0)), std::asinh(1.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: asinh(1)\n";
+			++failures;
+		}
+		if (!IsClose(asinh(efloat<8>(-3.0)), std::asinh(-3.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: asinh(-3)\n";
+			++failures;
+		}
+		if (!IsClose(asinh(efloat<8>(1e-4)), std::asinh(1e-4))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: asinh(1e-4)\n";
+			++failures;
+		}
+
+		if (!IsClose(acosh(efloat<8>(1.0)), 0.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: acosh(1) != 0\n";
+			++failures;
+		}
+		if (!IsClose(acosh(efloat<8>(2.0)), std::acosh(2.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: acosh(2)\n";
+			++failures;
+		}
+		if (!IsClose(acosh(efloat<8>(1.0001)), std::acosh(1.0001), 1e-9)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: acosh(1.0001)\n";
+			++failures;
+		}
+
+		if (atanh(efloat<8>(0.0)) != 0.0) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(0) != 0\n";
+			++failures;
+		}
+		if (!IsClose(atanh(efloat<8>(0.5)), std::atanh(0.5))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(0.5)\n";
+			++failures;
+		}
+		if (!IsClose(atanh(efloat<8>(-0.9)), std::atanh(-0.9))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(-0.9)\n";
+			++failures;
+		}
+		if (!IsClose(atanh(efloat<8>(1e-4)), std::atanh(1e-4))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(1e-4)\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 5. Identity cosh^2 - sinh^2 == 1 at full precision (oracle-grade)
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying cosh^2 - sinh^2 == 1...\n";
+	{
+		efloat<16> x(0.7);  // 512-bit working precision
+		efloat<16> s = sinh(x), c = cosh(x);
+		efloat<16> id = c * c - s * s;
+		int64_t    sc = AgreementScale(id, efloat<16>(1.0));
+		// require agreement to well beyond double (< 2^-200 ~ 60 digits)
+		if (sc > -200) {
+			if (reportTestCases)
+				std::cout << "    FAIL: cosh^2-sinh^2-1 scale=" << sc << " (want <=-200)\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 6. tanh == sinh/cosh (internal consistency)
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying tanh == sinh/cosh...\n";
+	{
+		efloat<16> x(1.3);
+		efloat<16> lhs = tanh(x);
+		efloat<16> rhs = sinh(x) / cosh(x);
+		int64_t    sc  = AgreementScale(lhs, rhs);
+		if (sc > -200) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh vs sinh/cosh scale=" << sc << "\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 7. Inverse round-trips at full precision (oracle-grade)
+	//      asinh(sinh(x)) == x, acosh(cosh(x)) == x (x>0), atanh(tanh(x)) == x
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying inverse round-trips...\n";
+	{
+		efloat<16> x(0.9);
+		int64_t    s1 = AgreementScale(asinh(sinh(x)), x);
+		int64_t    s2 = AgreementScale(acosh(cosh(x)), x);
+		int64_t    s3 = AgreementScale(atanh(tanh(x)), x);
+		if (s1 > -200) {
+			if (reportTestCases)
+				std::cout << "    FAIL: asinh(sinh(x)) scale=" << s1 << "\n";
+			++failures;
+		}
+		if (s2 > -200) {
+			if (reportTestCases)
+				std::cout << "    FAIL: acosh(cosh(x)) scale=" << s2 << "\n";
+			++failures;
+		}
+		if (s3 > -200) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(tanh(x)) scale=" << s3 << "\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 8. Special values
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying special values...\n";
+	{
+		efloat<8> pinf;
+		pinf.setinf(false);
+		efloat<8> ninf;
+		ninf.setinf(true);
+		efloat<8> nan;
+		nan.setnan();
+
+		if (!sinh(pinf).isinf() || sinh(pinf).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: sinh(+inf)\n";
+			++failures;
+		}
+		if (!sinh(ninf).isinf() || sinh(ninf).sign() != -1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: sinh(-inf)\n";
+			++failures;
+		}
+		if (!cosh(pinf).isinf() || cosh(pinf).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: cosh(+inf)\n";
+			++failures;
+		}
+		if (!cosh(ninf).isinf() || cosh(ninf).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: cosh(-inf) != +inf\n";
+			++failures;
+		}
+		if (!IsClose(tanh(pinf), 1.0) || !IsClose(tanh(ninf), -1.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: tanh(+/-inf)\n";
+			++failures;
+		}
+		if (!sinh(nan).isnan() || !cosh(nan).isnan() || !tanh(nan).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: fwd(nan)\n";
+			++failures;
+		}
+
+		if (!asinh(pinf).isinf() || asinh(pinf).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: asinh(+inf)\n";
+			++failures;
+		}
+		if (!asinh(ninf).isinf() || asinh(ninf).sign() != -1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: asinh(-inf)\n";
+			++failures;
+		}
+		if (!acosh(pinf).isinf() || acosh(pinf).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: acosh(+inf)\n";
+			++failures;
+		}
+
+		// domain errors -> NaN
+		clear_efloat_exceptions();
+		if (!acosh(efloat<8>(0.5)).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: acosh(0.5) not NaN\n";
+			++failures;
+		}
+		if (!acosh(ninf).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: acosh(-inf) not NaN\n";
+			++failures;
+		}
+		if (!atanh(efloat<8>(2.0)).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(2) not NaN\n";
+			++failures;
+		}
+		if (!atanh(pinf).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(+inf) not NaN\n";
+			++failures;
+		}
+
+		// poles -> +/-inf
+		if (!atanh(efloat<8>(1.0)).isinf() || atanh(efloat<8>(1.0)).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(1) != +inf\n";
+			++failures;
+		}
+		if (!atanh(efloat<8>(-1.0)).isinf() || atanh(efloat<8>(-1.0)).sign() != -1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: atanh(-1) != -inf\n";
+			++failures;
+		}
+	}
+
+	return failures;
+}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat mathematical hyperbolic library";
+	std::string test_tag            = "hyperbolic";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatHyperbolic(reportTestCases), "efloat", "hyperbolic manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases +=
+	    ReportTestResult(VerifyEfloatHyperbolic(reportTestCases), "efloat", "hyperbolic foundational");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif
+} catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+} catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/math/hyperbolic.hpp
+++ b/include/sw/universal/number/efloat/math/hyperbolic.hpp
@@ -1,0 +1,192 @@
+// hyperbolic.hpp: hyperbolic and inverse hyperbolic functions for efloat
+//                 (sinh, cosh, tanh, asinh, acosh, atanh)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+#include <cmath>
+#include <universal/number/efloat/math/exponent.hpp>   // exp, expm1
+#include <universal/number/efloat/math/logarithm.hpp>  // log1p
+#include <universal/number/efloat/math/sqrt.hpp>       // sqrt
+
+namespace sw {
+namespace universal {
+
+// ----------------------------------------------------------------------------
+// The forward functions are built on the exact identities
+//     sinh(x) = (e^x - e^-x)/2,  cosh(x) = (e^x + e^-x)/2,  tanh(x) = (e^2x-1)/(e^2x+1)
+// and the inverses on
+//     asinh(x) = log(x + sqrt(x^2+1)),  acosh(x) = log(x + sqrt(x^2-1)),
+//     atanh(x) = 0.5*log((1+x)/(1-x)).
+// Where the naive identity would cancel near zero, the expm1/log1p forms are
+// used instead so that accuracy tracks the operand's full working precision
+// (not just double). All special-value results match <cmath>.
+// ----------------------------------------------------------------------------
+
+// sinh: hyperbolic sine (odd). sinh(+/-0)=+/-0, sinh(+/-inf)=+/-inf.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> sinh(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return x;
+	if (x.iszero())
+		return x;  // preserve signed zero
+	if (x.isinf()) {
+		efloat<nlimbs> inf;
+		inf.setinf(x.sign() == -1);
+		return inf;
+	}
+
+	const efloat<nlimbs> one(1.0), two(2.0), half(0.5);
+	efloat<nlimbs>       abs_x(x);
+	abs_x.setsign(false);
+	if (abs_x < half) {
+		// sinh(x) = u(u+2) / (2(u+1)),  u = e^x - 1 = expm1(x); accurate as x -> 0
+		efloat<nlimbs> u = expm1(x);
+		return u * (u + two) / (two * (u + one));
+	}
+	// |x| >= 0.5: no cancellation, and exp's inf/zero handling gives the right
+	// overflow behavior (sinh(+huge)=+inf, sinh(-huge)=-inf).
+	return (exp(x) - exp(-x)) * half;
+}
+
+// cosh: hyperbolic cosine (even). cosh(+/-0)=1, cosh(+/-inf)=+inf.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> cosh(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return x;
+	if (x.iszero())
+		return efloat<nlimbs>(1.0);
+	if (x.isinf()) {
+		efloat<nlimbs> inf;
+		inf.setinf(false);
+		return inf;
+	}
+
+	const efloat<nlimbs> one(1.0), half(0.5);
+	efloat<nlimbs>       abs_x(x);
+	abs_x.setsign(false);            // cosh is even
+	efloat<nlimbs> ex = exp(abs_x);  // >= 1 (or +inf for huge x)
+	// cosh(x) = (e^|x| + e^-|x|)/2; a sum of positives, so never cancels.
+	return (ex + one / ex) * half;
+}
+
+// tanh: hyperbolic tangent (odd). tanh(+/-0)=+/-0, tanh(+/-inf)=+/-1.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> tanh(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return x;
+	if (x.iszero())
+		return x;  // preserve signed zero
+	if (x.isinf())
+		return efloat<nlimbs>(x.sign() == -1 ? -1.0 : 1.0);
+
+	const efloat<nlimbs> one(1.0), two(2.0);
+	efloat<nlimbs>       abs_x(x);
+	abs_x.setsign(false);
+	// tanh(|x|) = w/(w+2),  w = e^(2|x|) - 1 = expm1(2|x|); accurate as x -> 0.
+	efloat<nlimbs> w = expm1(two * abs_x);
+	efloat<nlimbs> t = w.isinf() ? one : (w / (w + two));  // saturates to 1 for huge |x|
+	if (x.sign() == -1)
+		t.setsign(true);
+	return t;
+}
+
+// asinh: inverse hyperbolic sine (odd). asinh(+/-0)=+/-0, asinh(+/-inf)=+/-inf.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> asinh(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return x;
+	if (x.iszero())
+		return x;  // preserve signed zero
+	if (x.isinf()) {
+		efloat<nlimbs> inf;
+		inf.setinf(x.sign() == -1);
+		return inf;
+	}
+
+	const efloat<nlimbs> one(1.0);
+	efloat<nlimbs>       a(x);
+	a.setsign(false);
+	// asinh(a) = log(a + sqrt(a^2+1)) = log1p(a + a^2/(1 + sqrt(1+a^2)))
+	// (the log1p form avoids cancellation in the argument as a -> 0).
+	efloat<nlimbs> a2 = a * a;
+	efloat<nlimbs> s  = sqrt(one + a2);
+	efloat<nlimbs> r  = log1p(a + a2 / (one + s));
+	if (x.sign() == -1)
+		r.setsign(true);
+	return r;
+}
+
+// acosh: inverse hyperbolic cosine. Domain x >= 1. acosh(1)=+0, acosh(+inf)=+inf.
+//        acosh(x<1) is a domain error -> NaN.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> acosh(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return x;
+	if (x.isinf()) {
+		if (x.sign() == -1) {  // acosh(-inf) is undefined
+			efloat<nlimbs> nan;
+			nan.setnan();
+			if (!std::is_constant_evaluated())
+				efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+			return nan;
+		}
+		return x;  // acosh(+inf) = +inf
+	}
+
+	const efloat<nlimbs> one(1.0);
+	if (x < one) {  // includes all negatives; domain error
+		efloat<nlimbs> nan;
+		nan.setnan();
+		if (!std::is_constant_evaluated())
+			efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+	// acosh(x) = log(x + sqrt(x^2-1)) = log1p((x-1) + sqrt((x-1)(x+1)))
+	// (the log1p form keeps precision near x = 1, where acosh -> 0).
+	efloat<nlimbs> xm1 = x - one;
+	return log1p(xm1 + sqrt(xm1 * (x + one)));
+}
+
+// atanh: inverse hyperbolic tangent. Domain |x| < 1. atanh(+/-0)=+/-0,
+//        atanh(+/-1)=+/-inf (pole), atanh(|x|>1) and atanh(+/-inf) -> NaN.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> atanh(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return x;
+	if (x.iszero())
+		return x;  // preserve signed zero
+	if (x.isinf()) {
+		efloat<nlimbs> nan;
+		nan.setnan();
+		if (!std::is_constant_evaluated())
+			efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+
+	const efloat<nlimbs> one(1.0), two(2.0), half(0.5);
+	efloat<nlimbs>       abs_x(x);
+	abs_x.setsign(false);
+	if (abs_x == one) {  // pole at +/-1
+		efloat<nlimbs> inf;
+		inf.setinf(x.sign() == -1);
+		if (!std::is_constant_evaluated())
+			efloat_exception_flags.set(ExceptionFlag::DivisionByZero);
+		return inf;
+	}
+	if (abs_x > one) {  // domain error
+		efloat<nlimbs> nan;
+		nan.setnan();
+		if (!std::is_constant_evaluated())
+			efloat_exception_flags.set(ExceptionFlag::InvalidOperation);
+		return nan;
+	}
+	// atanh(x) = 0.5*log((1+x)/(1-x)) = 0.5*log1p(2x/(1-x)); accurate as x -> 0
+	// and sign-correct for negative x.
+	return half * log1p((two * x) / (one - x));
+}
+
+}  // namespace universal
+}  // namespace sw

--- a/include/sw/universal/number/efloat/math/hyperbolic.hpp
+++ b/include/sw/universal/number/efloat/math/hyperbolic.hpp
@@ -7,6 +7,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
 #include <cmath>
+#include <type_traits>                                 // std::is_constant_evaluated
+#include <universal/behavior/status_flags.hpp>         // ExceptionFlag, efloat_exception_flags
 #include <universal/number/efloat/math/exponent.hpp>   // exp, expm1
 #include <universal/number/efloat/math/logarithm.hpp>  // log1p
 #include <universal/number/efloat/math/sqrt.hpp>       // sqrt

--- a/include/sw/universal/number/efloat/mathlib.hpp
+++ b/include/sw/universal/number/efloat/mathlib.hpp
@@ -13,6 +13,7 @@
 #include <universal/number/efloat/math/truncate.hpp>
 #include <universal/number/efloat/math/constants/efloat_constants.hpp>
 #include <universal/number/efloat/math/trigonometry.hpp>
+#include <universal/number/efloat/math/hyperbolic.hpp>
 #include <universal/number/efloat/math/pow.hpp>
 #include <universal/number/efloat/math/fractional.hpp>
 #include <universal/number/efloat/math/minmax.hpp>


### PR DESCRIPTION
## Summary
- Implements the hyperbolic / inverse-hyperbolic library `math/hyperbolic.hpp` for `efloat`, matching the repository-wide math structure (cf. `posit/math/hyperbolic.hpp`).
- Built on efloat's own `exp`/`expm1`/`log1p`/`sqrt`, so accuracy tracks the operand's **full working precision** (nlimbs*32 bits), not just double.
- Sub-issue of Epic #1092 (efloat mathlib); analogous to the trig work (#1115/#1137).

## Numerical approach
- **sinh**: `u(u+2)/(2(u+1))`, `u=expm1(x)` for `|x|<0.5` (no cancellation as x->0); direct `(e^x-e^-x)/2` otherwise (correct +/-inf overflow via `exp`).
- **cosh**: `(e^|x|+e^-|x|)/2` -- a sum of positives, never cancels.
- **tanh**: `w/(w+2)`, `w=expm1(2|x|)`, saturating to 1 for huge `|x|`; sign applied afterward.
- **asinh/acosh**: `log1p` forms that stay accurate near 0 and near x=1.
- **atanh**: `0.5*log1p(2x/(1-x))`.

## Special values (all match `<cmath>`)
`cosh(+/-inf)=+inf`, `tanh(+/-inf)=+/-1`, `acosh(x<1)` and `acosh(-inf)` -> NaN (FE_INVALID), `atanh(+/-1)` -> +/-inf (FE_DIVBYZERO), `atanh(|x|>1)` and `atanh(+/-inf)` -> NaN (FE_INVALID). Signed zero preserved. `constexpr`-compatible.

## Changes
- `include/sw/universal/number/efloat/math/hyperbolic.hpp` -- new header (6 functions)
- `include/sw/universal/number/efloat/mathlib.hpp` -- include the new header
- `elastic/efloat/math/hyperbolic.cpp` -- new regression test (auto-globbed by the math test CMake)

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_hyperbolic | OK | PASS | OK | PASS |

Test covers accuracy vs `<cmath>`, small-argument (expm1) paths, saturation, special values / domain errors, and high-precision oracle identities at 512 bits: `cosh^2-sinh^2==1`, `tanh==sinh/cosh`, and asinh/acosh/atanh round-trips all agree to `< 2^-200`. cppcheck-clean; clang-formatted.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #1114

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hyperbolic functions for efloat values: `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, and `atanh`.
  * Added handling for special values, signed zero, infinities, domain errors, and pole behavior.
  * Made the new functions available through the standard efloat math library.

* **Tests**
  * Added regression coverage against standard math results, mathematical identities, edge cases, and numerical consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->