### PR TITLE
feat(elreal): round_to<cfloat<N,E>> -- Phase 8 real-FP conversion for arbitrary cfloat targets

### DIFF
--- a/elastic/elreal/rounding/round_to.cpp
+++ b/elastic/elreal/rounding/round_to.cpp
@@ -1,15 +1,20 @@
-// round_to.cpp: regression tests for elreal Phase 8 real floating-point conversion (#932).
+// round_to.cpp: regression tests for elreal Phase 8 real floating-point conversion (#932, #1182).
 //
 // round_to<Target>(ZBCL<FpType>, RoundingMode) rounds an exact-real elreal stream
-// to double / float / dd / qd. This suite validates:
+// to double / float / dd / qd (#932) or to an arbitrary cfloat<nbits,es,...>
+// (#1182). This suite validates:
 //   - correctly-rounded: every result matches the exact value rounded to the
 //     target's significand bits, verified against the independent einteger dyadic
 //     oracle, for all four rounding modes;
 //   - idempotence: round_to<T>(round_to<T>(x)) == round_to<T>(x);
 //   - monotonicity across nested precisions: (double,float), (dd,double), (qd,dd);
-//   - lossless roundtrip: round_to<double>(from_native<double>(x)) == x;
+//   - lossless roundtrip: round_to<double>(from_native<double>(x)) == x, and for
+//     cfloat, round_to<Cf>(exact-value-of-c) == c for every finite c;
 //   - determinism: the result depends only on the value and mode, not the path
-//     that produced the ZBCL.
+//     that produced the ZBCL;
+//   - cfloat exponent-range handling: overflow to +/-inf (or maxpos/maxneg),
+//     gradual underflow to subnormals, and flush-to-zero, across a spread of
+//     <nbits,es> configs and subnormal/max-exponent flag combinations.
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -25,6 +30,7 @@
 #include <universal/number/elreal/elreal.hpp>
 #include <universal/number/dd/dd.hpp>
 #include <universal/number/qd/qd.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
 #include <universal/verification/elreal_reference_digits.hpp>   // dyadic, zbcl_to_dyadic
 #include <universal/verification/test_suite.hpp>
 
@@ -216,6 +222,203 @@ namespace {
 		return fails;
 	}
 
