### PR TITLE
feat(ereal): add fdim, modf, rint, nearbyint (parity with efloat)

### DIFF
--- a/elastic/ereal/math/functions/fractional.cpp
+++ b/elastic/ereal/math/functions/fractional.cpp
@@ -46,6 +46,32 @@ namespace {
 			return nrOfFailedTestCases;
 		}
 
+		// Verify modf: split into fractional part (returned) and integer part (*iptr)
+		template<typename Real>
+		int VerifyModf(bool reportTestCases) {
+			int nrOfFailedTestCases = 0;
+			// {input, expected integer part, expected fractional part}
+			const double cases[][3] = {
+				{ 3.75, 3.0, 0.75}, {-3.75, -3.0, -0.75}, {0.25, 0.0, 0.25},
+				{-0.25, 0.0, -0.25}, {5.0, 5.0, 0.0}, {-2.0, -2.0, 0.0},
+			};
+			for (const auto& c : cases) {
+				Real ip;
+				Real fr = modf(Real(c[0]), &ip);
+				if (ip != Real(c[1]) || fr != Real(c[2])) {
+					if (reportTestCases) std::cout << "    FAIL modf(" << c[0] << ") int=" << double(ip)
+					                               << " frac=" << double(fr) << " expected int=" << c[1] << " frac=" << c[2] << "\n";
+					++nrOfFailedTestCases;
+				}
+				// identity: int + frac == x
+				if (ip + fr != Real(c[0])) {
+					if (reportTestCases) std::cout << "    FAIL modf(" << c[0] << ") int+frac != x\n";
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
 		// Verify remainder function with IEEE round-to-nearest-even
 		template<typename Real>
 		int VerifyRemainder(bool reportTestCases) {
@@ -341,6 +367,9 @@ try {
 
 	test_tag = "remainder";
 	nrOfFailedTestCases += ReportTestResult(VerifyRemainder<ereal<>>(reportTestCases), "remainder(ereal)", test_tag);
+
+	test_tag = "modf";
+	nrOfFailedTestCases += ReportTestResult(VerifyModf<ereal<>>(reportTestCases), "modf(ereal)", test_tag);
 
 	test_tag = "fmod vs remainder";
 	nrOfFailedTestCases += ReportTestResult(VerifyFmodVsRemainder<ereal<>>(reportTestCases), "fmod vs remainder", test_tag);

--- a/elastic/ereal/math/functions/minmax.cpp
+++ b/elastic/ereal/math/functions/minmax.cpp
@@ -111,6 +111,29 @@ namespace {
 			return nrOfFailedTestCases;
 		}
 
+		// Verify fdim: positive difference (x - y if x > y, else +0)
+		template<typename Real>
+		int VerifyFdim(bool reportTestCases) {
+			int nrOfFailedTestCases = 0;
+			const double cases[][3] = {
+				{5.0, 3.0, 2.0}, {3.0, 5.0, 0.0}, {-2.0, -7.0, 5.0}, {4.0, 4.0, 0.0}, {-3.0, 2.0, 0.0},
+			};
+			for (const auto& c : cases) {
+				Real r = fdim(Real(c[0]), Real(c[1]));
+				if (r != Real(c[2])) {
+					if (reportTestCases) std::cout << "    FAIL fdim(" << c[0] << "," << c[1] << ") != " << c[2] << " got " << double(r) << "\n";
+					++nrOfFailedTestCases;
+				}
+			}
+			// NaN propagation
+			Real nan(std::numeric_limits<double>::quiet_NaN());
+			if (!fdim(nan, Real(1.0)).isnan() || !fdim(Real(1.0), nan).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL fdim NaN propagation\n";
+				++nrOfFailedTestCases;
+			}
+			return nrOfFailedTestCases;
+		}
+
 		// Property fuzzer: ordering, the min+max == a+b conservation, commutativity,
 		// and the min(a,b) == -max(-a,-b) reflection, over random pairs.
 		template<typename Real>
@@ -193,6 +216,9 @@ try {
 
 	test_tag = "max";
 	nrOfFailedTestCases += ReportTestResult(VerifyMax<ereal<>>(reportTestCases), "max(ereal)", test_tag);
+
+	test_tag = "fdim";
+	nrOfFailedTestCases += ReportTestResult(VerifyFdim<ereal<>>(reportTestCases), "fdim(ereal)", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/elastic/ereal/math/functions/truncate.cpp
+++ b/elastic/ereal/math/functions/truncate.cpp
@@ -158,6 +158,33 @@ namespace {
 			return nrOfFailedTestCases;
 		}
 
+		// Verify rint / nearbyint: round to nearest, halfway to EVEN (unlike round,
+		// which is halfway away from zero). nearbyint == rint for ereal.
+		template<typename Real>
+		int VerifyRint(bool reportTestCases) {
+			int nrOfFailedTestCases = 0;
+
+			// {input, expected} -- ties resolve to the even neighbor
+			const double cases[][2] = {
+				{ 2.5, 2.0}, { 3.5, 4.0}, {-2.5, -2.0}, {-3.5, -4.0},   // ties -> even
+				{ 2.4, 2.0}, { 2.6, 3.0}, {-2.4, -2.0}, {-2.6, -3.0},   // non-ties
+				{ 0.5, 0.0}, { 1.5, 2.0}, {-0.5,  0.0}, { 5.0,  5.0},
+			};
+			for (const auto& c : cases) {
+				Real rr = rint(Real(c[0]));
+				Real nn = nearbyint(Real(c[0]));
+				if (rr != Real(c[1])) {
+					if (reportTestCases) std::cout << "    FAIL rint(" << c[0] << ") != " << c[1] << " got " << double(rr) << "\n";
+					++nrOfFailedTestCases;
+				}
+				if (nn != rr) {
+					if (reportTestCases) std::cout << "    FAIL nearbyint(" << c[0] << ") != rint\n";
+					++nrOfFailedTestCases;
+				}
+			}
+			return nrOfFailedTestCases;
+		}
+
 		// Property fuzzer: bracketing, reflection, toward-zero, and agreement
 		// with the std:: rounding of the projected double, over random values.
 		template<typename Real>
@@ -250,6 +277,9 @@ try {
 
 	test_tag = "round";
 	nrOfFailedTestCases += ReportTestResult(VerifyRound<ereal<>>(reportTestCases), "round(ereal)", test_tag);
+
+	test_tag = "rint";
+	nrOfFailedTestCases += ReportTestResult(VerifyRint<ereal<>>(reportTestCases), "rint/nearbyint(ereal)", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/include/sw/universal/number/ereal/math/functions/fractional.hpp
+++ b/include/sw/universal/number/ereal/math/functions/fractional.hpp
@@ -87,4 +87,21 @@ namespace sw { namespace universal {
 		return x - (n * y);
 	}
 
+	// modf: split x into integer and fractional parts. Returns the fractional
+	// part (same sign as x) and stores the integer part (toward zero) in *iptr.
+	template<unsigned maxlimbs>
+	inline ereal<maxlimbs> modf(const ereal<maxlimbs>& x, ereal<maxlimbs>* iptr) {
+		if (x.isnan()) {
+			if (iptr != nullptr) *iptr = x;
+			return x;
+		}
+		if (x.isinf()) {
+			if (iptr != nullptr) *iptr = x;
+			return x.isneg() ? -ereal<maxlimbs>(0.0) : ereal<maxlimbs>(0.0);
+		}
+		ereal<maxlimbs> ipart = trunc(x);
+		if (iptr != nullptr) *iptr = ipart;
+		return x - ipart;   // fractional part; subtraction carries x's sign
+	}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/ereal/math/functions/minmax.hpp
+++ b/include/sw/universal/number/ereal/math/functions/minmax.hpp
@@ -22,4 +22,11 @@ namespace sw { namespace universal {
 		return (x > y) ? x : y;
 	}
 
+	// fdim: positive difference -- x - y if x > y, otherwise +0 (NaN if either is NaN)
+	template<unsigned maxlimbs>
+	inline ereal<maxlimbs> fdim(const ereal<maxlimbs>& x, const ereal<maxlimbs>& y) {
+		if (x.isnan() || y.isnan()) return ereal<maxlimbs>(std::numeric_limits<double>::quiet_NaN());
+		return (x > y) ? (x - y) : ereal<maxlimbs>(0.0);
+	}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/ereal/math/functions/truncate.hpp
+++ b/include/sw/universal/number/ereal/math/functions/truncate.hpp
@@ -103,4 +103,29 @@ namespace sw { namespace universal {
 		return result;
 	}
 
+	// rint: round to the nearest integer, halfway cases to even (IEEE default).
+	// ereal has no dynamic rounding mode, so rint always uses round-to-nearest-even.
+	template<unsigned maxlimbs>
+	inline ereal<maxlimbs> rint(const ereal<maxlimbs>& x) {
+		if (x.isnan() || x.isinf() || x.iszero()) return x;
+
+		ereal<maxlimbs> f    = floor(x);   // largest integer <= x
+		ereal<maxlimbs> diff = x - f;      // fractional part in [0, 1)
+		ereal<maxlimbs> half(0.5);
+		if (diff < half) return f;
+		if (diff > half) return f + ereal<maxlimbs>(1.0);
+
+		// exactly halfway: pick the even neighbor. f is even iff f/2 is an integer.
+		ereal<maxlimbs> hf = f * half;
+		if (floor(hf) == hf) return f;
+		return f + ereal<maxlimbs>(1.0);
+	}
+
+	// nearbyint: identical to rint for ereal. (std distinguishes them only by the
+	// FE_INEXACT flag, which ereal does not model.)
+	template<unsigned maxlimbs>
+	inline ereal<maxlimbs> nearbyint(const ereal<maxlimbs>& x) {
+		return rint(x);
+	}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/ereal/mathlib.hpp
+++ b/include/sw/universal/number/ereal/mathlib.hpp
@@ -98,9 +98,9 @@ namespace sw { namespace universal {
 	// Note: log(), log2(), log10(), log1p() are defined in math/functions/logarithm.hpp
 	// Note: sqrt(), cbrt() are defined in math/functions/sqrt.hpp and cbrt.hpp
 	// Note: sin(), cos(), tan(), asin(), acos(), atan(), atan2() are defined in math/functions/trigonometry.hpp
-	// Note: floor(), ceil(), trunc(), round() are defined in math/functions/truncate.hpp
-	// Note: fmod(), remainder() are defined in math/functions/fractional.hpp
-	// Note: min(), max() are defined in math/functions/minmax.hpp
+	// Note: floor(), ceil(), trunc(), round(), rint(), nearbyint() are defined in math/functions/truncate.hpp
+	// Note: fmod(), remainder(), modf() are defined in math/functions/fractional.hpp
+	// Note: min(), max(), fdim() are defined in math/functions/minmax.hpp
 	// Note: hypot() is defined in math/functions/hypot.hpp
 	// Note: erf(), erfc(), tgamma(), lgamma() are defined in math/functions/error_and_gamma.hpp
 	// Note: copysign(), frexp(), ldexp() are defined in math/functions/numerics.hpp


### PR DESCRIPTION
## Summary
Adds the four `<cmath>` functions `efloat` had but `ereal` lacked (#1165), computed in ereal's own expansion arithmetic:

- **fdim** (`minmax.hpp`): `x > y ? x - y : +0`; NaN propagates.
- **modf** (`fractional.hpp`): returns the fractional part (sign of x), stores the integer part (`trunc`, toward zero) in `*iptr`.
- **rint / nearbyint** (`truncate.hpp`): round to nearest, **halfway to even** (IEEE default) -- distinct from ereal's existing `round()` (halfway *away* from zero). ereal has no dynamic rounding mode or FE_INEXACT flag, so `nearbyint` == `rint`.

## Changes
- `math/functions/minmax.hpp`, `fractional.hpp`, `truncate.hpp` -- the four functions.
- `mathlib.hpp` -- location notes updated.
- `elastic/ereal/math/functions/{minmax,fractional,truncate}.cpp` -- test cases added to the existing suites.

## Verification
Checked against `std::` on gcc and clang, including round-half-to-even ties (`2.5->2`, `3.5->4`, `-2.5->-2`, `-3.5->-4`) and the `modf` `int+frac == x` identity. cppcheck-clean.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| ereal_truncate / minmax / fractional | PASS | PASS |

Resolves #1165
Relates to #582

Generated with [Claude Code](https://claude.com/claude-code)