### PR TITLE
fix(interval): round arithmetic outward to restore the containment property

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -45,6 +45,7 @@ jobs:
             lns
             dbns
             areal
+            interval
             bfloat16
             dfloat
             hfloat

--- a/include/sw/universal/number/interval/interval_impl.hpp
+++ b/include/sw/universal/number/interval/interval_impl.hpp
@@ -23,6 +23,40 @@
 
 namespace sw { namespace universal {
 
+// Outward-rounding helpers for interval arithmetic. Realizing the mathematical
+// interval rules in finite precision requires DIRECTED rounding: the lower bound
+// toward -inf and the upper bound toward +inf. Otherwise each endpoint can move
+// inward by up to half an ulp per operation and the enclosure loses the containment
+// property (the Fundamental Theorem of Interval Arithmetic). We round outward with
+// nextafter rather than the FPU rounding mode (fesetround) because nextafter is
+// Scalar-generic -- the hardware rounding mode has no effect on posit/cfloat/lns
+// arithmetic, and interval<posit<...>> is a target use case. (#1234)
+namespace interval_detail {
+	template<typename Scalar>
+	inline Scalar round_down(Scalar x) noexcept {   // toward -inf
+		using std::nextafter;
+		return nextafter(x, -std::numeric_limits<Scalar>::infinity());
+	}
+	template<typename Scalar>
+	inline Scalar round_up(Scalar x) noexcept {      // toward +inf
+		using std::nextafter;
+		return nextafter(x, std::numeric_limits<Scalar>::infinity());
+	}
+	// widen a converted lower bound outward only when the conversion was inexact,
+	// so exactly-representable operands keep zero-width endpoints (interval<double>(2)
+	// stays [2,2]) while an inexact cross-type cast (interval<float>(0.1)) is enclosed.
+	template<typename Scalar, typename T>
+	inline Scalar enclose_lo(T v) noexcept {
+		Scalar s = static_cast<Scalar>(v);
+		return (static_cast<T>(s) == v) ? s : round_down(s);
+	}
+	template<typename Scalar, typename T>
+	inline Scalar enclose_hi(T v) noexcept {
+		Scalar s = static_cast<Scalar>(v);
+		return (static_cast<T>(s) == v) ? s : round_up(s);
+	}
+}
+
 /// <summary>
 /// A parameterized interval number type [lo, hi] representing a closed interval.
 /// The Scalar type can be any numeric type: float, double, or Universal types like cfloat<>.
@@ -49,13 +83,17 @@ public:
 	constexpr interval& operator=(interval&&) noexcept = default;
 
 	// construct from a single value (degenerate interval [v, v])
+	// NOTE: NOT constexpr -- a cross-type or unrepresentable value must be enclosed
+	// with outward rounding (nextafter), which is not a constexpr operation. (#1234)
 	template<typename T, typename = std::enable_if_t<std::is_arithmetic_v<T> || std::is_same_v<T, Scalar>>>
-	constexpr interval(T v) noexcept : _lo(static_cast<Scalar>(v)), _hi(static_cast<Scalar>(v)) {}
+	interval(T v) noexcept
+		: _lo(interval_detail::enclose_lo<Scalar>(v)), _hi(interval_detail::enclose_hi<Scalar>(v)) {}
 
-	// construct from explicit lower and upper bounds
+	// construct from explicit lower and upper bounds (each enclosed outward if the
+	// conversion to Scalar is inexact)
 	template<typename T, typename U>
-	constexpr interval(T lo, U hi) noexcept
-		: _lo(static_cast<Scalar>(lo)), _hi(static_cast<Scalar>(hi)) {
+	interval(T lo, U hi) noexcept
+		: _lo(interval_detail::enclose_lo<Scalar>(lo)), _hi(interval_detail::enclose_hi<Scalar>(hi)) {
 		// ensure proper ordering
 		if (_lo > _hi) std::swap(_lo, _hi);
 	}
@@ -83,30 +121,30 @@ public:
 
 	// arithmetic operators
 	interval& operator+=(const interval& rhs) noexcept {
-		// [a,b] + [c,d] = [a+c, b+d]
-		_lo = _lo + rhs._lo;
-		_hi = _hi + rhs._hi;
+		// [a,b] + [c,d] = [a+c, b+d], rounded outward (lo down, hi up)
+		_lo = interval_detail::round_down(Scalar(_lo + rhs._lo));
+		_hi = interval_detail::round_up(Scalar(_hi + rhs._hi));
 		return *this;
 	}
 
 	interval& operator-=(const interval& rhs) noexcept {
-		// [a,b] - [c,d] = [a-d, b-c]
-		Scalar newLo = _lo - rhs._hi;
-		Scalar newHi = _hi - rhs._lo;
+		// [a,b] - [c,d] = [a-d, b-c], rounded outward
+		Scalar newLo = interval_detail::round_down(Scalar(_lo - rhs._hi));
+		Scalar newHi = interval_detail::round_up(Scalar(_hi - rhs._lo));
 		_lo = newLo;
 		_hi = newHi;
 		return *this;
 	}
 
 	interval& operator*=(const interval& rhs) noexcept {
-		// [a,b] * [c,d] = [min(ac,ad,bc,bd), max(ac,ad,bc,bd)]
+		// [a,b] * [c,d] = [min(ac,ad,bc,bd), max(ac,ad,bc,bd)], rounded outward
 		Scalar ac = _lo * rhs._lo;
 		Scalar ad = _lo * rhs._hi;
 		Scalar bc = _hi * rhs._lo;
 		Scalar bd = _hi * rhs._hi;
 
-		_lo = std::min({ac, ad, bc, bd});
-		_hi = std::max({ac, ad, bc, bd});
+		_lo = interval_detail::round_down(std::min({ac, ad, bc, bd}));
+		_hi = interval_detail::round_up(std::max({ac, ad, bc, bd}));
 		return *this;
 	}
 
@@ -124,8 +162,13 @@ public:
 			return *this;
 		}
 #endif
-		// Compute reciprocal of rhs: [1/d, 1/c]
-		interval reciprocal(Scalar(1) / rhs._hi, Scalar(1) / rhs._lo);
+		// Compute reciprocal of rhs: [1/d, 1/c], each endpoint rounded outward
+		// (1/x is generally inexact); the subsequent *= rounds the products outward too.
+		Scalar recipLo = interval_detail::round_down(Scalar(Scalar(1) / rhs._hi));
+		Scalar recipHi = interval_detail::round_up(Scalar(Scalar(1) / rhs._lo));
+		interval reciprocal;
+		reciprocal.setlo(recipLo);
+		reciprocal.sethi(recipHi);
 		return *this *= reciprocal;
 	}
 
@@ -180,14 +223,15 @@ public:
 		return (_lo + _hi) / Scalar(2);
 	}
 
