### PR TITLE
feat(efloat): give nextafter/nexttoward their own math/next.hpp + fix ULP precision bug

### DIFF
--- a/elastic/efloat/math/next.cpp
+++ b/elastic/efloat/math/next.cpp
@@ -2,9 +2,9 @@
 //
 // nextafter(x, y) returns the value one ULP from x toward y, at x's WORKING
 // precision. Covers direction, precision-consistent ULP magnitude (the property
-// a stored-limb-count ULP got wrong), within-binade reversibility, zero/sign,
-// and special values. nexttoward mirrors nextafter with a long double target.
-// (Issue #1120)
+// a stored-limb-count ULP got wrong), reversibility in both directions across
+// the power-of-two boundary, zero/sign, and special values. nexttoward mirrors
+// nextafter with a long double target. (Issue #1120)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -101,19 +101,56 @@ int VerifyEfloatNext(bool reportTestCases) {
 	}
 
 	// ---------------------------------------------------------------------
-	// 4. within-binade reversibility: step up then down returns x exactly.
-	//    (Down across the binade boundary halves the ULP, so we only test the
-	//    up-then-down direction, which stays inside [1,2).)
+	// 4. reversibility in both directions, including across the power-of-two
+	//    boundary. Stepping toward zero from an exact power of two crosses
+	//    into the lower (half-ULP) binade; the step must still be reversible.
 	// ---------------------------------------------------------------------
 	if (reportTestCases)
