### PR TITLE
ci: drop github-actions from Dependabot to stop CI storm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,25 +44,11 @@ updates:
           - "minor"
           - "patch"
 
-  # ---- GitHub Actions used by the CI workflows ----
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
-    reviewers:
-      - "Ravenwater"
-    # "build(deps): ..." -- same type/scope as the npm updates, which the
-    # conventional-commit PR-title lint already accepts.
-    commit-message:
-      prefix: "build"
-      include: "scope"
-    groups:
-      github-actions:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
+  # NOTE: a "github-actions" ecosystem is deliberately NOT configured here.
+  # Any action-version bump edits .github/workflows/*, and the heavy CI
+  # (cmake.yml matrix, coverage.yml, sanitizers.yml, clang-tidy.yml) is NOT
+  # path-filtered for workflow-only changes -- so each such PR would trigger the
+  # full 11-platform + sanitizer + coverage suite, a CI storm (observed
+  # 2026-07-25 when it was briefly enabled). Re-introduce github-actions tracking
+  # only after the heavy workflows are taught to skip workflow-only diffs (e.g. a
+  # dorny/paths-filter gate) or the updates are grouped into a single monthly PR.


### PR DESCRIPTION
## Problem

Merging the Dependabot config (#1218) made Dependabot open **6 PRs at once**. The **github-actions** ones (#1220-#1224) each edit `.github/workflows/*`, which the heavy CI (`cmake.yml` 11-platform matrix, `coverage.yml`, `sanitizers.yml`, `clang-tidy.yml`) does **not** path-ignore -- so each triggered the full expensive suite simultaneously. That's the CI storm.

## Fix
- Remove the `github-actions` ecosystem from `.github/dependabot.yml`.
- Keep npm `/docs-site` (the matrix path-ignores `docs-site/**`, so those PRs only run the cheap `check-ascii`/`build`/`lint-pr-title` checks).
- Document the prerequisite for re-adding action tracking safely (path-filter the heavy workflows for workflow-only diffs, or a single grouped monthly PR).

Already closed the 5 runaway github-actions PRs (#1220-#1224) and cancelled their in-flight runs. #1219 (docs-site npm group) stays open -- it's cheap.

Config-only; YAML validated, ASCII-clean.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency-management configuration for workflow-related components.
  * Documented the current configuration and guidance for future re-enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->