### PR TITLE
fix: eliminate implicit limb-mask narrowing via shared bit_clear_mask helper (#1260)

### DIFF
--- a/include/sw/universal/internal/bit_manipulation.hpp
+++ b/include/sw/universal/internal/bit_manipulation.hpp
@@ -1,0 +1,24 @@
+#pragma once
+// bit_manipulation.hpp: shared limb/bit mask helpers for the block storage types
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+namespace sw { namespace universal {
+
+// bit_clear_mask: a mask of limb type `bt` with every bit set EXCEPT bit
+// (i % bitsInBlock). Clear a single bit of a limb with:
+//     limb = static_cast<bt>(limb & bit_clear_mask<bt>(i, bitsInBlock));
+//
+// The narrowing to `bt` is intentional -- only the low bitsInBlock bits of the
+// complemented mask are meaningful -- and is made EXPLICIT here so the idiom does
+// not emit -Wconversion (GCC/Clang) or C4244 (MSVC) at every instantiation site,
+// which it previously did when written inline as `bt null = ~(1ull << i)` (#1260).
+template<typename bt>
+constexpr bt bit_clear_mask(unsigned i, unsigned bitsInBlock) noexcept {
+	return static_cast<bt>(~(bt(1) << (i % bitsInBlock)));
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -14,6 +14,8 @@
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/internal/blocktype/carry.hpp>
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 
 enum class BinaryNumberType {
@@ -678,7 +680,7 @@ public:
 #endif
 #endif
 			bt blockBits = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block[blockIndex] = bt((blockBits & null) | mask);

--- a/include/sw/universal/internal/blockfraction/blockfraction.hpp
+++ b/include/sw/universal/internal/blockfraction/blockfraction.hpp
@@ -14,6 +14,8 @@
 #include <universal/internal/blockfraction/blockfraction_fwd.hpp>
 #include <universal/internal/blocktype/carry.hpp>
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 
 // structure for blockfraction<nbits> to capture quotient and remainder during long division
@@ -373,7 +375,7 @@ public:
 		unsigned blockIndex = i / bitsInBlock;
 		if (blockIndex < nrBlocks) {
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block[blockIndex] = bt((block & null) | mask);

--- a/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
+++ b/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
@@ -39,6 +39,8 @@
    such as blocktriple.
 
  */
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 
 // Encoding of the blocksignificand
@@ -405,7 +407,7 @@ public:
 		unsigned blockIndex = i / bitsInBlock;
 		if (blockIndex < nrBlocks) {
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block[blockIndex] = bt((block & null) | mask);

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -26,6 +26,8 @@
 #define TRACE_CONVERSION 0
 #endif
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 		
 	constexpr bool AREAL_NIBBLE_MARKER = true;
@@ -1224,7 +1226,7 @@ public:
 #endif
 #endif
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block[blockIndex] = bt((block & null) | mask);

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -51,6 +51,8 @@
 #define TRACE_CONVERSION 0
 #endif
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 
 /*
@@ -1308,7 +1310,7 @@ public:
 		unsigned blockIndex = i / bitsInBlock;
 		if (blockIndex < nrBlocks) {
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block[blockIndex] = bt((block & null) | mask);

--- a/include/sw/universal/number/dbns/dbns_impl.hpp
+++ b/include/sw/universal/number/dbns/dbns_impl.hpp
@@ -17,6 +17,8 @@
 #include <universal/number/dbns/dbns_fwd.hpp>
 #include <math/constexpr_math.hpp>
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 		
 	// arithmetic event statistics
@@ -404,7 +406,7 @@ public:
 		unsigned blockIndex = i / bitsInBlock;
 		if (i < nbits) {
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block[blockIndex] = bt((block & null) | mask);

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -34,6 +34,8 @@ you need the exception types defined, but you have the option to throw them
 #include <universal/number/support/decimal.hpp>
 #include <universal/internal/blocktriple/blocktriple.hpp>
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 
 enum class IntegerNumberType {
@@ -887,7 +889,7 @@ public:
 		unsigned blockIndex = i / bitsInBlock;
 		if (blockIndex < nrBlocks) {
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block[blockIndex] = bt((block & null) | mask);

--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -18,6 +18,8 @@
 #include <universal/number/lns/lns_fwd.hpp>
 #include <universal/number/lns/lns_addsub_algorithms.hpp>
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 		
 	// arithmetic event statistics
@@ -319,7 +321,7 @@ public:
 		unsigned blockIndex = i / bitsInBlock;
 		if (i < nbits) {
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			//_block[i / bitsInBlock] = bt((block & null) | mask);

--- a/include/sw/universal/number/posit/posit_exponent.hpp
+++ b/include/sw/universal/number/posit/posit_exponent.hpp
@@ -6,6 +6,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw { namespace universal {
 
 static constexpr int GEOMETRIC_ROUND_DOWN   = -2;
@@ -65,7 +67,7 @@ public:
 	constexpr void setbit(unsigned i, bool v = true) noexcept {
 		if (i < es) {
 			std::uint32_t block = _expBits;
-			std::uint32_t null = ~(1ull << i);
+			std::uint32_t null = bit_clear_mask<std::uint32_t>(i, 32);
 			std::uint32_t bit = std::uint32_t(v ? 1u : 0u);
 			std::uint32_t mask = std::uint32_t(bit << i);
 			_expBits = std::uint32_t((block & null) | mask);

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -36,6 +36,8 @@
 #include <universal/internal/abstract/triple.hpp>
 #include <math/constexpr_math/exp2.hpp>
 
+#include <universal/internal/bit_manipulation.hpp>
+
 namespace sw {	namespace universal {
 
 // Forward definitions
@@ -298,7 +300,7 @@ public:
 		unsigned blockIndex = i / bitsInBlock;
 		if (i < nbits) {
 			bt block = _block[blockIndex];
-			bt null = ~(1ull << (i % bitsInBlock));
+			bt null = bit_clear_mask<bt>(i, bitsInBlock);
 			bt bit = bt(v ? 1 : 0);
 			bt mask = bt(bit << (i % bitsInBlock));
 			_block.setblock(blockIndex, bt((block & null) | mask));

--- a/internal/blockbinary/api/bit_clear_mask.cpp
+++ b/internal/blockbinary/api/bit_clear_mask.cpp
@@ -1,0 +1,80 @@
+//  bit_clear_mask.cpp : test suite for the shared bit_clear_mask limb-mask helper (#1260)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstdint>
+#include <iostream>
+
+#include <universal/internal/bit_manipulation.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// bit_clear_mask<bt>(i, bitsInBlock) must equal a bt with every bit set except
+	// bit (i % bitsInBlock) -- the mask used to clear one bit via (limb & mask).
+	template<typename bt>
+	int VerifyBitClearMask(const char* tag, bool reportTestCases) {
+		constexpr unsigned bitsInBlock = sizeof(bt) * 8u;
+		int nrOfFailures = 0;
+		for (unsigned i = 0; i < bitsInBlock; ++i) {
+			bt observed = bit_clear_mask<bt>(i, bitsInBlock);
+			// reference built in 64-bit then explicitly narrowed (the intended value)
+			bt expected = static_cast<bt>(~(static_cast<std::uint64_t>(1) << i));
+			if (observed != expected) {
+				++nrOfFailures;
+				if (reportTestCases) std::cout << "    FAIL " << tag << " i=" << i
+					<< " observed=0x" << std::hex << static_cast<std::uint64_t>(observed)
+					<< " expected=0x" << static_cast<std::uint64_t>(expected) << std::dec << '\n';
+			}
+		}
+		// i beyond bitsInBlock must wrap via the % reduction (matches the call sites)
+		if (bit_clear_mask<bt>(bitsInBlock + 3u, bitsInBlock) != bit_clear_mask<bt>(3u, bitsInBlock)) {
+			++nrOfFailures;
+			if (reportTestCases) std::cout << "    FAIL " << tag << " modulo reduction\n";
+		}
+		return nrOfFailures;
+	}
+
+}  // anonymous namespace
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "bit_clear_mask limb-mask helper (#1260)";
+	std::string test_tag    = "bit_clear_mask";
+	bool reportTestCases    = true;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// compile-time: the helper is constexpr and the truncation is exact
+	static_assert(bit_clear_mask<std::uint8_t>(0, 8) == std::uint8_t(0xFE), "bit_clear_mask<uint8_t>(0) must be 0xFE");
+	static_assert(bit_clear_mask<std::uint8_t>(7, 8) == std::uint8_t(0x7F), "bit_clear_mask<uint8_t>(7) must be 0x7F");
+	static_assert(bit_clear_mask<std::uint16_t>(15, 16) == std::uint16_t(0x7FFF), "bit_clear_mask<uint16_t>(15)");
+
+	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint8_t>("uint8_t", reportTestCases), "bit_clear_mask<uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint16_t>("uint16_t", reportTestCases), "bit_clear_mask<uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint32_t>("uint32_t", reportTestCases), "bit_clear_mask<uint32_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint64_t>("uint64_t", reportTestCases), "bit_clear_mask<uint64_t>", test_tag);
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught unexpected runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << '\n';
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
The idiom `bt null = ~(1ull << (i % bitsInBlock))` in `setbit` builds a 64-bit mask and implicitly narrows it to the limb type `bt`. The truncation is intended (only the low `bitsInBlock` bits matter) but implicit, so `-Wconversion` (GCC/Clang) and **C4244** (MSVC) fire at *every template instantiation site* -- observed flooding downstream builds (stillwater-sc/mp-blas CI).

## Fix
New dependency-free constexpr helper, `internal/bit_manipulation.hpp`:
```cpp
template<typename bt>
constexpr bt bit_clear_mask(unsigned i, unsigned bitsInBlock) noexcept {
    return static_cast<bt>(~(bt(1) << (i % bitsInBlock)));
}
```
The narrowing is now **explicit** (warning-free) in one place, and every site routes through it.

**The issue listed 5 files; the identical idiom was actually in 10** -- I converted all of them so it cannot drift into the next number system (the issue's stated goal):
`blockbinary`, `blockfraction`, `blocksignificand`, `cfloat`, `lns`, `posit_exponent`, `integer`, `takum`, `areal`, `dbns`. (`posit_exponent`'s `std::uint32_t` variant uses `bit_clear_mask<std::uint32_t>(i, 32)`.)

## Changes
- `include/sw/universal/internal/bit_manipulation.hpp` -- new helper
- 10 headers -- route `setbit`'s mask through the helper + include it
- `internal/blockbinary/api/bit_clear_mask.cpp` -- new regression (all bit positions of uint8/16/32/64 + constexpr static_asserts)

## Verification
- Helper is `-Wconversion -Wall -Wpedantic -Werror` clean on gcc **and** clang, and produces the identical mask to the reference for every bit position of all 4 limb widths.
- All 10 consumers compile + run clean on both compilers.
- `bb_bit_clear_mask`, `bb_api`, `cfloat_api`, `cfloat_assignment`, `posit_api`, `posit_conversion`, `posit_to_native_narrowing`, `lns_api`, `lns_conversion`, `areal_api` PASS on gcc + clang (setbit behavior unchanged).

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Resolves #1260

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bit updates across supported numeric types by using consistently sized masks.
  * Corrected handling of bit positions across different storage widths, including wrapped positions.

* **Tests**
  * Added coverage for bit-mask generation across 8-, 16-, 32-, and 64-bit values.
  * Added compile-time and runtime checks for expected masking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->