-	// radius (half-width) of the interval
-	constexpr Scalar rad() const noexcept {
-		return (_hi - _lo) / Scalar(2);
+	// radius (half-width) of the interval -- rounded UP so that mid() +/- rad()
+	// still covers [lo, hi] (#1234). Not constexpr: nextafter is a runtime op.
+	Scalar rad() const noexcept {
+		return interval_detail::round_up(Scalar((_hi - _lo) / Scalar(2)));
 	}
 
-	// width of the interval
-	constexpr Scalar width() const noexcept {
-		return _hi - _lo;
+	// width of the interval -- rounded UP so it never underestimates the true width
+	Scalar width() const noexcept {
+		return interval_detail::round_up(Scalar(_hi - _lo));
 	}
 
 	// magnitude: max of |lo| and |hi|
@@ -449,13 +493,14 @@ inline interval<Scalar> abs(const interval<Scalar>& x) {
 template<typename Scalar>
 inline interval<Scalar> sqr(const interval<Scalar>& x) {
 	if (x.contains_zero()) {
-		Scalar maxSq = x.mag() * x.mag();
-		return interval<Scalar>(Scalar(0), maxSq);
+		Scalar maxSq = interval_detail::round_up(Scalar(x.mag() * x.mag()));
+		return interval<Scalar>(Scalar(0), maxSq);   // lower bound 0 is exact
 	}
 	else {
 		Scalar loSq = x.lo() * x.lo();
 		Scalar hiSq = x.hi() * x.hi();
-		return interval<Scalar>(std::min(loSq, hiSq), std::max(loSq, hiSq));
+		return interval<Scalar>(interval_detail::round_down(std::min(loSq, hiSq)),
+		                        interval_detail::round_up(std::max(loSq, hiSq)));
 	}
 }
 
@@ -468,8 +513,10 @@ inline interval<Scalar> sqrt(const interval<Scalar>& x) {
 		throw interval_negative_sqrt_arg();
 	}
 #endif
-	Scalar lo = x.lo() < Scalar(0) ? Scalar(0) : sqrt(x.lo());
-	Scalar hi = sqrt(x.hi());
+	// sqrt is inexact in general: round the lower bound down and the upper bound up.
+	// A clamped-to-zero lower bound (negative sqrt argument) stays exactly 0.
+	Scalar lo = x.lo() < Scalar(0) ? Scalar(0) : interval_detail::round_down(Scalar(sqrt(x.lo())));
+	Scalar hi = interval_detail::round_up(Scalar(sqrt(x.hi())));
 	return interval<Scalar>(lo, hi);
 }
 

--- a/static/range/interval/arithmetic/addition.cpp
+++ b/static/range/interval/arithmetic/addition.cpp
@@ -37,7 +37,7 @@ int VerifyIntervalAddition(bool reportTestCases) {
 		Interval b(Scalar(3), Scalar(4));
 		Interval c = a + b;
 		Interval expected(Scalar(4), Scalar(6));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " + " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -49,7 +49,7 @@ int VerifyIntervalAddition(bool reportTestCases) {
 		Interval b(Scalar(-5), Scalar(-2));
 		Interval c = a + b;
 		Interval expected(Scalar(-8), Scalar(-3));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " + " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -61,7 +61,7 @@ int VerifyIntervalAddition(bool reportTestCases) {
 		Interval b(Scalar(1), Scalar(3));
 		Interval c = a + b;
 		Interval expected(Scalar(0), Scalar(5));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " + " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -73,7 +73,7 @@ int VerifyIntervalAddition(bool reportTestCases) {
 		Interval b(Scalar(3));
 		Interval c = a + b;
 		Interval expected(Scalar(5));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " + " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -85,7 +85,7 @@ int VerifyIntervalAddition(bool reportTestCases) {
 		Interval b(Scalar(3), Scalar(4));
 		a += b;
 		Interval expected(Scalar(4), Scalar(6));
-		if (a != expected) {
+		if (!expected.subset_of(a)) {  // containment (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: += operator, result = " << a << " (expected " << expected << ")\n";
 		}
@@ -96,7 +96,7 @@ int VerifyIntervalAddition(bool reportTestCases) {
 		Interval a(Scalar(1), Scalar(2));
 		Interval c = a + Scalar(3);
 		Interval expected(Scalar(4), Scalar(5));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " + 3 = " << c << " (expected " << expected << ")\n";
 		}

--- a/static/range/interval/arithmetic/containment.cpp
+++ b/static/range/interval/arithmetic/containment.cpp
@@ -1,0 +1,183 @@
+// containment.cpp: the Fundamental Theorem of Interval Arithmetic must hold
+//
+// interval<Scalar> must round OUTWARD so that for all x in X and y in Y,
+// x o y  in  fl(X o Y), evaluated over the exact reals (#1234). Before the fix,
+// interval arithmetic used round-to-nearest and the computed enclosure could be
+// narrower than the true range -- e.g. interval(0.1)*interval(0.1) had width 0 and
+// did not contain the exact product. This suite exercises INEXACT operands (which
+// the equality-on-small-integers tests structurally cannot), plus a randomized
+// containment fuzz and a tightness bound so a future fix cannot regress into
+// uselessly wide intervals.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <universal/number/interval/interval.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace sw { namespace universal {
+
+	// higher-precision (long double) evaluation of a scalar operation, used as the
+	// containment reference. Operands are the exact double endpoints.
+	enum class Op { add, sub, mul };
+	inline long double apply(Op op, long double x, long double y) {
+		switch (op) {
+		case Op::add: return x + y;
+		case Op::sub: return x - y;
+		default:      return x * y;
+		}
+	}
+	inline interval<double> apply(Op op, const interval<double>& X, const interval<double>& Y) {
+		switch (op) {
+		case Op::add: return X + Y;
+		case Op::sub: return X - Y;
+		default:      return X * Y;
+		}
+	}
+
+	// ---- 1. deterministic containment on inexact operands ----------------------
+	int VerifyInexactContainment(bool reportTestCases) {
+		using I = interval<double>;
+		int fails = 0;
+		auto check = [&](const char* tag, const I& R, long double truth) {
+			if (!((long double)R.lo() <= truth && truth <= (long double)R.hi())) {
+				++fails;
+				if (reportTestCases) std::cout << "    FAIL " << tag << ": " << (double)truth
+					<< " not in [" << R.lo() << ", " << R.hi() << "]\n";
+			}
+		};
+		// the issue's reproduction: 0.1 * 0.1 is inexact, must be enclosed with nonzero width
+		{ double a = 0.1; I p = I(a) * I(a); check("0.1*0.1", p, (long double)a * (long double)a);
+		  if (!(p.width() > 0.0)) { ++fails; if (reportTestCases) std::cout << "    FAIL 0.1*0.1 has zero width\n"; } }
+		// a third, and its reciprocal
+		{ double a = 1.0/3.0; I r = I(1.0) / I(3.0); check("1/3", r, 1.0L/3.0L); }
+		// sqrt(2) via sqr round-trip: sqrt([2,2]) must enclose the true sqrt(2)
+		{ I s = sqrt(I(2.0)); check("sqrt(2)", s, std::sqrt(2.0L)); }
+		// composition: an 8-term accumulation of 0.1 must carry nonzero uncertainty
+		{ I acc(0.0); for (int i = 0; i < 8; ++i) acc = acc + I(0.1);
+		  long double truth = 8.0L * 0.1L;   // exact-real target for the sum of the double 0.1
+		  check("sum 8x0.1", acc, truth);
+		  if (!(acc.width() > 0.0)) { ++fails; if (reportTestCases) std::cout << "    FAIL 8x0.1 sum has zero width\n"; } }
+		// cross-type constructor: interval<float>(double 0.1) must enclose the double 0.1
+		{ interval<float> f(0.1);
+		  if (!((double)f.lo() <= 0.1 && 0.1 <= (double)f.hi())) {
+			++fails; if (reportTestCases) std::cout << "    FAIL interval<float>(0.1) does not contain double 0.1\n"; } }
+		return fails;
+	}
+
+	// ---- 2. randomized containment fuzz ----------------------------------------
+	// random X, Y; sample points x in X, y in Y; assert x o y in fl(X o Y).
+	int VerifyContainmentFuzz(bool reportTestCases, int nrTests, uint64_t seed) {
+		using I = interval<double>;
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-10.0, 10.0);
+		std::uniform_real_distribution<double> S(0.0, 1.0);
+		const Op ops[] = { Op::add, Op::sub, Op::mul };
+		for (int t = 0; t < nrTests; ++t) {
+			double a = U(rng), b = U(rng); if (a > b) std::swap(a, b);
+			double c = U(rng), d = U(rng); if (c > d) std::swap(c, d);
+			I X(a, b), Y(c, d);
+			for (Op op : ops) {
+				I R = apply(op, X, Y);
+				// sample points: endpoints and a few interior points of each interval
+				for (double sx : {0.0, 1.0, S(rng), S(rng)}) {
+					for (double sy : {0.0, 1.0, S(rng), S(rng)}) {
+						long double x = (long double)a + (long double)sx * ((long double)b - a);
+						long double y = (long double)c + (long double)sy * ((long double)d - c);
+						long double r = apply(op, x, y);
+						if (!((long double)R.lo() <= r && r <= (long double)R.hi())) {
+							++fails;
+							if (reportTestCases && fails < 10) std::cout << "    FAIL fuzz: point " << (double)r
+								<< " not in [" << R.lo() << ", " << R.hi() << "]\n";
+						}
+					}
+				}
+			}
+		}
+		return fails;
+	}
+
+	// ---- 3. tightness: the enclosure must not be uselessly wide ----------------
+	// for a single operation, the optimal enclosure width is the true-range width; we
+	// allow a small slack (a few ulps) so Stage-1 outward rounding passes but a future
+	// regression to grossly wide intervals is caught.
+	int VerifyTightness(bool reportTestCases, int nrTests, uint64_t seed) {
+		using I = interval<double>;
+		int fails = 0;
+		std::mt19937_64 rng(seed);
+		std::uniform_real_distribution<double> U(-10.0, 10.0);
+		const Op ops[] = { Op::add, Op::sub, Op::mul };
+		for (int t = 0; t < nrTests; ++t) {
+			double a = U(rng), b = U(rng); if (a > b) std::swap(a, b);
+			double c = U(rng), d = U(rng); if (c > d) std::swap(c, d);
+			I X(a, b), Y(c, d);
+			for (Op op : ops) {
+				I R = apply(op, X, Y);
+				// true range over the reals: min/max of the operation over the corners
+				long double corners[4] = {
+					apply(op, (long double)a, (long double)c), apply(op, (long double)a, (long double)d),
+					apply(op, (long double)b, (long double)c), apply(op, (long double)b, (long double)d) };
+				long double tlo = corners[0], thi = corners[0];
+				for (int k = 1; k < 4; ++k) { tlo = std::min(tlo, corners[k]); thi = std::max(thi, corners[k]); }
+				long double trueWidth = thi - tlo;
+				long double got = (long double)R.width();
+				long double ulp = std::ldexp(1.0L, std::ilogb(std::max(std::abs(tlo), std::abs(thi))) - 52);
+				if (got > trueWidth + 8.0L * ulp) {   // generous slack; catches gross over-widening
+					++fails;
+					if (reportTestCases && fails < 10) std::cout << "    FAIL tightness: width " << (double)got
+						<< " >> true " << (double)trueWidth << "\n";
+				}
+			}
+		}
+		return fails;
+	}
+
+}} // namespace sw::universal
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 0
+#define REGRESSION_LEVEL_3 0
+#define REGRESSION_LEVEL_4 0
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+	std::string test_suite = "interval containment (Fundamental Theorem of Interval Arithmetic) (#1234)";
+	int nrOfFailedTestCases = 0;
+	bool reportTestCases = true;
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	int base = 20000;
+#if REGRESSION_LEVEL_2
+	base = 100000;
+#endif
+
+	nrOfFailedTestCases += ReportTestResult(VerifyInexactContainment(reportTestCases),
+		"containment on inexact operands (0.1*0.1, 1/3, sqrt(2), sum, cross-type)", "containment");
+	nrOfFailedTestCases += ReportTestResult(VerifyContainmentFuzz(reportTestCases, base, 0x1234ABCD),
+		"randomized containment fuzz (+ - *)", "containment");
+	nrOfFailedTestCases += ReportTestResult(VerifyTightness(reportTestCases, base, 0xCAFED00D),
+		"tightness bound (enclosure not uselessly wide)", "containment");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/range/interval/arithmetic/division.cpp
+++ b/static/range/interval/arithmetic/division.cpp
@@ -40,8 +40,7 @@ int VerifyIntervalDivision(bool reportTestCases) {
 		// Products: 4*0.333=1.333, 4*0.5=2, 6*0.333=2, 6*0.5=3
 		Interval expected(Scalar(4)/Scalar(3), Scalar(3));
 		// Allow some tolerance for floating point
-		if (std::abs(double(c.lo()) - double(expected.lo())) > 1e-6 ||
-		    std::abs(double(c.hi()) - double(expected.hi())) > 1e-6) {
+		if (!expected.subset_of(c)) {  // containment (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " / " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -55,8 +54,7 @@ int VerifyIntervalDivision(bool reportTestCases) {
 		// a * [-1/2, -1/3] = [4, 6] * [-0.5, -0.333...]
 		// Products: 4*(-0.5)=-2, 4*(-0.333)=-1.333, 6*(-0.5)=-3, 6*(-0.333)=-2
 		Interval expected(Scalar(-3), Scalar(4)/Scalar(-3));
-		if (std::abs(double(c.lo()) - double(expected.lo())) > 1e-6 ||
-		    std::abs(double(c.hi()) - double(expected.hi())) > 1e-6) {
+		if (!expected.subset_of(c)) {  // containment (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " / " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -68,7 +66,7 @@ int VerifyIntervalDivision(bool reportTestCases) {
 		Interval b(Scalar(2));
 		Interval c = a / b;
 		Interval expected(Scalar(3));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " / " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -81,8 +79,7 @@ int VerifyIntervalDivision(bool reportTestCases) {
 		a /= b;
 		// [8, 12] * [1/4, 1/2] = [2, 6]
 		Interval expected(Scalar(2), Scalar(6));
-		if (std::abs(double(a.lo()) - double(expected.lo())) > 1e-6 ||
-		    std::abs(double(a.hi()) - double(expected.hi())) > 1e-6) {
+		if (!expected.subset_of(a)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: /= operator, result = " << a << " (expected " << expected << ")\n";
 		}
@@ -93,7 +90,7 @@ int VerifyIntervalDivision(bool reportTestCases) {
 		Interval a(Scalar(4), Scalar(6));
 		Interval c = a / Scalar(2);
 		Interval expected(Scalar(2), Scalar(3));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " / 2 = " << c << " (expected " << expected << ")\n";
 		}

--- a/static/range/interval/arithmetic/multiplication.cpp
+++ b/static/range/interval/arithmetic/multiplication.cpp
@@ -37,7 +37,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval b(Scalar(3), Scalar(4));
 		Interval c = a * b;
 		Interval expected(Scalar(3), Scalar(8));  // [1*3, 2*4]
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -49,7 +49,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval b(Scalar(-4), Scalar(-2));
 		Interval c = a * b;
 		Interval expected(Scalar(2), Scalar(12));  // [(-1)*(-2), (-3)*(-4)]
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -61,7 +61,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval b(Scalar(-4), Scalar(-3));
 		Interval c = a * b;
 		Interval expected(Scalar(-8), Scalar(-3));  // [2*(-4), 1*(-3)]
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -73,7 +73,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval b(Scalar(3), Scalar(4));
 		Interval c = a * b;
 		Interval expected(Scalar(-4), Scalar(8));  // [(-1)*4, 2*4]
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -86,7 +86,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval c = a * b;
 		// Products: (-1)*(-3)=3, (-1)*4=-4, 2*(-3)=-6, 2*4=8
 		Interval expected(Scalar(-6), Scalar(8));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -98,7 +98,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval b(Scalar(4), Scalar(5));
 		a *= b;
 		Interval expected(Scalar(8), Scalar(15));
-		if (a != expected) {
+		if (!expected.subset_of(a)) {  // containment (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: *= operator, result = " << a << " (expected " << expected << ")\n";
 		}
@@ -109,7 +109,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval a(Scalar(1), Scalar(2));
 		Interval c = a * Scalar(3);
 		Interval expected(Scalar(3), Scalar(6));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * 3 = " << c << " (expected " << expected << ")\n";
 		}
@@ -120,7 +120,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval a(Scalar(1), Scalar(2));
 		Interval c = a * Scalar(-3);
 		Interval expected(Scalar(-6), Scalar(-3));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * (-3) = " << c << " (expected " << expected << ")\n";
 		}
@@ -132,7 +132,7 @@ int VerifyIntervalMultiplication(bool reportTestCases) {
 		Interval b(Scalar(4));
 		Interval c = a * b;
 		Interval expected(Scalar(12));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " * " << b << " = " << c << " (expected " << expected << ")\n";
 		}

--- a/static/range/interval/arithmetic/subtraction.cpp
+++ b/static/range/interval/arithmetic/subtraction.cpp
@@ -37,7 +37,7 @@ int VerifyIntervalSubtraction(bool reportTestCases) {
 		Interval b(Scalar(1), Scalar(2));
 		Interval c = a - b;
 		Interval expected(Scalar(1), Scalar(4));  // [3-2, 5-1]
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " - " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -49,7 +49,7 @@ int VerifyIntervalSubtraction(bool reportTestCases) {
 		Interval b(Scalar(2), Scalar(4));
 		Interval c = a - b;
 		Interval expected(Scalar(-3), Scalar(1));  // [1-4, 3-2]
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " - " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -61,7 +61,7 @@ int VerifyIntervalSubtraction(bool reportTestCases) {
 		Interval b(Scalar(-5), Scalar(-2));
 		Interval c = a - b;
 		Interval expected(Scalar(-1), Scalar(4));  // [-3-(-2), -1-(-5)]
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " - " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -73,7 +73,7 @@ int VerifyIntervalSubtraction(bool reportTestCases) {
 		Interval b(Scalar(3));
 		Interval c = a - b;
 		Interval expected(Scalar(2));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: " << a << " - " << b << " = " << c << " (expected " << expected << ")\n";
 		}
@@ -85,7 +85,7 @@ int VerifyIntervalSubtraction(bool reportTestCases) {
 		Interval b(Scalar(1), Scalar(2));
 		a -= b;
 		Interval expected(Scalar(3), Scalar(6));
-		if (a != expected) {
+		if (!expected.subset_of(a)) {  // containment (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: -= operator, result = " << a << " (expected " << expected << ")\n";
 		}
@@ -96,7 +96,7 @@ int VerifyIntervalSubtraction(bool reportTestCases) {
 		Interval a(Scalar(1), Scalar(3));
 		Interval c = -a;
 		Interval expected(Scalar(-3), Scalar(-1));
-		if (c != expected) {
+		if (!expected.subset_of(c)) {  // containment: computed interval must enclose the true result (#1234)
 			++nrOfFailedTestCases;
 			if (reportTestCases) std::cout << "FAIL: -" << a << " = " << c << " (expected " << expected << ")\n";
 		}


### PR DESCRIPTION
## Summary
`interval<Scalar>` performed arithmetic under round-to-nearest, so the computed enclosure could be **narrower than the true range** -- the Fundamental Theorem of Interval Arithmetic silently failed. The classic symptom (from the issue): `interval(0.1) * interval(0.1)` returned a **zero-width** interval that did **not contain** the exact product.

## Fix (Stage 1 of #1234)
Round every inexact endpoint **outward** -- lower bound toward -inf, upper toward +inf -- via `nextafter`. `nextafter` rather than `fesetround` because it is **`Scalar`-generic** (the FPU rounding mode has no effect on posit/cfloat/lns, and `interval<posit<...>>` is a target).

- Outward rounding in `operator+= -= *= /=` (incl. the reciprocal endpoints), `sqr()`, `sqrt()`; rounded **up** in `width()`/`rad()`.
- Constructors enclose outward **only when the conversion is inexact** (round-trip check): `interval<double>(2)` stays `[2,2]`, `interval<float>(0.1)` is enclosed. Those ctors + `rad()`/`width()` are no longer `constexpr` (nextafter is runtime).
- Free/scalar-mixed operators inherit the fix (delegate to members/ctors). Unchanged (already exact): unary `-`, `abs`, `intersect`, `hull`, comparison/`contains`.

## Changes
- `include/sw/universal/number/interval/interval_impl.hpp` -- the fix (`interval_detail::round_down/round_up/enclose_*`).
- `arithmetic/{addition,subtraction,multiplication,division}.cpp` -- the existing suites asserted **equality on small integers** (vacuous -- no rounding ever occurred), so a widening fix breaks them by design; **converted to containment** (`expected.subset_of(computed)`).
- `arithmetic/containment.cpp` (new) -- inexact operands (`0.1*0.1`, `1/3`, `sqrt(2)`, 8-term sum, cross-type ctor), a **randomized fuzz** asserting `x o y in fl(X o Y)` vs a long-double reference, and a **tightness bound** so a future change can't regress into uselessly wide intervals.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| interval_{addition,subtraction,multiplication,division} | PASS | PASS |
| interval_containment (new) | PASS | PASS |
| interval_{api,logic,conversion,educational_demo} (no-regression) | PASS | PASS |

Verified the issue's reproduction: `I(0.1)*I(0.1)` is now `[0.0100000000000000002, 0.0100000000000000037]` (nonzero width) and **contains** the exact product.

## Follow-up (Stage 2, optional)
EFT (TwoSum/TwoProduct) to widen only when the op is actually inexact -- recovers 1-ulp-optimal enclosures and lets the exact-integer cases assert equality again. Unblocks stillwater-sc/mp-blas#12.

## Test plan
- [ ] Fast CI (gcc + clang CI_LITE); promote when satisfied

Resolves #1234

Generated with [Claude Code](https://claude.com/claude-code)