### PR TITLE
refactor(efloat): nexttoward builds target directly from long double

### DIFF
--- a/elastic/efloat/math/next.cpp
+++ b/elastic/efloat/math/next.cpp
@@ -218,6 +218,17 @@ int VerifyEfloatNext(bool reportTestCases) {
 				std::cout << "    FAIL: nexttoward(1,2) !> 1\n";
 			++failures;
 		}
+		// The target's full long double precision is preserved (#1160): a target
+		// within one double-ULP of x, but distinguishable in long double, still
+		// supplies a direction. The old double-cast collapsed it to == x (no step).
+		if constexpr (sizeof(long double) > sizeof(double)) {
+			long double justAbove = 1.0L + std::ldexp(1.0L, -60);   // rounds to 1.0 as a double
+			if (!(nexttoward(x, justAbove) > x)) {
+				if (reportTestCases)
+					std::cout << "    FAIL: nexttoward toward sub-double-ULP target did not step up\n";
+				++failures;
+			}
+		}
 	}
 
 	return failures;

--- a/include/sw/universal/number/efloat/math/next.hpp
+++ b/include/sw/universal/number/efloat/math/next.hpp
@@ -81,15 +81,14 @@ constexpr efloat<nlimbs> nextafter(const efloat<nlimbs>& x, const efloat<nlimbs>
 
 // nexttoward: same as nextafter, but the direction argument is long double.
 //
-// The target only supplies a DIRECTION (via the x == y / y > x comparisons), so
-// it is converted to double. efloat's long double constructor is currently
-// non-functional (efloat(2.0L) yields 0), so constructing the target from long
-// double directly would misdirect the step; the double conversion is deliberate.
-// The only consequence is that two long double targets closer than one double
-// ULP collapse -- a sub-double-ULP direction distinction not worth the risk.
+// The target is built directly from long double so no direction information is
+// lost. On platforms where LONG_DOUBLE_SUPPORT is off, long double aliases double
+// and the efloat(double) constructor is selected instead -- also exact.
+// (efloat's long double conversion was fixed in #1160; this previously routed
+// through double as a workaround for the constructor returning 0.)
 template<unsigned nlimbs>
 constexpr efloat<nlimbs> nexttoward(const efloat<nlimbs>& x, long double y) {
-	return nextafter(x, efloat<nlimbs>(static_cast<double>(y)));
+	return nextafter(x, efloat<nlimbs>(y));
 }
 
 }  // namespace universal


### PR DESCRIPTION
## Summary
Follow-up cleanup enabled by #1160. `nexttoward` previously routed its `long double` direction argument through `double` as a workaround for efloat's broken `long double` constructor. Now that the constructor is fixed, it builds the target directly, so no direction information is lost.

## Changes
- `include/sw/universal/number/efloat/math/next.hpp` -- `efloat<nlimbs>(static_cast<double>(y))` -> `efloat<nlimbs>(y)`; comment updated.
- `elastic/efloat/math/next.cpp` -- regression guard: a target within one double-ULP of `x` but distinguishable in `long double` (`1 + 2^-60`) now supplies a valid direction and steps up; the old double-cast collapsed it to `== x` (no step). Gated on `sizeof(long double) > sizeof(double)`.

On platforms where `LONG_DOUBLE_SUPPORT` is off (`long double` aliases `double`), the `efloat(double)` constructor is selected instead -- also exact.

Verified the new assertion is non-vacuous: `static_cast<double>(1 + 2^-60) == 1.0`, so the old path gave no step (0) while the direct path steps up (1).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| efloat_next | OK | PASS | OK | PASS |

cppcheck-clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready NNN`

Relates to #1120, #1160

Generated with [Claude Code](https://claude.com/claude-code)