### PR TITLE
feat(posit): add a rounded scalar fma overload to posit1 and posito

### DIFF
--- a/include/sw/universal/number/posit1/posit_impl.hpp
+++ b/include/sw/universal/number/posit1/posit_impl.hpp
@@ -2700,9 +2700,11 @@ posit<nbits, es> fabs(const posit<nbits, es>& v) {
 
 // Atomic fused operators
 
-// FMA: fused multiply-add:  a*b + c
+// fma_value: fused multiply-add building block a*b + c, returning the UNROUNDED
+// full-precision product-sum as an internal::value. The public rounded scalar fma
+// (below) rounds this once into a posit. (Renamed from fma; #1197.)
 template<unsigned nbits, unsigned es>
-internal::value<1 + 2 * (nbits - es)> fma(const posit<nbits, es>& a, const posit<nbits, es>& b, const posit<nbits, es>& c) {
+internal::value<1 + 2 * (nbits - es)> fma_value(const posit<nbits, es>& a, const posit<nbits, es>& b, const posit<nbits, es>& c) {
 	constexpr unsigned fbits = nbits - 3 - es;
 	constexpr unsigned fhbits = fbits + 1;      // size of positFraction + hidden bit
 	constexpr unsigned mbits = 2 * fhbits;      // size of the multiplier output
@@ -2747,6 +2749,17 @@ internal::value<1 + 2 * (nbits - es)> fma(const posit<nbits, es>& a, const posit
 	}
 
 	return sum;
+}
+
+// FMA: fused multiply-add a*b + c with a SINGLE rounding into posit.
+// Forms the exact product-sum via fma_value (full-precision internal::value) and
+// rounds it once with convert() -- more accurate than the two-rounding a*b + c, and
+// a drop-in scalar (returns the posit type) matching the modern posit fma. (#1197)
+template<unsigned nbits, unsigned es>
+posit<nbits, es> fma(const posit<nbits, es>& a, const posit<nbits, es>& b, const posit<nbits, es>& c) {
+	posit<nbits, es> result;
+	convert(fma_value(a, b, c), result);   // single rounding; convert handles zero/NaR
+	return result;
 }
 
 // FAM: fused add-multiply: (a + b) * c

--- a/include/sw/universal/number/posito/posito_impl.hpp
+++ b/include/sw/universal/number/posito/posito_impl.hpp
@@ -2353,9 +2353,11 @@ posito<nbits, es> fabs(const posito<nbits, es>& v) {
 
 // Atomic fused operators
 
-// FMA: fused multiply-add:  a*b + c
+// fma_value: fused multiply-add building block a*b + c, returning the UNROUNDED
+// full-precision product-sum as an internal::value. The public rounded scalar fma
+// (below) rounds this once into a posito. (Renamed from fma; #1197.)
 template<unsigned nbits, unsigned es>
-internal::value<1 + 2 * (nbits - es)> fma(const posito<nbits, es>& a, const posito<nbits, es>& b, const posito<nbits, es>& c) {
+internal::value<1 + 2 * (nbits - es)> fma_value(const posito<nbits, es>& a, const posito<nbits, es>& b, const posito<nbits, es>& c) {
 	constexpr unsigned fbits = nbits - 3 - es;
 	constexpr unsigned fhbits = fbits + 1;      // size of fraction + hidden bit
 	constexpr unsigned mbits = 2 * fhbits;      // size of the multiplier output
@@ -2376,14 +2378,14 @@ internal::value<1 + 2 * (nbits - es)> fma(const posito<nbits, es>& a, const posi
 			sum.setzero();
 		}
 		else {
-			ctmp.set(sign(c), scale(c), extract_fraction<nbits, es, fbits>(c), c.iszero(), c.isnar());
+			c.normalize(ctmp);  // decode c into (sign,scale,fraction) -- posito uses normalize(), not extract_fraction (#1197)
 			sum.template right_extend<fbits, abits + 1>(ctmp); // right-extend the c input argument and assign to sum
 		}
 	}
 	else { // else clause guarantees that the product is non-zero	
 		// first, the multiply: transform the inputs into (sign,scale,fraction) triples
-		va.set(sign(a), scale(a), extract_fraction<nbits, es, fbits>(a), a.iszero(), a.isnar());;
-		vb.set(sign(b), scale(b), extract_fraction<nbits, es, fbits>(b), b.iszero(), b.isnar());;
+		a.normalize(va);  // posito decodes via normalize(), not extract_fraction (#1197)
+		b.normalize(vb);
 
 		module_multiply(va, vb, product);    // multiply the two inputs
 
@@ -2392,7 +2394,7 @@ internal::value<1 + 2 * (nbits - es)> fma(const posito<nbits, es>& a, const posi
 			sum.template right_extend<mbits, abits + 1>(product);   // right-extend the product and assign to sum
 		}
 		else {
-			ctmp.set(sign(c), scale(c), extract_fraction<nbits, es, fbits>(c), c.iszero(), c.isnar());
+			c.normalize(ctmp);  // decode c into (sign,scale,fraction) -- posito uses normalize(), not extract_fraction (#1197)
 			internal::value<mbits> vc;
 			vc.template right_extend<fbits, mbits>(ctmp); // right-extend the c argument and assign to adder input
 			module_add<mbits, abits>(product, vc, sum);
@@ -2400,6 +2402,17 @@ internal::value<1 + 2 * (nbits - es)> fma(const posito<nbits, es>& a, const posi
 	}
 
 	return sum;
+}
+
+// FMA: fused multiply-add a*b + c with a SINGLE rounding into posito.
+// Forms the exact product-sum via fma_value (full-precision internal::value) and
+// rounds it once with convert() -- more accurate than the two-rounding a*b + c, and
+// a drop-in scalar (returns the posito type) matching the modern posit fma. (#1197)
+template<unsigned nbits, unsigned es>
+posito<nbits, es> fma(const posito<nbits, es>& a, const posito<nbits, es>& b, const posito<nbits, es>& c) {
+	posito<nbits, es> result;
+	convert(fma_value(a, b, c), result);   // single rounding; convert handles zero/NaR
+	return result;
 }
 
 // FAM: fused add-multiply: (a + b) * c

--- a/static/tapered/posit1/arithmetic/fma_rounded.cpp
+++ b/static/tapered/posit1/arithmetic/fma_rounded.cpp
@@ -1,0 +1,152 @@
+// fma_rounded.cpp: functional tests for the rounded scalar posit fma(a,b,c)
+//
+// posit1's fma historically returned an UNROUNDED internal::value building block, not a
+// drop-in scalar (#1197). A public fma overload now returns the posit type with a single
+// rounding (exact product-sum via fma_value, then one convert), matching the modern posit
+// fma; the unrounded variant is retained as fma_value.
+//
+// This suite validates the rounded fma against an INDEPENDENT fused reference: for small
+// posits whose product is exact in double, round(std::fmal(a,b,c)) is the correctly-rounded
+// result. We check: correctly-rounded agreement, single-rounding superiority over the naive
+// two-rounding a*b + c under cancellation, and NaR propagation.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <universal/number/posit1/posit1.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// correctly-rounded vs an independent fused long-double reference (exact for small posits)
+	template<unsigned nbits, unsigned es>
+	int VerifyCorrectlyRounded(bool reportTestCases, int nrTests, uint64_t seed) {
+		using Posit = posit<nbits, es>;
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-4.0, 4.0);
+		for (int t = 0; t < nrTests; ++t) {
+			Posit a(U(rng)), b(U(rng)), c(U(rng));
+			Posit r = fma(a, b, c);
+			if (r.isnar()) continue;
+			long double tru = std::fmal((long double)double(a), (long double)double(b), (long double)double(c));
+			Posit ref{ double(tru) };
+			if (r != ref) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL fma(" << double(a) << ", " << double(b) << ", " << double(c)
+					<< ") = " << double(r) << "  expected " << double(ref) << '\n';
+			}
+		}
+		return fails;
+	}
+
+	// fused single-rounding beats the naive two-rounding a*b + c
+	template<unsigned nbits, unsigned es>
+	int VerifyFusedBeatsNaive(bool reportTestCases, int nrTests, uint64_t seed, int& disagreements) {
+		using Posit = posit<nbits, es>;
+		int fails = 0;
+		disagreements = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-4.0, 4.0);
+		for (int t = 0; t < nrTests; ++t) {
+			Posit a(U(rng)), b(U(rng)), c(U(rng));
+			Posit r = fma(a, b, c);
+			if (r.isnar()) continue;
+			long double tru = std::fmal((long double)double(a), (long double)double(b), (long double)double(c));
+			Posit ref{ double(tru) };
+			if (r != ref) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL (fused != oracle)\n";
+			}
+			Posit naive = a * b; naive = naive + c;   // two roundings
+			if (naive != ref) ++disagreements;
+		}
+		return fails;
+	}
+
+	// NaR propagation
+	template<unsigned nbits, unsigned es>
+	int VerifyNaR(bool reportTestCases) {
+		using Posit = posit<nbits, es>;
+		int fails = 0;
+		Posit nar; nar.setnar();
+		const Posit one(1.0), two(2.0);
+		if (!fma(nar, one, two).isnar()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(NaR,1,2) not NaR\n"; }
+		if (!fma(one, nar, two).isnar()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,NaR,2) not NaR\n"; }
+		if (!fma(one, two, nar).isnar()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,2,NaR) not NaR\n"; }
+		// fma(a,b,0) == a*b (exact product path)
+		if (fma(two, two, Posit(0.0)) != (two * two)) {
+			++fails;
+			if (reportTestCases) std::cout << "    FAIL fma(2,2,0) != 4\n";
+		}
+		return fails;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite = "posit1 rounded scalar fma(a,b,c) (#1197)";
+	int nrOfFailedTestCases = 0;
+	bool reportTestCases = true;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += VerifyNaR<16, 1>(true);
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+	int base = 10000;
+#if REGRESSION_LEVEL_2
+	base = 50000;
+#endif
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<16, 1>(reportTestCases, base, 0x1970), "fma correctly-rounded posit<16,1>", "fma");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<20, 2>(reportTestCases, base, 0x1971), "fma correctly-rounded posit<20,2>", "fma");
+	{
+		int disagreements = 0;
+		nrOfFailedTestCases += ReportTestResult(
+			VerifyFusedBeatsNaive<16, 1>(reportTestCases, base, 0x1972, disagreements),
+			"fma fused == oracle posit<16,1>", "fma");
+		std::cout << "    (fused vs naive: the two-rounding a*b + c disagreed with the exact result in "
+			<< disagreements << " of " << base << " cases -- fma is single-rounded)\n";
+	}
+	nrOfFailedTestCases += ReportTestResult(VerifyNaR<16, 1>(reportTestCases), "fma NaR / identities posit<16,1>", "fma");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/posito/arithmetic/fma.cpp
+++ b/static/tapered/posito/arithmetic/fma.cpp
@@ -1,0 +1,152 @@
+// fma_rounded.cpp: functional tests for the rounded scalar posit fma(a,b,c)
+//
+// posito.s fma historically returned an UNROUNDED internal::value building block, not a
+// drop-in scalar (#1197). A public fma overload now returns the posit type with a single
+// rounding (exact product-sum via fma_value, then one convert), matching the modern posit
+// fma; the unrounded variant is retained as fma_value.
+//
+// This suite validates the rounded fma against an INDEPENDENT fused reference: for small
+// posits whose product is exact in double, round(std::fmal(a,b,c)) is the correctly-rounded
+// result. We check: correctly-rounded agreement, single-rounding superiority over the naive
+// two-rounding a*b + c under cancellation, and NaR propagation.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <universal/number/posito/posito.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// correctly-rounded vs an independent fused long-double reference (exact for small posits)
+	template<unsigned nbits, unsigned es>
+	int VerifyCorrectlyRounded(bool reportTestCases, int nrTests, uint64_t seed) {
+		using Posit = posito<nbits, es>;
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-4.0, 4.0);
+		for (int t = 0; t < nrTests; ++t) {
+			Posit a(U(rng)), b(U(rng)), c(U(rng));
+			Posit r = fma(a, b, c);
+			if (r.isnar()) continue;
+			long double tru = std::fmal((long double)double(a), (long double)double(b), (long double)double(c));
+			Posit ref{ double(tru) };
+			if (r != ref) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL fma(" << double(a) << ", " << double(b) << ", " << double(c)
+					<< ") = " << double(r) << "  expected " << double(ref) << '\n';
+			}
+		}
+		return fails;
+	}
+
+	// fused single-rounding beats the naive two-rounding a*b + c
+	template<unsigned nbits, unsigned es>
+	int VerifyFusedBeatsNaive(bool reportTestCases, int nrTests, uint64_t seed, int& disagreements) {
+		using Posit = posito<nbits, es>;
+		int fails = 0;
+		disagreements = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-4.0, 4.0);
+		for (int t = 0; t < nrTests; ++t) {
+			Posit a(U(rng)), b(U(rng)), c(U(rng));
+			Posit r = fma(a, b, c);
+			if (r.isnar()) continue;
+			long double tru = std::fmal((long double)double(a), (long double)double(b), (long double)double(c));
+			Posit ref{ double(tru) };
+			if (r != ref) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL (fused != oracle)\n";
+			}
+			Posit naive = a * b; naive = naive + c;   // two roundings
+			if (naive != ref) ++disagreements;
+		}
+		return fails;
+	}
+
+	// NaR propagation
+	template<unsigned nbits, unsigned es>
+	int VerifyNaR(bool reportTestCases) {
+		using Posit = posito<nbits, es>;
+		int fails = 0;
+		Posit nar; nar.setnar();
+		const Posit one(1.0), two(2.0);
+		if (!fma(nar, one, two).isnar()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(NaR,1,2) not NaR\n"; }
+		if (!fma(one, nar, two).isnar()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,NaR,2) not NaR\n"; }
+		if (!fma(one, two, nar).isnar()) { ++fails; if (reportTestCases) std::cout << "    FAIL fma(1,2,NaR) not NaR\n"; }
+		// fma(a,b,0) == a*b (exact product path)
+		if (fma(two, two, Posit(0.0)) != (two * two)) {
+			++fails;
+			if (reportTestCases) std::cout << "    FAIL fma(2,2,0) != 4\n";
+		}
+		return fails;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite = "posito rounded scalar fma(a,b,c) (#1197)";
+	int nrOfFailedTestCases = 0;
+	bool reportTestCases = true;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += VerifyNaR<16, 1>(true);
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+
+#else
+
+	int base = 10000;
+#if REGRESSION_LEVEL_2
+	base = 50000;
+#endif
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<16, 1>(reportTestCases, base, 0x1970), "fma correctly-rounded posito<16,1>", "fma");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<20, 2>(reportTestCases, base, 0x1971), "fma correctly-rounded posito<20,2>", "fma");
+	{
+		int disagreements = 0;
+		nrOfFailedTestCases += ReportTestResult(
+			VerifyFusedBeatsNaive<16, 1>(reportTestCases, base, 0x1972, disagreements),
+			"fma fused == oracle posito<16,1>", "fma");
+		std::cout << "    (fused vs naive: the two-rounding a*b + c disagreed with the exact result in "
+			<< disagreements << " of " << base << " cases -- fma is single-rounded)\n";
+	}
+	nrOfFailedTestCases += ReportTestResult(VerifyNaR<16, 1>(reportTestCases), "fma NaR / identities posito<16,1>", "fma");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Sub-issue of the universal fma epic #1189. `posit1` and `posito`'s `fma` returned an **unrounded** `internal::value` building block, not a drop-in scalar. This adds a public `fma` overload that returns the posit/posito type with a **single rounding** (exact product-sum via the retained building block, then one `convert()`), matching the modern posit `fma`.

