### PR TITLE
fix(lns): correct quire<lns> accuracy docs -- not an exact accumulator

### DIFF
--- a/include/sw/universal/number/lns/fdp.hpp
+++ b/include/sw/universal/number/lns/fdp.hpp
@@ -6,20 +6,34 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
-// LNS stores values as (-1)^sign * 2^exponent where the exponent is a
-// fixed-point number. Multiplication in LNS is addition of exponents (exact),
-// but quire accumulation requires linear-domain values.
+// LNS stores values as (-1)^sign * 2^exponent where the exponent is a fixed-point
+// number with rbits fractional bits. Multiplication in LNS is addition of exponents
+// (exact in the log domain), but a quire is a LINEAR fixed-point register, so the
+// product must be deposited as a linear value.
 //
-// quire_mul converts two lns operands to double, multiplies exactly in double
-// (since lns values are always exactly representable as powers of 2 to the
-// precision of the exponent), then packs the product into a blocktriple
-// for quire accumulation.
+// IMPORTANT -- quire<lns> is NOT an exact accumulator (unlike quire<posit> and
+// quire<cfloat>). An lns product is 2^(e_a + e_b) = 2^(k + m/2^rbits). For m != 0
+// that value is IRRATIONAL (if 2^(p/q) were rational, unique factorization forces
+// q | p), so it is not a dyadic rational -- and no linear fixed-point super-
+// accumulator, at ANY width, can represent a general lns product exactly. This is a
+// structural property lns lacks: posit and cfloat values are dyadic, so their products
+// land exactly on a wide-enough fixed-point grid; lns values do not. Earlier revisions
+// of this header claimed lns values are "always exactly representable as powers of 2";
+// that holds only when the exponent is an integer, and is the source of the confusion.
 //
-// This double-precision path is exact for lns types up to ~52 exponent
-// fractional bits. For wider types, a native log-to-linear conversion
-// using extended-precision arithmetic would be needed.
+// quire_mul therefore ROUNDS each product once before depositing it. The current
+// implementation forms the product on the double/frexp path and packs 2*rbits
+// significand bits -- i.e. it rounds at ~the lns representation precision, well below
+// the quire's own precision. So the quire-dot error is bounded by the PRODUCT-
+// representation error, not by the accumulation; for narrow lns (e.g. lns<16,8>) this
+// can be WORSE than accumulating the same terms in a promoted double. For an accurate
+// lns dot product, promote to a double accumulator.
 //
-// Relates to #345, #549
+// A future enhancement could round each product at the quire's full precision instead
+// of double's, recovering a single-rounding-per-term guarantee (still not exact). See
+// #1203 and stillwater-sc/mp-blas#11.
+//
+// Relates to #345, #549, #1203
 
 #include <vector>
 #include <cmath>
