### PR TITLE
feat(bfloat16): add fused fma(a,b,c) with RNE rounding

### DIFF
--- a/include/sw/universal/number/bfloat16/bfloat16_fwd.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_fwd.hpp
@@ -11,5 +11,7 @@ namespace sw { namespace universal {
 // forward references
 class bfloat16;
 inline bool parse(const std::string& number, bfloat16& v);
+// fused multiply-add: a*b + c with a single round-to-nearest-even (see math/functions/fma.hpp)
+inline bfloat16 fma(bfloat16 a, bfloat16 b, bfloat16 c);
 
 }}  // namespace sw::universal

--- a/include/sw/universal/number/bfloat16/math/functions/fma.hpp
+++ b/include/sw/universal/number/bfloat16/math/functions/fma.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// fma.hpp: fused multiply-add fma(a,b,c) = a*b + c for bfloat16 (Google Brain float)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Single-rounding fused multiply-add: widen the operands to float, form a*b + c
+// with std::fma (one IEEE rounding to float), and round the result once into
+// bfloat16 via the RNE bfloat16(float) constructor (magic-bias round-to-nearest-even,
+// with NaN preserved and out-of-range collapsing to +/-inf).
+//
+// This is correctly rounded to bfloat16: a bfloat16 carries 8 significand bits, and
+// the product of two of them is EXACT in float (16 <= 24 significand bits), so
+// std::fma yields the correctly-rounded-to-float a*b + c. Because float's 24 bits
+// satisfy p >= 2*q + 2 for the bfloat16 target q = 8 (24 >= 18), the subsequent
+// float -> bfloat16 rounding is innocuous: the double rounding equals a single
+// round-to-nearest-even of the exact a*b + c. std::fma also gives the IEEE special
+// cases (inf*0 + c -> NaN, NaN propagation) for free.
+//
+// Sub-issue of #1189 (universal fma). Relates to #1193.
+
+#include <cmath>
+
+namespace sw { namespace universal {
+
+inline bfloat16 fma(bfloat16 a, bfloat16 b, bfloat16 c) {
+	return bfloat16(std::fma(float(a), float(b), float(c)));
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/bfloat16/mathlib.hpp
+++ b/include/sw/universal/number/bfloat16/mathlib.hpp
@@ -10,6 +10,7 @@
 //#include <universal/number/bfloat16/math/functions/complex.hpp>
 #include <universal/number/bfloat16/math/functions/error_and_gamma.hpp>
 #include <universal/number/bfloat16/math/functions/exponent.hpp>
+#include <universal/number/bfloat16/math/functions/fma.hpp>
 #include <universal/number/bfloat16/math/functions/fractional.hpp>
 #include <universal/number/bfloat16/math/functions/hyperbolic.hpp>
 #include <universal/number/bfloat16/math/functions/hypot.hpp>

--- a/static/float/bfloat16/math/fma.cpp
+++ b/static/float/bfloat16/math/fma.cpp
@@ -139,6 +139,13 @@ namespace {
 		chk(fma(two, three, zero), bfloat16(6.0f), "2*3+0 == 6");
 		chk(fma(zero, three, two), two,            "0*3+2 == 2");
 		chk(fma(one, three, two),  bfloat16(5.0f), "1*3+2 == 5");
+		// deterministic round-to-nearest-even ties (ulp at 1.0 is 2^-7):
+		//   1 + 2^-8   is the midpoint of 1.0 and 1+2^-7   -> even significand 1.0
+		//   1 + 3*2^-8 is the midpoint of 1+2^-7 and 1+2^-6 -> even significand 1+2^-6
+		const bfloat16 halfUlp(std::ldexp(1.0f, -8));         // 2^-8
+		const bfloat16 threeHalfUlp(std::ldexp(3.0f, -8));    // 3*2^-8
+		chk(fma(one, one, halfUlp),      one,                              "1*1+2^-8 tie -> 1.0 (even down)");
+		chk(fma(one, one, threeHalfUlp), bfloat16(1.0f + std::ldexp(1.0f, -6)), "1*1+3*2^-8 tie -> 1+2^-6 (even up)");
 		return fails;
 	}
 

--- a/static/float/bfloat16/math/fma.cpp
+++ b/static/float/bfloat16/math/fma.cpp
@@ -1,0 +1,204 @@
+// fma.cpp: functional tests for the bfloat16 fused multiply-add fma(a,b,c)
+//
+// bfloat16 had no fma (#1193, sub-issue of the universal fma epic #1189). The new
+// fma widens to float, forms a*b + c with std::fma (one rounding to float), and
+// rounds once into bfloat16 via the RNE bfloat16(float) constructor. Because a
+// bfloat16 product is EXACT in float (16 <= 24 significand bits) and float's 24 bits
+// satisfy 24 >= 2*8 + 2 for the bfloat16 target, the float -> bfloat16 double
+// rounding is innocuous: the result is the correctly-rounded-to-nearest-even
+// bfloat16 value of the exact a*b + c.
+//
+// This suite validates against an INDEPENDENT oracle that widens to double instead
+// of float: bfloat16(std::fma(double(a),double(b),double(c))). Both paths equal
+// RNE(exact a*b + c), so they must agree bit-for-bit; disagreement reveals a bug.
+// We also check: single-rounding superiority over the naive two-rounding
+// bfloat16 a*b + c, IEEE special values (inf*0 -> NaN, inf/NaN propagation), and
+// tie-to-even behavior.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	bfloat16 bf16_from_bits(uint16_t bits) {
+		bfloat16 b;
+		b.setbits(bits);
+		return b;
+	}
+
+	// NaN-aware bit-faithful comparison: bfloat16 values are exact in float, so
+	// float() equality is exact for finite/inf; NaN compares equal to NaN.
+	bool match(bfloat16 r, bfloat16 e) {
+		if (isnan(r) || isnan(e)) return isnan(r) && isnan(e);
+		return float(r) == float(e);
+	}
+
+	// independent oracle: exact a*b + c rounded once to bfloat16, via the double path
+	bfloat16 fma_oracle(bfloat16 a, bfloat16 b, bfloat16 c) {
+		return bfloat16(std::fma(double(a), double(b), double(c)));
+	}
+
+	// ---- 1. correctly-rounded vs the independent double-path oracle -----------
+	int VerifyFmaVsOracle(bool reportTestCases, int nrTests, uint64_t seed) {
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_int_distribution<uint32_t> B(0, 0xFFFF);
+		for (int t = 0; t < nrTests; ++t) {
+			bfloat16 a = bf16_from_bits(uint16_t(B(rng)));
+			bfloat16 b = bf16_from_bits(uint16_t(B(rng)));
+			bfloat16 c = bf16_from_bits(uint16_t(B(rng)));
+			bfloat16 r = fma(a, b, c);
+			bfloat16 e = fma_oracle(a, b, c);
+			if (!match(r, e)) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL fma(" << a << ", " << b << ", " << c << ") = " << r
+					<< " (" << to_binary(r) << ")  expected " << e << " (" << to_binary(e) << ")\n";
+			}
+		}
+		return fails;
+	}
+
+	// exhaustive over a with random (b,c): covers every bfloat16 first operand,
+	// including subnormals / inf / NaN.
+	int VerifyFmaExhaustiveA(bool reportTestCases, int samplesPerA, uint64_t seed) {
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_int_distribution<uint32_t> B(0, 0xFFFF);
+		for (uint32_t abits = 0; abits <= 0xFFFF; ++abits) {
+			bfloat16 a = bf16_from_bits(uint16_t(abits));
+			for (int s = 0; s < samplesPerA; ++s) {
+				bfloat16 b = bf16_from_bits(uint16_t(B(rng)));
+				bfloat16 c = bf16_from_bits(uint16_t(B(rng)));
+				if (!match(fma(a, b, c), fma_oracle(a, b, c))) {
+					++fails;
+					if (reportTestCases && fails < 20) std::cout << "    FAIL fma(" << a << ", " << b << ", " << c << ")\n";
+				}
+			}
+		}
+		return fails;
+	}
+
+	// ---- 2. fused single-rounding beats the naive two-rounding a*b + c ---------
+	int VerifyFmaFusedBeatsNaive(bool reportTestCases, int nrTests, uint64_t seed, int& disagreements) {
+		int fails = 0;
+		disagreements = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_int_distribution<uint32_t> B(0, 0xFFFF);
+		for (int t = 0; t < nrTests; ++t) {
+			bfloat16 a = bf16_from_bits(uint16_t(B(rng)));
+			bfloat16 b = bf16_from_bits(uint16_t(B(rng)));
+			bfloat16 c = bf16_from_bits(uint16_t(B(rng)));
+			bfloat16 e = fma_oracle(a, b, c);
+			if (!match(fma(a, b, c), e)) {  // fma must ALWAYS be correctly rounded
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL (fused != oracle) fma(" << a << ", " << b << ", " << c << ")\n";
+			}
+			bfloat16 naive = a * b; naive = naive + c;   // two bfloat16 roundings
+			if (isnan(e) || isnan(naive)) continue;      // only count finite disagreements
+			if (!match(naive, e)) ++disagreements;
+		}
+		return fails;
+	}
+
+	// ---- 3. IEEE special values -----------------------------------------------
+	int VerifySpecialValues(bool reportTestCases) {
+		int fails = 0;
+		const bfloat16 inf  = bf16_from_bits(0x7F80);   // +inf
+		const bfloat16 ninf = bf16_from_bits(0xFF80);   // -inf
+		const bfloat16 zero(0.0f), one(1.0f), two(2.0f), three(3.0f);
+		auto chk = [&](bfloat16 r, bfloat16 e, const char* tag) {
+			if (!match(r, e)) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL special: " << tag << " -> " << r << " expected " << e << '\n';
+			}
+		};
+		chk(fma(inf, zero, one),  fma_oracle(inf, zero, one),  "inf*0+1 (NaN)");
+		chk(fma(inf, two, three), fma_oracle(inf, two, three), "inf*2+3 (inf)");
+		chk(fma(two, three, inf), fma_oracle(two, three, inf), "2*3+inf (inf)");
+		chk(fma(two, three, ninf),fma_oracle(two, three, ninf),"2*3-inf (-inf)");
+		chk(fma(ninf, two, one),  fma_oracle(ninf, two, one),  "-inf*2+1 (-inf)");
+		// NaN propagation
+		const bfloat16 nan = bf16_from_bits(0x7FC0);
+		if (!isnan(fma(nan, one, one))) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(NaN,1,1) not NaN\n"; }
+		if (!isnan(fma(one, nan, one))) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,NaN,1) not NaN\n"; }
+		if (!isnan(fma(one, one, nan))) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,1,NaN) not NaN\n"; }
+		// exact identities
+		chk(fma(two, three, zero), bfloat16(6.0f), "2*3+0 == 6");
+		chk(fma(zero, three, two), two,            "0*3+2 == 2");
+		chk(fma(one, three, two),  bfloat16(5.0f), "1*3+2 == 5");
+		return fails;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite = "bfloat16 fused multiply-add fma(a,b,c) (#1193)";
+	int nrOfFailedTestCases = 0;
+	bool reportTestCases = true;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += VerifySpecialValues(true);
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+	int base = 20000;
+	int samplesPerA = 2;
+#if REGRESSION_LEVEL_2
+	base = 100000;
+	samplesPerA = 8;
+#endif
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyFmaVsOracle(reportTestCases, base, 0xB16F), "fma vs double-path oracle", "fma");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyFmaExhaustiveA(reportTestCases, samplesPerA, 0x0A16), "fma exhaustive first operand", "fma");
+	{
+		int disagreements = 0;
+		nrOfFailedTestCases += ReportTestResult(
+			VerifyFmaFusedBeatsNaive(reportTestCases, base, 0xF00D, disagreements), "fma fused == oracle", "fma");
+		std::cout << "    (fused vs naive: the two-rounding bfloat16 a*b + c disagreed with the exact result in "
+			<< disagreements << " of " << base << " finite cases -- fma is single-rounded)\n";
+	}
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecialValues(reportTestCases), "fma IEEE special values", "fma");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Sub-issue of the universal fma epic #1189. `bfloat16` had no `fma`; this adds a free `sw::universal::fma(a,b,c)` that widens to float, forms `a*b + c` with `std::fma` (one rounding to float), and rounds once into bfloat16 via the RNE `bfloat16(float)` constructor.

