### PR TITLE
feat(math): add fma, scalbn, logb, ilogb to efloat and ereal

### DIFF
--- a/elastic/efloat/math/numerics.cpp
+++ b/elastic/efloat/math/numerics.cpp
@@ -179,13 +179,20 @@ int VerifyEfloatNumerics(bool reportTestCases) {
 				++failures;
 			}
 		}
-		// fma exactness: with 512-bit precision x*y+z carries no rounding
-		EH a(123456789.0), b(987654321.0), c(0.5);
-		EH got  = fma(a, b, c);
-		EH want = a * b + c;
-		if (got != want) {
+		// fma is EXACT (no intermediate rounding): (2^30+1)*(2^30-1) = 2^60 - 1,
+		// representable in high-precision efloat but NOT in double (rounds to 2^60).
+		// Build the expected value independently of the product (scalbn/subtract),
+		// so the check is not a tautology against x*y+z.
+		EH x30(1073741825.0), y30(1073741823.0);  // 2^30 + 1, 2^30 - 1
+		EH pm1 = scalbn(EH(1.0), 60) - EH(1.0);   // 2^60 - 1
+		if (fma(x30, y30, EH(0.0)) != pm1) {
 			if (reportTestCases)
-				std::cout << "    FAIL: fma != x*y+z\n";
+				std::cout << "    FAIL: fma not exact (2^60-1)\n";
+			++failures;
+		}
+		if (fma(x30, y30, EH(2.0)) != pm1 + EH(2.0)) {  // z folded in exactly
+			if (reportTestCases)
+				std::cout << "    FAIL: fma z addend\n";
 			++failures;
 		}
 		// ilogb special values

--- a/elastic/efloat/math/numerics.cpp
+++ b/elastic/efloat/math/numerics.cpp
@@ -1,8 +1,9 @@
-// numerics.cpp: regression tests for efloat numeric support functions (frexp, ldexp).
+// numerics.cpp: regression tests for efloat numeric support functions
+//               (frexp, ldexp, scalbn, logb, ilogb, fma).
 //
-// ldexp(x, n) = x * 2^n and frexp(x, &e) split x into m * 2^e with m in [0.5,1).
-// Both only move efloat's binary exponent, so they are exact at any precision.
-// (Issue #1164)
+// ldexp/scalbn only move efloat's binary exponent (exact); frexp splits into
+// m * 2^e with m in [0.5,1); logb/ilogb return the radix-2 exponent; fma computes
+// x*y+z with no intermediate rounding. (Issues #1164, #1166)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -10,6 +11,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
 #include <cmath>
+#include <climits>
 #include <limits>
 #include <universal/number/efloat/efloat.hpp>
 #include <universal/verification/test_suite.hpp>
@@ -152,6 +154,58 @@ int VerifyEfloatNumerics(bool reportTestCases) {
 		if (ldexp(E(3.5), 0) != E(3.5)) {
 			if (reportTestCases)
 				std::cout << "    FAIL: ldexp(x,0) != x\n";
+			++failures;
+		}
+	}
+
+	// ---------------------------------------------------------------------
+	// 5. scalbn, logb, ilogb, fma
+	// ---------------------------------------------------------------------
+	if (reportTestCases)
+		std::cout << "  Verifying scalbn/logb/ilogb/fma...\n";
+	{
+		for (double v : {1.0, 3.0, -2.5, 0.75, 100.0}) {
+			for (int n : {-5, 0, 3, 20}) {
+				if (double(scalbn(E(v), n)) != std::scalbn(v, n)) {
+					if (reportTestCases)
+						std::cout << "    FAIL: scalbn(" << v << "," << n << ")\n";
+					++failures;
+				}
+			}
+			if (double(logb(E(v))) != std::logb(v) || ilogb(E(v)) != std::ilogb(v)) {
+				if (reportTestCases)
+					std::cout << "    FAIL: logb/ilogb(" << v << ") got " << double(logb(E(v))) << "/" << ilogb(E(v))
+					          << "\n";
+				++failures;
+			}
+		}
+		// fma exactness: with 512-bit precision x*y+z carries no rounding
+		EH a(123456789.0), b(987654321.0), c(0.5);
+		EH got  = fma(a, b, c);
+		EH want = a * b + c;
+		if (got != want) {
+			if (reportTestCases)
+				std::cout << "    FAIL: fma != x*y+z\n";
+			++failures;
+		}
+		// ilogb special values
+		E z(0.0), pinf;
+		pinf.setinf(false);
+		E nan;
+		nan.setnan();
+		if (ilogb(z) != FP_ILOGB0 || ilogb(pinf) != INT_MAX || ilogb(nan) != FP_ILOGBNAN) {
+			if (reportTestCases)
+				std::cout << "    FAIL: ilogb special values\n";
+			++failures;
+		}
+		if (!logb(z).isinf() || logb(z).sign() != -1) {
+			if (reportTestCases)
+				std::cout << "    FAIL: logb(0) != -inf\n";
+			++failures;
+		}
+		if (!logb(nan).isnan()) {
+			if (reportTestCases)
+				std::cout << "    FAIL: logb(nan)\n";
 			++failures;
 		}
 	}

--- a/elastic/ereal/math/functions/numerics.cpp
+++ b/elastic/ereal/math/functions/numerics.cpp
@@ -158,12 +158,18 @@ namespace {
 				}
 			}
 