@@ -30,15 +44,17 @@
 namespace sw { namespace universal {
 
 // ============================================================================
-// quire_mul: unrounded full-precision product for quire accumulation
+// quire_mul: ROUNDED lns product for quire accumulation (NOT exact -- see the file
+// header: a general lns product is irrational and cannot be exact in a linear quire).
 //
-// Converts both lns operands to double, multiplies, then decomposes the
-// product into a blocktriple<product_fbits, REP, bt> for quire accumulation.
+// Converts both lns operands to double, multiplies, then decomposes the product into a
+// blocktriple<product_fbits, REP, bt> with product_fbits = 2*rbits.
 //
-// The REP blocktriple with fbits=product_fbits gives:
+// The REP blocktriple gives:
 //   bfbits = product_fbits + 2
 //   radix  = product_fbits
-// which is sufficient to hold the double-precision product significand.
+// so it carries 2*rbits significand bits -- the product is rounded to ~the lns
+// representation precision before it enters the quire, NOT to the quire's precision.
 // ============================================================================
 template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
 blocktriple<2*rbits, BlockTripleOperator::REP, bt>

--- a/include/sw/universal/traits/quire_traits.hpp
+++ b/include/sw/universal/traits/quire_traits.hpp
@@ -181,6 +181,14 @@ struct quire_traits<fixpnt<nbits, rbits, arithmetic, bt>> {
 //
 // NOTE: This is a provisional sizing. LNS quire support (issue #549) may
 // reveal that a different formula or approach is needed.
+//
+// ACCURACY: unlike quire<posit> / quire<cfloat>, quire<lns> is NOT an exact
+// accumulator. An lns product is 2^(k + m/2^rbits), irrational for m != 0, so it is
+// not a dyadic rational and cannot be represented exactly in any linear fixed-point
+// quire at any width. quire_mul(lns,lns) rounds each product (see number/lns/fdp.hpp),
+// so the quire-dot error is bounded by the product-representation error, not by the
+// accumulation -- for narrow lns it can be worse than a promoted-double accumulator.
+// For accurate lns dot products, promote to double. (#1203)
 // ============================================================================
 template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
 struct quire_traits<lns<nbits, rbits, bt, xtra...>> {

--- a/static/quire/api/lns_quire_accuracy.cpp
+++ b/static/quire/api/lns_quire_accuracy.cpp
@@ -1,0 +1,117 @@
+// lns_quire_accuracy.cpp: pins the documented accuracy characteristics of quire<lns> (#1203)
+//
+// quire<lns> is NOT an exact accumulator. An lns product is 2^(k + m/2^rbits), irrational
+// for m != 0, so it cannot be represented exactly in any linear fixed-point quire at any
+// width (see number/lns/fdp.hpp). quire_mul rounds each product at ~the lns representation
+// precision -- well below the quire's own precision -- so the quire-dot error is bounded by
+// the PRODUCT-representation error, not by the accumulation, and for narrow lns it can be
+// worse than a promoted-double accumulator.
+//
+// This is executable documentation of that contract (guarding against a regression to the
+// old, incorrect "lns products are always exact" claim):
+//   1. integer-exponent (power-of-2) operands with a power-of-2 result ARE exact;
+//   2. fractional-exponent operands are NOT -- the quire-dot error, measured against a
+//      long-double reference over the SAME quantized values (isolating product/accumulation
+//      error from input quantization), is orders of magnitude above binary64 precision.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <universal/number/lns/lns.hpp>
+#include <universal/number/lns/fdp.hpp>   // explicit until #1201 has the aggregator pull it in
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// (1) integer-exponent (power-of-2) product AND power-of-2 result -> exact
+	template<unsigned nbits, unsigned rbits>
+	int VerifyExactPowerOfTwo(const char* tag, bool reportTestCases) {
+		using Lns = lns<nbits, rbits>;
+		// 2*2 + 2*2 = 8 : products 4,4 (integer exponents, exact), sum 8 = 2^3 (representable)
+		std::vector<Lns> x = { Lns(2), Lns(2) };
+		std::vector<Lns> y = { Lns(2), Lns(2) };
+		double d = double(fdp(x, y));
+		if (d != 8.0) {
+			if (reportTestCases) std::cout << "    FAIL exact power-of-2 dot<" << tag << "> = " << d << " expected 8\n";
+			return 1;
+		}
+		return 0;
+	}
+
+	// (2) fractional-exponent operands -> quire<lns> is NOT exact and far from double accuracy.
+	// Reference: long-double dot over the SAME quantized lns values (double(x[i])), so the
+	// measured error is purely the quire's product/accumulation rounding, not input quantization.
+	template<unsigned nbits, unsigned rbits>
+	int VerifyQuireNotExact(const char* tag, bool reportTestCases, double floor_error) {
+		using Lns = lns<nbits, rbits>;
+		std::vector<Lns> x, y;
+		for (int i = 1; i <= 64; ++i) {           // fractional values -> fractional log exponents
+			x.push_back(Lns(1.0 + 0.5 / i));
+			y.push_back(Lns(1.0 - 0.25 / i));
+		}
+		long double ref = 0.0L;
+		for (std::size_t i = 0; i < x.size(); ++i)
+			ref += (long double)double(x[i]) * (long double)double(y[i]);
+		double d = double(fdp(x, y));
+		double err = std::fabs((double)((long double)d - ref));
+		// contract: the lns quire error sits WELL above binary64 precision (a promoted-double
+		// accumulator would land near 1e-15). If this ever drops below floor_error, the quire
+		// was made more accurate -- update the doc + this threshold.
+		if (err < floor_error) {
+			if (reportTestCases) std::cout << "    FAIL quire<lns> unexpectedly accurate for " << tag
+				<< ": err=" << err << " < floor " << floor_error << " (did the product rounding change?)\n";
+			return 1;
+		}
+		if (reportTestCases) std::cout << "    [characterization] quire<" << tag << "> dot error = " << err
+			<< "  (a promoted-double accumulator would be ~1e-15)\n";
+		return 0;
+	}
+
+}  // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite = "quire<lns> accuracy contract: rounded, not exact (#1203)";
+	int nrOfFailedTestCases = 0;
+	bool reportTestCases = true;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	int fails = 0;
+	fails += VerifyExactPowerOfTwo<16, 8>("lns<16,8>", reportTestCases);
+	fails += VerifyExactPowerOfTwo<32, 16>("lns<32,16>", reportTestCases);
+	// error floors sit far above binary64 (~1e-15) but well below each config's actual error
+	// (lns<16,8> ~1e-6, lns<32,16> ~1e-10), so these are robust.
+	fails += VerifyQuireNotExact<16, 8>("lns<16,8>", reportTestCases, 1e-9);
+	fails += VerifyQuireNotExact<32, 16>("lns<32,16>", reportTestCases, 1e-13);
+
+	nrOfFailedTestCases += ReportTestResult(fails, "quire<lns> exact for power-of-2, rounded otherwise", "lns_quire");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
Resolves #1203 per the maintainer disposition in the thread (the original "make the lns quire exact" request is **mathematically unachievable**).

`quire_mul(lns,lns)`'s header claimed lns values are *"always exactly representable as powers of 2"*, implying `quire<lns>` is an exact accumulator like `quire<posit>` / `quire<cfloat>`. **That is false.** An lns product is `2^(k + m/2^rbits)`, **irrational** for `m != 0` (if `2^(p/q)` were rational, unique factorization forces `q | p`), so it is not a dyadic rational and **cannot be represented exactly in any linear fixed-point quire at any width**. lns does not admit an exact dot product -- a structural property posit/cfloat have (dyadic values) and lns does not.

The real, documented defect: `quire_mul` rounds each product at ~the lns representation precision (a blocktriple with `2*rbits` significand bits) instead of the quire's precision, so for narrow lns (e.g. `lns<16,8>`) the quire is **orders of magnitude worse than a promoted-double accumulator**. For accurate lns dot products, promote to double.

## Changes
- `number/lns/fdp.hpp` -- corrected the misleading comments (the false "exact powers of 2" / "double-precision path is exact" claims) with the accurate structural explanation.
- `traits/quire_traits.hpp` -- accuracy note on `quire_traits<lns>` so downstream code doesn't assume the posit/cfloat guarantee transfers.
- `static/quire/api/lns_quire_accuracy.cpp` -- **new characterization test** pinning the contract: power-of-2 operands with a power-of-2 result are exact; fractional operands are not (quire-dot error vs a long-double reference over the same quantized values sits orders of magnitude above binary64). Guards against reintroducing the false "exact" claim.

**Behavior is unchanged** -- this is a documentation/characterization fix.

## Not done (and why)
- "Make the lns quire exact" -- impossible (see above).
- "Round each product at the quire's full precision" (single-rounding-per-term, still not exact) -- a real future enhancement, deferred; tracked via stillwater-sc/mp-blas#11.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| quire_lns_quire_accuracy | PASS | PASS |

## Test plan
- [ ] Fast CI passes; promote when satisfied
- [ ] (maintainer) consider retitling the issue to "quire_mul(lns,lns) rounds at double precision instead of quire precision"

Resolves #1203
Relates to stillwater-sc/mp-blas#11, #13

Generated with [Claude Code](https://claude.com/claude-code)