### PR TITLE
fix(quire): NaR-state propagation + gated overflow (no-throw config)

### DIFF
--- a/include/sw/universal/number/cfloat/cfloat.hpp
+++ b/include/sw/universal/number/cfloat/cfloat.hpp
@@ -37,10 +37,15 @@
 #define CFLOAT_EXCEPT noexcept
 #else
 #if CFLOAT_THROW_ARITHMETIC_EXCEPTION
-#define CFLOAT_EXCEPT 
+#define CFLOAT_EXCEPT
 #else
 #define CFLOAT_EXCEPT noexcept
 #endif
+#endif
+// the fused dot product accumulator (quire, via fdp.hpp) must honor the same
+// exception policy as the cfloat it accumulates for (#1226)
+#if !defined(QUIRE_THROW_ARITHMETIC_EXCEPTION)
+#define QUIRE_THROW_ARITHMETIC_EXCEPTION CFLOAT_THROW_ARITHMETIC_EXCEPTION
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/cfloat/fdp.hpp
+++ b/include/sw/universal/number/cfloat/fdp.hpp
@@ -72,6 +72,7 @@ quire_resolve(const quire<cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, 
 	constexpr int bt_radix = BT::radix;  // = 2*fbits
 
 	Scalar result;
+	if (q.isnan()) { result.setnan(); return result; }  // NaR propagated through the accumulator (#1226)
 	if (q.iszero()) {
 		result.setzero();
 		return result;

--- a/include/sw/universal/number/dbns/dbns.hpp
+++ b/include/sw/universal/number/dbns/dbns.hpp
@@ -34,6 +34,11 @@
 // default is to use std::cerr for signalling an error
 #define DBNS_THROW_ARITHMETIC_EXCEPTION 0
 #endif
+// the fused dot product accumulator (quire, via fdp.hpp) must honor the same
+// exception policy as the dbns it accumulates for (#1226)
+#if !defined(QUIRE_THROW_ARITHMETIC_EXCEPTION)
+#define QUIRE_THROW_ARITHMETIC_EXCEPTION DBNS_THROW_ARITHMETIC_EXCEPTION
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions

--- a/include/sw/universal/number/dbns/fdp.hpp
+++ b/include/sw/universal/number/dbns/fdp.hpp
@@ -97,6 +97,11 @@ dbns<nbits, fbbits, bt, xtra...>
 quire_resolve(const quire<dbns<nbits, fbbits, bt, xtra...>, capacity, LimbType>& q) {
 	using Scalar = dbns<nbits, fbbits, bt, xtra...>;
 
+	if (q.isnan()) {  // NaR propagated through the accumulator (#1226)
+		Scalar result;
+		result.setnan();
+		return result;
+	}
 	if (q.iszero()) {
 		Scalar result;
 		result.setzero();

--- a/include/sw/universal/number/fixpnt/fixpnt.hpp
+++ b/include/sw/universal/number/fixpnt/fixpnt.hpp
@@ -42,6 +42,11 @@
 // default is to use std::cerr for signalling an error
 #define FIXPNT_THROW_ARITHMETIC_EXCEPTION 0
 #endif
+// the fused dot product accumulator (quire, via fdp.hpp) must honor the same
+// exception policy as the fixpnt it accumulates for (#1226)
+#if !defined(QUIRE_THROW_ARITHMETIC_EXCEPTION)
+#define QUIRE_THROW_ARITHMETIC_EXCEPTION FIXPNT_THROW_ARITHMETIC_EXCEPTION
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions

--- a/include/sw/universal/number/lns/fdp.hpp
+++ b/include/sw/universal/number/lns/fdp.hpp
@@ -137,6 +137,11 @@ lns<nbits, rbits, bt, xtra...>
 quire_resolve(const quire<lns<nbits, rbits, bt, xtra...>, capacity, LimbType>& q) {
 	using Scalar = lns<nbits, rbits, bt, xtra...>;
 
+	if (q.isnan()) {  // NaR propagated through the accumulator (#1226)
+		Scalar result;
+		result.setnan();
+		return result;
+	}
 	if (q.iszero()) {
 		Scalar result;
 		result.setzero();

--- a/include/sw/universal/number/lns/lns.hpp
+++ b/include/sw/universal/number/lns/lns.hpp
@@ -36,6 +36,11 @@
 #if !defined(BITBLOCK_THROW_ARITHMETIC_EXCEPTION)
 #define BITBLOCK_THROW_ARITHMETIC_EXCEPTION LNS_THROW_ARITHMETIC_EXCEPTION
 #endif
+// the fused dot product accumulator (quire, via fdp.hpp) must honor the same
+// exception policy as the lns it accumulates for (#1226)
+#if !defined(QUIRE_THROW_ARITHMETIC_EXCEPTION)
+#define QUIRE_THROW_ARITHMETIC_EXCEPTION LNS_THROW_ARITHMETIC_EXCEPTION
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions

--- a/include/sw/universal/number/posit/fdp.hpp
+++ b/include/sw/universal/number/posit/fdp.hpp
@@ -59,6 +59,7 @@ quire_resolve(const quire<posit<nbits, es, bt>, capacity, LimbType>& q) {
 	constexpr int bt_radix = BT::radix;  // = 2*fbits
 
 	Scalar result;
+	if (q.isnan()) { result.setnar(); return result; }  // NaR propagated through the accumulator (#1226)
 	if (q.iszero()) {
 		result.setzero();
 		return result;

--- a/include/sw/universal/number/posit/posit.hpp
+++ b/include/sw/universal/number/posit/posit.hpp
@@ -39,6 +39,11 @@
 // for the blocktriple<> class assume the same behavior as requested for posits
 #define BLOCKTRIPLE_THROW_ARITHMETIC_EXCEPTION POSIT_THROW_ARITHMETIC_EXCEPTION
 #endif
+// the fused dot product accumulator (quire, via fdp.hpp) must honor the same
+// exception policy as the posit it accumulates for (#1226)
+#if !defined(QUIRE_THROW_ARITHMETIC_EXCEPTION)
+#define QUIRE_THROW_ARITHMETIC_EXCEPTION POSIT_THROW_ARITHMETIC_EXCEPTION
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///                         END OF BEHAVIOR SWITCHES                                 ///

--- a/include/sw/universal/number/quire/quire_impl.hpp
+++ b/include/sw/universal/number/quire/quire_impl.hpp
@@ -70,7 +70,7 @@ public:
 	using accumulator_type = blockbinary<qbits, LimbType, BinaryNumberType::Unsigned>;
 
 	// Constructors
-	quire() : _sign(false), _accu{} {}
+	quire() : _sign(false), _nan(false), _accu{} {}
 	quire(int8_t   iv) { *this = static_cast<int64_t>(iv); }
 	quire(int16_t  iv) { *this = static_cast<int64_t>(iv); }
 	quire(int32_t  iv) { *this = static_cast<int64_t>(iv); }
@@ -87,7 +87,7 @@ public:
 	quire(const blocktriple<fbits, op, bt>& rhs) { *this = rhs; }
 
 	// specific value constructor
-	constexpr quire(const SpecificValue code) noexcept : _sign{false}, _accu{}
+	constexpr quire(const SpecificValue code) noexcept : _sign{false}, _nan{false}, _accu{}
 	{
 		switch (code) {
 		case SpecificValue::maxpos:
@@ -111,7 +111,11 @@ public:
 		case SpecificValue::nar:
 		case SpecificValue::qnan:
 		case SpecificValue::snan:
-			throw operand_is_nar{};  // quire has no representation for infinities or NaNs
+			// The quire has no numeric encoding for infinities or NaNs; record the
+			// non-finite state instead. (This constructor is noexcept, so the old
+			// unconditional throw here actually called std::terminate.)
+			_nan = true;
+			break;
 		}
 	}
 
@@ -120,15 +124,24 @@ public:
 
 	template<unsigned fbits, BlockTripleOperator op, typename bt>
 	quire& operator=(const blocktriple<fbits, op, bt>& rhs) {
-		reset();
+		reset();  // clears the NaR state as well: a fresh assignment starts finite
 		if (rhs.iszero()) return *this;
-		if (rhs.isinf() || rhs.isnan()) throw operand_is_nar{};
+		// NaR/NaN/Inf operand: record the non-finite state (propagates on resolve).
+		if (rhs.isinf() || rhs.isnan()) { _nan = true; return *this; }
 		_sign = rhs.sign();
 
 		int scale = rhs.scale();
+#if QUIRE_THROW_ARITHMETIC_EXCEPTION
 		if (scale >  static_cast<int>(half_range)) throw operand_too_large_for_quire{};
 		if (scale < -static_cast<int>(half_range)) throw operand_too_small_for_quire{};
-
+#else
+		// Opt-out build: an operand outside the quire's dynamic range cannot be
+		// represented; leave the quire zero rather than throwing.
+		if (scale >  static_cast<int>(half_range) || scale < -static_cast<int>(half_range)) {
+			reset();
+			return *this;
+		}
+#endif
 		place_blocktriple(rhs);
 		return *this;
 	}
@@ -157,7 +170,11 @@ public:
 			: static_cast<uint64_t>(rhs);
 		if (magnitude == 0) return *this;
 		unsigned msb = find_msb(magnitude);
+#if QUIRE_THROW_ARITHMETIC_EXCEPTION
 		if (msb > half_range + capacity) throw operand_too_large_for_quire{};
+#else
+		if (msb > half_range + capacity) { reset(); return *this; }
+#endif
 		// place integer value at the radix point (integers have scale >= 0)
 		for (unsigned i = 0; i < 64 && i < msb; ++i) {
 			if (magnitude & (uint64_t(1) << i)) {
@@ -174,7 +191,11 @@ public:
 		_sign = false;
 		if (rhs == 0) return *this;
 		unsigned msb = find_msb(rhs);
+#if QUIRE_THROW_ARITHMETIC_EXCEPTION
 		if (msb > half_range + capacity) throw operand_too_large_for_quire{};
+#else
+		if (msb > half_range + capacity) { reset(); return *this; }
+#endif
 		for (unsigned i = 0; i < 64 && i < msb; ++i) {
 			if (rhs & (uint64_t(1) << i)) {
 				_accu.setbit(radix_point + i);
@@ -207,13 +228,22 @@ public:
 	/// Add a blocktriple value to the quire
 	template<unsigned fbits, BlockTripleOperator op, typename bt>
 	quire& operator+=(const blocktriple<fbits, op, bt>& rhs) {
+		if (_nan) return *this;             // NaR is sticky: once set, accumulation is a no-op
 		if (rhs.iszero()) return *this;
-		if (rhs.isinf() || rhs.isnan()) throw operand_is_nar{};
+		// NaR/NaN/Inf operand: the sum becomes NaR and stays NaR.
+		if (rhs.isinf() || rhs.isnan()) { _nan = true; return *this; }
 
 		int scale = rhs.scale();
+#if QUIRE_THROW_ARITHMETIC_EXCEPTION
 		if (scale >  static_cast<int>(half_range)) throw operand_too_large_for_quire{};
 		if (scale < -static_cast<int>(half_range)) throw operand_too_small_for_quire{};
-
+#else
+		// Opt-out build: an operand outside the quire's dynamic range cannot be
+		// represented; skip it rather than throwing (leaves the running sum intact).
+		if (scale >  static_cast<int>(half_range) || scale < -static_cast<int>(half_range)) {
+			return *this;
+		}
+#endif
 		if (_sign == rhs.sign()) {
 			add_blocktriple(rhs);
 		}
@@ -269,6 +299,8 @@ public:
 
 	/// Add two quires
 	quire& operator+=(const quire& rhs) {
+		if (_nan) return *this;                 // NaR is sticky
+		if (rhs._nan) { _nan = true; return *this; }
 		if (rhs.iszero()) return *this;
 		if (_sign == rhs._sign) {
 			_accu += rhs._accu;
@@ -315,7 +347,10 @@ public:
 	// ////////////////////////////////////////////////////////////////=
 	// Selectors
 	// ////////////////////////////////////////////////////////////////=
-	bool iszero() const noexcept { return _accu.none(); }
+	bool iszero() const noexcept { return !_nan && _accu.none(); }
+	bool isnan()  const noexcept { return _nan; }  // non-finite (NaR/NaN/Inf) state
+	bool isnar()  const noexcept { return _nan; }  // posit-flavored alias for isnan()
+	bool isinf()  const noexcept { return _nan; }  // the quire collapses Inf into the NaR state
 	bool sign() const noexcept { return _sign; }
 	bool isneg() const noexcept { return _sign; }
 	bool ispos() const noexcept { return !_sign; }
@@ -358,35 +393,42 @@ public:
 	// ////////////////////////////////////////////////////////////////=
 	void reset() noexcept {
 		_sign = false;
+		_nan  = false;
 		_accu.clear();
 	}
 	void clear() noexcept { reset(); }
 	void set_sign(bool v) noexcept { _sign = v; }
+	void setnan() noexcept { reset(); _nan = true; }  // force the non-finite (NaR) state
 	void setbit(unsigned index) {
 		if (index >= qbits) throw std::out_of_range("quire bit index out of range");
 		_accu.setbit(index);
 	}
 	void zero() noexcept {
 		_sign = false;
+		_nan  = false;
 		_accu.clear();
 	}
 	void maxpos() noexcept {
 		_sign = false;
+		_nan  = false;
 		_accu.clear();
 		_accu.flip();  // largest value all bits set
 	}
 	void minpos() noexcept {
 		_sign = false;
+		_nan  = false;
 		_accu.clear();
 		_accu.setbit(0);  // smallest value has MSB at 0
 	}
 	void minneg() noexcept {
 		_sign = true;
+		_nan  = false;
 		_accu.clear();
 		_accu.setbit(0);  // smallest negative value has MSB at 0
 	}
 	void maxneg() noexcept {
 		_sign = true;
+		_nan  = false;
 		_accu.clear();
 		_accu.flip();  // largest negative value has all bits set
 	}
@@ -398,6 +440,7 @@ public:
 	/// Convert quire value to a blocktriple<qbits, REP>
 	blocktriple<qbits, BlockTripleOperator::REP, LimbType> to_blocktriple() const {
 		blocktriple<qbits, BlockTripleOperator::REP, LimbType> result;
+		if (_nan) { result.setnan(); return result; }
 		if (iszero()) { result.setzero(_sign); return result; }
 
 		// find MSB to determine scale
@@ -433,6 +476,7 @@ public:
 		static_assert(sizeof(TargetType) <= 8,
 			"convert_to<T>() uses double as intermediate and is limited to 53 bits "
 			"of significand precision. Use to_blocktriple() for wider target types.");
+		if (_nan) return TargetType(std::numeric_limits<double>::quiet_NaN());
 		if (iszero()) return TargetType(0);
 		// find the scale
 		int s = scale();
@@ -515,6 +559,11 @@ public:
 
 private:
 	bool             _sign;
+	// Non-finite (NaR/NaN/Inf) state. The quire accumulator has no numeric
+	// encoding for infinities or NaNs, so a NaR operand sets this sticky flag;
+	// it propagates through accumulation and surfaces as the number system's
+	// NaR/NaN on resolve. See #1226.
+	bool             _nan;
 	accumulator_type _accu;
 
 	// ////////////////////////////////////////////////////////////////=
@@ -659,6 +708,7 @@ std::string to_binary(const quire<NumberType, capacity, LimbType>& q) {
 	constexpr unsigned qb = quire<NumberType, capacity, LimbType>::qbits;
 	constexpr unsigned cb = qb - capacity;
 	std::stringstream  ostr;
+	if (q.isnan()) { ostr << "nar"; return ostr.str(); }
 	ostr << (q.sign() ? "-:" : "+:");
 	// print capacity + '_' + upper bits (above radix), then '.', then lower bits
 	for (int i = static_cast<int>(qb) - 1; i >= static_cast<int>(cb); --i) {
@@ -682,6 +732,7 @@ std::string to_binary(const quire<NumberType, capacity, LimbType>& q) {
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator==(const quire<NumberType, capacity, LimbType>& lhs,
                 const quire<NumberType, capacity, LimbType>& rhs) {
+	if (lhs._nan || rhs._nan) return false;         // NaR compares unordered (IEEE-style)
 	if (lhs.iszero() && rhs.iszero()) return true;  // +0 == -0
 	return lhs._sign == rhs._sign && lhs._accu == rhs._accu;
 }
@@ -695,6 +746,7 @@ bool operator!=(const quire<NumberType, capacity, LimbType>& lhs,
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator<(const quire<NumberType, capacity, LimbType>& lhs,
                const quire<NumberType, capacity, LimbType>& rhs) {
+	if (lhs._nan || rhs._nan) return false;          // NaR is unordered
 	if (lhs.iszero() && rhs.iszero()) return false;  // +0 == -0
 	if (lhs._sign != rhs._sign) return lhs._sign;  // negative < positive
 	// Both same sign: compare magnitudes using MSB-first unsigned comparison.
@@ -726,12 +778,14 @@ bool operator>(const quire<NumberType, capacity, LimbType>& lhs,
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator<=(const quire<NumberType, capacity, LimbType>& lhs,
                 const quire<NumberType, capacity, LimbType>& rhs) {
+	if (lhs._nan || rhs._nan) return false;  // NaR is unordered (can't reuse !(rhs<lhs))
 	return !(rhs < lhs);
 }
 
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator>=(const quire<NumberType, capacity, LimbType>& lhs,
                 const quire<NumberType, capacity, LimbType>& rhs) {
+	if (lhs._nan || rhs._nan) return false;  // NaR is unordered (can't reuse !(lhs<rhs))
 	return !(lhs < rhs);
 }
 

--- a/include/sw/universal/number/quire/quire_impl.hpp
+++ b/include/sw/universal/number/quire/quire_impl.hpp
@@ -561,6 +561,7 @@ public:
 				parsed_accu.setbit(accu_bit);
 			}
 		}
+		_nar  = false;  // successfully loaded finite bits: leave the NaR state behind
 		_sign = parsed_sign;
 		_accu = parsed_accu;
 		return true;

--- a/include/sw/universal/number/quire/quire_impl.hpp
+++ b/include/sw/universal/number/quire/quire_impl.hpp
@@ -70,7 +70,7 @@ public:
 	using accumulator_type = blockbinary<qbits, LimbType, BinaryNumberType::Unsigned>;
 
 	// Constructors
-	quire() : _sign(false), _nan(false), _accu{} {}
+	quire() : _sign(false), _nar(false), _accu{} {}
 	quire(int8_t   iv) { *this = static_cast<int64_t>(iv); }
 	quire(int16_t  iv) { *this = static_cast<int64_t>(iv); }
 	quire(int32_t  iv) { *this = static_cast<int64_t>(iv); }
@@ -87,7 +87,7 @@ public:
 	quire(const blocktriple<fbits, op, bt>& rhs) { *this = rhs; }
 
 	// specific value constructor
-	constexpr quire(const SpecificValue code) noexcept : _sign{false}, _nan{false}, _accu{}
+	constexpr quire(const SpecificValue code) noexcept : _sign{false}, _nar{false}, _accu{}
 	{
 		switch (code) {
 		case SpecificValue::maxpos:
@@ -114,7 +114,7 @@ public:
 			// The quire has no numeric encoding for infinities or NaNs; record the
 			// non-finite state instead. (This constructor is noexcept, so the old
 			// unconditional throw here actually called std::terminate.)
-			_nan = true;
+			_nar = true;
 			break;
 		}
 	}
@@ -127,7 +127,7 @@ public:
 		reset();  // clears the NaR state as well: a fresh assignment starts finite
 		if (rhs.iszero()) return *this;
 		// NaR/NaN/Inf operand: record the non-finite state (propagates on resolve).
-		if (rhs.isinf() || rhs.isnan()) { _nan = true; return *this; }
+		if (rhs.isinf() || rhs.isnan()) { _nar = true; return *this; }
 		_sign = rhs.sign();
 
 		int scale = rhs.scale();
@@ -228,10 +228,10 @@ public:
 	/// Add a blocktriple value to the quire
 	template<unsigned fbits, BlockTripleOperator op, typename bt>
 	quire& operator+=(const blocktriple<fbits, op, bt>& rhs) {
-		if (_nan) return *this;             // NaR is sticky: once set, accumulation is a no-op
+		if (_nar) return *this;             // NaR is sticky: once set, accumulation is a no-op
 		if (rhs.iszero()) return *this;
 		// NaR/NaN/Inf operand: the sum becomes NaR and stays NaR.
-		if (rhs.isinf() || rhs.isnan()) { _nan = true; return *this; }
+		if (rhs.isinf() || rhs.isnan()) { _nar = true; return *this; }
 
 		int scale = rhs.scale();
 #if QUIRE_THROW_ARITHMETIC_EXCEPTION
@@ -299,8 +299,8 @@ public:
 
 	/// Add two quires
 	quire& operator+=(const quire& rhs) {
-		if (_nan) return *this;                 // NaR is sticky
-		if (rhs._nan) { _nan = true; return *this; }
+		if (_nar) return *this;                 // NaR is sticky
+		if (rhs._nar) { _nar = true; return *this; }
 		if (rhs.iszero()) return *this;
 		if (_sign == rhs._sign) {
 			_accu += rhs._accu;
@@ -347,10 +347,10 @@ public:
 	// ////////////////////////////////////////////////////////////////=
 	// Selectors
 	// ////////////////////////////////////////////////////////////////=
-	bool iszero() const noexcept { return !_nan && _accu.none(); }
-	bool isnan()  const noexcept { return _nan; }  // non-finite (NaR/NaN/Inf) state
-	bool isnar()  const noexcept { return _nan; }  // posit-flavored alias for isnan()
-	bool isinf()  const noexcept { return _nan; }  // the quire collapses Inf into the NaR state
+	bool iszero() const noexcept { return !_nar && _accu.none(); }
+	bool isnan()  const noexcept { return _nar; }  // non-finite (NaR/NaN/Inf) state
+	bool isnar()  const noexcept { return _nar; }  // posit-flavored alias for isnan()
+	bool isinf()  const noexcept { return _nar; }  // the quire collapses Inf into the NaR state
 	bool sign() const noexcept { return _sign; }
 	bool isneg() const noexcept { return _sign; }
 	bool ispos() const noexcept { return !_sign; }
@@ -393,42 +393,42 @@ public:
 	// ////////////////////////////////////////////////////////////////=
 	void reset() noexcept {
 		_sign = false;
-		_nan  = false;
+		_nar  = false;
 		_accu.clear();
 	}
 	void clear() noexcept { reset(); }
 	void set_sign(bool v) noexcept { _sign = v; }
-	void setnan() noexcept { reset(); _nan = true; }  // force the non-finite (NaR) state
+	void setnan() noexcept { reset(); _nar = true; }  // force the non-finite (NaR) state
 	void setbit(unsigned index) {
 		if (index >= qbits) throw std::out_of_range("quire bit index out of range");
 		_accu.setbit(index);
 	}
 	void zero() noexcept {
 		_sign = false;
-		_nan  = false;
+		_nar  = false;
 		_accu.clear();
 	}
 	void maxpos() noexcept {
 		_sign = false;
-		_nan  = false;
+		_nar  = false;
 		_accu.clear();
 		_accu.flip();  // largest value all bits set
 	}
 	void minpos() noexcept {
 		_sign = false;
-		_nan  = false;
+		_nar  = false;
 		_accu.clear();
 		_accu.setbit(0);  // smallest value has MSB at 0
 	}
 	void minneg() noexcept {
 		_sign = true;
-		_nan  = false;
+		_nar  = false;
 		_accu.clear();
 		_accu.setbit(0);  // smallest negative value has MSB at 0
 	}
 	void maxneg() noexcept {
 		_sign = true;
-		_nan  = false;
+		_nar  = false;
 		_accu.clear();
 		_accu.flip();  // largest negative value has all bits set
 	}
@@ -440,7 +440,7 @@ public:
 	/// Convert quire value to a blocktriple<qbits, REP>
 	blocktriple<qbits, BlockTripleOperator::REP, LimbType> to_blocktriple() const {
 		blocktriple<qbits, BlockTripleOperator::REP, LimbType> result;
-		if (_nan) { result.setnan(); return result; }
+		if (_nar) { result.setnan(); return result; }
 		if (iszero()) { result.setzero(_sign); return result; }
 
 		// find MSB to determine scale
@@ -476,7 +476,7 @@ public:
 		static_assert(sizeof(TargetType) <= 8,
 			"convert_to<T>() uses double as intermediate and is limited to 53 bits "
 			"of significand precision. Use to_blocktriple() for wider target types.");
-		if (_nan) {
+		if (_nar) {
 			// Only floating-point targets have a NaN encoding; converting a NaN
 			// double to an integral type is undefined behavior, so return 0 there.
 			if constexpr (std::is_floating_point_v<TargetType>) {
@@ -572,7 +572,7 @@ private:
 	// encoding for infinities or NaNs, so a NaR operand sets this sticky flag;
 	// it propagates through accumulation and surfaces as the number system's
 	// NaR/NaN on resolve. See #1226.
-	bool             _nan;
+	bool             _nar;
 	accumulator_type _accu;
 
 	// ////////////////////////////////////////////////////////////////=
@@ -741,7 +741,7 @@ std::string to_binary(const quire<NumberType, capacity, LimbType>& q) {
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator==(const quire<NumberType, capacity, LimbType>& lhs,
                 const quire<NumberType, capacity, LimbType>& rhs) {
-	if (lhs._nan || rhs._nan) return false;         // NaR compares unordered (IEEE-style)
+	if (lhs._nar || rhs._nar) return false;         // NaR compares unordered (IEEE-style)
 	if (lhs.iszero() && rhs.iszero()) return true;  // +0 == -0
 	return lhs._sign == rhs._sign && lhs._accu == rhs._accu;
 }
@@ -755,7 +755,7 @@ bool operator!=(const quire<NumberType, capacity, LimbType>& lhs,
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator<(const quire<NumberType, capacity, LimbType>& lhs,
                const quire<NumberType, capacity, LimbType>& rhs) {
-	if (lhs._nan || rhs._nan) return false;          // NaR is unordered
+	if (lhs._nar || rhs._nar) return false;          // NaR is unordered
 	if (lhs.iszero() && rhs.iszero()) return false;  // +0 == -0
 	if (lhs._sign != rhs._sign) return lhs._sign;  // negative < positive
 	// Both same sign: compare magnitudes using MSB-first unsigned comparison.
@@ -787,14 +787,14 @@ bool operator>(const quire<NumberType, capacity, LimbType>& lhs,
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator<=(const quire<NumberType, capacity, LimbType>& lhs,
                 const quire<NumberType, capacity, LimbType>& rhs) {
-	if (lhs._nan || rhs._nan) return false;  // NaR is unordered (can't reuse !(rhs<lhs))
+	if (lhs._nar || rhs._nar) return false;  // NaR is unordered (can't reuse !(rhs<lhs))
 	return !(rhs < lhs);
 }
 
 template<typename NumberType, unsigned capacity, typename LimbType>
 bool operator>=(const quire<NumberType, capacity, LimbType>& lhs,
                 const quire<NumberType, capacity, LimbType>& rhs) {
-	if (lhs._nan || rhs._nan) return false;  // NaR is unordered (can't reuse !(lhs<rhs))
+	if (lhs._nar || rhs._nar) return false;  // NaR is unordered (can't reuse !(lhs<rhs))
 	return !(lhs < rhs);
 }
 

--- a/include/sw/universal/number/quire/quire_impl.hpp
+++ b/include/sw/universal/number/quire/quire_impl.hpp
@@ -476,7 +476,16 @@ public:
 		static_assert(sizeof(TargetType) <= 8,
 			"convert_to<T>() uses double as intermediate and is limited to 53 bits "
 			"of significand precision. Use to_blocktriple() for wider target types.");
-		if (_nan) return TargetType(std::numeric_limits<double>::quiet_NaN());
+		if (_nan) {
+			// Only floating-point targets have a NaN encoding; converting a NaN
+			// double to an integral type is undefined behavior, so return 0 there.
+			if constexpr (std::is_floating_point_v<TargetType>) {
+				return TargetType(std::numeric_limits<double>::quiet_NaN());
+			}
+			else {
+				return TargetType(0);
+			}
+		}
 		if (iszero()) return TargetType(0);
 		// find the scale
 		int s = scale();

--- a/numeric/quire/posit/nar_propagation.cpp
+++ b/numeric/quire/posit/nar_propagation.cpp
@@ -8,61 +8,80 @@
 #include <universal/utility/directives.hpp>
 
 // This translation unit deliberately exercises the DEFAULT (opt-out) exception
-// configuration: posit.hpp defaults POSIT_THROW_ARITHMETIC_EXCEPTION to 0 and now
-// forwards that to QUIRE_THROW_ARITHMETIC_EXCEPTION, so the quire must NOT throw.
-#include <universal/number/posit/posit.hpp>
+// configuration: each number-system umbrella defaults *_THROW_ARITHMETIC_EXCEPTION
+// to 0 and now forwards that to QUIRE_THROW_ARITHMETIC_EXCEPTION, so the quire must
+// NOT throw. It covers the shared quire NaR machinery across the representative
+// number systems whose quire_resolve NaN handling changed (posit, cfloat, lns, dbns).
+#include <universal/number/posit/posit.hpp>       // includes posit/fdp.hpp (quire_mul/quire_resolve)
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/cfloat/fdp.hpp>        // fdp is opt-in for the non-posit types
+#include <universal/number/lns/lns.hpp>
+#include <universal/number/lns/fdp.hpp>
+#include <universal/number/dbns/dbns.hpp>
+#include <universal/number/dbns/fdp.hpp>
 #include <universal/number/quire/quire.hpp>
 #include <universal/verification/test_reporters.hpp>
 
 #include <iostream>
 #include <string>
 
+// The non-finite API differs by type: posit uses setnar()/isnar(), while
+// cfloat/lns/dbns use setnan()/isnan(). Bridge them with C++20 requires.
+template<typename Scalar> void set_nonfinite(Scalar& x) {
+	if constexpr (requires { x.setnar(); }) x.setnar(); else x.setnan();
+}
+template<typename Scalar> bool is_nonfinite(const Scalar& x) {
+	if constexpr (requires { x.isnar(); }) return x.isnar(); else return x.isnan();
+}
+
 // A NaR operand reaching the quire sets the sticky non-finite state, propagates
-// through further accumulation, and resolves back to the posit's NaR -- without
-// throwing (the reporter's C-ABI / noexcept use case).
-template<typename Posit>
+// through further accumulation, and resolves back to the number system's NaR --
+// without throwing (the reporter's C-ABI / noexcept use case).
+template<typename Scalar>
 int VerifyQuireNaRPropagation(bool reportTestCases) {
 	using namespace sw::universal;
 	int nrOfFailedTestCases = 0;
+	std::string tag = type_tag(Scalar());
 
-	Posit nar; nar.setnar();
-	Posit one(1.0f);
+	Scalar nan; set_nonfinite(nan);
+	Scalar one(1.0f);
 
-	quire<Posit> q;
+	quire<Scalar> q;
 	// the reproducer: this used to throw sw::universal::operand_is_nar
-	q += quire_mul(nar, one);
-	if (!q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: quire did not enter NaR state after NaR product\n"; }
+	q += quire_mul(nan, one);
+	if (!q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL(" << tag << "): quire did not enter NaR state after NaR product\n"; }
 
-	// NaR resolves back to the posit's NaR
-	Posit r = quire_resolve(q);
-	if (!r.isnar()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: quire_resolve did not return NaR\n"; }
+	// NaR resolves back to the number system's NaR
+	Scalar r = quire_resolve(q);
+	if (!is_nonfinite(r)) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL(" << tag << "): quire_resolve did not return NaR\n"; }
 
 	// NaR is sticky: accumulating a finite product does not clear it
 	q += quire_mul(one, one);
-	if (!q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: NaR state was not sticky under further accumulation\n"; }
+	if (!q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL(" << tag << "): NaR state was not sticky under further accumulation\n"; }
 
 	// a fresh assignment of a finite value clears the NaR state
 	q = quire_mul(one, one);
-	if (q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: finite assignment did not clear NaR state\n"; }
+	if (q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL(" << tag << "): finite assignment did not clear NaR state\n"; }
 
 	return nrOfFailedTestCases;
 }
 
 // A NaR quire compares unordered (IEEE-style): every comparison is false, and
 // inequality is true -- including against itself.
-template<typename Posit>
+template<typename Scalar>
 int VerifyQuireNaRComparisons(bool reportTestCases) {
 	using namespace sw::universal;
 	int nrOfFailedTestCases = 0;
+	std::string tag = type_tag(Scalar());
 
-	Posit nar; nar.setnar();
-	Posit one(1.0f);
+	Scalar nan; set_nonfinite(nan);
+	Scalar one(1.0f);
 
-	quire<Posit> a;  a += quire_mul(nar, one);  // NaR
-	quire<Posit> b;  b += quire_mul(one, one);  // finite
+	quire<Scalar> a;  a += quire_mul(nan, one);  // NaR
+	quire<Scalar> b;  b += quire_mul(one, one);  // finite
 
 	auto expect = [&](bool cond, const char* what) {
-		if (!cond) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: " << what << '\n'; }
+		if (!cond) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL(" << tag << "): " << what << '\n'; }
 	};
 	expect(!(a == b), "NaR == finite should be false");
 	expect(  a != b , "NaR != finite should be true");
@@ -94,7 +113,7 @@ int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite          = "posit<> quire NaR propagation (no-throw config, #1226)";
+	std::string test_suite          = "quire NaR propagation (no-throw config, #1226)";
 	std::string test_tag            = "quire NaR";
 	bool        reportTestCases     = true;
 	int         nrOfFailedTestCases = 0;
@@ -111,14 +130,19 @@ try {
 #else
 
 #	if REGRESSION_LEVEL_1
+	// posit is the canonical quire user; also cover the other changed resolvers
 	nrOfFailedTestCases += VerifyQuireNaRPropagation<posit<16, 1>>(reportTestCases);
 	nrOfFailedTestCases += VerifyQuireNaRComparisons<posit<16, 1>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRPropagation<cfloat<8, 3, std::uint8_t, true, false, false>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRPropagation<lns<8, 4>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRPropagation<dbns<8, 3>>(reportTestCases);
 #	endif
 
 #	if REGRESSION_LEVEL_2
 	nrOfFailedTestCases += VerifyQuireNaRPropagation<posit<32, 2>>(reportTestCases);
-	nrOfFailedTestCases += VerifyQuireNaRComparisons<posit<32, 2>>(reportTestCases);
 	nrOfFailedTestCases += VerifyQuireNaRPropagation<posit<8, 0>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRComparisons<cfloat<8, 3, std::uint8_t, true, false, false>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRComparisons<lns<8, 4>>(reportTestCases);
 #	endif
 
 #	if REGRESSION_LEVEL_3

--- a/numeric/quire/posit/nar_propagation.cpp
+++ b/numeric/quire/posit/nar_propagation.cpp
@@ -1,0 +1,144 @@
+//  nar_propagation.cpp : verify the quire honors the no-throw configuration and
+//  propagates NaR as a value instead of throwing (issue #1226)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+
+// This translation unit deliberately exercises the DEFAULT (opt-out) exception
+// configuration: posit.hpp defaults POSIT_THROW_ARITHMETIC_EXCEPTION to 0 and now
+// forwards that to QUIRE_THROW_ARITHMETIC_EXCEPTION, so the quire must NOT throw.
+#include <universal/number/posit/posit.hpp>
+#include <universal/number/quire/quire.hpp>
+#include <universal/verification/test_reporters.hpp>
+
+#include <iostream>
+#include <string>
+
+// A NaR operand reaching the quire sets the sticky non-finite state, propagates
+// through further accumulation, and resolves back to the posit's NaR -- without
+// throwing (the reporter's C-ABI / noexcept use case).
+template<typename Posit>
+int VerifyQuireNaRPropagation(bool reportTestCases) {
+	using namespace sw::universal;
+	int nrOfFailedTestCases = 0;
+
+	Posit nar; nar.setnar();
+	Posit one(1.0f);
+
+	quire<Posit> q;
+	// the reproducer: this used to throw sw::universal::operand_is_nar
+	q += quire_mul(nar, one);
+	if (!q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: quire did not enter NaR state after NaR product\n"; }
+
+	// NaR resolves back to the posit's NaR
+	Posit r = quire_resolve(q);
+	if (!r.isnar()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: quire_resolve did not return NaR\n"; }
+
+	// NaR is sticky: accumulating a finite product does not clear it
+	q += quire_mul(one, one);
+	if (!q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: NaR state was not sticky under further accumulation\n"; }
+
+	// a fresh assignment of a finite value clears the NaR state
+	q = quire_mul(one, one);
+	if (q.isnan()) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: finite assignment did not clear NaR state\n"; }
+
+	return nrOfFailedTestCases;
+}
+
+// A NaR quire compares unordered (IEEE-style): every comparison is false, and
+// inequality is true -- including against itself.
+template<typename Posit>
+int VerifyQuireNaRComparisons(bool reportTestCases) {
+	using namespace sw::universal;
+	int nrOfFailedTestCases = 0;
+
+	Posit nar; nar.setnar();
+	Posit one(1.0f);
+
+	quire<Posit> a;  a += quire_mul(nar, one);  // NaR
+	quire<Posit> b;  b += quire_mul(one, one);  // finite
+
+	auto expect = [&](bool cond, const char* what) {
+		if (!cond) { ++nrOfFailedTestCases; if (reportTestCases) std::cout << "FAIL: " << what << '\n'; }
+	};
+	expect(!(a == b), "NaR == finite should be false");
+	expect(  a != b , "NaR != finite should be true");
+	expect(!(a <  b), "NaR <  finite should be false");
+	expect(!(a <= b), "NaR <= finite should be false");
+	expect(!(a >  b), "NaR >  finite should be false");
+	expect(!(a >= b), "NaR >= finite should be false");
+	expect(!(a == a), "NaR == NaR should be false (unordered)");
+	expect(  a != a , "NaR != NaR should be true (unordered)");
+
+	return nrOfFailedTestCases;
+}
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#	undef REGRESSION_LEVEL_1
+#	undef REGRESSION_LEVEL_2
+#	undef REGRESSION_LEVEL_3
+#	undef REGRESSION_LEVEL_4
+#	define REGRESSION_LEVEL_1 1
+#	define REGRESSION_LEVEL_2 1
+#	define REGRESSION_LEVEL_3 0
+#	define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite          = "posit<> quire NaR propagation (no-throw config, #1226)";
+	std::string test_tag            = "quire NaR";
+	bool        reportTestCases     = true;
+	int         nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += VerifyQuireNaRPropagation<posit<16, 1>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRComparisons<posit<16, 1>>(reportTestCases);
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;  // ignore errors
+#else
+
+#	if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += VerifyQuireNaRPropagation<posit<16, 1>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRComparisons<posit<16, 1>>(reportTestCases);
+#	endif
+
+#	if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += VerifyQuireNaRPropagation<posit<32, 2>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRComparisons<posit<32, 2>>(reportTestCases);
+	nrOfFailedTestCases += VerifyQuireNaRPropagation<posit<8, 0>>(reportTestCases);
+#	endif
+
+#	if REGRESSION_LEVEL_3
+#	endif
+
+#	if REGRESSION_LEVEL_4
+#	endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+} catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+} catch (const sw::universal::quire_exception& err) {
+	// A quire exception here is itself a failure: this suite runs in the
+	// no-throw configuration, so NaR/overflow must never throw.
+	std::cerr << "unexpected quire exception (no-throw config was requested): " << err.what() << '\n';
+	return EXIT_FAILURE;
+} catch (...) {
+	std::cerr << "Caught unknown exception" << '\n';
+	return EXIT_FAILURE;
+}

--- a/static/quire/api/generalized_quire.cpp
+++ b/static/quire/api/generalized_quire.cpp
@@ -230,36 +230,40 @@ int TestQuireQuireAddition() {
 	return nrOfFailedTestCases;
 }
 
-// Test exception handling
-int TestExceptions() {
+// Test non-finite (NaR/NaN/Inf) handling.
+// In the default (opt-out) exception configuration the quire does NOT throw on a
+// non-finite operand: it records a sticky NaR state that propagates and resolves
+// back to the number system's NaR, matching scalar arithmetic (#1226).
+int TestNonFiniteHandling() {
 	int nrOfFailedTestCases = 0;
 
 	using Scalar = cfloat<32, 8, uint32_t, true, false, false>;
-	quire<Scalar> q;
 
-	// Test NaR/NaN assignment
+	// Assigning a NaN blocktriple sets the quire NaR state instead of throwing.
 	blocktriple<23, BlockTripleOperator::REP, uint32_t> nan_val;
 	nan_val.setnan();
-	try {
-		q = nan_val;
-		std::cerr << "FAIL: assigning NaN should throw operand_is_nar\n";
+	quire<Scalar> q;
+	q = nan_val;
+	if (!q.isnan()) {
+		std::cerr << "FAIL: assigning NaN should set the quire NaR state (no throw)\n";
 		++nrOfFailedTestCases;
-	}
-	catch (const operand_is_nar&) {
-		// expected
 	}
 
-	// Test inf assignment
+	// Adding an inf blocktriple to a fresh quire also sets the NaR state.
 	blocktriple<23, BlockTripleOperator::REP, uint32_t> inf_val;
 	inf_val.setinf();
-	try {
-		q += inf_val;
-		std::cerr << "FAIL: adding inf should throw operand_is_nar\n";
+	quire<Scalar> qi;
+	qi += inf_val;
+	if (!qi.isnan()) {
+		std::cerr << "FAIL: adding inf should set the quire NaR state (no throw)\n";
 		++nrOfFailedTestCases;
 	}
-	catch (const operand_is_nar&) {
-		// expected
-	}
+
+	// NaR is sticky and a fresh finite assignment clears it.
+	q += inf_val;
+	if (!q.isnan()) { std::cerr << "FAIL: NaR state should be sticky\n"; ++nrOfFailedTestCases; }
+	q = 1;
+	if (q.isnan()) { std::cerr << "FAIL: finite assignment should clear the NaR state\n"; ++nrOfFailedTestCases; }
 
 	return nrOfFailedTestCases;
 }
@@ -297,7 +301,7 @@ try {
 	nrOfFailedTestCases += ReportTestResult(TestPositQuire(), "quire<posit<32,2>>", "posit quire");
 	nrOfFailedTestCases += ReportTestResult(TestFixpntQuire(), "quire<fixpnt<16,8>>", "fixpnt quire");
 	nrOfFailedTestCases += ReportTestResult(TestQuireQuireAddition(), "quire<cfloat<32,8>>", "quire-quire addition");
-	nrOfFailedTestCases += ReportTestResult(TestExceptions(), "quire<cfloat<32,8>>", "exception handling");
+	nrOfFailedTestCases += ReportTestResult(TestNonFiniteHandling(), "quire<cfloat<32,8>>", "non-finite (NaR) handling");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/static/quire/api/generalized_quire.cpp
+++ b/static/quire/api/generalized_quire.cpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <cmath>  // std::isnan
 #include <universal/number/cfloat/cfloat.hpp>
 #include <universal/number/cfloat/fdp.hpp>
 #include <universal/number/posit/posit.hpp>
@@ -239,7 +240,8 @@ int TestNonFiniteHandling() {
 
 	using Scalar = cfloat<32, 8, uint32_t, true, false, false>;
 
-	// Assigning a NaN blocktriple sets the quire NaR state instead of throwing.
+	// Assigning a NaN blocktriple sets the quire NaR state instead of throwing,
+	// and the NaR resolves back to a non-finite scalar (convert_to<double> = NaN).
 	blocktriple<23, BlockTripleOperator::REP, uint32_t> nan_val;
 	nan_val.setnan();
 	quire<Scalar> q;
@@ -248,22 +250,36 @@ int TestNonFiniteHandling() {
 		std::cerr << "FAIL: assigning NaN should set the quire NaR state (no throw)\n";
 		++nrOfFailedTestCases;
 	}
+	if (!std::isnan(q.convert_to<double>())) {
+		std::cerr << "FAIL: a NaR quire should resolve to NaN\n";
+		++nrOfFailedTestCases;
+	}
 
-	// Adding an inf blocktriple to a fresh quire also sets the NaR state.
+	// NaR is sticky: a subsequent FINITE accumulation is a no-op, so the quire
+	// stays NaR and still resolves to NaN (this exercises the sticky short-circuit
+	// on a finite operand, not on another non-finite one).
+	q += quire_mul(Scalar(1.0f), Scalar(1.0f));
+	if (!q.isnan() || !std::isnan(q.convert_to<double>())) {
+		std::cerr << "FAIL: NaR should be sticky under finite accumulation\n";
+		++nrOfFailedTestCases;
+	}
+
+	// A fresh finite assignment clears the NaR state and resolves to that value.
+	q = int64_t(1);
+	if (q.isnan() || q.convert_to<double>() != 1.0) {
+		std::cerr << "FAIL: finite assignment should clear the NaR state\n";
+		++nrOfFailedTestCases;
+	}
+
+	// An inf blocktriple on a fresh quire also sets the NaR state.
 	blocktriple<23, BlockTripleOperator::REP, uint32_t> inf_val;
 	inf_val.setinf();
 	quire<Scalar> qi;
 	qi += inf_val;
-	if (!qi.isnan()) {
+	if (!qi.isnan() || !std::isnan(qi.convert_to<double>())) {
 		std::cerr << "FAIL: adding inf should set the quire NaR state (no throw)\n";
 		++nrOfFailedTestCases;
 	}
-
-	// NaR is sticky and a fresh finite assignment clears it.
-	q += inf_val;
-	if (!q.isnan()) { std::cerr << "FAIL: NaR state should be sticky\n"; ++nrOfFailedTestCases; }
-	q = 1;
-	if (q.isnan()) { std::cerr << "FAIL: finite assignment should clear the NaR state\n"; ++nrOfFailedTestCases; }
 
 	return nrOfFailedTestCases;
 }


### PR DESCRIPTION
## Summary

Resolves #1226. The quire threw **unconditionally** on NaR and out-of-range operands, ignoring the `QUIRE_THROW_ARITHMETIC_EXCEPTION` macro that `quire.hpp` already declared (default 0). A build that opted out of arithmetic exceptions (`POSIT_THROW_ARITHMETIC_EXCEPTION 0`) still aborted the moment a NaR reached the accumulator via `quire_mul` -- breaking C-ABI shims, `noexcept`, and `-fno-exceptions` contexts. The reporter hit this in Julia bindings running a preconditioned-CG experiment.

Implements **both** fixes the issue proposed, scoped:

### 1. NaR state (fix #2) -- NaR becomes a value
- The quire gains a sticky non-finite flag `_nan`. A NaR/Inf/NaN operand **sets** it instead of throwing; it propagates through further accumulation (no-op once set), is cleared by a fresh finite assignment, and **surfaces back through `quire_resolve`** as the number system's NaR/NaN.
- This makes NaR propagate exactly like scalar posit and **removes the special case** rather than making it configurable -- NaR never throws in either configuration.
- Comparisons treat a NaR quire as **unordered** (IEEE-style: all false, `!=` true, including vs. itself).
- Fixes a latent bug: the `noexcept` `SpecificValue` constructor previously `throw`-ed, i.e. called `std::terminate`.

### 2. Overflow gate (fix #1) -- out-of-range is configurable
- `operand_too_large/small_for_quire` throws are now gated behind `QUIRE_THROW_ARITHMETIC_EXCEPTION`. In the opt-out build an out-of-range operand is **skipped** (running sum left intact) instead of throwing.
- Each number-system umbrella (**posit, cfloat, lns, fixpnt, dbns**) now forwards `*_THROW_ARITHMETIC_EXCEPTION` to `QUIRE_THROW_ARITHMETIC_EXCEPTION`, mirroring the existing `BLOCKTRIPLE` forwarding.

NaR surfaces on resolve for posit (`setnar`), cfloat/lns/dbns (`setnan`); fixpnt has no non-finite encoding and never produces a NaR operand, so it is unchanged.

## Changes
- `quire/quire_impl.hpp` -- `_nan` state, set-not-throw at the 3 NaR sites, gated overflow at the 6 range sites, propagation in `+=`/`-=`, `isnan/isnar/isinf/setnan`, `iszero`/`reset`/value-setters updated, NaN-aware `convert_to`/`to_blocktriple`/`to_binary`/comparisons.
- `{posit,cfloat,lns,dbns}/fdp.hpp` -- `quire_resolve` returns NaR when the quire is non-finite.
- `{posit,cfloat,lns,fixpnt,dbns}/*.hpp` -- forward the exception policy to the quire.
- `numeric/quire/posit/nar_propagation.cpp` -- new regression test.

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| posit_nar_propagation (new) | OK | PASS | OK | PASS |
| posit_quires / posit_quire_accumulation | OK | PASS | -- | -- |
| cfloat_quires / ieee754_quires | OK | PASS | -- | -- |
| exact issue reproducer | OK | no abort (NaR propagates, resolves to NaR) | OK | no abort |
| 5 umbrellas + quire (`-Wall -Wpedantic`) | -- | -- | OK | -- |

## Behavior note
NaR is now **ungated** (always propagates as a value, in both throw and no-throw builds), matching scalar posit and the issue's fix #2 rationale. Only the **overflow** checks are gated by the macro. Anyone who previously relied on the quire throwing `operand_is_nar` on a NaR operand will now get NaR propagation instead.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1226

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NaN/NaR and infinity propagation through fused dot-product accumulators, including quire-to-scalar resolution.
  - Updated non-finite handling so NaR/NaN comparisons are unordered (order comparisons are false).
- **New Features**
  - Added quire helpers to query/set non-finite states (isnan/isnar/isinf/setnan).
- **Improvements**
  - Unified quire arithmetic-exception behavior to match the underlying number types.
- **Tests**
  - Added/updated regression coverage for quire NaR propagation and unordered comparison semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->