### PR TITLE
fix(cfloat): round_style is round_to_nearest, not toward_zero (#1254)

### DIFF
--- a/include/sw/universal/number/cfloat/numeric_limits.hpp
+++ b/include/sw/universal/number/cfloat/numeric_limits.hpp
@@ -72,7 +72,9 @@ public:
 	static constexpr bool is_modulo                = false;
 	static constexpr bool traps                    = false;
 	static constexpr bool tinyness_before          = false;
-	static constexpr float_round_style round_style = round_toward_zero;
+	// cfloat rounds to nearest, ties to even (see cfloat_impl.hpp::round(), the classic
+	// guard/round/sticky round-to-even logic), not toward zero (#1254).
+	static constexpr float_round_style round_style = round_to_nearest;
 };
 
 }

--- a/static/float/cfloat/api/traits.cpp
+++ b/static/float/cfloat/api/traits.cpp
@@ -119,6 +119,29 @@ try {
 		std::cout << "one more than that                           = " << scale(sp) + 1 << '\n';
 		std::cout << "std::numeric_limits<single>::max_exponent    = " << std::numeric_limits<single>::max_exponent << '\n';
 	}
+
+	// round_style must report round_to_nearest: cfloat rounds to nearest, ties to even
+	// (cfloat_impl.hpp::round()), NOT toward zero (#1254). Verify the label AND the behavior.
+	{
+		using Real = cfloat<8, 2, std::uint8_t, true, false, false>;   // with subnormals
+		static_assert(std::numeric_limits<Real>::round_style == std::round_to_nearest,
+			"cfloat round_style must be round_to_nearest (#1254)");
+		if (std::numeric_limits<Real>::round_style != std::round_to_nearest) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL: cfloat round_style is not round_to_nearest\n";
+		}
+		// behavior: 0.25 * 3.9375 = 0.984375 lies exactly halfway between the representable
+		// 0.96875 (subnormal, odd) and 1.0 (normal, even); RNE picks the even neighbor 1.0,
+		// whereas round_toward_zero would pick the smaller-magnitude 0.96875.
+		Real tie = Real(0.25) * Real(3.9375);
+		if (double(tie) != 1.0) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL: cfloat tie 0.25*3.9375 = " << double(tie) << " (expected 1.0 by round-to-even)\n";
+		}
+		else {
+			std::cout << "cfloat round-to-nearest-even (label + tie behavior): PASS\n";
+		}
+	}
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
 }


### PR DESCRIPTION
## Summary
`std::numeric_limits<cfloat<...>>::round_style` reported `round_toward_zero`, but cfloat arithmetic rounds **to nearest, ties to even** (`cfloat_impl.hpp::round()` -- the classic guard/round/sticky round-to-even logic). `round_error()` was already `0.5` (the RNE value), corroborating the mislabel.

Downstream code that inspects `round_style` to decide whether error-free transformations are valid would wrongly conclude cfloat is not round-to-nearest. Surfaced while analyzing `interval<cfloat>` EFT validity (#1249 / #1255).

## Changes
- `include/sw/universal/number/cfloat/numeric_limits.hpp` -- `round_style = round_to_nearest`
- `static/float/cfloat/api/traits.cpp` -- regression asserting the label (`static_assert`) and the behavior: `0.25 * 3.9375 = 0.984375` is a tie between subnormal `0.96875` (odd) and normal `1.0` (even); RNE picks `1.0`, toward-zero would pick `0.96875`.

No production code branches on the value; cfloat api/logic/traits all pass.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| cfloat_traits | PASS | PASS |
| cfloat_api | PASS | PASS |
| cfloat_logic | PASS | PASS |

Resolves #1254

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cfloat numeric metadata to report round-to-nearest behavior.
  * Ensured halfway calculations use ties-to-even rounding consistently.

* **Tests**
  * Added coverage validating the reported rounding mode and a representative halfway-rounding result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->