### PR TITLE
docs(efloat): correct stale constexpr-surface comment in efloat_impl.hpp

### DIFF
--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -112,11 +112,12 @@ public:
 	// "_limb has one element of value 0" representation for callers that
 	// inspect bits()/significant().  Sign-only and state-only selectors
 	// and modifiers operate purely on the trivial members and are
-	// constexpr-clean.  Compound arithmetic and free comparison operators
-	// are currently stubs (returning *this or a constant) and are
-	// therefore promoted to constexpr too -- the surface lights up at
-	// constant evaluation today, and real arithmetic semantics will
-	// inherit constexpr automatically when implemented.
+	// constexpr-clean.  Compound arithmetic and the free comparison
+	// operators are fully implemented and used at runtime; they still
+	// carry the constexpr specifier for a uniform interface, but because
+	// they operate on the heap-allocated _limb expansion they escape
+	// constant evaluation (the same #747 transient-allocation limit) and
+	// so cannot be exercised in a constant expression.
 	// Out of scope (heap-escape boundary): native-type ctors / operator=
 	// (convert_ieee754 calls std::fpclassify which is not constexpr in
 	// C++20), conversion-out (std::pow), parse() (std::regex).


### PR DESCRIPTION
## Summary
Comment-only fix. The `#747` partial-constexpr note in `efloat_impl.hpp` claimed *"Compound arithmetic and free comparison operators are currently stubs (returning `*this` or a constant) ... real arithmetic semantics will inherit constexpr automatically when implemented."*

That is stale and **actively misleading** -- it led a CodeRabbit reviewer (on PR #1168) to conclude efloat's arithmetic was unimplemented and could not substantiate high-precision claims. In reality those operators are fully implemented and used at runtime (`efloat exp(1)` matches the mpmath `e` literal to 60+ digits).

Reworded to state what actually holds: the operators carry the `constexpr` specifier for a uniform interface but escape constant evaluation because they operate on the heap-allocated `_limb` expansion (the same transient-allocation limit `#747` describes), so they run only at runtime.

## Verification
Comment-only; `efloat` compiles and runs unchanged (api test PASSES). No other stale "stub" claims remain in the file. ASCII-clean.

## Test plan
- [ ] Fast CI passes

Relates to #747

Generated with [Claude Code](https://claude.com/claude-code)