### PR TITLE
chore(blas): Phase 4 start -- deprecate the linear-algebra layer; drop CG study from build

### DIFF
--- a/docs/migration/linear-algebra-extraction.md
+++ b/docs/migration/linear-algebra-extraction.md
@@ -1,0 +1,34 @@
+# Linear-algebra extraction (Universal -> MTL5 + mp-*)
+
+Universal's BLAS (`include/sw/blas/`) and container types
+(`include/sw/numeric/containers/`) were built to study posit/quire dynamics.
+That functionality is now superseded by **MTL5**
+(https://github.com/stillwater-sc/mtl5), a standalone C++20 linear-algebra
+library, and the mixed-precision *experiments* have moved to the **mp-*
+composition repos**. Tracking epic: universal#1204.
+
+## Where things moved
+
+| Was in Universal | Now |
+|------------------|-----|
+| `blas/` L1/L2/L3, solvers, generators, vmath, utes | MTL5 (`MTL5::mtl5`) -- already present; the few missing utilities (`linspace`, `magic`) were added |
+| `numeric/containers/` (matrix/vector/tensor) | MTL5 containers (`mtl::mat`, `mtl::vec`) |
+| dense LU iterative refinement (`ext/solvers/luir`, `squeeze`, `nbe`) | MTL5 `mtl::lu_iterative_refine` + `mtl::normwise_backward_error`; the posit/precision experiments in **mp-ir** |
+| fdp / quire reproducibility studies, mpdot/mpfma | **mp-blas** (via the quire accumulator bridge) |
+| stationary + CG iterative-method studies | **mp-iterative** |
+| numerics studies (roots/integration/interpolation/optimization/approximation) | **mp-numerics** |
+
+## Architectural rule
+
+MTL5 never depends on Universal -- it is the general linear-algebra layer,
+generic over the scalar type. All MTL5 + Universal coupling (the quire
+super-accumulator plugged into MTL5's `accumulator_traits`) lives in the `mp-*`
+repos, via `include/mtl/math/quire_accumulator.hpp`.
+
+## Deprecation
+
+`<blas/...>` and `<numeric/containers/...>` are **deprecated** and emit a
+`#pragma message` on include (silence with `-DUNIVERSAL_SUPPRESS_DEPRECATION`).
+They will be removed from Universal after this deprecation release, leaving
+Universal a pure number-systems library. New linear-algebra work should target
+MTL5 + the mp-* repos.

--- a/include/sw/blas/blas.hpp
+++ b/include/sw/blas/blas.hpp
@@ -10,6 +10,18 @@
 #ifndef _STILLWATER_BLAS_LIBRARY
 #define _STILLWATER_BLAS_LIBRARY
 
+// -------------------------------------------------------------------------
+// DEPRECATED (universal#1204): Universal's <blas/...> linear-algebra library is
+// being extracted. Use MTL5 for linear algebra
+// (https://github.com/stillwater-sc/mtl5) and the mp-* composition repos for the
+// mixed-precision experiments (mp-blas, mp-iterative, mp-ir, mp-numerics).
+// These headers will be removed from Universal after this deprecation release.
+// Define UNIVERSAL_SUPPRESS_DEPRECATION to silence this notice.
+// -------------------------------------------------------------------------
+#ifndef UNIVERSAL_SUPPRESS_DEPRECATION
+#pragma message("DEPRECATED: Universal <blas/...> is being extracted to MTL5 + mp-* (see universal#1204); define UNIVERSAL_SUPPRESS_DEPRECATION to silence")
+#endif
+
 #include <cstdint>
 
 // Numeric containers

--- a/include/sw/blas/blas.hpp
+++ b/include/sw/blas/blas.hpp
@@ -19,7 +19,7 @@
 // Define UNIVERSAL_SUPPRESS_DEPRECATION to silence this notice.
 // -------------------------------------------------------------------------
 #ifndef UNIVERSAL_SUPPRESS_DEPRECATION
-#pragma message("DEPRECATED: Universal <blas/...> is being extracted to MTL5 + mp-* (see universal#1204); define UNIVERSAL_SUPPRESS_DEPRECATION to silence")
+#pragma message("DEPRECATED: <blas/...> extracted to MTL5 + mp-* (see universal#1204)")
 #endif
 
 #include <cstdint>

--- a/include/sw/numeric/containers.hpp
+++ b/include/sw/numeric/containers.hpp
@@ -14,7 +14,7 @@
 // Define UNIVERSAL_SUPPRESS_DEPRECATION to silence this notice.
 // -------------------------------------------------------------------------
 #ifndef UNIVERSAL_SUPPRESS_DEPRECATION
-#pragma message("DEPRECATED: Universal <numeric/containers/...> is being extracted to MTL5 (see universal#1204); define UNIVERSAL_SUPPRESS_DEPRECATION to silence")
+#pragma message("DEPRECATED: <numeric/containers/...> extracted to MTL5 (see universal#1204)")
 #endif
 
 // aggregation types for serialization

--- a/include/sw/numeric/containers.hpp
+++ b/include/sw/numeric/containers.hpp
@@ -6,6 +6,17 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+// -------------------------------------------------------------------------
+// DEPRECATED (universal#1204): the <numeric/containers/...> matrix/vector/tensor
+// types are being extracted alongside the BLAS. Use MTL5's containers
+// (https://github.com/stillwater-sc/mtl5). These headers will be removed from
+// Universal after this deprecation release.
+// Define UNIVERSAL_SUPPRESS_DEPRECATION to silence this notice.
+// -------------------------------------------------------------------------
+#ifndef UNIVERSAL_SUPPRESS_DEPRECATION
+#pragma message("DEPRECATED: Universal <numeric/containers/...> is being extracted to MTL5 (see universal#1204); define UNIVERSAL_SUPPRESS_DEPRECATION to silence")
+#endif
+
 // aggregation types for serialization
 constexpr uint32_t UNIVERSAL_AGGREGATE_SCALAR = 0x1001;
 constexpr uint32_t UNIVERSAL_AGGREGATE_VECTOR = 0x2002;

--- a/mixedprecision/tensor/CMakeLists.txt
+++ b/mixedprecision/tensor/CMakeLists.txt
@@ -1,5 +1,12 @@
-file (GLOB KRYLOV_SRCS "./cg/*.cpp")
-file (GLOB DNN_SRCS "./dnn/*.cpp")
+# CG mixed-precision study (./cg/*.cpp): REMOVED FROM THE BUILD (universal#1204,
+# Phase 4). The pure variants (mv-dot x cmp-dot, mv-fdp x cmp-fdp) are migrated to
+# mp-iterative (applications/krylov/cg_precision). The mixed variants
+# (mv-dot x cmp-fdp, mv-fdp x cmp-dot) will be redesigned in mp-iterative with a
+# separate matvec/dot accumulator. The ./cg/ sources are intentionally LEFT IN
+# PLACE for reference during that redesign, but are no longer compiled here.
+#
+# file (GLOB KRYLOV_SRCS "./cg/*.cpp")
+# compile_all("true" "mp" "Mixed-Precision/Tensor Algebra/Krylov/Conjugate Gradient" "${KRYLOV_SRCS}")
 
-compile_all("true" "mp" "Mixed-Precision/Tensor Algebra/Krylov/Conjugate Gradient" "${KRYLOV_SRCS}")
+file (GLOB DNN_SRCS "./dnn/*.cpp")
 compile_all("true" "mp" "Mixed-Precision/Tensor Algebra/DNN" "${DNN_SRCS}")


### PR DESCRIPTION
## Summary
Begins **Phase 4** (#1209) of the linear-algebra extraction (epic #1204): the **deprecation-window** step, ahead of removing Universal's BLAS + containers next release. Every experiment has now been re-homed to MTL5 + the mp-* repos (Phase 3, #1208), so Universal's linear-algebra layer can be wound down.

## Changes
- **`include/sw/blas/blas.hpp`**, **`include/sw/numeric/containers.hpp`** -- emit a `#pragma message` on include, pointing users to MTL5 + the mp-* repos and noting these headers will be removed. Informational only (does **not** fail `-Werror` on gcc/clang -- verified); silence with `-DUNIVERSAL_SUPPRESS_DEPRECATION`.
- **`mixedprecision/tensor/CMakeLists.txt`** -- drop the CG mixed-precision study (`./cg/*.cpp`) from the build. Its pure variants are migrated to mp-iterative (`applications/krylov/cg_precision`); the mixed variants will be **redesigned in mp-iterative** with a separate matvec/dot accumulator. The `./cg/` sources are **intentionally left in place** for reference during that redesign -- only the `compile_all()` is removed.
- **`docs/migration/linear-algebra-extraction.md`** -- where each piece moved (MTL5 / mp-blas / mp-iterative / mp-ir / mp-numerics) + the deprecation notice.

## Not in this PR (the removal step, after a deprecation release)
Full deletion of `blas/`, `numeric/containers/`, `linalg/`, `mixedprecision/`, `benchmark/*/blas`, the BLAS-consuming `applications/*`, and the `UNIVERSAL_BUILD_LINEAR_ALGEBRA_*` / `MIXEDPRECISION_SDK` CMake options.

## Validation
- `#include <blas/blas.hpp>` compiles under gcc **and** clang with `-Werror` (the pragma is a note, exit 0); `-DUNIVERSAL_SUPPRESS_DEPRECATION` silences it.
- ASCII guard passes.

Relates to #1209. Part of epic #1204.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for BLAS and numeric container functionality moving to MTL5 and related repositories, including replacement locations and deprecation timeline.

* **Deprecations**
  * Added compile-time deprecation warnings for legacy BLAS and numeric container headers.
  * Added a build flag to suppress these deprecation notices.

* **Build Changes**
  * Removed mixed-precision Krylov conjugate-gradient sources from the active build configuration (DNN build remains unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->