### PR TITLE
feat(tools): accuracy-vs-compute-time characterization for elreal and ereal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1307,6 +1307,7 @@ add_subdirectory("benchmark/accuracy/quantization")
 add_subdirectory("benchmark/accuracy/range")
 add_subdirectory("benchmark/accuracy/blockformat")
 add_subdirectory("benchmark/accuracy/lns")
+add_subdirectory("benchmark/accuracy/adaptive")
 endif(UNIVERSAL_BUILD_BENCHMARK_ACCURACY)
 
 # range benchmarks

--- a/benchmark/accuracy/adaptive/CMakeLists.txt
+++ b/benchmark/accuracy/adaptive/CMakeLists.txt
@@ -1,0 +1,6 @@
+file (GLOB SOURCES "./*.cpp")
+
+# "false": build the characterization tool but do not register it as a ctest --
+# it is a measurement utility (its output is data, not pass/fail) and a full
+# sweep of the elreal transcendentals takes seconds.
+compile_all("false" "accuracy" "Benchmarks/Accuracy/adaptive" "${SOURCES}")

--- a/benchmark/accuracy/adaptive/characterize.cpp
+++ b/benchmark/accuracy/adaptive/characterize.cpp
@@ -11,7 +11,7 @@
 // Output is a CSV to stdout followed by a per-function saturation/knee summary and
 // an elreal-vs-ereal comparison (which type is cheaper for a target accuracy).
 //
-// Usage: characterize [maxDepth=4] [reps=5]
+// Usage: characterize [maxDepth=3] [reps=3]
 //   maxDepth  highest elreal depth to sweep (2..maxDepth); ereal sweeps a fixed
 //             limb list {2,4,8,12,16}. Raise for a full characterization run.
 //   reps      timing repeats (median).
@@ -162,11 +162,21 @@ namespace {
 		}
 	}
 
