### PR TITLE
fix(efloat): implement long double conversion (was yielding 0)

### DIFF
--- a/elastic/efloat/conversion/long_double.cpp
+++ b/elastic/efloat/conversion/long_double.cpp
@@ -1,0 +1,194 @@
+// long_double.cpp: regression tests for efloat <-> long double conversion.
+//
+// Before the fix, efloat's convert_ieee754 only built limbs for sizeof(Real) of
+// 4 or 8, so a wide long double (sizeof 16 on x86-64) produced 0. The conversion
+// now decomposes the value into an exact sum of doubles (scaled via frexp/ldexp),
+// preserving the full significand and the extended exponent range in both
+// directions. On platforms where long double aliases double the extended-
+// precision/range checks are skipped. (Issue #1160)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <universal/number/efloat/efloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+#if LONG_DOUBLE_SUPPORT
+
+int VerifyEfloatLongDouble(bool reportTestCases) {
+	using namespace sw::universal;
+	using E      = efloat<8>;  // 256-bit
+	int failures = 0;
+
+	// -----------------------------------------------------------------
+	// 1. the reported bug: the constructor no longer yields 0
+	// -----------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying long double constructor (no longer 0)...\n";
+	{
+		for (long double v : {1.0L, 2.0L, 3.5L, 100.0L, -7.25L, 0.5L}) {
+			E x(v);
+			if (double(x) != static_cast<double>(v)) {
+				if (reportTestCases)
+					std::cout << "    FAIL: efloat(" << double(v) << "L) -> " << double(x) << "\n";
+				++failures;
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------
+	// 2. round-trip exactness through both directions
+	// -----------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying long double round-trip...\n";
+	{
+		for (long double v : {1.0L, 3.5L, 0.1L, -2.75L, 3.14159265358979323846L, 100.0L}) {
+			if (static_cast<long double>(E(v)) != v) {
+				if (reportTestCases)
+					std::cout << "    FAIL: round-trip " << double(v) << "L\n";
+				++failures;
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------
+	// 3. special values
+	// -----------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying special values...\n";
+	{
+		E negzero(-0.0L);
+		if (!negzero.iszero()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: -0.0L not zero\n";
+			++failures;
+		}
+
+		long double inf = std::numeric_limits<long double>::infinity();
+		E           pinf(inf), ninf(-inf);
+		if (!pinf.isinf() || pinf.sign() != 1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: +inf in\n";
+			++failures;
+		}
+		if (!ninf.isinf() || ninf.sign() != -1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: -inf in\n";
+			++failures;
+		}
+		if (static_cast<long double>(pinf) != inf) {
+			if (reportTestCases)
+				std::cout << "    FAIL: +inf out\n";
+			++failures;
+		}
+
+		E nan(std::numeric_limits<long double>::quiet_NaN());
+		if (!nan.isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nan in\n";
+			++failures;
+		}
+		if (!std::isnan(static_cast<long double>(nan))) {
+			if (reportTestCases)
+				std::cout << "    FAIL: nan out\n";
+			++failures;
+		}
+	}
+
+	// -----------------------------------------------------------------
+	// 4. wide long double only: precision and exponent range beyond double
+	// -----------------------------------------------------------------
+	if constexpr (sizeof(long double) > sizeof(double)) {
+		if (reportTestCases)
+			std::cout << "  Verifying beyond-double precision + range...\n";
+
+		// significand bit below double's 53: 1 + 2^-60 must survive
+		{
+			E x(1.0L + std::ldexp(1.0L, -60));
+			E one(1.0);
+			E d = x - one;
+			d.setsign(false);
+			if (d.iszero() || d.scale() != -60) {
+				if (reportTestCases)
+					std::cout << "    FAIL: 1+2^-60 lost, scale=" << (d.iszero() ? 0 : d.scale()) << "\n";
+				++failures;
+			}
+			if (static_cast<long double>(x) != 1.0L + std::ldexp(1.0L, -60)) {
+				if (reportTestCases)
+					std::cout << "    FAIL: 1+2^-60 round-trip\n";
+				++failures;
+			}
+		}
+
+		// exponent range beyond double (double tops out near 2^1023 / 2^-1074).
+		// Use exact powers of two so the round-trip comparison is exact and to
+		// dodge a cppcheck parser limitation on huge decimal long double literals.
+		for (long double v : {std::ldexp(1.0L, 1100), std::ldexp(-3.0L, 1200), std::ldexp(1.0L, -1100),
+		                      std::ldexp(1.0L, 16000), std::ldexp(1.0L, -16000)}) {
+			E x(v);
+			if (x.iszero() || x.isinf()) {
+				if (reportTestCases)
+					std::cout << "    FAIL: range value collapsed\n";
+				++failures;
+			}
+			if (static_cast<long double>(x) != v) {
+				if (reportTestCases)
+					std::cout << "    FAIL: extended-range round-trip\n";
+				++failures;
+			}
+		}
+	}
+
+	return failures;
+}
+
+#endif  // LONG_DOUBLE_SUPPORT
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 0
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main() try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "efloat long double conversion library";
+	std::string test_tag            = "long double";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if LONG_DOUBLE_SUPPORT
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyEfloatLongDouble(reportTestCases), "efloat", "long double");
+#	endif
+#else
+	if (reportTestCases)
+		std::cout << "  long double aliases double on this platform; nothing wide to test\n";
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+} catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+} catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>      // std::fpclassify, std::frexp, std::ldexp (long double conversions)
 #include <string>
 #include <sstream>
 #include <iostream>
@@ -181,9 +182,76 @@ public:
 
 #if LONG_DOUBLE_SUPPORT
 	efloat(long double iv)                      noexcept { *this = iv; }
-	efloat& operator=(long double rhs)          noexcept { return convert_ieee754(rhs); }
-	explicit operator long double()       const noexcept { return convert_to_ieee754<long double>(); }
-#endif 
+
+	// convert_ieee754 only builds limbs for sizeof(Real) of 4 or 8, so a wide
+	// long double (sizeof 16 on x86-64) produced 0. Decompose instead: frexp the
+	// value into m * 2^e with m in [0.5,1) (safely inside double's range), split m
+	// into an exact sum of doubles via the working double path, then apply e with
+	// setexponent(). This preserves the full long double significand AND its
+	// extended exponent range. Platforms where long double == double take the
+	// direct path.
+	efloat& operator=(long double rhs) noexcept {
+		if constexpr (sizeof(long double) <= sizeof(double)) {
+			return convert_ieee754(static_cast<double>(rhs));
+		}
+		else {
+			switch (std::fpclassify(rhs)) {
+			case FP_ZERO:
+			case FP_NAN:
+			case FP_INFINITE:
+				return convert_ieee754(static_cast<double>(rhs));
+			default:
+				break;
+			}
+			int e = 0;
+			long double m = std::frexp(rhs, &e);
+			clear();
+			long double r = m;
+			for (int i = 0; i < 8 && r != 0.0L; ++i) {
+				double hi = static_cast<double>(r);
+				if (hi == 0.0) break;   // remainder fell below double's range
+				*this += efloat(hi);
+				r -= static_cast<long double>(hi);
+			}
+			if (!iszero()) setexponent(scale() + e);
+			return *this;
+		}
+	}
+
+	explicit operator long double() const noexcept {
+		if constexpr (sizeof(long double) <= sizeof(double)) {
+			return static_cast<long double>(convert_to_ieee754<double>());
+		}
+		else {
+			switch (_state) {
+			case FloatingPointState::Zero:         return _sign ? -0.0L : 0.0L;
+			case FloatingPointState::QuietNaN:
+			case FloatingPointState::SignalingNaN: return std::numeric_limits<long double>::quiet_NaN();
+			case FloatingPointState::Infinite:     return _sign ? -std::numeric_limits<long double>::infinity()
+			                                                     :  std::numeric_limits<long double>::infinity();
+			case FloatingPointState::Normal:
+			default:
+				break;
+			}
+			// bring |x| into [1,2), extract as an exact sum of doubles, then scale
+			// by the true (wide) exponent -- the dual of the assignment above.
+			const std::int64_t k = scale();
+			efloat n(*this);
+			n.setsign(false);
+			n.setexponent(0);
+			long double s = 0.0L;
+			efloat r(n);
+			for (int i = 0; i < 4 && !r.iszero(); ++i) {
+				double hi = static_cast<double>(r);
+				if (hi == 0.0) break;
+				s += static_cast<long double>(hi);
+				r -= efloat(hi);
+			}
+			if (_sign) s = -s;
+			return std::ldexp(s, static_cast<int>(k));
+		}
+	}
+#endif
 
 	// instance precision management
 	unsigned get_precision() const noexcept { return _precision_limbs * 32; }


### PR DESCRIPTION
## Summary
Fixes #1160. `efloat`'s `convert_ieee754` only builds mantissa limbs for `sizeof(Real)` of 4 or 8; the `else` branch was a no-op `static_assert(true)`, so a wide `long double` (`sizeof 16` on x86-64) pushed **no limbs** and normalized to **0**. Both directions were affected -- the constructor/assignment silently produced 0, and `operator long double()` capped at double precision.

## Fix (both directions, portable, exact)
- **`operator=(long double)`**: `frexp` into `m * 2^e` with `m` in `[0.5,1)` (safely inside double's range), decompose `m` into an exact sum of doubles via the working `double` path, then apply `e` with `setexponent()`. Preserves the full significand **and** the extended exponent range.
- **`operator long double()`**: the dual -- bring `|x|` into `[1,2)`, extract as an exact sum of doubles, scale by the true exponent with `ldexp`.
- Platforms where `long double == double` take a direct `convert_ieee754(double)` path (`if constexpr`), so nothing changes there.

Why decomposition rather than bit-extraction: `long double` layout is platform-dependent (80-bit x87 with an explicit integer bit on x86-64, IEEE binary128 elsewhere). The frexp/sum-of-doubles approach is layout-agnostic and exact.

## Changes
- `include/sw/universal/number/efloat/efloat_impl.hpp` -- implement both conversions (+ explicit `<cmath>` include). **Only** the `LONG_DOUBLE_SUPPORT` block changed; no reformatting of the rest of the file.
- `elastic/efloat/conversion/long_double.cpp` -- new regression test (auto-globbed by the conversion CMake).

## Test coverage
Constructor no-longer-0, both-direction round-trip exactness, special values (`+/-0`, `+/-inf`, NaN), and -- gated on `sizeof(long double) > sizeof(double)` -- beyond-double precision (`1 + 2^-60` survives) and extended exponent range (`2^1100`, `2^-1100`, `2^16000`).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_long_double | OK | PASS | OK | PASS |
| efloat_api / lossless / to_string (regression) | OK | PASS | OK | PASS |

cppcheck-clean, clang-formatted (the test file only -- the header was hand-edited to avoid whole-file reformatting).

## Follow-up
The `nexttoward` `long double -> double` workaround in `math/next.hpp` (added in #1120) can now be simplified; left as a separate change.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready NNN`

Resolves #1160

Generated with [Claude Code](https://claude.com/claude-code)