-			// fma(x,y,z) == x*y + z
-			for (const double* t : {(const double[]){2.0, 3.0, 4.0}, (const double[]){-1.5, 2.0, 0.5}}) {
-				if (fma(Real(t[0]), Real(t[1]), Real(t[2])) != Real(t[0]) * Real(t[1]) + Real(t[2])) {
-					if (reportTestCases) std::cout << "    FAIL fma(" << t[0] << "," << t[1] << "," << t[2] << ")\n";
-					++nrOfFailedTestCases;
-				}
+			// fma is EXACT: (2^30+1)*(2^30-1) = 2^60 - 1, representable in ereal but
+			// not in double. Build the expected value independently of the product
+			// (scalbn/subtract), so this is not a tautology against x*y+z.
+			Real x30(1073741825.0), y30(1073741823.0);      // 2^30 + 1, 2^30 - 1
+			Real pm1 = scalbn(Real(1.0), 60) - Real(1.0);   // 2^60 - 1
+			if (fma(x30, y30, Real(0.0)) != pm1) {
+				if (reportTestCases) std::cout << "    FAIL fma not exact (2^60-1)\n";
+				++nrOfFailedTestCases;
+			}
+			if (fma(x30, y30, Real(2.0)) != pm1 + Real(2.0)) {   // z folded in exactly
+				if (reportTestCases) std::cout << "    FAIL fma z addend\n";
+				++nrOfFailedTestCases;
 			}
 
 			// ilogb / logb special values

--- a/elastic/ereal/math/functions/numerics.cpp
+++ b/elastic/ereal/math/functions/numerics.cpp
@@ -9,6 +9,7 @@
 #include <universal/verification/test_suite.hpp>
 
 #include <cmath>
+#include <climits>
 #include <limits>
 #include <random>
 
@@ -138,6 +139,46 @@ namespace {
 			return nrOfFailedTestCases;
 		}
 
+		// Verify scalbn, logb, ilogb, fma against std:: (double-range values)
+		template<typename Real>
+		int VerifyScalbnLogbFma(bool reportTestCases) {
+			int nrOfFailedTestCases = 0;
+
+			for (double v : {1.0, 2.0, 3.0, 0.75, 0.5, 100.0, -8.0, 1023.5, 0.1}) {
+				for (int n : {-5, 0, 3, 20}) {
+					if (double(scalbn(Real(v), n)) != std::scalbn(v, n)) {
+						if (reportTestCases) std::cout << "    FAIL scalbn(" << v << "," << n << ")\n";
+						++nrOfFailedTestCases;
+					}
+				}
+				if (double(logb(Real(v))) != std::logb(v) || ilogb(Real(v)) != std::ilogb(v)) {
+					if (reportTestCases) std::cout << "    FAIL logb/ilogb(" << v << ") got "
+					                               << double(logb(Real(v))) << "/" << ilogb(Real(v)) << "\n";
+					++nrOfFailedTestCases;
+				}
+			}
+
+			// fma(x,y,z) == x*y + z
+			for (const double* t : {(const double[]){2.0, 3.0, 4.0}, (const double[]){-1.5, 2.0, 0.5}}) {
+				if (fma(Real(t[0]), Real(t[1]), Real(t[2])) != Real(t[0]) * Real(t[1]) + Real(t[2])) {
+					if (reportTestCases) std::cout << "    FAIL fma(" << t[0] << "," << t[1] << "," << t[2] << ")\n";
+					++nrOfFailedTestCases;
+				}
+			}
+
+			// ilogb / logb special values
+			Real zero(0.0), inf(std::numeric_limits<double>::infinity()), nan(std::numeric_limits<double>::quiet_NaN());
+			if (ilogb(zero) != FP_ILOGB0 || ilogb(inf) != INT_MAX || ilogb(nan) != FP_ILOGBNAN) {
+				if (reportTestCases) std::cout << "    FAIL ilogb special values\n";
+				++nrOfFailedTestCases;
+			}
+			if (!logb(zero).isinf() || !logb(nan).isnan()) {
+				if (reportTestCases) std::cout << "    FAIL logb special values\n";
+				++nrOfFailedTestCases;
+			}
+			return nrOfFailedTestCases;
+		}
+
 		// Property fuzzer: copysign sign/magnitude and frexp/ldexp round trips
 		// over random finite values.
 		template<typename Real>
@@ -230,6 +271,9 @@ try {
 
 	test_tag = "frexp/ldexp roundtrip";
 	nrOfFailedTestCases += ReportTestResult(VerifyFrexpLdexpRoundtrip<ereal<>>(reportTestCases), "frexp/ldexp roundtrip", test_tag);
+
+	test_tag = "scalbn/logb/ilogb/fma";
+	nrOfFailedTestCases += ReportTestResult(VerifyScalbnLogbFma<ereal<>>(reportTestCases), "scalbn/logb/ilogb/fma(ereal)", test_tag);
 #endif
 
 #if REGRESSION_LEVEL_2

--- a/include/sw/universal/number/efloat/math/numerics.hpp
+++ b/include/sw/universal/number/efloat/math/numerics.hpp
@@ -1,10 +1,12 @@
-// numerics.hpp: numeric support functions (frexp, ldexp) for efloat
+// numerics.hpp: numeric support functions (frexp, ldexp, scalbn, logb, ilogb, fma) for efloat
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
+#include <cmath>    // FP_ILOGB0, FP_ILOGBNAN
+#include <climits>  // INT_MAX
 
 namespace sw {
 namespace universal {
@@ -37,6 +39,54 @@ constexpr efloat<nlimbs> frexp(const efloat<nlimbs>& x, int* exp) {
 	efloat<nlimbs> mantissa(x);
 	mantissa.setexponent(-1);  // leading bit at 2^-1 -> |mantissa| in [0.5, 1)
 	return mantissa;
+}
+
+// scalbn(x, n) = x * 2^n -- identical to ldexp for a radix-2 type.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> scalbn(const efloat<nlimbs>& x, int n) {
+	return ldexp(x, n);
+}
+
+// logb(x): the unbiased radix-2 exponent of x as a floating-point value,
+// floor(log2(|x|)) -- exactly scale() for a normalized efloat. logb(0) = -inf
+// (raises DivisionByZero), logb(+/-inf) = +inf, logb(nan) = nan.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> logb(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return x;
+	if (x.isinf()) {
+		efloat<nlimbs> inf;
+		inf.setinf(false);
+		return inf;
+	}
+	if (x.iszero()) {
+		efloat<nlimbs> ninf;
+		ninf.setinf(true);
+		if (!std::is_constant_evaluated())
+			efloat_exception_flags.set(ExceptionFlag::DivisionByZero);
+		return ninf;
+	}
+	return efloat<nlimbs>(static_cast<long long>(x.scale()));
+}
+
+// ilogb(x): logb as an int, with the <cmath> special values.
+template<unsigned nlimbs>
+inline int ilogb(const efloat<nlimbs>& x) {
+	if (x.isnan())
+		return FP_ILOGBNAN;
+	if (x.isinf())
+		return INT_MAX;
+	if (x.iszero())
+		return FP_ILOGB0;
+	return static_cast<int>(x.scale());
+}
+
+// fma(x, y, z) = x*y + z. efloat's product carries no intermediate rounding at the
+// working precision, so this is at least as accurate as a hardware fused
+// multiply-add. 0*inf yields NaN through efloat's own multiply, matching IEEE.
+template<unsigned nlimbs>
+constexpr efloat<nlimbs> fma(const efloat<nlimbs>& x, const efloat<nlimbs>& y, const efloat<nlimbs>& z) {
+	return x * y + z;
 }
 
 }  // namespace universal

--- a/include/sw/universal/number/ereal/math/functions/numerics.hpp
+++ b/include/sw/universal/number/ereal/math/functions/numerics.hpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>    // std::logb, std::ilogb, FP_ILOGB0, FP_ILOGBNAN
+#include <climits>  // INT_MAX
+#include <limits>   // std::numeric_limits
 
 namespace sw { namespace universal {
 
@@ -57,6 +60,50 @@ namespace sw { namespace universal {
 		} else {
 			return -x;
 		}
+	}
+
+	// scalbn(x, n) = x * 2^n -- identical to ldexp for a radix-2 type.
+	template<unsigned maxlimbs>
+	inline ereal<maxlimbs> scalbn(const ereal<maxlimbs>& x, int n) {
+		return ldexp(x, n);
+	}
+
+	// ilogb(x): unbiased radix-2 exponent floor(log2(|x|)) as an int, with the
+	// <cmath> special values. The leading component fixes the exponent to within
+	// one, so start from its ilogb and correct against the full magnitude (the
+	// lower components can pull |x| across a power-of-two boundary).
+	template<unsigned maxlimbs>
+	inline int ilogb(const ereal<maxlimbs>& x) {
+		if (x.isnan()) return FP_ILOGBNAN;
+		if (x.isinf()) return INT_MAX;
+		if (x.iszero()) return FP_ILOGB0;
+
+		int e = std::ilogb(x.limbs()[0]);
+		ereal<maxlimbs> ax = x.isneg() ? -x : x;              // |x|
+		if (ax < ldexp(ereal<maxlimbs>(1.0), e)) {
+			--e;
+		}
+		else if (ax >= ldexp(ereal<maxlimbs>(1.0), e + 1)) {
+			++e;
+		}
+		return e;
+	}
+
+	// logb(x): ilogb as a floating value. logb(0) = -inf, logb(+/-inf) = +inf,
+	// logb(nan) = nan.
+	template<unsigned maxlimbs>
+	inline ereal<maxlimbs> logb(const ereal<maxlimbs>& x) {
+		if (x.isnan()) return x;
+		if (x.isinf()) return ereal<maxlimbs>(std::numeric_limits<double>::infinity());
+		if (x.iszero()) return ereal<maxlimbs>(-std::numeric_limits<double>::infinity());
+		return ereal<maxlimbs>(static_cast<double>(ilogb(x)));
+	}
+
+	// fma(x, y, z) = x*y + z. ereal multiplies in exact expansion arithmetic, so
+	// no intermediate rounding is introduced. 0*inf yields NaN, matching IEEE.
+	template<unsigned maxlimbs>
+	inline ereal<maxlimbs> fma(const ereal<maxlimbs>& x, const ereal<maxlimbs>& y, const ereal<maxlimbs>& z) {
+		return x * y + z;
 	}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/ereal/mathlib.hpp
+++ b/include/sw/universal/number/ereal/mathlib.hpp
@@ -103,7 +103,7 @@ namespace sw { namespace universal {
 	// Note: min(), max(), fdim() are defined in math/functions/minmax.hpp
 	// Note: hypot() is defined in math/functions/hypot.hpp
 	// Note: erf(), erfc(), tgamma(), lgamma() are defined in math/functions/error_and_gamma.hpp
-	// Note: copysign(), frexp(), ldexp() are defined in math/functions/numerics.hpp
+	// Note: copysign(), frexp(), ldexp(), scalbn(), logb(), ilogb(), fma() are defined in math/functions/numerics.hpp
 	// Note: fpclassify(), isnan(), isinf(), isfinite(), isnormal(), signbit() are defined in math/functions/classify.hpp
 	// Note: nextafter(), nexttoward() are defined in math/functions/next.hpp
 

--- a/include/sw/universal/number/ereal/mathlib.hpp
+++ b/include/sw/universal/number/ereal/mathlib.hpp
@@ -113,10 +113,9 @@ namespace sw { namespace universal {
 	// argument reduction) all compute in ereal expansion arithmetic.
 	//
 	// Remaining mathlib work is tracked under #582:
-	//   - <cmath> parity: fdim, modf, rint, nearbyint (#1165); fma, scalbn, logb,
-	//     ilogb (#1166)
 	//   - complex<ereal> binding: is_universal_number + real/imag/conj (#1167)
 	//   - a per-call precision-request API (e.g. sqrt(x, 200)) remains a possible
 	//     future enhancement
+	// (<cmath> parity complete: fdim/modf/rint/nearbyint #1165, fma/scalbn/logb/ilogb #1166.)
 
 }} // namespace sw::universal


### PR DESCRIPTION
## Summary
The last `<cmath>` functions missing from **both** adaptive-precision Oracle types (#1166), added to each type's `numerics.hpp` on native arithmetic:

- **scalbn**(x, n) = `x * 2^n` -- delegates to `ldexp` (exact binary-exponent shift).
- **logb**(x) = `floor(log2(|x|))` as a float; **ilogb**(x) = same as int, with the `<cmath>` special values (`ilogb(0)=FP_ILOGB0`, `ilogb(inf)=INT_MAX`, `ilogb(nan)=FP_ILOGBNAN`; `logb(0)=-inf`, `logb(inf)=+inf`, `logb(nan)=nan`).
  - efloat: exact from `scale()` (the leading-bit exponent).
  - ereal: from the leading component's `std::ilogb`, **corrected by ±1** against the full magnitude (lower components can pull `|x|` across a power-of-two boundary).
- **fma**(x, y, z) = `x*y + z`. Both types multiply exactly at their working precision, so no intermediate rounding is introduced; `0*inf` yields NaN through the type's own multiply, matching IEEE.

## Changes
- `efloat/math/numerics.hpp`, `ereal/math/functions/numerics.hpp` -- the four functions.
- `ereal/mathlib.hpp` -- location note updated.
- `elastic/efloat/math/numerics.cpp`, `elastic/ereal/math/functions/numerics.cpp` -- test cases added.

## Verification
Checked against `std::` on gcc and clang for both types, including logb binade boundaries (0.75, 0.5, 1023.5) and the ilogb/logb special values. cppcheck-clean.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| efloat_numerics | PASS | PASS |
| ereal_numerics | PASS | PASS |

Resolves #1166
Relates to #582

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `scalbn`, `logb`, `ilogb`, and `fma` support for extended-precision number types.
  * Implemented IEEE-style special-case behavior for zero, infinity, and NaN, with appropriate zero handling for `logb`.
* **Tests**
  * Added regression coverage validating these operations against standard-library equivalents across representative input ranges.
  * Added accuracy checks for `fma`, including an exactness scenario, plus additional special-value verification.
* **Documentation**
  * Updated mathlib status notes to reflect the new function locations/coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->