+	// ==== cfloat targets (#1182) ==============================================
+	//
+	// A cfloat has a finite es-bit exponent range, so round_to<cfloat> has to
+	// classify the value as normal, subnormal, overflow, or flush-to-zero, and
+	// round the significand at the right absolute bit position for that region.
+	// The oracle below re-derives the correctly-rounded cfloat *independently*
+	// from the exact dyadic using bigint arithmetic, then we compare bit patterns.
+
+	// expected_cfloat<Cf>(D, mode): round the exact dyadic D onto cfloat<Cf>'s
+	// representable grid under `mode`, returning the target cfloat. This mirrors
+	// the number system's encoding but derives the mantissa entirely with einteger
+	// (a different substrate than the round.hpp double-expansion implementation).
+	template<typename Cf>
+	Cf expected_cfloat(dyadic D, RoundingMode mode) {
+		Cf r;
+		if (D.numerator.iszero()) { r.setzero(); return r; }
+		bigint n = D.numerator;
+		bool   neg = n.sign();
+		if (neg) n = -n;
+		int msb = -1; { bigint t = n; int b = 0; while (!t.iszero()) { t >>= 1; ++b; } msb = b - 1; }
+		int e0 = msb + D.scale;                                  // true binary exponent
+
+		constexpr int  fbits             = static_cast<int>(Cf::fbits);
+		constexpr int  MIN_EXP_NORMAL    = Cf::MIN_EXP_NORMAL;
+		constexpr int  MIN_EXP_SUBNORMAL = Cf::MIN_EXP_SUBNORMAL;
+		constexpr int  MAX_EXP           = Cf::MAX_EXP;
+		constexpr int  EXP_BIAS          = Cf::EXP_BIAS;
+		constexpr bool hasSubnormals     = Cf::hasSubnormals;
+
+		int  cut; bool normalRegion;
+		if (e0 >= MIN_EXP_NORMAL) { cut = e0 - fbits;        normalRegion = true;  }
+		else if (hasSubnormals)   { cut = MIN_EXP_SUBNORMAL; normalRegion = false; }
+		else                      { cut = MIN_EXP_NORMAL;    normalRegion = false; }
+
+		// round n * 2^scale at absolute bit `cut` -> non-negative integer mantissa
+		int   shift = cut - D.scale;
+		bigint keep, rem;
+		if (shift <= 0) { keep = shl(n, -shift); rem = bigint(0); }
+		else            { keep = shr(n, shift);  rem = n - shl(keep, shift); }
+		bool up = false;
+		if (shift > 0 && !rem.iszero()) {
+			bigint half = shl(bigint(1), shift - 1);
+			bigint d2 = rem - half; int rc = d2.iszero() ? 0 : (d2.sign() ? -1 : 1);
+			switch (mode) {
+			case RoundingMode::RoundToZero:         break;
+			case RoundingMode::RoundTowardPositive: up = !neg; break;
+			case RoundingMode::RoundTowardNegative: up =  neg; break;
+			case RoundingMode::RoundToNearest:
+			default:
+				if (rc > 0) up = true;
+				else if (rc == 0) { bigint k2 = keep; up = !((k2 - shl(shr(k2, 1), 1)).iszero()); }
+				break;
+			}
+		}
+		if (up) keep = keep + bigint(1);
+		std::uint64_t absM = 0; { bigint t = keep; int b = 0; while (!t.iszero()) { std::uint64_t bit = ((t - shl(shr(t, 1), 1)).iszero() ? 0ull : 1ull); absM |= (bit << b); t >>= 1; ++b; } }
+
+		auto assemble = [&](std::uint64_t be, std::uint64_t fr) -> Cf {
+			std::uint64_t raw = (neg ? 1ull : 0ull); raw <<= Cf::es; raw |= be; raw <<= Cf::fbits; raw |= fr;
+			Cf c; c.setbits(raw);
+			if constexpr (Cf::isSaturating) { if (c.isnan()) { if (neg) c.maxneg(); else c.maxpos(); } }
+			else { if (c.isnan()) c.setinf(neg); }
+			return c;
+		};
+		auto overflow = [&]() -> Cf {
+			Cf c; bool toInf;
+			switch (mode) {
+			case RoundingMode::RoundToZero:         toInf = false; break;
+			case RoundingMode::RoundTowardPositive: toInf = !neg;  break;
+			case RoundingMode::RoundTowardNegative: toInf =  neg;  break;
+			default:                                toInf = true;  break;
+			}
+			if constexpr (Cf::isSaturating) toInf = false;
+			if (toInf) c.setinf(neg); else { if (neg) c.maxneg(); else c.maxpos(); }
+			return c;
+		};
+
+		if (normalRegion) {
+			int expv = e0;
+			if (absM == (1ull << (fbits + 1))) { absM >>= 1; ++expv; }
+			if (expv > MAX_EXP) return overflow();
+			return assemble(static_cast<std::uint64_t>(expv + EXP_BIAS), absM & Cf::ALL_ONES_FR);
+		}
+		else {
+			if (absM == 0) { Cf c; c.setzero(); c.setsign(neg); return c; }
+			if constexpr (!hasSubnormals) return assemble(static_cast<std::uint64_t>(MIN_EXP_NORMAL + EXP_BIAS), 0ull);
+			if (absM >= (1ull << fbits)) return assemble(static_cast<std::uint64_t>(MIN_EXP_NORMAL + EXP_BIAS), 0ull);
+			return assemble(0ull, absM);
+		}
+	}
+
+	// build a ZBCL that exactly represents a finite cfloat value. Exact when the
+	// value's exponent fits the double range and fbits <= 52 (all configs tested).
+	template<typename Cf>
+	ZBCL<double> zbcl_of_cfloat(const Cf& c) { return from_native<double>(double(c)); }
+
+	// ---- cfloat correctly-rounded vs the independent bigint oracle ------------
+	template<typename Cf>
+	int VerifyCfloatCorrectlyRounded(bool reportTestCases, int nrTests, std::uint64_t seed, int scaleSpread) {
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		for (int t = 0; t < nrTests; ++t) {
+			elreal<double> v(0.0);
+			int nt = 1 + static_cast<int>(rng() % 5);
+			for (int j = 0; j < nt; ++j) {
+				double m = static_cast<double>(static_cast<std::int64_t>(rng() % 8000) - 4000) / static_cast<double>(1 + (rng() % 256));
+				int sc = static_cast<int>(rng() % static_cast<unsigned>(2 * scaleSpread)) - scaleSpread;
+				v = v + elreal<double>(std::ldexp(m, sc));
+				v.precision(12);
+			}
+			if (v.iszero()) continue;
+			dyadic D = zbcl_to_dyadic(v.stream());
+			for (int mi = 0; mi < 4; ++mi) {
+				Cf got = round_to<Cf>(v.stream(), kModes[mi]);
+				Cf exp = expected_cfloat<Cf>(D, kModes[mi]);
+				if (!(got == exp)) {
+					if (reportTestCases) std::cout << "    FAIL cfloat correctly-rounded " << kModeName[mi] << " got=" << to_binary(got) << " exp=" << to_binary(exp) << '\n';
+					++fails;
+				}
+			}
+		}
+		return fails;
+	}
+
+	// ---- cfloat lossless roundtrip: round_to<Cf>(exact-value-of-c) == c -------
+	// exhaustive over all encodings for narrow configs (strongest encoding check)
+	template<typename Cf>
+	int VerifyCfloatRoundtrip(bool reportTestCases) {
+		int fails = 0;
+		static_assert(Cf::nbits <= 16, "exhaustive roundtrip only for narrow cfloat configs");
+		const unsigned NR = (1u << Cf::nbits);
+		for (unsigned i = 0; i < NR; ++i) {
+			Cf c; c.setbits(i);
+			if (c.isnan() || c.isinf() || c.iszero()) continue;
+			ZBCL<double> z = zbcl_of_cfloat(c);
+			for (int mi = 0; mi < 4; ++mi) {
+				Cf got = round_to<Cf>(z, kModes[mi]);
+				if (!(got == c)) {
+					if (reportTestCases) std::cout << "    FAIL cfloat roundtrip " << kModeName[mi] << " c=" << to_binary(c) << " got=" << to_binary(got) << '\n';
+					++fails;
+				}
+			}
+		}
+		return fails;
+	}
+
+	// ---- cfloat idempotence: round_to<Cf>(exact-value-of round_to<Cf>(x)) ----
+	template<typename Cf>
+	int VerifyCfloatIdempotence(bool reportTestCases, int nrTests, std::uint64_t seed) {
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		for (int t = 0; t < nrTests; ++t) {
+			elreal<double> v = random_value(rng);
+			if (v.iszero()) continue;
+			for (int mi = 0; mi < 4; ++mi) {
+				Cf a = round_to<Cf>(v.stream(), kModes[mi]);
+				if (a.isnan() || a.isinf() || a.iszero()) continue;
+				Cf b = round_to<Cf>(zbcl_of_cfloat(a), kModes[mi]);
+				if (!(b == a)) {
+					if (reportTestCases) std::cout << "    FAIL cfloat idempotence " << kModeName[mi] << " a=" << to_binary(a) << " b=" << to_binary(b) << '\n';
+					++fails;
+				}
+			}
+		}
+		return fails;
+	}
+
+	// ---- cfloat overflow / underflow boundaries ------------------------------
+	template<typename Cf>
+	int VerifyCfloatBoundaries(bool reportTestCases, double big, double tiny) {
+		int fails = 0;
+		for (int s = 0; s < 2; ++s) {                            // overflow: +-big -> inf/maxpos
+			bool sign = (s != 0);
+			elreal<double> e(sign ? -big : big);
+			for (int mi = 0; mi < 4; ++mi) {
+				Cf got = round_to<Cf>(e.stream(), kModes[mi]);
+				bool toInf; switch (kModes[mi]) { case RoundingMode::RoundToZero: toInf = false; break; case RoundingMode::RoundTowardPositive: toInf = !sign; break; case RoundingMode::RoundTowardNegative: toInf = sign; break; default: toInf = true; }
+				if (Cf::isSaturating) toInf = false;
+				Cf exp; if (toInf) exp.setinf(sign); else { if (sign) exp.maxneg(); else exp.maxpos(); }
+				if (!(got == exp)) { if (reportTestCases) std::cout << "    FAIL cfloat overflow " << kModeName[mi] << " got=" << to_binary(got) << " exp=" << to_binary(exp) << '\n'; ++fails; }
+			}
+		}
+		for (int s = 0; s < 2; ++s) {                            // underflow: +-tiny -> zero/minpos
+			bool sign = (s != 0);
+			elreal<double> e(sign ? -tiny : tiny);
+			for (int mi = 0; mi < 4; ++mi) {
+				Cf got = round_to<Cf>(e.stream(), kModes[mi]);
+				Cf exp;
+				if      (kModes[mi] == RoundingMode::RoundTowardPositive && !sign) exp.minpos();
+				else if (kModes[mi] == RoundingMode::RoundTowardNegative &&  sign) exp.minneg();
+				else { exp.setzero(); exp.setsign(sign); }
+				if (!(got == exp)) { if (reportTestCases) std::cout << "    FAIL cfloat underflow " << kModeName[mi] << " got=" << to_binary(got) << " exp=" << to_binary(exp) << '\n'; ++fails; }
+			}
+		}
+		return fails;
+	}
+
 }  // anonymous namespace
 
 #define MANUAL_TESTING 0
