### PR TITLE
feat(efloat): give hypot its own math/hypot.hpp header + dedicated test

### DIFF
--- a/elastic/efloat/math/hypot.cpp
+++ b/elastic/efloat/math/hypot.cpp
@@ -1,0 +1,269 @@
+// hypot.cpp: regression tests for the efloat hypotenuse function.
+//
+// hypot(x,y) = sqrt(x^2 + y^2), computed with scale-by-max so intermediates
+// neither overflow nor underflow, on efloat's own arithmetic (full precision).
+// Covers Pythagorean values, symmetry, zeros, overflow/underflow prevention,
+// IEEE special values, and high-precision oracle identities. (Issue #1121)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+template<unsigned nlimbs>
+bool IsClose(const sw::universal::efloat<nlimbs>& a, double target_val, double tolerance = 1e-12) {
+	double diff = std::abs(double(a) - target_val);
+	return diff <= tolerance * (1.0 + std::abs(target_val));
+}
+
+// |a - b| as a binary scale; very negative means agreement to that many bits.
+template<unsigned nlimbs>
+int64_t AgreementScale(const sw::universal::efloat<nlimbs>& a, const sw::universal::efloat<nlimbs>& b) {
+	sw::universal::efloat<nlimbs> d = a - b;
+	d.setsign(false);
+	return d.iszero() ? -1000000 : d.scale();
+}
+
+int VerifyEfloatHypot(bool reportTestCases) {
+	using namespace sw::universal;
+	using E      = efloat<8>;   // 256-bit
+	using EH     = efloat<16>;  // 512-bit for high-precision identities
+	int failures = 0;
+
+	// ---------------------------------------------------------------------
+	// 1. exact Pythagorean values (3-4-5 and its 6-8-10 multiple are exact:
+	//    r = min/max = 0.75 is exactly representable in binary)
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying exact Pythagorean values...\n";
+	{
+		if (hypot(E(3.0), E(4.0)) != E(5.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(3,4) != 5\n";
+			++failures;
+		}
+		if (hypot(E(4.0), E(3.0)) != E(5.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(4,3) != 5\n";
+			++failures;
+		}
+		if (hypot(E(6.0), E(8.0)) != E(10.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(6,8) != 10\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. symmetry: hypot(x,y) == hypot(y,x) == hypot(x,-y) == hypot(-x,y)
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying symmetry...\n";
+	{
+		E a(2.5), b(7.25);
+		E h = hypot(a, b);
+		if (hypot(b, a) != h) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot not symmetric in args\n";
+			++failures;
+		}
+		if (hypot(a, -b) != h) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(x,-y) != hypot(x,y)\n";
+			++failures;
+		}
+		if (hypot(-a, b) != h) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(-x,y) != hypot(x,y)\n";
+			++failures;
+		}
+		if (hypot(-a, -b) != h) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(-x,-y) != hypot(x,y)\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 3. zero arguments: hypot(0,y) == |y|, hypot(x,0) == |x|, hypot(0,0)==0
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying zero arguments...\n";
+	{
+		if (hypot(E(0.0), E(7.0)) != E(7.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(0,7) != 7\n";
+			++failures;
+		}
+		if (hypot(E(-7.0), E(0.0)) != E(7.0)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(-7,0) != 7\n";
+			++failures;
+		}
+		if (!hypot(E(0.0), E(0.0)).iszero()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(0,0) != 0\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 4. overflow/underflow prevention -- the whole reason hypot exists.
+	//    A naive sqrt(x*x + y*y) would over/underflow; scale-by-max must not.
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying overflow/underflow prevention...\n";
+	{
+		E big = hypot(E(3e200), E(4e200));
+		if (big.isnan() || big.isinf() || !IsClose(big / E(1e200), 5.0, 1e-12)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(3e200,4e200) not ~5e200 (got scale " << big.scale() << ")\n";
+			++failures;
+		}
+		E small = hypot(E(3e-200), E(4e-200));
+		if (small.iszero() || !IsClose(small / E(1e-200), 5.0, 1e-12)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(3e-200,4e-200) not ~5e-200\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 5. IEEE special values
+	//    - +/-inf in either argument -> +inf (even if the other is NaN)
+	//    - otherwise NaN in either argument -> NaN
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying special values...\n";
+	{
+		E pinf;
+		pinf.setinf(false);
+		E ninf;
+		ninf.setinf(true);
+		E nan;
+		nan.setnan();
+
+		if (!hypot(pinf, E(1.0)).isinf() || hypot(pinf, E(1.0)).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(+inf,1) != +inf\n";
+			++failures;
+		}
+		if (!hypot(E(1.0), ninf).isinf() || hypot(E(1.0), ninf).sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(1,-inf) != +inf\n";
+			++failures;
+		}
+		// infinity suppresses NaN
+		if (!hypot(pinf, nan).isinf()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(+inf,NaN) != +inf\n";
+			++failures;
+		}
+		if (!hypot(nan, ninf).isinf()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(NaN,-inf) != +inf\n";
+			++failures;
+		}
+		// NaN otherwise
+		if (!hypot(nan, E(1.0)).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(NaN,1) != NaN\n";
+			++failures;
+		}
+		if (!hypot(E(1.0), nan).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(1,NaN) != NaN\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 6. oracle-grade: hypot(x,y)^2 == x^2 + y^2 at 512-bit
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying hypot^2 == x^2+y^2 at 512-bit...\n";
+	{
+		EH      x(0.7), y(1.3);
+		EH      h  = hypot(x, y);
+		EH      h2 = h * h;
+		EH      s  = x * x + y * y;
+		int64_t sc = AgreementScale(h2, s);
+		if (sc > -400) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot^2 vs x^2+y^2 scale=" << sc << "\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 7. oracle-grade: hypot(1,1) == sqrt(2) to full working precision
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying hypot(1,1) == sqrt(2)...\n";
+	{
+		EH      h  = hypot(EH(1.0), EH(1.0));
+		EH      s2 = sqrt(EH(2.0));
+		int64_t sc = AgreementScale(h, s2);
+		if (sc > -400) {
+			if (reportTestCases)
+				std::cout << "    FAIL: hypot(1,1) vs sqrt(2) scale=" << sc << "\n";
+			++failures;
+		}
+	}
+
+	return failures;
+}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat mathematical hypot library";
+	std::string test_tag            = "hypot";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatHypot(reportTestCases), "efloat", "hypot manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatHypot(reportTestCases), "efloat", "hypot foundational");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif
+} catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+} catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/math/hypot.hpp
+++ b/include/sw/universal/number/efloat/math/hypot.hpp
@@ -1,0 +1,52 @@
+// hypot.hpp: hypotenuse function hypot(x, y) = sqrt(x^2 + y^2) for efloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+#include <universal/number/efloat/math/sqrt.hpp>  // sqrt
+
+namespace sw {
+namespace universal {
+
+// hypot(x, y) = sqrt(x^2 + y^2), computed with scale-by-max so the intermediate
+// x^2 + y^2 neither overflows nor underflows. Unlike the double-delegating shims
+// in most number systems, this runs on efloat's own arithmetic and sqrt, so the
+// result carries the operand's full working precision. IEEE-754 special cases:
+//   - if either argument is +/-inf, the result is +inf (even if the other is NaN)
+//   - otherwise if either argument is NaN, the result is NaN
+//   - hypot(x, y) == hypot(y, x) == hypot(x, -y); hypot(0, y) == |y|
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> hypot(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	// IEEE-754: Infinity suppresses NaN inside hypot! Infinity check must run first.
+	if (x.isinf() || y.isinf()) {
+		efloat<nlimbs> inf;
+		inf.setinf(false);
+		return inf;
+	}
+	if (x.isnan() || y.isnan()) {
+		efloat<nlimbs> nan;
+		nan.setnan();
+		return nan;
+	}
+
+	efloat<nlimbs> abs_x(x);
+	abs_x.setsign(false);
+	efloat<nlimbs> abs_y(y);
+	abs_y.setsign(false);
+
+	// Scale by max to prevent intermediate underflow/overflow
+	efloat<nlimbs> max_val = (abs_x < abs_y) ? abs_y : abs_x;
+	efloat<nlimbs> min_val = (abs_x < abs_y) ? abs_x : abs_y;
+
+	if (max_val.iszero()) {
+		return efloat<nlimbs>(0.0);
+	}
+
+	efloat<nlimbs> r = min_val / max_val;
+	return max_val * sqrt(efloat<nlimbs>(1.0) + r * r);
+}
+
+}  // namespace universal
+}  // namespace sw

--- a/include/sw/universal/number/efloat/math/sqrt.hpp
+++ b/include/sw/universal/number/efloat/math/sqrt.hpp
@@ -1,4 +1,4 @@
-// sqrt.hpp: square root, cube root, and hypotenuse functions for efloat
+// sqrt.hpp: square root and cube root functions for efloat
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -90,34 +90,6 @@ constexpr efloat<nlimbs> cbrt(const efloat<nlimbs>& a) {
 		y.setsign(true);
 	}
 	return y;
-}
-
-// hypot: hypotenuse function sqrt(x^2 + y^2) with scale-based overflow prevention
-template<unsigned nlimbs>
-constexpr efloat<nlimbs> hypot(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
-	// IEEE-754: Infinity suppresses NaN inside hypot! Infinity check must run first.
-	if (x.isinf() || y.isinf()) {
-		efloat<nlimbs> inf; inf.setinf(false);
-		return inf;
-	}
-	if (x.isnan() || y.isnan()) {
-		efloat<nlimbs> nan; nan.setnan();
-		return nan;
-	}
-
-	efloat<nlimbs> abs_x(x); abs_x.setsign(false);
-	efloat<nlimbs> abs_y(y); abs_y.setsign(false);
-
-	// Scale by max to prevent intermediate underflow/overflow
-	efloat<nlimbs> max_val = (abs_x < abs_y) ? abs_y : abs_x;
-	efloat<nlimbs> min_val = (abs_x < abs_y) ? abs_x : abs_y;
-
-	if (max_val.iszero()) {
-		return efloat<nlimbs>(0.0);
-	}
-
-	efloat<nlimbs> r = min_val / max_val;
-	return max_val * sqrt(efloat<nlimbs>(1.0) + r * r);
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/efloat/mathlib.hpp
+++ b/include/sw/universal/number/efloat/mathlib.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <universal/number/efloat/math/sqrt.hpp>
+#include <universal/number/efloat/math/hypot.hpp>
 #include <universal/number/efloat/math/exponent.hpp>
 #include <universal/number/efloat/math/logarithm.hpp>
 #include <universal/number/efloat/math/classify.hpp>


### PR DESCRIPTION
## Summary
Issue #1121 asks for `efloat/math/hypot.hpp`. `hypot(x,y)` was **already implemented** for efloat -- but it lived inside `sqrt.hpp` and had no dedicated test. Notably, efloat's version is a proper native scale-by-max implementation (`sqrt(x^2+y^2)` without intermediate over/underflow) on efloat's own arithmetic, so it is **full-precision** -- unlike the `std::hypot(double,double)` shims most number systems ship.

This PR relocates it to its own header (repo-wide one-function-per-header convention) and adds the dedicated regression test.

## Changes
- **Move** `hypot` from `math/sqrt.hpp` into new `math/hypot.hpp` (which includes `sqrt.hpp` for its `sqrt` dependency). No behavioral change; `sqrt.hpp` title updated to "square root and cube root".
- Wire `math/hypot.hpp` into `mathlib.hpp` after `sqrt.hpp`. **Safe**: only `mathlib.hpp` and `hyperbolic.hpp` include `sqrt.hpp` directly, and hyperbolic needs only `sqrt`; every consumer reaches `hypot` via the mathlib umbrella.
- Add `elastic/efloat/math/hypot.cpp`.

## Test coverage
Exact Pythagorean values (3-4-5, 6-8-10), symmetry (`hypot(x,y)==hypot(y,x)==hypot(x,-y)`), zero cases, **overflow/underflow prevention** (`hypot(3e200,4e200)`, `hypot(3e-200,4e-200)` -- the whole reason hypot exists), IEEE special values (inf suppresses NaN), and two **512-bit oracle identities** (`hypot^2==x^2+y^2`, `hypot(1,1)==sqrt(2)`, agreeing to < 2^-400).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_hypot | OK | PASS | OK | PASS |
| efloat_sqrt_precision (regression) | OK | PASS | OK | PASS |
| efloat_math (regression) | OK | PASS | OK | PASS |

cppcheck-clean, clang-formatted.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #1121

Generated with [Claude Code](https://claude.com/claude-code)