+	// ereal arithmetic operators are inline and visible in this TU, so a plain
+	// fixed-input result can be folded/hoisted out of the timing loop -- read a
+	// limb through a volatile sink each rep to keep the work observable.
+	template<unsigned N>
+	double sink_limb(const ereal<N>& r) {
+		return r.limbs().empty() ? 0.0 : r.limbs()[0];
+	}
+
 	template<unsigned N>
 	void run_ereal_N(int reps) {
 		for (const auto& c : cases()) {
 			ereal<N> x(c.arg), r;
-			double t = time_ns([&] { r = apply(c.op, x); }, reps);
+			volatile double sink = 0.0;
+			double t = time_ns([&] { r = apply(c.op, x); sink = sink_limb(r); }, reps);
+			(void)sink;
 			int digits = agreed_decimal_digits(ereal_to_dyadic(r), c.ref);
 			emit({ "ereal", c.name, static_cast<long>(N), t, digits });
 		}
@@ -200,9 +210,12 @@ namespace {
 	void run_arithmetic_ereal_N(int reps) {
 		const double A = 1.4142135623730951, B = 2.7182818284590452;
 		ereal<N> a(A), b(B), r;
-		emit({ "ereal", "add", static_cast<long>(N), time_ns([&] { r = a + b; }, reps), -1 });
-		emit({ "ereal", "mul", static_cast<long>(N), time_ns([&] { r = a * b; }, reps), -1 });
-		emit({ "ereal", "div", static_cast<long>(N), time_ns([&] { r = a / b; }, reps), -1 });
+		volatile double sink = 0.0;
+		auto timeOp = [&](auto fn) { return time_ns([&] { r = fn(); sink = sink_limb(r); }, reps); };
+		emit({ "ereal", "add", static_cast<long>(N), timeOp([&] { return a + b; }), -1 });
+		emit({ "ereal", "mul", static_cast<long>(N), timeOp([&] { return a * b; }), -1 });
+		emit({ "ereal", "div", static_cast<long>(N), timeOp([&] { return a / b; }), -1 });
+		(void)sink;
 	}
 
 	template<unsigned... Ns>

--- a/benchmark/accuracy/adaptive/characterize.cpp
+++ b/benchmark/accuracy/adaptive/characterize.cpp
@@ -1,0 +1,300 @@
+// characterize.cpp: accuracy-vs-compute-time characterization for the adaptive-
+//                   precision real oracles elreal (lazy ZBCL) and ereal (Priest/
+//                   Shewchuk expansion).
+//
+// For each function it sweeps the precision knob -- elreal `depth`, ereal limb
+// count `N` -- and reports, per (type, function, knob):
+//   * wall-clock time per evaluation (median over repeats), and
+//   * accuracy as decimal digits of agreement with an independent ~320-digit
+//     reference, via the exact dyadic oracle (verification/elreal_reference_digits.hpp
+//     for elreal, a limb-sum dyadic for ereal), plus correct bits and rel error.
+// Output is a CSV to stdout followed by a per-function saturation/knee summary and
+// an elreal-vs-ereal comparison (which type is cheaper for a target accuracy).
+//
+// Usage: characterize [maxDepth=4] [reps=5]
+//   maxDepth  highest elreal depth to sweep (2..maxDepth); ereal sweeps a fixed
+//             limb list {2,4,8,12,16}. Raise for a full characterization run.
+//   reps      timing repeats (median).
+//
+// This is a MEASUREMENT tool only -- it does not optimize the implementations.
+// Resolves issue #1040.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <vector>
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/ereal/ereal.hpp>
+#include <universal/verification/elreal_reference_digits.hpp>  // dyadic, zbcl_to_dyadic, agreed_decimal_digits
+#include <math/constants/reference_constants.hpp>              // s_pi, s_e, s_ln2, s_sqrt2, s_sin_half, ...
+
+namespace {
+
+	using namespace sw::universal;
+
+	// ------------------------------------------------------------------ timing
+	double median(std::vector<double>& v) {
+		if (v.empty()) return 0.0;
+		std::sort(v.begin(), v.end());
+		const size_t n = v.size();
+		return (n % 2) ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
+	}
+
+	template<typename F>
+	double time_ns(F&& f, int reps) {
+		std::vector<double> t;
+		t.reserve(static_cast<size_t>(reps));
+		for (int i = 0; i < reps; ++i) {
+			auto a = std::chrono::steady_clock::now();
+			f();
+			auto b = std::chrono::steady_clock::now();
+			t.push_back(std::chrono::duration<double, std::nano>(b - a).count());
+		}
+		return median(t);
+	}
+
+	// ---------------------------------------------------------------- accuracy
+	constexpr double kLog2of10 = 3.321928094887362;
+
+	int correct_bits(int digits) { return static_cast<int>(std::lround(digits * kLog2of10)); }
+
+	// rel error implied by d matching decimal digits (a reporting estimate)
+	double rel_error(int digits) { return (digits <= 0) ? 1.0 : std::pow(10.0, -digits); }
+
+	// build the exact dyadic value of an ereal from its (non-overlapping) limbs
+	template<unsigned N>
+	dyadic ereal_to_dyadic(const ereal<N>& x) {
+		dyadic acc;  // 0
+		for (double limb : x.limbs()) acc = acc + dyadic::from_double(limb);
+		return acc;
+	}
+
+	// ------------------------------------------------------------------- cases
+	enum class Op { Sqrt, Exp, Log, Sin, Cos, Tan, Sinh, Cosh, Tanh };
+
+	struct Case {
+		Op               op;
+		const char*      name;
+		double           arg;
+		std::string_view ref;   // ~320-digit reference for f(arg)
+	};
+
+	const std::vector<Case>& cases() {
+		static const std::vector<Case> c = {
+			{ Op::Sqrt, "sqrt@2",  2.0, s_sqrt2   },
+			{ Op::Exp,  "exp@1",   1.0, s_e       },
+			{ Op::Log,  "log@2",   2.0, s_ln2     },
+			{ Op::Sin,  "sin@0.5", 0.5, s_sin_half },
+			{ Op::Cos,  "cos@0.5", 0.5, s_cos_half },
+			{ Op::Tan,  "tan@0.5", 0.5, s_tan_half },
+			{ Op::Sinh, "sinh@0.5",0.5, s_sinh_half },
+			{ Op::Cosh, "cosh@0.5",0.5, s_cosh_half },
+			{ Op::Tanh, "tanh@0.5",0.5, s_tanh_half },
+		};
+		return c;
+	}
+
+	template<typename Real>
+	Real apply(Op op, const Real& x) {
+		switch (op) {
+		case Op::Sqrt: return sqrt(x);
+		case Op::Exp:  return exp(x);
+		case Op::Log:  return log(x);
+		case Op::Sin:  return sin(x);
+		case Op::Cos:  return cos(x);
+		case Op::Tan:  return tan(x);
+		case Op::Sinh: return sinh(x);
+		case Op::Cosh: return cosh(x);
+		case Op::Tanh: return tanh(x);
+		}
+		return x;
+	}
+
+	// ------------------------------------------------------------------- rows
+	struct Row {
+		std::string type;    // "elreal" | "ereal"
+		std::string func;
+		long        knob;    // elreal depth or ereal N
+		double      time_ns;
+		int         digits;  // -1 if not measured
+	};
+
+	std::vector<Row> g_rows;
+
+	void emit(const Row& r) {
+		std::cout << r.type << ",double," << r.func << ',' << r.knob << ','
+		          << std::llround(r.time_ns) << ',' << r.digits << ','
+		          << (r.digits < 0 ? 0 : correct_bits(r.digits)) << ',';
+		if (r.digits < 0) std::cout << "n/a";
+		else              std::cout << std::scientific << std::setprecision(1) << rel_error(r.digits) << std::defaultfloat;
+		std::cout << '\n';
+		g_rows.push_back(r);
+	}
+
+	// ----------------------------------------------------------------- sweeps
+	void run_elreal(int maxDepth, int reps) {
+		for (const auto& c : cases()) {
+			for (int d = 2; d <= maxDepth; ++d) {
+				elreal<double> x(c.arg);
+				x.precision(static_cast<std::size_t>(d));
+				volatile double sink = 0.0;
+				double t = time_ns([&] {
+					elreal<double> r = apply(c.op, x);
+					sink = r.approx<double>(static_cast<std::size_t>(d));  // force materialization to depth d
+				}, reps);
+				(void)sink;
+				elreal<double> r = apply(c.op, x);
+				(void)r.approx<double>(static_cast<std::size_t>(d));       // force before reading the stream
+				int digits = agreed_decimal_digits(zbcl_to_dyadic(r.stream()), c.ref);
+				emit({ "elreal", c.name, d, t, digits });
+			}
+		}
+	}
+
+	template<unsigned N>
+	void run_ereal_N(int reps) {
+		for (const auto& c : cases()) {
+			ereal<N> x(c.arg), r;
+			double t = time_ns([&] { r = apply(c.op, x); }, reps);
+			int digits = agreed_decimal_digits(ereal_to_dyadic(r), c.ref);
+			emit({ "ereal", c.name, static_cast<long>(N), t, digits });
+		}
+	}
+
+	template<unsigned... Ns>
+	void run_ereal(int reps) {
+		(run_ereal_N<Ns>(reps), ...);   // fixed compile-time limb list
+	}
+
+	// arithmetic: accuracy is exact for a single op, so report time only (digits=-1).
+	// The interesting axis is the renorm cost growth (elreal ~depth^2, ereal ~N^2).
+	void run_arithmetic(int maxDepth, int reps) {
+		const double A = 1.4142135623730951, B = 2.7182818284590452;
+		for (int d = 2; d <= maxDepth; ++d) {
+			elreal<double> a(A), b(B);
+			a.precision(static_cast<std::size_t>(d));
+			b.precision(static_cast<std::size_t>(d));
+			volatile double sink = 0.0;
+			auto timeOp = [&](auto fn) {
+				return time_ns([&] { elreal<double> r = fn(); sink = r.approx<double>(static_cast<std::size_t>(d)); }, reps);
+			};
+			emit({ "elreal", "add", d, timeOp([&] { return a + b; }), -1 });
+			emit({ "elreal", "mul", d, timeOp([&] { return a * b; }), -1 });
+			emit({ "elreal", "div", d, timeOp([&] { return a / b; }), -1 });
+			(void)sink;
+		}
+	}
+
+	template<unsigned N>
+	void run_arithmetic_ereal_N(int reps) {
+		const double A = 1.4142135623730951, B = 2.7182818284590452;
+		ereal<N> a(A), b(B), r;
+		emit({ "ereal", "add", static_cast<long>(N), time_ns([&] { r = a + b; }, reps), -1 });
+		emit({ "ereal", "mul", static_cast<long>(N), time_ns([&] { r = a * b; }, reps), -1 });
+		emit({ "ereal", "div", static_cast<long>(N), time_ns([&] { r = a / b; }, reps), -1 });
+	}
+
+	template<unsigned... Ns>
+	void run_arithmetic_ereal(int reps) {
+		(run_arithmetic_ereal_N<Ns>(reps), ...);
+	}
+
+	// ---------------------------------------------------------------- summary
+	// per (type, function): saturation knob (first reaching >=95% of max digits)
+	// and the accuracy/time knee (knob maximizing digits per log10(time)).
+	void summary() {
+		std::vector<std::string> funcs;
+		for (const auto& c : cases()) funcs.push_back(c.name);
+
+		std::cout << "\n== per-function summary (accuracy saturation + accuracy/time knee) ==\n";
+		for (const char* type : { "elreal", "ereal" }) {
+			for (const auto& f : funcs) {
+				std::vector<const Row*> rs;
+				for (const auto& r : g_rows)
+					if (r.type == type && r.func == f && r.digits >= 0) rs.push_back(&r);
+				if (rs.empty()) continue;
+				std::sort(rs.begin(), rs.end(), [](const Row* a, const Row* b) { return a->knob < b->knob; });
+				int maxDig = 0;
+				for (auto* r : rs) maxDig = std::max(maxDig, r->digits);
+				long satKnob = rs.back()->knob;
+				for (auto* r : rs) if (r->digits >= (maxDig * 95) / 100) { satKnob = r->knob; break; }
+				const Row* knee = rs.front();
+				double bestScore = -1.0;
+				for (auto* r : rs) {
+					double score = r->digits / std::max(1.0, std::log10(std::max(1.0, r->time_ns)));
+					if (score > bestScore) { bestScore = score; knee = r; }
+				}
+				std::cout << "  " << std::left << std::setw(7) << type << ' ' << std::setw(9) << f
+				          << " saturates ~" << (std::string(type) == "elreal" ? "depth " : "N=") << satKnob
+				          << " (" << maxDig << " digits); knee at "
+				          << (std::string(type) == "elreal" ? "depth " : "N=") << knee->knob
+				          << " (" << knee->digits << " digits, " << std::llround(knee->time_ns) << " ns)\n";
+			}
+		}
+
+		// elreal-vs-ereal: cheapest config reaching a target accuracy, per function
+		const int target = 30;  // digits
+		std::cout << "\n== elreal vs ereal: cheapest config reaching >=" << target << " digits ==\n";
+		for (const auto& f : funcs) {
+			auto cheapest = [&](const char* type) -> const Row* {
+				const Row* best = nullptr;
+				for (const auto& r : g_rows)
+					if (r.type == type && r.func == f && r.digits >= target)
+						if (!best || r.time_ns < best->time_ns) best = &r;
+				return best;
+			};
+			const Row* e = cheapest("elreal");
+			const Row* r = cheapest("ereal");
+			std::cout << "  " << std::left << std::setw(9) << f << ' ';
+			if (e) std::cout << "elreal depth " << e->knob << " @ " << std::llround(e->time_ns) << " ns";
+			else   std::cout << "elreal (not reached)";
+			std::cout << "  vs  ";
+			if (r) std::cout << "ereal N=" << r->knob << " @ " << std::llround(r->time_ns) << " ns";
+			else   std::cout << "ereal (not reached)";
+			if (e && r) std::cout << "  -> " << (e->time_ns < r->time_ns ? "elreal" : "ereal") << " cheaper";
+			std::cout << '\n';
+		}
+	}
+
+}  // anonymous namespace
+
+int main(int argc, char** argv) try {
+	// Defaults are deliberately small so a first look is quick; the elreal
+	// transcendentals cost 100s of ms at depth >= 4, so raise maxDepth for a full
+	// characterization run (e.g. `characterize 6 9`).
+	int maxDepth = (argc > 1) ? std::atoi(argv[1]) : 3;
+	int reps     = (argc > 2) ? std::atoi(argv[2]) : 3;
+	if (maxDepth < 2) maxDepth = 2;
+	if (reps < 1) reps = 1;
+
+	std::cout << "# adaptive-precision accuracy-vs-compute-time characterization (issue #1040)\n";
+	std::cout << "# elreal depth sweep 2.." << maxDepth << ", ereal limb list {2,4,8,12,16}, reps=" << reps << "\n";
+	std::cout << "type,FpType,function,depth,time_ns,correct_digits,correct_bits,rel_error\n";
+
+	run_elreal(maxDepth, reps);
+	run_ereal<2, 4, 8, 12, 16>(reps);
+	run_arithmetic(maxDepth, reps);
+	run_arithmetic_ereal<2, 4, 8, 12, 16>(reps);
+
+	summary();
+	return EXIT_SUCCESS;
+}
+catch (const std::exception& e) {
+	std::cerr << "Caught exception: " << e.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/benchmark/accuracy/adaptive/plot.gnuplot
+++ b/benchmark/accuracy/adaptive/plot.gnuplot
@@ -1,0 +1,32 @@
+# plot.gnuplot: render the accuracy-vs-compute-time Pareto curves for the adaptive
+#               real oracles from the characterize tool's CSV (issue #1040).
+#
+# Usage:
+#   ./characterize 6 9 > adaptive.csv          # generate a fuller sweep
+#   gnuplot -e "DATA='adaptive.csv'" plot.gnuplot
+#
+# Produces adaptive_pareto.png: correct decimal digits (y) vs time per evaluation
+# (x, log scale), one point series per type. Rows with correct_digits < 0
+# (arithmetic, no reference) are dropped by the column-6 filter.
+
+if (!exists("DATA")) DATA = 'adaptive.csv'
+
+set datafile separator ","
+set datafile commentschars "#"
+
+set terminal pngcairo size 900,600 enhanced
+set output 'adaptive_pareto.png'
+
+set title "adaptive-precision oracles: accuracy vs compute time (issue #1040)"
+set xlabel "time per evaluation (ns, log scale)"
+set ylabel "correct decimal digits"
+set logscale x
+set grid
+set key left top
+
+# column layout: 1=type 2=FpType 3=function 4=knob 5=time_ns 6=correct_digits
+plot \
+  DATA using (stringcolumn(1) eq "elreal" && $6 >= 0 ? $5 : 1/0):6 \
+       with points pt 7 ps 1.2 lc rgb "#1f77b4" title "elreal (depth sweep)", \
+  DATA using (stringcolumn(1) eq "ereal"  && $6 >= 0 ? $5 : 1/0):6 \
+       with points pt 5 ps 1.2 lc rgb "#d62728" title "ereal (limb sweep)"


### PR DESCRIPTION
## Summary
Resolves #1040 (focused-core scope). A new characterization utility `benchmark/accuracy/adaptive/characterize.cpp` maps, for the adaptive-precision real oracles **elreal** (lazy ZBCL) and **ereal** (Priest/Shewchuk expansion), the relationship between **accuracy, the precision knob, and wall-clock time** -- so library default depths can be chosen from evidence rather than guesswork.

## What it measures
For each function it sweeps the knob -- elreal `depth` (runtime) and ereal limb count `N` (a fixed compile-time list `{2,4,8,12,16}`) -- and reports:
- **median wall-clock time** per evaluation, and
- **accuracy** as decimal digits of agreement with an independent ~320-digit reference (`math/constants/reference_constants.hpp`), via the exact **dyadic oracle**: `verification/elreal_reference_digits.hpp`'s `zbcl_to_dyadic` + `agreed_decimal_digits` for elreal, and a limb-sum dyadic for ereal, plus correct bits and an implied relative error.

## Output
A CSV `(type, FpType, function, depth, time_ns, correct_digits, correct_bits, rel_error)`, then a per-function **saturation-depth + accuracy/time-knee** summary and an **elreal-vs-ereal comparison** (cheapest config reaching a target accuracy). Sample:
```
type,FpType,function,depth,time_ns,correct_digits,correct_bits,rel_error
elreal,double,sqrt@2,2,128684,32,106,1.0e-32
ereal,double,sqrt@2,2,2264774,128,425,1.0e-128
...
== elreal vs ereal: cheapest config reaching >=30 digits ==
  sqrt@2  elreal depth 2 @ 113506 ns  vs  ereal N=2 @ 2247398 ns  -> elreal cheaper
  sin@0.5 elreal depth 2 @ ...        vs  ereal N=2 @ ...         -> ereal cheaper
```

Functions: `sqrt/exp/log/sin/cos/tan/sinh/cosh/tanh` against their reference values (sqrt@2, exp@1, log@2, {sin,cos,tan,sinh,cosh,tanh}@0.5), plus `add/mul/div` timing (accuracy exact, so time-only). A gnuplot script renders the accuracy-vs-time Pareto curves.

## Deliverables (issue #1040 checklist)
- [x] CSV output `(type, FpType, function, depth, time_ns, correct_bits, rel_error)`
- [x] Per-function saturation-depth + accuracy/time knee summary
- [x] elreal vs ereal comparison on the same axes
- [x] gnuplot script to render the curves

## Changes
- `benchmark/accuracy/adaptive/characterize.cpp` (new) -- the tool
- `benchmark/accuracy/adaptive/CMakeLists.txt` (new) -- `compile_all("false")`: builds in CI but is a measurement utility, not a pass/fail ctest
- `benchmark/accuracy/adaptive/plot.gnuplot` (new)
- `CMakeLists.txt` -- one `add_subdirectory` under the accuracy-benchmark block

## Notes / scope
- Host FpType fixed to `double`; the `float`/`bfloat16`/`fp16` host matrix is deferred to a follow-up (bfloat16/fp16 as an elreal host has known narrow-host edge cases).
- Usage: `characterize [maxDepth=3] [reps=3]`; raise `maxDepth` for a full sweep -- the elreal transcendentals cost 100s of ms at depth >= 4, so defaults are kept small.
- Measurement only -- it does not modify the elreal/ereal implementations (explicitly out of scope in the issue).

## Test Results
| | gcc build | gcc run | clang build | clang run |
|--|--|--|--|--|
| accuracy_characterize | OK (CMake target) | OK | OK | OK |

cppcheck: only `useStlAlgorithm` style/inconclusive suggestions (raw loops kept for clarity). ASCII-clean.

## Test plan
- [ ] Fast CI passes

Resolves #1040

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an adaptive-precision accuracy benchmark for supported mathematical operations.
  * Reports accuracy, computation time, saturation points, and efficiency comparisons between precision modes.
  * Supports configurable benchmark depth and repetition counts.
  * Added CSV output and a plotting script for visualizing accuracy-versus-time tradeoffs.

* **Build**
  * The benchmark is included when accuracy benchmarks are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->