@@ -233,7 +436,7 @@ namespace {
 int main()
 try {
 	using namespace sw::universal;
-	std::string test_suite = "elreal Phase 8 (#932) real floating-point conversion round_to<double|float|dd|qd>";
+	std::string test_suite = "elreal Phase 8 (#932, #1182) real floating-point conversion round_to<double|float|dd|qd|cfloat>";
 	int nrOfFailedTestCases = 0;
 	bool reportTestCases = true;
 	ReportTestSuiteHeader(test_suite, reportTestCases);
@@ -257,6 +460,36 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyMonotonicity(reportTestCases, base), "round_to monotonicity (double,float)/(dd,double)/(qd,dd)", "monotone");
 	nrOfFailedTestCases += ReportTestResult(VerifyLosslessRoundtrip(reportTestCases, base), "round_to<double> lossless roundtrip", "roundtrip");
 	nrOfFailedTestCases += ReportTestResult(VerifyDeterminism(reportTestCases, base), "round_to determinism", "determinism");
+
+	// ---- cfloat targets (#1182): a spread of <nbits,es> and flag combinations
+	using cf32   = cfloat<32, 8, std::uint32_t, true,  true,  false>;   // IEEE single-like
+	using cf64   = cfloat<64, 11, std::uint64_t, true, true,  false>;   // IEEE double-like
+	using cf16   = cfloat<16, 5, std::uint16_t, true,  true,  false>;   // IEEE half-like
+	using cf11   = cfloat<11, 5, std::uint16_t, true,  true,  false>;   // narrow exponent range
+	using cf16ns = cfloat<16, 5, std::uint16_t, false, true,  false>;   // no subnormals (flush-to-zero)
+	using cf16nn = cfloat<16, 5, std::uint16_t, false, false, false>;   // no subnormals, no max-exp values
+
+	// correctly-rounded vs the independent bigint oracle (spread of scales to reach
+	// the normal / subnormal / overflow / flush regions of each config)
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatCorrectlyRounded<cf32>(reportTestCases, base, 0xC0FFEEu, 120), "round_to<cfloat<32,8>> correctly-rounded", "cfloat<32,8>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatCorrectlyRounded<cf64>(reportTestCases, base, 0xBADF00Du, 120), "round_to<cfloat<64,11>> correctly-rounded", "cfloat<64,11>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatCorrectlyRounded<cf16>(reportTestCases, base, 0x5EEDu, 25), "round_to<cfloat<16,5>> correctly-rounded", "cfloat<16,5>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatCorrectlyRounded<cf11>(reportTestCases, base, 0xABCDu, 25), "round_to<cfloat<11,5>> correctly-rounded", "cfloat<11,5>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatCorrectlyRounded<cf16ns>(reportTestCases, base, 0xF00Du, 25), "round_to<cfloat<16,5,no-sub>> correctly-rounded", "cfloat<16,5,no-sub>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatCorrectlyRounded<cf16nn>(reportTestCases, base, 0x1234u, 25), "round_to<cfloat<16,5,no-sub,no-sup>> correctly-rounded", "cfloat<16,5,no-sub,no-sup>");
+
+	// exhaustive lossless roundtrip over every finite encoding (narrow configs)
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatRoundtrip<cf16>(reportTestCases), "round_to<cfloat<16,5>> exhaustive roundtrip", "cfloat<16,5>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatRoundtrip<cf11>(reportTestCases), "round_to<cfloat<11,5>> exhaustive roundtrip", "cfloat<11,5>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatRoundtrip<cf16ns>(reportTestCases), "round_to<cfloat<16,5,no-sub>> exhaustive roundtrip", "cfloat<16,5,no-sub>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatRoundtrip<cf16nn>(reportTestCases), "round_to<cfloat<16,5,no-sub,no-sup>> exhaustive roundtrip", "cfloat<16,5,no-sub,no-sup>");
+
+	// idempotence and overflow/underflow boundaries
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatIdempotence<cf32>(reportTestCases, base, 0x1DEu), "round_to<cfloat<32,8>> idempotence", "cfloat<32,8>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatIdempotence<cf16>(reportTestCases, base, 0x2DEu), "round_to<cfloat<16,5>> idempotence", "cfloat<16,5>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatBoundaries<cf16>(reportTestCases, 1e30, 1e-30), "round_to<cfloat<16,5>> overflow/underflow", "cfloat<16,5>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatBoundaries<cf32>(reportTestCases, 1e300, 1e-300), "round_to<cfloat<32,8>> overflow/underflow", "cfloat<32,8>");
+	nrOfFailedTestCases += ReportTestResult(VerifyCfloatBoundaries<cf11>(reportTestCases, 1e30, 1e-30), "round_to<cfloat<11,5>> overflow/underflow", "cfloat<11,5>");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/include/sw/universal/number/elreal/round.hpp
+++ b/include/sw/universal/number/elreal/round.hpp
@@ -26,11 +26,14 @@
 #include <cmath>
 #include <algorithm>
 #include <vector>
+#include <cstdint>
 #include <universal/behavior/rounding.hpp>          // RoundingMode
 #include <universal/number/elreal/block.hpp>
 #include <universal/number/elreal/zbcl.hpp>
 #include <universal/number/dd/dd.hpp>
 #include <universal/number/qd/qd.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/traits/cfloat_traits.hpp>
 
 namespace sw { namespace universal {
 
@@ -75,24 +78,16 @@ namespace elreal_round_detail {
 		lo = d - hi;                                            // exact
 	}
 
-	// Round a ZBCL to P significand bits under `mode`, returning the result as a
-	// normalised non-overlapping double expansion (descending; empty for zero).
-	template<typename FpType>
-	inline std::vector<double> round_to_bits(const ZBCL<FpType>& x, int P, RoundingMode mode) {
-		constexpr int kbits = block<FpType>::k;
-		const std::size_t need = static_cast<std::size_t>((P + 2 * kbits) / kbits) + 3;
-		std::vector<block<FpType>> blks = x.take(need + 1);
-		const bool moreBelow = (blks.size() > need);
-		if (blks.size() > need) blks.resize(need);
-
-		// widen blocks to doubles (exact for float/double/bfloat16 hosts)
-		std::vector<double> blk;
-		blk.reserve(blks.size());
-		for (const auto& b : blks) { double d = b.template value_as<double>(); if (d != 0.0) blk.push_back(d); }
+	// Round a widened non-overlapping expansion `blk` at absolute bit position
+	// `cut` under `mode`, returning the rounded kept expansion in the same units
+	// (descending, non-overlapping; empty for zero). `moreBelow` marks exact
+	// content strictly below the retained blocks, so an exactly-half round-off is
+	// really more-than-half. Splitting at `cut`, renormalising the round-off, and
+	// classifying against the half-ulp 2^(cut-1) are all shift-invariant, so the
+	// caller is free to pass an expansion scaled by any common power of two (used
+	// by the cfloat path to keep working doubles near 1.0 and dodge overflow).
+	inline std::vector<double> round_expansion_at(const std::vector<double>& blk, int cut, RoundingMode mode, bool moreBelow) {
 		if (blk.empty()) return {};
-
-		const int  e0   = std::ilogb(blk[0]);
-		const int  cut  = e0 - P + 1;                           // lowest kept bit
 		const bool Vpos = (blk[0] > 0.0);
 
 		std::vector<double> kept, ro;
@@ -139,6 +134,185 @@ namespace elreal_round_detail {
 		return renorm(kept);
 	}
 
+	// Round a ZBCL to P significand bits under `mode`, returning the result as a
+	// normalised non-overlapping double expansion (descending; empty for zero).
+	template<typename FpType>
+	inline std::vector<double> round_to_bits(const ZBCL<FpType>& x, int P, RoundingMode mode) {
+		constexpr int kbits = block<FpType>::k;
+		const std::size_t need = static_cast<std::size_t>((P + 2 * kbits) / kbits) + 3;
+		std::vector<block<FpType>> blks = x.take(need + 1);
+		const bool moreBelow = (blks.size() > need);
+		if (blks.size() > need) blks.resize(need);
+
+		// widen blocks to doubles (exact for float/double/bfloat16 hosts)
+		std::vector<double> blk;
+		blk.reserve(blks.size());
+		for (const auto& b : blks) { double d = b.template value_as<double>(); if (d != 0.0) blk.push_back(d); }
+		if (blk.empty()) return {};
+
+		const int e0  = std::ilogb(blk[0]);
+		const int cut = e0 - P + 1;                             // lowest kept bit
+		return round_expansion_at(blk, cut, mode, moreBelow);
+	}
+
+	// ---- cfloat conversion -----------------------------------------------------
+	//
+	// round_to_cfloat<Cf>(x, mode) rounds an exact-real elreal stream to an
+	// arbitrary cfloat<nbits,es,...> target. Unlike the native-double targets, a
+	// cfloat has a finite es-bit exponent range, so the result can overflow to
+	// +/-inf (or maxpos/maxneg for saturating configs), underflow to a subnormal
+	// or to zero, and the subnormal path rounds at a reduced, fixed precision. The
+	// significand rounding reuses round_expansion_at (all four modes); the final
+	// bit construction mirrors cfloat's own convert() so the two agree on the
+	// exponent field, the carry-into-hidden-bit binade bump, and the projection of
+	// an all-ones exponent field onto inf.
+
+	// overflow: magnitude is above the largest finite cfloat value.
+	template<typename Cf>
+	inline Cf cfloat_overflow(bool sign, RoundingMode mode) {
+		Cf r;
+		bool toInf;
+		switch (mode) {
+		case RoundingMode::RoundToZero:         toInf = false;  break;
+		case RoundingMode::RoundTowardPositive: toInf = !sign;  break;   // +inf only when positive
+		case RoundingMode::RoundTowardNegative: toInf =  sign;  break;   // -inf only when negative
+		case RoundingMode::RoundToNearest:
+		default:                                toInf = true;   break;
+		}
+		if constexpr (Cf::isSaturating) toInf = false;                    // saturating never yields inf
+		if (toInf) r.setinf(sign);
+		else { if (sign) r.maxneg(); else r.maxpos(); }
+		return r;
+	}
+
+	// underflow: magnitude is strictly below the half-ulp of the smallest
+	// representable value, so it rounds to zero except when a directed mode pushes
+	// it out to the smallest representable value on its own side.
+	template<typename Cf>
+	inline Cf cfloat_underflow(bool sign, RoundingMode mode) {
+		Cf r;
+		if (mode == RoundingMode::RoundTowardPositive && !sign) { r.minpos(); return r; }
+		if (mode == RoundingMode::RoundTowardNegative &&  sign) { r.minneg(); return r; }
+		r.setzero(); r.setsign(sign);
+		return r;
+	}
+
+	// assemble a finite cfloat from a sign, a biased exponent field, and a fraction
+	// field, then project an all-ones exponent encoding onto inf/maxpos exactly as
+	// cfloat's convert() does. Requires nbits <= 64 (the raw path).
+	template<typename Cf>
+	inline Cf cfloat_assemble(bool sign, std::uint64_t biasedExponent, std::uint64_t fracbits) {
+		std::uint64_t raw = (sign ? 1ull : 0ull);
+		raw <<= Cf::es;
+		raw |= biasedExponent;
+		raw <<= Cf::fbits;
+		raw |= fracbits;
+		Cf r; r.setbits(raw);
+		if constexpr (Cf::isSaturating) {
+			if (r.isnan()) { if (sign) r.maxneg(); else r.maxpos(); }
+		}
+		else {
+			if (r.isnan()) r.setinf(sign);
+		}
+		return r;
+	}
+
+	template<typename Cf, typename FpType>
+	inline Cf round_to_cfloat(const ZBCL<FpType>& x, RoundingMode mode) {
+		static_assert(Cf::nbits <= 64, "round_to<cfloat>: only nbits <= 64 targets are supported");
+		static_assert(Cf::fbits <= 52, "round_to<cfloat>: fraction bits (nbits-es-1) must fit a double significand (<= 52)");
+		using exp_t = typename block<FpType>::exp_t;
+		constexpr int  fbits             = static_cast<int>(Cf::fbits);
+		constexpr int  MIN_EXP_NORMAL    = Cf::MIN_EXP_NORMAL;
+		constexpr int  MIN_EXP_SUBNORMAL = Cf::MIN_EXP_SUBNORMAL;
+		constexpr int  MAX_EXP           = Cf::MAX_EXP;
+		constexpr int  EXP_BIAS          = Cf::EXP_BIAS;
+		constexpr bool hasSubnormals     = Cf::hasSubnormals;
+		constexpr int  kbits             = block<FpType>::k;
+
+		// take enough blocks to resolve fbits+guard significand bits plus a borrow bit
+		const std::size_t need = static_cast<std::size_t>((fbits + 3 * kbits) / kbits) + 4;
+		std::vector<block<FpType>> blks = x.take(need + 1);
+		const bool moreBelow = (blks.size() > need);
+		if (blks.size() > need) blks.resize(need);
+
+		// locate the leading (dominant) block: it fixes the sign and the exponent
+		// estimate. Do it with the wide combined exponent so extreme scales cannot
+		// overflow int.
+		const block<FpType>* lead = nullptr;
+		for (const auto& b : blks) { if (!b.is_zero_block()) { lead = &b; break; } }
+		if (lead == nullptr) { Cf z; z.setzero(); return z; }        // exact zero -> +0
+		const bool  sign = (lead->sign() < 0);
+		const exp_t E0   = lead->exponent();
+
+		// range guards using the wide exponent (a signed tail can only shift the
+		// true binade by one, so a two-binade margin is always safe).
+		if (E0 > exp_t(MAX_EXP + 1)) return cfloat_overflow<Cf>(sign, mode);
+		const int lowGuard = hasSubnormals ? (MIN_EXP_SUBNORMAL - 2) : (MIN_EXP_NORMAL - 2);
+		if (E0 < exp_t(lowGuard)) return cfloat_underflow<Cf>(sign, mode);
+
+		// inside the comfortable window E0 fits int; widen blocks RELATIVE to it so
+		// the working doubles stay near 1.0 (exact: block value = v * 2^exp).
+		const int e0est = static_cast<int>(E0);
+		std::vector<double> rel;
+		rel.reserve(blks.size());
+		for (const auto& b : blks) {
+			if (b.is_zero_block()) continue;
+			double m = static_cast<double>(b.v);                 // the block mantissa piece
+			int    e = static_cast<int>(b.exp) - e0est;          // block's own exponent field, relative
+			double d = std::ldexp(m, e);
+			if (d != 0.0) rel.push_back(d);
+		}
+		if (rel.empty()) { Cf z; z.setzero(); return z; }
+		std::vector<double> relN = renorm(rel);                  // descending, exact
+
+		// true leading exponent: a leading exact power-of-two (|relN[0]| == 1.0)
+		// with an opposite-sign tail means the magnitude dipped below 2^e0est, so
+		// the true binade is one lower (the signed-non-overlapping-tail case).
+		int e0 = e0est;
+		if (std::fabs(relN[0]) == 1.0 && relN.size() > 1 && ((relN[1] < 0.0) == (relN[0] > 0.0))) --e0;
+
+		// classify against the cfloat's range and pick the absolute cut (lowest
+		// representable bit) for this value.
+		int cut;
+		bool normalRegion;
+		if (e0 >= MIN_EXP_NORMAL) { cut = e0 - fbits;          normalRegion = true;  }
+		else if (hasSubnormals)   { cut = MIN_EXP_SUBNORMAL;   normalRegion = false; }
+		else                      { cut = MIN_EXP_NORMAL;      normalRegion = false; } // flush: ULP = minpos
+
+		const int relCut = cut - e0est;                          // cut in relative units
+		std::vector<double> keptRel = round_expansion_at(relN, relCut, mode, moreBelow);
+
+		// mantissa integer M = |rounded value| / 2^cut (each kept component is a
+		// multiple of 2^relCut, so the descaled contributions are exact integers).
+		long long M = 0;
+		for (double d : keptRel) M += std::llround(std::ldexp(d, -relCut));
+		std::uint64_t absM = static_cast<std::uint64_t>(M < 0 ? -M : M);
+
+		if (normalRegion) {
+			int expv = e0;
+			if (absM == (1ull << (fbits + 1))) { absM >>= 1; ++expv; }   // 1.11..1 -> 10.00.. carry
+			if (expv > MAX_EXP) return cfloat_overflow<Cf>(sign, mode);
+			std::uint64_t biasedExponent = static_cast<std::uint64_t>(expv + EXP_BIAS);
+			std::uint64_t fracbits = absM & Cf::ALL_ONES_FR;             // drop the hidden bit
+			return cfloat_assemble<Cf>(sign, biasedExponent, fracbits);
+		}
+		else {
+			if (absM == 0) { Cf z; z.setzero(); z.setsign(sign); return z; }
+			if constexpr (!hasSubnormals) {
+				// flush region (no subnormals): the ULP is minpos_normal itself, so
+				// absM is in {0,1}; absM == 1 is the smallest normal, not a subnormal
+				// encoding (an exp field of 0 with a nonzero fraction is invalid here).
+				return cfloat_assemble<Cf>(sign, static_cast<std::uint64_t>(MIN_EXP_NORMAL + EXP_BIAS), 0ull);
+			}
+			if (absM >= (1ull << fbits)) {                               // promoted to smallest normal
+				return cfloat_assemble<Cf>(sign, static_cast<std::uint64_t>(MIN_EXP_NORMAL + EXP_BIAS), 0ull);
+			}
+			// genuine subnormal (hasSubnormals): exponent field 0, fraction = M
+			return cfloat_assemble<Cf>(sign, 0ull, absM);
+		}
+	}
+
 }  // namespace elreal_round_detail
 
 // round_to<Target>(x, mode): correctly-rounded conversion of an exact-real elreal
@@ -171,9 +345,12 @@ inline Target round_to(const ZBCL<FpType>& x, RoundingMode mode = RoundingMode::
 		result.renorm();
 		return result;
 	}
+	else if constexpr (is_cfloat<Target>) {
+		return round_to_cfloat<Target>(x, mode);
+	}
 	else {
 		static_assert(std::is_same_v<Target, double>,
-		              "round_to<Target>: unsupported target (use double, float, dd, or qd; cfloat is tracked separately)");
+		              "round_to<Target>: unsupported target (use double, float, dd, qd, or cfloat<nbits,es,...>)");
 		return Target{};
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `round_to<cfloat<nbits,es,bt,hasSubnormals,hasMaxExpValues,isSaturating>>(ZBCL<FpType>, RoundingMode)` -- the fifth Phase 8 conversion target, following the four native-double-expansion targets (`double`, `float`, `dd`, `qd`) from #932 / PR #1181.
- The genuinely new part vs the native targets is cfloat's finite `es`-bit exponent range: the result can overflow to `+/-inf` (or `maxpos`/`maxneg` for saturating configs), underflow to a subnormal or to zero, and the subnormal path rounds at a reduced, fixed precision.

## Approach
- Factor the mode-aware guard/round/sticky core out of `round_to_bits` into `round_expansion_at(blk, cut, mode, moreBelow)`, shared by both the native and cfloat paths (identical native behavior preserved).
- **Relative widening**: cfloat blocks are widened relative to the leading exponent so working doubles stay near 1.0, dodging `double` overflow/underflow for wide-exponent configs (e.g. `cfloat<64,11>`, whose range exceeds `double`'s). Strictly safer than the absolute `value_as<double>` used by the native path.
- **Wide-exponent range guards** decide extreme overflow/underflow before any `int` cast; the signed-non-overlapping-tail borrow is detected to recover the true binade.
- **Bit construction mirrors cfloat's own `convert()`**: biased exponent field, carry-into-hidden-bit binade bump, subnormal (exp field 0) vs smallest-normal promotion, no-subnormals flush-to-`minpos`, and the all-ones-exponent -> `inf` / saturating `maxpos`/`maxneg` projection. cfloat's RNE-only `convert()`/`roundingDecision` are not reusable for the four directed modes, so the significand rounding is done through the shared mode-aware primitive.

## Changes
- `include/sw/universal/number/elreal/round.hpp` -- extract `round_expansion_at`; add `round_to_cfloat<Cf>` + `cfloat_overflow`/`cfloat_underflow`/`cfloat_assemble` helpers; dispatch via `is_cfloat` in `round_to`. Umbrella now transitively includes `cfloat.hpp` (header-only).
- `elastic/elreal/rounding/round_to.cpp` -- independent einteger-dyadic `expected_cfloat<Cf>()` oracle (rounds at the correct absolute cut, classifies range) + config-swept correctly-rounded, exhaustive lossless roundtrip, idempotence, and overflow/underflow tests.

## Validation
Independent bigint-dyadic oracle across `cfloat<32,8>`, `cfloat<64,11>`, `cfloat<16,5>`, narrow `cfloat<11,5>`, and no-subnormals / no-max-exp configs, all four rounding modes, plus **exhaustive lossless roundtrip over every finite encoding** of the narrow configs, idempotence, and overflow/underflow boundaries.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| el_round_round_to | OK | PASS (20/20) | OK | PASS (20/20) |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready <NNN>`

Resolves #1182

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting extended real values to configurable cfloat formats.
  * Added accurate rounding across supported rounding modes, including normal, subnormal, overflow, underflow, and flush-to-zero cases.
  * Added saturation handling for configurations that support it.

* **Bug Fixes**
  * Improved consistency and correctness when rounding extended real values to floating-point targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->