Since C++ can't overload on return type alone, the unrounded variant is **renamed to `fma_value`** (the issue authorizes this; it had no external callers).

## posito latent bug (fixed)
posito's `fma_value` decoded inputs with `extract_fraction<>`, which is defined for **posit1, not posito** -- a type error that was **dormant because the posito `fma` template was never instantiated**. My new posito test is the first to instantiate it, surfacing the bug. Fixed to use posito's own `normalize()` decode path (the same one `operator*=` uses).

> posito's `fam` has the same dormant `extract_fraction` issue; left as-is (out of scope for this fma change, and also never instantiated).

## Changes
- `posit1/posit_impl.hpp`, `posito/posito_impl.hpp` -- rename `fma` -> `fma_value`, add rounded `fma`; fix posito decode.
- `static/tapered/posit1/arithmetic/fma_rounded.cpp`, `static/tapered/posito/arithmetic/fma.cpp` -- new oracle tests.

## Verification -- independent fused reference
For small posits the product is exact in double, so `round(std::fmal(a,b,c))` is the correctly-rounded result:
- correctly-rounded agreement (`posit<16,1>`, `posit<20,2>`; posito equivalents)
- **single-rounding superiority**: naive two-rounding `a*b + c` disagreed with the exact result in **~29% (2889/10000)** of cases; fma matched the oracle in all
- NaR propagation; `fma(a,b,0) == a*b`

The existing `posit1 arithmetic/fma.cpp` demo still passes (it rounded via assignment to a posit).

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| posit1_fma_rounded | PASS | PASS |
| posito_fma | PASS | PASS |
| posit1_fma (existing demo) | OK | OK |

Resolves #1197
Relates to #1189

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added correctly rounded fused multiply-add support for posit and posito scalar values.
  - FMA now performs the multiplication and addition with a single final rounding step.
  - Special values, including NaR and zero operands, are handled consistently.

- **Tests**
  - Added coverage validating correct rounding, NaR propagation, zero identities, and differences from naïve two-step arithmetic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->