### PR TITLE
ci: add Dependabot config for docs-site npm + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot configuration for stillwater-sc/universal
+#
+# Scope: the repo's only package manifest is the documentation site
+# (docs-site/, an npm/Astro project). The C++ library itself is header-only
+# with no dependency manifest, so there is nothing for Dependabot to track there.
+#
+# Governance: Dependabot only OPENS pull requests. It cannot merge them --
+# main requires 1 approving review plus the required status checks
+# (check-ascii, build, lint-pr-title). See docs/maintenance and the branch
+# protection on main. Reviews route to the maintainer via `reviewers`.
+#
+# Security updates (for known vulnerabilities) are enabled separately in repo
+# Settings and are independent of this file.
+version: 2
+
+updates:
+  # ---- documentation site (npm / Astro) ----
+  - package-ecosystem: "npm"
+    directory: "/docs-site"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    # Keep the queue small so PRs are reviewed, not accumulated.
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docs-site"
+    reviewers:
+      - "Ravenwater"
+    # Title becomes "build(deps): ..." / "build(deps-dev): ..." to satisfy the
+    # conventional-commit PR-title lint (type=build, scope=deps).
+    commit-message:
+      prefix: "build"
+      prefix-development: "build"
+      include: "scope"
+    # Bundle low-risk minor/patch bumps into one PR to cut review churn;
+    # majors still arrive as individual, separately-reviewable PRs.
+    groups:
+      docs-site-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- GitHub Actions used by the CI workflows ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "Ravenwater"
+    # "build(deps): ..." -- same type/scope as the npm updates, which the
+    # conventional-commit PR-title lint already accepts.
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a committed `.github/dependabot.yml`. Previously Dependabot ran **security-updates-only** (repo Settings toggle, no config file); this brings it under version control with low-noise, maintainer-reviewed settings.

Follows the branch-protection hardening after #1217 (a Dependabot bump that reached main unreviewed via admin override). Dependabot still **only opens PRs** -- it cannot merge, because main now requires 1 review + the required checks (`check-ascii`, `build`, `lint-pr-title`).

## Config
- **npm `/docs-site`** (Astro docs site -- the repo's only manifest): weekly (Mon 06:00 UTC), minor/patch **grouped into a single PR**, majors arrive separately, `open-pull-requests-limit: 5`, labeled `dependencies`/`docs-site`, review routed to the maintainer.
- **github-actions `/`**: monthly, grouped, limit 5, labeled `github-actions`. (Standard CI hygiene since the repo leans heavily on Actions -- drop this block if you'd rather not track action versions.)
- Commit prefix `build(deps): ...` so the conventional-commit PR-title lint passes (the pattern `build(deps):` is already accepted by `lint-pr-title`).

Note: enabling version updates means slightly more PRs than security-only, but grouping + weekly/monthly cadence + the PR limit keep it tame, and every PR is now gated by review + CI.

## Test plan
- Config-only; YAML validated locally, ASCII-clean.
- The required checks (`check-ascii`, `build`, `lint-pr-title`) run on this PR.

Ready to merge once the required checks are green.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly updates for documentation-site dependencies.
  * Added automated monthly updates for GitHub Actions dependencies.
  * Grouped minor and patch updates to reduce update noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->