### PR TITLE
refactor(elreal): unify regression tests to standard MANUAL_TESTING + REGRESSION_LEVEL structure

### DIFF
--- a/elastic/elreal/api/api.cpp
+++ b/elastic/elreal/api/api.cpp
@@ -100,6 +100,19 @@ int verify_lazy_api() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -108,13 +121,28 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_construction();
     nrOfFailedTestCases += verify_arithmetic();
     nrOfFailedTestCases += verify_logic();
     nrOfFailedTestCases += verify_lazy_api();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/api/attributes.cpp
+++ b/elastic/elreal/api/attributes.cpp
@@ -101,6 +101,19 @@ int verify_manipulators() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -109,12 +122,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_numeric_limits();
     nrOfFailedTestCases += verify_attributes();
     nrOfFailedTestCases += verify_manipulators();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/api/lazy.cpp
+++ b/elastic/elreal/api/lazy.cpp
@@ -129,6 +129,19 @@ int verify_edge_cases() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -137,6 +150,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_memoisation();
     nrOfFailedTestCases += verify_prefix_stability();
     nrOfFailedTestCases += verify_convergence();
@@ -144,8 +168,12 @@ try {
     nrOfFailedTestCases += verify_stream_roundtrip();
     nrOfFailedTestCases += verify_edge_cases();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/api/math.cpp
+++ b/elastic/elreal/api/math.cpp
@@ -97,6 +97,19 @@ int verify_precision_threading() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -104,6 +117,17 @@ try {
     int nrOfFailedTestCases = 0;
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
 
     // bound the working precision so the transcendental series stay quick while
     // still resolving past host-double (this is the facade wiring test, not a
@@ -116,8 +140,12 @@ try {
     nrOfFailedTestCases += verify_binary();
     nrOfFailedTestCases += verify_precision_threading();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/add_renormalization.cpp
+++ b/elastic/elreal/arithmetic/add_renormalization.cpp
@@ -157,6 +157,19 @@ int verify_1057() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -165,11 +178,26 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify();
     nrOfFailedTestCases += verify_1057();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/addition.cpp
+++ b/elastic/elreal/arithmetic/addition.cpp
@@ -119,6 +119,19 @@ int verify_add(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -127,11 +140,26 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_add<double>("add<double>");
     nrOfFailedTestCases += verify_add<float>("add<float>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/class_arithmetic.cpp
+++ b/elastic/elreal/arithmetic/class_arithmetic.cpp
@@ -88,6 +88,19 @@ int verify_nonfinite() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -96,11 +109,26 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_finite();
     nrOfFailedTestCases += verify_nonfinite();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/division.cpp
+++ b/elastic/elreal/arithmetic/division.cpp
@@ -92,6 +92,19 @@ int verify_all(const std::string& host) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -100,12 +113,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_all<double>("div<double>");
     nrOfFailedTestCases += verify_all<float>("div<float>");
     nrOfFailedTestCases += verify_all<bfloat16>("div<bfloat16>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/division_exceptions.cpp
+++ b/elastic/elreal/arithmetic/division_exceptions.cpp
@@ -39,6 +39,19 @@ int verify(const std::string& host) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -47,11 +60,26 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify<double>("div<double>");
     nrOfFailedTestCases += verify<float>("div<float>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/exact_value_oracle.cpp
+++ b/elastic/elreal/arithmetic/exact_value_oracle.cpp
@@ -329,6 +329,19 @@ int sweep_quad_fullwidth(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -336,6 +349,17 @@ try {
     int nrOfFailedTestCases = 0;
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
 
     using cf24  = cfloat<24, 5, std::uint16_t, true, false, false>;
     using cf32  = cfloat<32, 8, std::uint32_t, true, false, false>;
@@ -368,8 +392,12 @@ try {
     // approximate behaviour with a truncation bound.
     nrOfFailedTestCases += sweep_eft_truncating<bfloat16>("bfloat16");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/multiplication.cpp
+++ b/elastic/elreal/arithmetic/multiplication.cpp
@@ -91,6 +91,19 @@ int verify_all(const std::string& host) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -99,12 +112,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_all<double>("mul<double>");
     nrOfFailedTestCases += verify_all<float>("mul<float>");
     nrOfFailedTestCases += verify_all<bfloat16>("mul<bfloat16>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/negation.cpp
+++ b/elastic/elreal/arithmetic/negation.cpp
@@ -62,6 +62,19 @@ int verify_all(const std::string& host) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -70,12 +83,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_all<double>("negate<double>");
     nrOfFailedTestCases += verify_all<float>("negate<float>");
     nrOfFailedTestCases += verify_all<bfloat16>("negate<bfloat16>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/online_muldiv.cpp
+++ b/elastic/elreal/arithmetic/online_muldiv.cpp
@@ -286,6 +286,19 @@ int verify_div_deep_reach() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -293,6 +306,17 @@ try {
     int nrOfFailedTestCases = 0;
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
 
     nrOfFailedTestCases += verify_infsum();
     nrOfFailedTestCases += verify_mul();
@@ -302,8 +326,12 @@ try {
     nrOfFailedTestCases += verify_div_dense_deep();
     nrOfFailedTestCases += verify_div_deep_reach();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/renorm_cancellation.cpp
+++ b/elastic/elreal/arithmetic/renorm_cancellation.cpp
@@ -71,6 +71,19 @@ int verify() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -79,10 +92,25 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify();
+
+#endif
 
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/arithmetic/threeAdd.cpp
+++ b/elastic/elreal/arithmetic/threeAdd.cpp
@@ -161,6 +161,19 @@ int verify_threeAdd(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -169,11 +182,26 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_threeAdd<double>("threeAdd<double>");
     nrOfFailedTestCases += verify_threeAdd<float>("threeAdd<float>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block/accessors.cpp
+++ b/elastic/elreal/block/accessors.cpp
@@ -62,6 +62,19 @@ int verify_accessors(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -70,6 +83,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_accessors<float>("block<float>");
     nrOfFailedTestCases += verify_accessors<double>("block<double>");
     nrOfFailedTestCases += verify_accessors<half>("block<half>");
@@ -77,8 +101,12 @@ try {
     nrOfFailedTestCases += verify_accessors<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
     nrOfFailedTestCases += verify_accessors<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block/construction.cpp
+++ b/elastic/elreal/block/construction.cpp
@@ -65,6 +65,19 @@ int verify_construction(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -73,6 +86,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_construction<float>("block<float>");
     nrOfFailedTestCases += verify_construction<double>("block<double>");
     nrOfFailedTestCases += verify_construction<half>("block<half>");
@@ -80,8 +104,12 @@ try {
     nrOfFailedTestCases += verify_construction<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
     nrOfFailedTestCases += verify_construction<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block/exp_offset.cpp
+++ b/elastic/elreal/block/exp_offset.cpp
@@ -74,6 +74,19 @@ int verify_exp(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -82,6 +95,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_exp<float>("block<float>");
     nrOfFailedTestCases += verify_exp<double>("block<double>");
     nrOfFailedTestCases += verify_exp<half>("block<half>");
@@ -89,8 +113,12 @@ try {
     nrOfFailedTestCases += verify_exp<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
     nrOfFailedTestCases += verify_exp<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block/predicates.cpp
+++ b/elastic/elreal/block/predicates.cpp
@@ -62,6 +62,19 @@ int verify_predicates(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -70,6 +83,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_predicates<float>("block<float>");
     nrOfFailedTestCases += verify_predicates<double>("block<double>");
     nrOfFailedTestCases += verify_predicates<half>("block<half>");
@@ -77,8 +101,12 @@ try {
     nrOfFailedTestCases += verify_predicates<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
     nrOfFailedTestCases += verify_predicates<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block/printers.cpp
+++ b/elastic/elreal/block/printers.cpp
@@ -54,6 +54,19 @@ int verify_printers(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -62,6 +75,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_printers<float>("block<float>");
     nrOfFailedTestCases += verify_printers<double>("block<double>");
     nrOfFailedTestCases += verify_printers<half>("block<half>");
@@ -69,8 +93,12 @@ try {
     nrOfFailedTestCases += verify_printers<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
     nrOfFailedTestCases += verify_printers<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block/zero_overlap.cpp
+++ b/elastic/elreal/block/zero_overlap.cpp
@@ -73,6 +73,19 @@ int verify_zero_overlap(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -81,6 +94,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_zero_overlap<float>("block<float>");
     nrOfFailedTestCases += verify_zero_overlap<double>("block<double>");
     nrOfFailedTestCases += verify_zero_overlap<half>("block<half>");
@@ -88,8 +112,12 @@ try {
     nrOfFailedTestCases += verify_zero_overlap<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
     nrOfFailedTestCases += verify_zero_overlap<cfloat<32, 8, std::uint32_t, true, false, false>>("block<cfloat<32,8>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block_eft/two_div.cpp
+++ b/elastic/elreal/block_eft/two_div.cpp
@@ -149,6 +149,19 @@ int verify_two_div(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -157,14 +170,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_two_div<float>("block<float>");
     nrOfFailedTestCases += verify_two_div<double>("block<double>");
     nrOfFailedTestCases += verify_two_div<half>("block<half>");
     nrOfFailedTestCases += verify_two_div<bfloat16>("block<bfloat16>");
     nrOfFailedTestCases += verify_two_div<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block_eft/two_mult.cpp
+++ b/elastic/elreal/block_eft/two_mult.cpp
@@ -158,6 +158,19 @@ int verify_two_mult(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -166,14 +179,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_two_mult<float>("block<float>");
     nrOfFailedTestCases += verify_two_mult<double>("block<double>");
     nrOfFailedTestCases += verify_two_mult<half>("block<half>");
     nrOfFailedTestCases += verify_two_mult<bfloat16>("block<bfloat16>");
     nrOfFailedTestCases += verify_two_mult<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/block_eft/two_sum.cpp
+++ b/elastic/elreal/block_eft/two_sum.cpp
@@ -155,6 +155,19 @@ int verify_two_sum(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -163,14 +176,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_two_sum<float>("block<float>");
     nrOfFailedTestCases += verify_two_sum<double>("block<double>");
     nrOfFailedTestCases += verify_two_sum<half>("block<half>");
     nrOfFailedTestCases += verify_two_sum<bfloat16>("block<bfloat16>");
     nrOfFailedTestCases += verify_two_sum<cfloat<24, 5, std::uint16_t, true, false, false>>("block<cfloat<24,5>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/conversion/conversion.cpp
+++ b/elastic/elreal/conversion/conversion.cpp
@@ -81,6 +81,19 @@ int verify_specific_values() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -89,12 +102,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_roundtrip();
     nrOfFailedTestCases += verify_nonfinite_convert();
     nrOfFailedTestCases += verify_specific_values();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/logic/logic.cpp
+++ b/elastic/elreal/logic/logic.cpp
@@ -93,6 +93,19 @@ int verify_inf_order() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -101,12 +114,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_finite_order();
     nrOfFailedTestCases += verify_nan_unordered();
     nrOfFailedTestCases += verify_inf_order();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/constants.cpp
+++ b/elastic/elreal/math/constants.cpp
@@ -143,6 +143,19 @@ int verify_highprec_double() {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -150,6 +163,17 @@ try {
     int nrOfFailedTestCases = 0;
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
 
     nrOfFailedTestCases += verify_series<double>(1e-12, "const<double>", kConstDepth);
     nrOfFailedTestCases += verify_series<float>(1e-6, "const<float>", kConstDepth);
@@ -160,8 +184,12 @@ try {
 
     nrOfFailedTestCases += verify_highprec_double();
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/constants_highprecision.cpp
+++ b/elastic/elreal/math/constants_highprecision.cpp
@@ -46,9 +46,9 @@
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 #include <iostream>
@@ -93,6 +93,15 @@ try {
     bool reportTestCases = true;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
 #if REGRESSION_LEVEL_4
     // The ten constants with both a high-precision generator and a reference string.
     nrOfFailedTestCases += check("pi",          pi_zbcl<double>(kDepth),          s_pi,          reportTestCases);
@@ -114,6 +123,8 @@ try {
 
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/exponent.cpp
+++ b/elastic/elreal/math/exponent.cpp
@@ -106,6 +106,19 @@ int verify_pow_int(double tol, const std::string& host, std::size_t depth) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -114,6 +127,17 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_explog<double>(1e-10, "explog<double>", kExpDepth);
     nrOfFailedTestCases += verify_explog<float>(1e-5, "explog<float>", kExpDepth);
 
@@ -121,8 +145,12 @@ try {
     nrOfFailedTestCases += verify_pow_int<float>(1e-5, "pow<float>", kPowIntDepth);
     nrOfFailedTestCases += verify_pow_int<bfloat16>(1e-1, "pow<bfloat16>", kPowIntDepth);
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/hyperbolic.cpp
+++ b/elastic/elreal/math/hyperbolic.cpp
@@ -78,6 +78,19 @@ int verify_all(double tol, const std::string& host, std::size_t depth) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -86,11 +99,26 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_all<double>(1e-10, "hyp<double>", kHypDepth);
     nrOfFailedTestCases += verify_all<float>(1e-5, "hyp<float>", kHypDepth);
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/hypot.cpp
+++ b/elastic/elreal/math/hypot.cpp
@@ -60,6 +60,19 @@ int verify_all(double tol, const std::string& host) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -68,12 +81,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_all<double>(1e-12, "hypot<double>");
     nrOfFailedTestCases += verify_all<float>(1e-6, "hypot<float>");
     nrOfFailedTestCases += verify_all<bfloat16>(1e-4, "hypot<bfloat16>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/payne_hanek.cpp
+++ b/elastic/elreal/math/payne_hanek.cpp
@@ -37,9 +37,9 @@
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 namespace {
@@ -128,6 +128,15 @@ try {
 	bool reportTestCases = true;
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+	// TODO: place hand-run diagnostics here (this branch ignores failures)
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
 	nrOfFailedTestCases += fast_sanity(reportTestCases);
 
 #if REGRESSION_LEVEL_4
@@ -171,6 +180,8 @@ try {
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
 	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/sqrt.cpp
+++ b/elastic/elreal/math/sqrt.cpp
@@ -66,6 +66,19 @@ int verify_all(double tol, const std::string& host) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -74,12 +87,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_all<double>(1e-12, "sqrt<double>");
     nrOfFailedTestCases += verify_all<float>(1e-6, "sqrt<float>");
     nrOfFailedTestCases += verify_all<bfloat16>(1e-4, "sqrt<bfloat16>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/transcendentals_highprecision.cpp
+++ b/elastic/elreal/math/transcendentals_highprecision.cpp
@@ -39,9 +39,9 @@
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 // asin(x)+acos(x) == pi/2 exercises add() over an EXACT leading-term cancellation
@@ -169,6 +169,15 @@ try {
     bool reportTestCases = true;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
     nrOfFailedTestCases += fast_identities(reportTestCases);
 
 #if REGRESSION_LEVEL_4
@@ -250,6 +259,8 @@ try {
 
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/math/trigonometry.cpp
+++ b/elastic/elreal/math/trigonometry.cpp
@@ -168,6 +168,19 @@ int verify_forward_trig(double tol, const std::string& host, bool nearZeroSquare
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -176,14 +189,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_atan<double>(1e-10, "atan<double>", kTrigDepth);
     nrOfFailedTestCases += verify_atan<float>(1e-5, "atan<float>", kTrigDepth);
     nrOfFailedTestCases += verify_asin_acos<double>(1e-10, "iasin<double>", kAsinDepth);
     nrOfFailedTestCases += verify_forward_trig<double>(1e-10, "trig<double>", true, kTrigDepth);
     nrOfFailedTestCases += verify_forward_trig<float>(1e-5, "trig<float>", false, kTrigDepth);
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/rounding/round_to.cpp
+++ b/elastic/elreal/rounding/round_to.cpp
@@ -225,9 +225,9 @@ namespace {
 #undef REGRESSION_LEVEL_3
 #undef REGRESSION_LEVEL_4
 #define REGRESSION_LEVEL_1 1
-#define REGRESSION_LEVEL_2 1
-#define REGRESSION_LEVEL_3 1
-#define REGRESSION_LEVEL_4 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
 #endif
 
 int main()
@@ -237,6 +237,15 @@ try {
 	int nrOfFailedTestCases = 0;
 	bool reportTestCases = true;
 	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	// TODO: place hand-run diagnostics here (this branch ignores failures)
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
 
 	int base = 2000;
 #if REGRESSION_LEVEL_2
@@ -251,6 +260,8 @@ try {
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
 	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/summation/alternating.cpp
+++ b/elastic/elreal/summation/alternating.cpp
@@ -75,6 +75,19 @@ int verify_leibniz(std::size_t depth, double tol, const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -83,12 +96,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     // depth=256 -> truncation error <= 1/512 ~ 2e-3; use a comfortable tolerance.
     nrOfFailedTestCases += verify_leibniz<double>(256, 5e-3, "leibniz<double>");
     nrOfFailedTestCases += verify_leibniz<float>(256, 5e-3, "leibniz<float>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/summation/depth_budget.cpp
+++ b/elastic/elreal/summation/depth_budget.cpp
@@ -64,6 +64,19 @@ int expect_ok(SeriesFactory make_series, std::size_t max_depth, const std::strin
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -71,6 +84,17 @@ try {
     int nrOfFailedTestCases = 0;
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
 
     // Divergent: constant series 1 + 1 + 1 + ... (magnitudes do not decrease).
     auto constant = []() {
@@ -108,8 +132,12 @@ try {
     };
     nrOfFailedTestCases += expect_ok<double>(geometric, 8, "sum (1/2)^n (convergent)");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/summation/exp_preview.cpp
+++ b/elastic/elreal/summation/exp_preview.cpp
@@ -72,6 +72,19 @@ int verify_exp(std::size_t depth, double tol, const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -80,14 +93,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     // depth=20 -> 1/20! ~ 4e-19 << double eps, so full double precision.
     nrOfFailedTestCases += verify_exp<double>(20, 1e-12, "exp<double>");
     // float host: the represented terms sum to e at float precision; compare in
     // double with a float-eps-scaled tolerance.
     nrOfFailedTestCases += verify_exp<float>(20, 1e-5, "exp<float>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/summation/geometric.cpp
+++ b/elastic/elreal/summation/geometric.cpp
@@ -97,6 +97,19 @@ int verify_all(const std::string& host) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -105,12 +118,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_all<double>("sum<double>");
     nrOfFailedTestCases += verify_all<float>("sum<float>");
     nrOfFailedTestCases += verify_all<single>("sum<cfloat<32,8>>");   // single = cfloat<32,8>
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/zbcl/cons_take.cpp
+++ b/elastic/elreal/zbcl/cons_take.cpp
@@ -83,6 +83,19 @@ int verify_cons_take(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -91,14 +104,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_cons_take<float>("ZBCL<float>");
     nrOfFailedTestCases += verify_cons_take<double>("ZBCL<double>");
     nrOfFailedTestCases += verify_cons_take<half>("ZBCL<half>");
     nrOfFailedTestCases += verify_cons_take<bfloat16>("ZBCL<bfloat16>");
     nrOfFailedTestCases += verify_cons_take<cfloat<24, 5, std::uint16_t, true, false, false>>("ZBCL<cfloat<24,5>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/zbcl/from_native.cpp
+++ b/elastic/elreal/zbcl/from_native.cpp
@@ -61,6 +61,19 @@ int verify_from_native(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -69,14 +82,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_from_native<float>("ZBCL<float>");
     nrOfFailedTestCases += verify_from_native<double>("ZBCL<double>");
     nrOfFailedTestCases += verify_from_native<half>("ZBCL<half>");
     nrOfFailedTestCases += verify_from_native<bfloat16>("ZBCL<bfloat16>");
     nrOfFailedTestCases += verify_from_native<cfloat<24, 5, std::uint16_t, true, false, false>>("ZBCL<cfloat<24,5>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/zbcl/laziness.cpp
+++ b/elastic/elreal/zbcl/laziness.cpp
@@ -97,6 +97,19 @@ int verify_laziness(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -105,12 +118,27 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_laziness<double>("ZBCL<double>");
     nrOfFailedTestCases += verify_laziness<float>("ZBCL<float>");
     nrOfFailedTestCases += verify_laziness<half>("ZBCL<half>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;

--- a/elastic/elreal/zbcl/zero_overlap_prefix.cpp
+++ b/elastic/elreal/zbcl/zero_overlap_prefix.cpp
@@ -72,6 +72,19 @@ int verify_prefix_zero_overlap(const std::string& tag) {
 
 } // anonymous
 
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
 int main()
 try {
     using namespace sw::universal;
@@ -80,14 +93,29 @@ try {
     bool reportTestCases = false;
     ReportTestSuiteHeader(test_suite, reportTestCases);
 
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+#if REGRESSION_LEVEL_1
+
     nrOfFailedTestCases += verify_prefix_zero_overlap<float>("ZBCL<float>");
     nrOfFailedTestCases += verify_prefix_zero_overlap<double>("ZBCL<double>");
     nrOfFailedTestCases += verify_prefix_zero_overlap<half>("ZBCL<half>");
     nrOfFailedTestCases += verify_prefix_zero_overlap<bfloat16>("ZBCL<bfloat16>");
     nrOfFailedTestCases += verify_prefix_zero_overlap<cfloat<24, 5, std::uint16_t, true, false, false>>("ZBCL<cfloat<24,5>>");
 
+#endif
+
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
 }
 catch (const std::exception& err) {
     std::cerr << "Caught unexpected exception: " << err.what() << std::endl;


### PR DESCRIPTION
## Summary
- Brings the entire elreal regression suite onto the repo-wide test skeleton (`MANUAL_TESTING` + `REGRESSION_LEVEL_[1234]`) that every other `static/*` and `elastic/*` test uses.
- Before this PR, only `math/asin_sqrt_precision.cpp` followed the standard; the other 44 tests used ad-hoc mains (bare `ReportTestResult` calls, or `REGRESSION_LEVEL` guards without the `#if MANUAL_TESTING` dispatch).

## Changes (44 files)
- **40 bare files** gain the full skeleton: `#define MANUAL_TESTING 0`, the `#ifndef REGRESSION_LEVEL_OVERRIDE` default block (`LEVEL_1=1`, `LEVEL_2/3/4=0`), and a `main()` split into `#if MANUAL_TESTING` (hand-run diagnostics, ignores failures) `/ #else` (regression body under `#if REGRESSION_LEVEL_1`) `/ #endif`.
- **4 files** that already carried the `REGRESSION_LEVEL` defines but lacked the dispatch (`math/constants_highprecision`, `math/payne_hanek`, `math/transcendentals_highprecision`, `rounding/round_to`) gain the missing `#if MANUAL_TESTING` split and have their in-file level defaults normalized to `LEVEL_1=1 / others=0`. Their heavy checks remain gated behind `#if REGRESSION_LEVEL_4`.

Test logic is unchanged. Behavior is preserved: CMake sets `REGRESSION_LEVEL_OVERRIDE` for any configured build, so in-file defaults only govern bare compiles, and all existing verify calls run at `LEVEL_1`.

## Test Results
| Scope | gcc build | gcc test | clang build | clang test |
|-------|-----------|----------|-------------|------------|
| all 45 elreal targets (default LEVEL_1) | OK | 45/45 PASS | OK | 45/45 PASS |
| 4 level-gated files @ REGRESSION_LEVEL_4 | OK | round_to PASS | - | - |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready`

Generated with [Claude Code](https://claude.com/claude-code)