### PR TITLE
feat(lns): add fma(a,b,c) for the log-domain number systems (lns + dbns)

### DIFF
--- a/include/sw/universal/number/dbns/dbns.hpp
+++ b/include/sw/universal/number/dbns/dbns.hpp
@@ -60,4 +60,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////
 /// math functions
+// NOTE: the full mathlib references a math/ subdirectory that does not exist yet, so it
+// stays disabled; math_functions.hpp holds the functions that are wired in (e.g. fma).
 //#include <universal/number/dbns/mathlib.hpp>
+#include <universal/number/dbns/math_functions.hpp>

--- a/include/sw/universal/number/dbns/dbns_fwd.hpp
+++ b/include/sw/universal/number/dbns/dbns_fwd.hpp
@@ -13,6 +13,9 @@ namespace sw { namespace universal {
 // core dbns types and functions
 template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra> class dbns;
 template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra> constexpr dbns<nbits, fbbits, bt, xtra...> abs(const dbns<nbits, fbbits, bt, xtra...>&);
+// fused multiply-add: a*b + c with a single add-domain rounding (see math_functions.hpp)
+template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
+dbns<nbits, fbbits, bt, xtra...> fma(const dbns<nbits, fbbits, bt, xtra...>&, const dbns<nbits, fbbits, bt, xtra...>&, const dbns<nbits, fbbits, bt, xtra...>&);
 template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra> dbns<nbits, fbbits, bt, xtra...> sqrt(const dbns<nbits, fbbits, bt, xtra...>&);
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/dbns/math_functions.hpp
+++ b/include/sw/universal/number/dbns/math_functions.hpp
@@ -5,7 +5,27 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>
+
 namespace sw { namespace universal {
 
+// fma(a,b,c) = a*b + c for the double-base logarithmic number system (dbns).
+//
+// In a (double-base) logarithmic number system the multiply is (near-)exact while the
+// ADD is the lossy step. fma forms the fused product-sum in a wide double intermediate
+// and rounds the result once into dbns via the value constructor, so the add-domain
+// rounding happens exactly once. A dbns significand is far narrower than double's 53
+// bits for the practical configurations, so double(x) is the exact represented value,
+// the product is exact in double, and the double -> dbns rounding is the single
+// rounding that determines the result. NaN propagates via the value constructor
+// (dbns has no infinity: isinf() is always false).
+//
+// Sub-issue of #1189 (universal fma). Relates to #1196.
+template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
+dbns<nbits, fbbits, bt, xtra...> fma(const dbns<nbits, fbbits, bt, xtra...>& a,
+                                     const dbns<nbits, fbbits, bt, xtra...>& b,
+                                     const dbns<nbits, fbbits, bt, xtra...>& c) {
+	return dbns<nbits, fbbits, bt, xtra...>(std::fma(double(a), double(b), double(c)));
+}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/dbns/math_functions.hpp
+++ b/include/sw/universal/number/dbns/math_functions.hpp
@@ -20,6 +20,13 @@ namespace sw { namespace universal {
 // rounding that determines the result. NaN propagates via the value constructor
 // (dbns has no infinity: isinf() is always false).
 //
+// LIMITATION: the double bridge assumes the operands and the exact a*b + c lie within
+// binary64's range and precision. A logarithmic encoding can have a wider dynamic
+// range than binary64, so operands (or a product-sum) whose magnitude exceeds ~1.8e308
+// overflow to infinity in the intermediate before the fma completes. A range-safe
+// log-domain fused path (working in the log/quire domain, cf. dbns/fdp.hpp) is a
+// possible future enhancement; this overload targets binary64-representable operands.
+//
 // Sub-issue of #1189 (universal fma). Relates to #1196.
 template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
 dbns<nbits, fbbits, bt, xtra...> fma(const dbns<nbits, fbbits, bt, xtra...>& a,

--- a/include/sw/universal/number/lns/lns_fwd.hpp
+++ b/include/sw/universal/number/lns/lns_fwd.hpp
@@ -13,6 +13,9 @@ namespace sw { namespace universal {
 // core lns types and functions
 template<unsigned nbits, unsigned rbits, typename bt, auto...x> class lns;
 template<unsigned nbits, unsigned rbits, typename bt, auto...x> constexpr lns<nbits, rbits, bt, x...> abs(const lns<nbits, rbits, bt, x...>&);
+// fused multiply-add: a*b + c with a single add-domain rounding (see math/fma.hpp)
+template<unsigned nbits, unsigned rbits, typename bt, auto...x>
+lns<nbits, rbits, bt, x...> fma(const lns<nbits, rbits, bt, x...>&, const lns<nbits, rbits, bt, x...>&, const lns<nbits, rbits, bt, x...>&);
 template<unsigned nbits, unsigned rbits, typename bt, auto...x> lns<nbits, rbits, bt, x...> sqrt(const lns<nbits, rbits, bt, x...>&);
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/lns/math/fma.hpp
+++ b/include/sw/universal/number/lns/math/fma.hpp
@@ -16,6 +16,13 @@
 // rounding that determines the result. NaN propagates via the value constructor
 // (lns has no infinity: isinf() is always false).
 //
+// LIMITATION: the double bridge assumes the operands and the exact a*b + c lie within
+// binary64's range and precision. A logarithmic encoding can have a wider dynamic
+// range than binary64, so operands (or a product-sum) whose magnitude exceeds ~1.8e308
+// overflow to infinity in the intermediate before the fma completes. A range-safe
+// log-domain fused path (working in the log/quire domain, cf. lns/fdp.hpp) is a
+// possible future enhancement; this overload targets binary64-representable operands.
+//
 // Sub-issue of #1189 (universal fma). Relates to #1196.
 
 #include <cmath>

--- a/include/sw/universal/number/lns/math/fma.hpp
+++ b/include/sw/universal/number/lns/math/fma.hpp
@@ -1,0 +1,31 @@
+#pragma once
+// fma.hpp: fused multiply-add fma(a,b,c) = a*b + c for the logarithmic number system (lns)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// In a logarithmic number system the multiply is (near-)exact -- it is an addition
+// of exponents -- while the ADD is the lossy step (a Gaussian-log table lookup that
+// rounds). fma forms the fused product-sum a*b + c in a wide double intermediate and
+// rounds the result once into lns via the value constructor, so the add-domain
+// rounding happens exactly once. An lns significand is far narrower than double's 53
+// bits for the practical configurations, so double(x) is the exact represented value,
+// the product is exact in double, and the double -> lns rounding is the single
+// rounding that determines the result. NaN propagates via the value constructor
+// (lns has no infinity: isinf() is always false).
+//
+// Sub-issue of #1189 (universal fma). Relates to #1196.
+
+#include <cmath>
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
+lns<nbits, rbits, bt, xtra...> fma(const lns<nbits, rbits, bt, xtra...>& a, const lns<nbits, rbits, bt, xtra...>& b,
+                                   const lns<nbits, rbits, bt, xtra...>& c) {
+	return lns<nbits, rbits, bt, xtra...>(std::fma(double(a), double(b), double(c)));
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/lns/mathlib.hpp
+++ b/include/sw/universal/number/lns/mathlib.hpp
@@ -10,6 +10,7 @@
 #include <universal/number/lns/math/complex.hpp>
 #include <universal/number/lns/math/error_and_gamma.hpp>
 #include <universal/number/lns/math/exponent.hpp>
+#include <universal/number/lns/math/fma.hpp>
 #include <universal/number/lns/math/fractional.hpp>
 #include <universal/number/lns/math/hyperbolic.hpp>
 #include <universal/number/lns/math/hypot.hpp>

--- a/static/logarithmic/dbns/math/fma.cpp
+++ b/static/logarithmic/dbns/math/fma.cpp
@@ -37,7 +37,6 @@ namespace {
 		for (int t = 0; t < nrTests; ++t) {
 			Dbns a(U(rng)), b(U(rng)), c(U(rng));
 			Dbns r = fma(a, b, c);
-			if (r.isnan()) continue;
 			// independent fused reference in long double: exact product then a single rounding
 			// (a plain da*db + dc would double-round and amplify cancellation -- which is exactly
 			// what fma avoids, so it must not be the oracle).

--- a/static/logarithmic/dbns/math/fma.cpp
+++ b/static/logarithmic/dbns/math/fma.cpp
@@ -1,0 +1,117 @@
+// fma.cpp: functional tests for the dbns (double-base logarithmic) fused multiply-add
+//
+// dbns had no fma (#1196, sub-issue of the universal fma epic #1189). In a (double-base)
+// logarithmic number system the multiply is (near-)exact while the ADD is the lossy step;
+// fma forms a*b + c in a wide double intermediate and rounds the result once into dbns via
+// the value constructor, so the add-domain rounding happens exactly once. Log-domain
+// encodings do not represent "nice" linear values exactly, so this suite does not test
+// exactness; it validates correctly-rounded agreement with an INDEPENDENT long-double
+// reference (a*b + c formed off the implementation's double/std::fma path) and NaN
+// propagation.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <universal/number/dbns/dbns.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// correctly rounded vs an independent long-double reference
+	template<unsigned nbits, unsigned fbbits, typename bt = uint16_t>
+	int VerifyCorrectlyRounded(bool reportTestCases, int nrTests, uint64_t seed) {
+		using Dbns = dbns<nbits, fbbits, bt>;
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-4.0, 4.0);
+		for (int t = 0; t < nrTests; ++t) {
+			Dbns a(U(rng)), b(U(rng)), c(U(rng));
+			Dbns r = fma(a, b, c);
+			if (r.isnan()) continue;
+			// independent fused reference in long double: exact product then a single rounding
+			// (a plain da*db + dc would double-round and amplify cancellation -- which is exactly
+			// what fma avoids, so it must not be the oracle).
+			long double tru = std::fmal((long double)double(a), (long double)double(b), (long double)double(c));
+			Dbns expected{ double(tru) };   // dbns rounds the reference the same way it would the exact result
+			if (r != expected) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL fma(" << double(a) << ", " << double(b) << ", " << double(c)
+					<< ") = " << double(r) << "  expected " << double(expected) << '\n';
+			}
+		}
+		return fails;
+	}
+
+	// NaN propagation (dbns has no infinity: isinf() is always false)
+	template<unsigned nbits, unsigned fbbits, typename bt = uint16_t>
+	int VerifyNaN(bool reportTestCases) {
+		using Dbns = dbns<nbits, fbbits, bt>;
+		int fails = 0;
+		const Dbns nan(std::numeric_limits<double>::quiet_NaN());
+		const Dbns one(1.0), two(2.0);
+		if (!fma(nan, one, two).isnan()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(NaN,1,2) not NaN\n"; }
+		if (!fma(one, nan, two).isnan()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,NaN,2) not NaN\n"; }
+		if (!fma(one, two, nan).isnan()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,2,NaN) not NaN\n"; }
+		return fails;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite = "dbns fused multiply-add fma(a,b,c) (#1196)";
+	int nrOfFailedTestCases = 0;
+	bool reportTestCases = true;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += VerifyNaN<16, 8>(true);
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+	int base = 10000;
+#if REGRESSION_LEVEL_2
+	base = 50000;
+#endif
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<16, 8>(reportTestCases, base, 0x2B20A), "fma correctly-rounded dbns<16,8>", "fma");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<20, 10>(reportTestCases, base, 0x2B21B), "fma correctly-rounded dbns<20,10>", "fma");
+	nrOfFailedTestCases += ReportTestResult(VerifyNaN<16, 8>(reportTestCases), "fma NaN propagation dbns<16,8>", "fma");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/logarithmic/lns/math/fma.cpp
+++ b/static/logarithmic/lns/math/fma.cpp
@@ -1,0 +1,117 @@
+// fma.cpp: functional tests for the lns (logarithmic number system) fused multiply-add
+//
+// lns had no fma (#1196, sub-issue of the universal fma epic #1189). In a logarithmic
+// number system the multiply is (near-)exact (an exponent addition) while the ADD is
+// the lossy step; fma forms a*b + c in a wide double intermediate and rounds the result
+// once into lns via the value constructor, so the add-domain rounding happens exactly
+// once. Log-domain encodings do not represent "nice" linear values exactly (e.g. 2.5),
+// so this suite does not test exactness; it validates correctly-rounded agreement with
+// an INDEPENDENT long-double reference (a*b + c formed off the implementation's
+// double/std::fma path) and NaN propagation.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <universal/number/lns/lns.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// correctly rounded vs an independent long-double reference
+	template<unsigned nbits, unsigned rbits, typename bt = uint16_t>
+	int VerifyCorrectlyRounded(bool reportTestCases, int nrTests, uint64_t seed) {
+		using Lns = lns<nbits, rbits, bt>;
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-4.0, 4.0);
+		for (int t = 0; t < nrTests; ++t) {
+			Lns a(U(rng)), b(U(rng)), c(U(rng));
+			Lns r = fma(a, b, c);
+			if (r.isnan()) continue;
+			// independent fused reference in long double: exact product then a single rounding
+			// (a plain da*db + dc would double-round and amplify cancellation -- which is exactly
+			// what fma avoids, so it must not be the oracle).
+			long double tru = std::fmal((long double)double(a), (long double)double(b), (long double)double(c));
+			Lns expected{ double(tru) };   // lns rounds the reference the same way it would the exact result
+			if (r != expected) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL fma(" << double(a) << ", " << double(b) << ", " << double(c)
+					<< ") = " << double(r) << "  expected " << double(expected) << '\n';
+			}
+		}
+		return fails;
+	}
+
+	// NaN propagation (lns has no infinity: isinf() is always false)
+	template<unsigned nbits, unsigned rbits, typename bt = uint16_t>
+	int VerifyNaN(bool reportTestCases) {
+		using Lns = lns<nbits, rbits, bt>;
+		int fails = 0;
+		const Lns nan(std::numeric_limits<double>::quiet_NaN());
+		const Lns one(1.0), two(2.0);
+		if (!fma(nan, one, two).isnan()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(NaN,1,2) not NaN\n"; }
+		if (!fma(one, nan, two).isnan()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,NaN,2) not NaN\n"; }
+		if (!fma(one, two, nan).isnan()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,2,NaN) not NaN\n"; }
+		return fails;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite = "lns fused multiply-add fma(a,b,c) (#1196)";
+	int nrOfFailedTestCases = 0;
+	bool reportTestCases = true;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += VerifyNaN<16, 8>(true);
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+	int base = 10000;
+#if REGRESSION_LEVEL_2
+	base = 50000;
+#endif
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<16, 8>(reportTestCases, base, 0x1A20A), "fma correctly-rounded lns<16,8>", "fma");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<24, 12>(reportTestCases, base, 0x1A21B), "fma correctly-rounded lns<24,12>", "fma");
+	nrOfFailedTestCases += ReportTestResult(VerifyNaN<16, 8>(reportTestCases), "fma NaN propagation lns<16,8>", "fma");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/logarithmic/lns/math/fma.cpp
+++ b/static/logarithmic/lns/math/fma.cpp
@@ -37,7 +37,6 @@ namespace {
 		for (int t = 0; t < nrTests; ++t) {
 			Lns a(U(rng)), b(U(rng)), c(U(rng));
 			Lns r = fma(a, b, c);
-			if (r.isnan()) continue;
 			// independent fused reference in long double: exact product then a single rounding
 			// (a plain da*db + dc would double-round and amplify cancellation -- which is exactly
 			// what fma avoids, so it must not be the oracle).


### PR DESCRIPTION
## Summary
Sub-issue of the universal fma epic #1189. Neither `lns` (logarithmic) nor `dbns` (double-base logarithmic) had an `fma`. Adds a free `sw::universal::fma` for both.

In the log domain the **multiply is (near-)exact** (an exponent addition) while the **ADD is the lossy step**. fma forms `a*b + c` in a wide double intermediate and rounds once into the log-domain encoding via the value constructor, so the add-domain rounding happens exactly once. An lns/dbns significand is far narrower than double's 53 bits, so `double(x)` is exact, the product is exact in double, and the double -> log-domain rounding is the single rounding that determines the result. NaN propagates via the value ctor (neither type has an infinity).

## Wiring note
`lns` follows the standard `math/` + `mathlib` pattern. `dbns` had **no wired math layer** -- its `mathlib.hpp` references a non-existent `math/` subdirectory and is disabled -- so fma lands in the orphan `math_functions.hpp`, which `dbns.hpp` now includes (the broken mathlib stays disabled).

## Changes
- `include/sw/universal/number/lns/math/fma.hpp` (+ `mathlib.hpp`, `lns_fwd.hpp`)
- `include/sw/universal/number/dbns/math_functions.hpp` (+ `dbns.hpp` include, `dbns_fwd.hpp`)
- `static/logarithmic/lns/math/fma.cpp` (target `lns_fma`), `static/logarithmic/dbns/math/fma.cpp` (target `dbns_fma`)

## Verification -- independent *fused* long-double reference
Correctly-rounded agreement with `std::fmal` (`lns<16,8>`/`<24,12>`, `dbns<16,8>`/`<20,10>`) + NaN propagation. Log-domain encodings don't represent nice linear values exactly, so exactness is not asserted.

**Notable**: the reference must itself be **fused** -- a naive `(long double)da*db + dc` double-rounds and *amplifies* cancellation, which is exactly what fma avoids. A failing case during development (`a*b + c` with `a*b ~ -c`, result ~1e-18) confirmed the single-rounding fma is the more accurate one; the oracle was fixed to `std::fmal`.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| lns_fma | PASS | PASS |
| dbns_fma | PASS | PASS |

Resolves #1196
Relates to #1189

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fused multiply-add (`fma`) support for both LNS and DBNS numeric types.
  * Computes `a × b + c` using fused behavior consistent with `std::fma` semantics, with NaN propagation handled via the existing value construction.
  * Exposed through the library’s math interfaces and headers for immediate use by existing type workflows.

* **Tests**
  * Added functional and randomized regression tests validating rounding accuracy and NaN behavior for `fma` on both LNS and DBNS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->