### PR TITLE
ci: scope Pages concurrency per-ref to stop cross-PR cancellation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,14 @@ permissions:
   pages: write
   id-token: write
 
+# Scope concurrency per ref, not globally. A single global "pages" group made
+# EVERY Documentation run (any branch/PR) cancel every other in-progress one --
+# so a burst of PRs turned into cross-PR "failure" red X's (observed 2026-07-25).
+# Per-ref: a new commit on a PR cancels that PR's stale build (cancel-in-progress
+# on pull_request), while main deploys queue and are never interrupted mid-deploy.
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: pages-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # Force Node.js 24 for all JavaScript actions (eliminates Node.js 20 deprecation warnings


### PR DESCRIPTION
## Problem

`docs.yml` used a **global** concurrency group with cancel-in-progress:
```yaml
concurrency:
  group: pages
  cancel-in-progress: true
```
Because the group is the same string for every branch/PR, any newly-started Documentation run **cancels every other in-progress one** -- on unrelated PRs. During the 2026-07-25 Dependabot github-actions storm, the flood of simultaneous Documentation runs serially cancelled each other, and cancelled runs show as red **failure**. That's why #1219 (a clean starlight/sharp patch bump, build verified locally: 83 pages, exit 0) showed "broken Documentation/CMake" -- it was collateral cancellation, not a real failure.

## Fix
```yaml
concurrency:
  group: pages-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
- **Per-ref group**: PR builds no longer cancel each other or main.
- **cancel-in-progress only on PRs**: a new commit on a PR still cancels that PR's stale build (saves CI); **main deploys queue and are never interrupted mid-deploy** (GitHub Pages best practice).

## Test plan
- Workflow-only change; YAML validated, ASCII-clean.
- Required checks (`check-ascii`, `build`, `lint-pr-title`) run on this PR; the `build` (Documentation) run itself exercises the new per-ref group.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub Pages deployment handling by isolating runs per branch or pull request.
  * Prevented active production deployments from being canceled, while retaining cancellation for pull request builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->