**Why it's correctly rounded (single rounding).** A bfloat16 carries 8 significand bits, so the product of two of them is **exact in float** (16 <= 24 bits) -- `std::fma` therefore yields the correctly-rounded-to-float `a*b + c`. Because float's 24 bits satisfy `p >= 2q + 2` for the bfloat16 target `q = 8` (24 >= 18), the subsequent float -> bfloat16 rounding is **innocuous**: the double rounding equals a single round-to-nearest-even of the exact `a*b + c`. `std::fma` also supplies the IEEE special cases (`inf*0 -> NaN`, NaN/inf propagation) for free.

## Changes
- `include/sw/universal/number/bfloat16/math/functions/fma.hpp` -- new free `fma(a,b,c)`.
- `include/sw/universal/number/bfloat16/mathlib.hpp` -- include it.
- `include/sw/universal/number/bfloat16/bfloat16_fwd.hpp` -- forward declaration.
- `static/float/bfloat16/math/fma.cpp` -- regression suite (target `bfloat16_fma`).

## Verification -- independent double-path oracle
The oracle widens to **double** instead of float: `bfloat16(std::fma(double(a),double(b),double(c)))`. Both paths equal `RNE(exact a*b + c)`, so they must agree bit-for-bit (NaN-aware comparison).

- randomized vs oracle
- **exhaustive over every bfloat16 first operand** (all 65536 patterns, incl. subnormals / inf / NaN) with random b, c
- **single-rounding superiority**: the naive two-rounding `bfloat16 a*b + c` disagreed with the exact result in **216 / 20000** finite cases; `fma` matched the oracle in **all** of them
- IEEE special values (`inf*0+1 -> NaN`, `inf*2+3 -> inf`, `2*3+/-inf`, NaN propagation, exact identities)

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| bfloat16_fma | OK | PASS | OK | PASS |

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #1193
Relates to #1189

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fused multiply-add support for `bfloat16` values, computing `a*b + c` with a single rounding step.
  * Made the operation available through the bfloat16 math library.

* **Tests**
  * Added comprehensive coverage for randomized values, exhaustive operand checks, rounding behavior, and IEEE special values such as infinities and NaNs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->