-		std::cout << "  Verifying up-then-down reversibility...\n";
+		std::cout << "  Verifying reversibility (both directions)...\n";
+	{
+		for (double v : {1.0, 2.0, 4.0, 0.5, 1.5, 3.7, -1.0, -2.0}) {
+			EH x(v);
+			EH up = nextafter(x, EH(v + 1e9));  // step away from zero
+			EH dn = nextafter(x, EH(v - 1e9));  // step toward zero
+			if (nextafter(up, x) != x) {
+				if (reportTestCases)
+					std::cout << "    FAIL: up round-trip at " << v << "\n";
+				++failures;
+			}
+			if (nextafter(dn, x) != x) {
+				if (reportTestCases)
+					std::cout << "    FAIL: down round-trip at " << v << "\n";
+				++failures;
+			}
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 4b. down-step from an exact power of two uses the lower binade's half
+	//     ULP, so it lands one representable value closer to x than the naive
+	//     same-binade ULP would, and is strictly below x and reversible.
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying power-of-two down-step...\n";
 	{
 		EH x(1.0);
-		EH up   = nextafter(x, EH(2.0));
-		EH back = nextafter(up, EH(0.0));
-		if (back != x) {
+		EH dn = nextafter(x, EH(0.0));
+		EH fullUlp(1.0);
+		fullUlp.setexponent(x.scale() - static_cast<int64_t>(x.get_precision()) + 1);
+		EH naive = x - fullUlp;  // what a same-binade ULP step would give
+		if (!(dn < x)) {
 			if (reportTestCases)
-				std::cout << "    FAIL: nextafter(nextafter(1,up),down) != 1\n";
+				std::cout << "    FAIL: pow2 down-step not < x\n";
+			++failures;
+		}
+		if (!(dn > naive)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: pow2 down-step not closer than full ULP\n";
+			++failures;
+		}
+		if (nextafter(dn, x) != x) {
+			if (reportTestCases)
+				std::cout << "    FAIL: pow2 down-step not reversible\n";
 			++failures;
 		}
 	}

--- a/elastic/efloat/math/next.cpp
+++ b/elastic/efloat/math/next.cpp
@@ -1,0 +1,235 @@
+// next.cpp: regression tests for efloat next-representable-value functions.
+//
+// nextafter(x, y) returns the value one ULP from x toward y, at x's WORKING
+// precision. Covers direction, precision-consistent ULP magnitude (the property
+// a stored-limb-count ULP got wrong), within-binade reversibility, zero/sign,
+// and special values. nexttoward mirrors nextafter with a long double target.
+// (Issue #1120)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+int VerifyEfloatNext(bool reportTestCases) {
+	using namespace sw::universal;
+	using E      = efloat<8>;   // 256-bit working precision
+	using EH     = efloat<16>;  // 512-bit working precision
+	int failures = 0;
+
+	// ---------------------------------------------------------------------
+	// 1. direction: step toward y lands strictly on the y side of x
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying step direction...\n";
+	{
+		E one(1.0);
+		if (!(nextafter(one, E(2.0)) > one)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(1,2) !> 1\n";
+			++failures;
+		}
+		if (!(nextafter(one, E(0.0)) < one)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(1,0) !< 1\n";
+			++failures;
+		}
+		E neg(-1.0);
+		if (!(nextafter(neg, E(-2.0)) < neg)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(-1,-2) !< -1\n";
+			++failures;
+		}
+		if (!(nextafter(neg, E(0.0)) > neg)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(-1,0) !> -1\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 2. x == y returns y unchanged
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying x == y short-circuit...\n";
+	{
+		E x(3.5);
+		if (nextafter(x, x) != x) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(x,x) != x\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 3. ULP magnitude tracks WORKING precision (the fixed bug: it used to
+	//    key off the stored limb count, giving a fixed 2^-31 step).
+	//    step = 2^(scale(x) - precision + 1); for x = 1.0 (scale 0) that is
+	//    2^-255 at 256-bit and 2^-511 at 512-bit.
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying precision-consistent ULP...\n";
+	{
+		E       x8(1.0);
+		E       step8 = nextafter(x8, E(2.0)) - x8;
+		int64_t want8 = x8.scale() - static_cast<int64_t>(x8.get_precision()) + 1;  // -255
+		if (step8.scale() != want8) {
+			if (reportTestCases)
+				std::cout << "    FAIL: efloat<8> ULP scale=" << step8.scale() << " (want " << want8 << ")\n";
+			++failures;
+		}
+		EH      x16(1.0);
+		EH      step16 = nextafter(x16, EH(2.0)) - x16;
+		int64_t want16 = x16.scale() - static_cast<int64_t>(x16.get_precision()) + 1;  // -511
+		if (step16.scale() != want16) {
+			if (reportTestCases)
+				std::cout << "    FAIL: efloat<16> ULP scale=" << step16.scale() << " (want " << want16 << ")\n";
+			++failures;
+		}
+		// higher precision => strictly smaller step
+		if (!(step16.scale() < step8.scale())) {
+			if (reportTestCases)
+				std::cout << "    FAIL: efloat<16> ULP not smaller than efloat<8>\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 4. within-binade reversibility: step up then down returns x exactly.
+	//    (Down across the binade boundary halves the ULP, so we only test the
+	//    up-then-down direction, which stays inside [1,2).)
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying up-then-down reversibility...\n";
+	{
+		EH x(1.0);
+		EH up   = nextafter(x, EH(2.0));
+		EH back = nextafter(up, EH(0.0));
+		if (back != x) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(nextafter(1,up),down) != 1\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 5. zero: step away from zero is a tiny value on the correct side
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying step from zero...\n";
+	{
+		E zero(0.0);
+		E zu = nextafter(zero, E(1.0));
+		E zd = nextafter(zero, E(-1.0));
+		if (!(zu > zero) || zu.scale() != -1074) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(0,+) scale=" << zu.scale() << "\n";
+			++failures;
+		}
+		if (!(zd < zero) || zd.sign() != -1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(0,-) not negative\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 6. special values: NaN in either argument -> NaN
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying special values...\n";
+	{
+		E nan;
+		nan.setnan();
+		if (!nextafter(nan, E(1.0)).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(NaN,1) != NaN\n";
+			++failures;
+		}
+		if (!nextafter(E(1.0), nan).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nextafter(1,NaN) != NaN\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 7. nexttoward mirrors nextafter with a long double target
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying nexttoward...\n";
+	{
+		E x(1.0);
+		if (nexttoward(x, 2.0L) != nextafter(x, E(2.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nexttoward != nextafter(2)\n";
+			++failures;
+		}
+		if (nexttoward(x, 0.0L) != nextafter(x, E(0.0))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nexttoward != nextafter(0)\n";
+			++failures;
+		}
+		if (!(nexttoward(x, 2.0L) > x)) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nexttoward(1,2) !> 1\n";
+			++failures;
+		}
+	}
+
+	return failures;
+}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat next representable value library";
+	std::string test_tag            = "next";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatNext(reportTestCases), "efloat", "next manual");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatNext(reportTestCases), "efloat", "next foundational");
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif
+} catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+} catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/math/fractional.hpp
+++ b/include/sw/universal/number/efloat/math/fractional.hpp
@@ -1,4 +1,4 @@
-// fractional.hpp: fractional, remainder, and adjacent step functions for efloat
+// fractional.hpp: fractional, remainder, and sign-copy functions for efloat
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -97,41 +97,6 @@ constexpr efloat<nlimbs> copysign(const efloat<nlimbs>& x, const efloat<nlimbs>&
 	efloat<nlimbs> res(x);
 	res.setsign(y.sign() == -1);
 	return res;
-}
-
-// nextafter: returns the next representable value of x in the direction of y at current precision
-template<unsigned nlimbs>
-constexpr efloat<nlimbs> nextafter(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
-	if (x.isnan() || y.isnan()) {
-		efloat<nlimbs> nan; nan.setnan();
-		return nan;
-	}
-	if (x == y) return y;
-
-	if (x.iszero()) {
-		// Step away from zero: use smallest subnormal exponent scale of double as minimum floor
-		efloat<nlimbs> ulp(1.0);
-		ulp.setexponent(-1074); // LSB position of double subnormals
-		return (y.sign() == -1) ? -ulp : ulp;
-	}
-
-	// Compute ULP at current precision layout
-	efloat<nlimbs> ulp(1.0);
-	ulp.setexponent(x.scale() - static_cast<int64_t>(x.bits().size() * 32) + 1);
-
-	efloat<nlimbs> res;
-	if (y > x) {
-		res = x + ulp;
-	} else {
-		res = x - ulp;
-	}
-	return res;
-}
-
-// nexttoward: same as nextafter, but y is long double (safely cast to double to prevent empty-limb parsing)
-template<unsigned nlimbs>
-constexpr efloat<nlimbs> nexttoward(const efloat<nlimbs>& x, long double y) {
-	return nextafter(x, efloat<nlimbs>(static_cast<double>(y)));
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/efloat/math/next.hpp
+++ b/include/sw/universal/number/efloat/math/next.hpp
@@ -9,12 +9,17 @@
 namespace sw {
 namespace universal {
 
-// nextafter: the next value representable at x's WORKING precision, in the
-// direction of y. The step is one unit-in-the-last-place, i.e. 2^(scale(x) -
-// precision + 1) where precision = get_precision() (the type's working precision
-// in bits), NOT the number of limbs currently occupied by x's mantissa -- a
-// value like 1.0 stores in a single limb, so keying the ULP off the stored limb
-// count would make the step 2^-31 regardless of the type's real precision.
+// nextafter: the value adjacent to x, one unit-in-the-last-place toward y, at
+// x's WORKING precision (get_precision(), the type's bit width -- NOT the number
+// of limbs currently occupied by x's mantissa, which for a value like 1.0 is a
+// single limb and would make the step a fixed 2^-31 regardless of precision).
+//
+// The ULP of the binade [2^k, 2^(k+1)) is 2^(k-P+1) for precision P. Stepping
+// TOWARD ZERO from an exact power of two 2^k crosses into the lower binade
+// [2^(k-1), 2^k), whose spacing is half as large (2^(k-P)); that neighbor is
+// computed at one extra limb of precision so its trailing bit is not rounded off
+// when aligned against 2^k. Every step round-trips: nextafter(nextafter(x,a),x)
+// == x in both directions, across power-of-two boundaries included.
 template<unsigned nlimbs>
 constexpr efloat<nlimbs> nextafter(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
 	if (x.isnan() || y.isnan()) {
@@ -34,15 +39,54 @@ constexpr efloat<nlimbs> nextafter(const efloat<nlimbs>& x, const efloat<nlimbs>
 		return (y.sign() == -1) ? -ulp : ulp;
 	}
 
-	// ULP at x's working precision: 2^(scale - precision + 1)
-	efloat<nlimbs> ulp(1.0);
-	ulp.setexponent(x.scale() - static_cast<int64_t>(x.get_precision()) + 1);
+	const int64_t P = static_cast<int64_t>(x.get_precision());
+	const int64_t k = x.scale();
 
-	return (y > x) ? (x + ulp) : (x - ulp);
+	// Work in magnitude, then re-attach x's sign. "magnitudeUp" is true when the
+	// step moves |x| away from zero (x>0 stepping up, or x<0 stepping down).
+	const bool xNeg        = (x.sign() == -1);
+	const bool magnitudeUp = ((y > x) != xNeg);
+
+	efloat<nlimbs> absx(x);
+	absx.setsign(false);
+
+	efloat<nlimbs> newmag;
+	if (magnitudeUp) {
+		// away from zero: ULP of |x|'s own binade
+		efloat<nlimbs> ulp(1.0);
+		ulp.setexponent(k - P + 1);
+		newmag = absx + ulp;
+	} else {
+		// toward zero: if |x| is an exact power of two, the neighbor lies in the
+		// lower binade a half-ULP away; otherwise it is one ULP of this binade.
+		efloat<nlimbs> pow2(1.0);
+		pow2.setexponent(k);
+		if (absx == pow2) {
+			efloat<nlimbs> half(1.0);
+			half.setexponent(k - P);
+			newmag = absx;
+			newmag.set_precision(static_cast<unsigned>(P) + 32);  // keep the trailing bit
+			newmag = newmag - half;
+			newmag.set_precision(static_cast<unsigned>(P));
+		} else {
+			efloat<nlimbs> ulp(1.0);
+			ulp.setexponent(k - P + 1);
+			newmag = absx - ulp;
+		}
+	}
+
+	newmag.setsign(xNeg);
+	return newmag;
 }
 
 // nexttoward: same as nextafter, but the direction argument is long double.
-// It is cast to double first to avoid empty-limb parsing of a wider type.
+//
+// The target only supplies a DIRECTION (via the x == y / y > x comparisons), so
+// it is converted to double. efloat's long double constructor is currently
+// non-functional (efloat(2.0L) yields 0), so constructing the target from long
+// double directly would misdirect the step; the double conversion is deliberate.
+// The only consequence is that two long double targets closer than one double
+// ULP collapse -- a sub-double-ULP direction distinction not worth the risk.
 template<unsigned nlimbs>
 constexpr efloat<nlimbs> nexttoward(const efloat<nlimbs>& x, long double y) {
 	return nextafter(x, efloat<nlimbs>(static_cast<double>(y)));

--- a/include/sw/universal/number/efloat/math/next.hpp
+++ b/include/sw/universal/number/efloat/math/next.hpp
@@ -1,0 +1,52 @@
+// next.hpp: next-representable-value functions (nextafter, nexttoward) for efloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+namespace sw {
+namespace universal {
+
+// nextafter: the next value representable at x's WORKING precision, in the
+// direction of y. The step is one unit-in-the-last-place, i.e. 2^(scale(x) -
+// precision + 1) where precision = get_precision() (the type's working precision
+// in bits), NOT the number of limbs currently occupied by x's mantissa -- a
+// value like 1.0 stores in a single limb, so keying the ULP off the stored limb
+// count would make the step 2^-31 regardless of the type's real precision.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> nextafter(const efloat<nlimbs>& x, const efloat<nlimbs>& y) {
+	if (x.isnan() || y.isnan()) {
+		efloat<nlimbs> nan;
+		nan.setnan();
+		return nan;
+	}
+	if (x == y)
+		return y;
+
+	if (x.iszero()) {
+		// Step away from zero. An arbitrary-precision type has no fixed smallest
+		// subnormal, so use the double smallest-subnormal exponent (2^-1074) as a
+		// sensible minimum floor.
+		efloat<nlimbs> ulp(1.0);
+		ulp.setexponent(-1074);
+		return (y.sign() == -1) ? -ulp : ulp;
+	}
+
+	// ULP at x's working precision: 2^(scale - precision + 1)
+	efloat<nlimbs> ulp(1.0);
+	ulp.setexponent(x.scale() - static_cast<int64_t>(x.get_precision()) + 1);
+
+	return (y > x) ? (x + ulp) : (x - ulp);
+}
+
+// nexttoward: same as nextafter, but the direction argument is long double.
+// It is cast to double first to avoid empty-limb parsing of a wider type.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> nexttoward(const efloat<nlimbs>& x, long double y) {
+	return nextafter(x, efloat<nlimbs>(static_cast<double>(y)));
+}
+
+}  // namespace universal
+}  // namespace sw

--- a/include/sw/universal/number/efloat/mathlib.hpp
+++ b/include/sw/universal/number/efloat/mathlib.hpp
@@ -17,6 +17,7 @@
 #include <universal/number/efloat/math/hyperbolic.hpp>
 #include <universal/number/efloat/math/pow.hpp>
 #include <universal/number/efloat/math/fractional.hpp>
+#include <universal/number/efloat/math/next.hpp>
 #include <universal/number/efloat/math/minmax.hpp>
 #include <universal/number/efloat/math/error_and_gamma.hpp>
 #include <universal/number/efloat/math/complex.hpp>


### PR DESCRIPTION
## Summary
Issue #1120 asks for `efloat/math/next.hpp`. `nextafter`/`nexttoward` already existed (in `fractional.hpp`), but had two gaps: no dedicated header/test, and **a real precision bug**.

## Bug fix (the substantive part)
`nextafter` computed its ULP as `2^(scale - bits().size()*32 + 1)` -- keying the step off the number of limbs **currently occupied** by the mantissa, not the type's working precision. A value like `1.0` stores in a single limb, so the step came out `2^-31` for `efloat<8>` (256-bit) **and** `efloat<16>` (512-bit) alike -- precision-independent and far too coarse.

Now uses `get_precision()`: step = `2^(scale - precision + 1)`, giving `2^-255 / 2^-511 / 2^-1023` at 256/512/1024-bit. (`get_precision()` also avoids the vector allocation `bits()` incurred, so it's more constexpr-friendly.)

## Structure
- Move `nextafter`/`nexttoward` from `math/fractional.hpp` into new `math/next.hpp` (repo one-function-per-header convention). `fractional.hpp` title updated.
- Wired into `mathlib.hpp`. **Safe**: only `mathlib.hpp` includes `fractional.hpp`, and everything reaches these via the umbrella.

## Changes
- `include/sw/universal/number/efloat/math/next.hpp` -- new header (bug-fixed impl)
- `include/sw/universal/number/efloat/math/fractional.hpp` -- removed the two functions
- `include/sw/universal/number/efloat/mathlib.hpp` -- include next.hpp
- `elastic/efloat/math/next.cpp` -- new regression test

## Test coverage
Direction, `x==y` short-circuit, **precision-consistent ULP magnitude** (regression guard for the fixed bug: asserts the step scale equals `scale - precision + 1` and that higher precision gives a strictly smaller step), within-binade up-then-down reversibility, step-from-zero, NaN propagation, and `nexttoward` mirroring `nextafter`.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_next | OK | PASS | OK | PASS |
| efloat_fractional (regression) | OK | PASS | OK | PASS |
| efloat_api (regression) | OK | PASS | OK | PASS |

cppcheck-clean, clang-formatted. The pre-existing `fractional.cpp` nextafter checks (direction only) still pass -- they never asserted the buggy magnitude.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #1120

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `nextafter` and `nexttoward` support for `efloat` values.
  * Added correct handling for zero values, NaNs, matching inputs, direction-aware stepping, and varying precision.
  * Made the new functions available through the standard `efloat` math header.

* **Tests**
  * Added regression coverage for stepping behavior, reversibility, precision, signed zero, NaNs, and long-double targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->