### PR TITLE
fix: eliminate shift-mask narrowing via shared bit_high_mask helper (#1261)

### DIFF
--- a/include/sw/universal/internal/bit_manipulation.hpp
+++ b/include/sw/universal/internal/bit_manipulation.hpp
@@ -21,4 +21,20 @@ constexpr bt bit_clear_mask(unsigned i, unsigned bitsInBlock) noexcept {
 	return static_cast<bt>(~(bt(1) << (i % bitsInBlock)));
 }
 
+// bit_high_mask: a mask of limb type `bt` with the highest `count` bits of a
+// bitsInBlock-wide limb set (equivalently, all-ones shifted left by
+// bitsInBlock - count). Used by the left-shift operators to select the upper
+// bits of a limb that move into the next word.
+//
+// As with bit_clear_mask, the narrowing to `bt` is intentional and EXPLICIT
+// here, so the idiom does not emit -Wconversion / MSVC C4244 at every
+// instantiation site, which it previously did when written inline as
+// `bt mask = 0xFFFFFFFFFFFFFFFF << (bitsInBlock - count)` (#1261). Building the
+// mask in `bt` also sidesteps the platform-dependent type of the unsuffixed
+// 64-bit literal (unsigned long on LP64 vs unsigned long long on Windows).
+template<typename bt>
+constexpr bt bit_high_mask(unsigned count, unsigned bitsInBlock) noexcept {
+	return static_cast<bt>(static_cast<bt>(~bt(0)) << (bitsInBlock - count));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -559,7 +559,7 @@ public:
 		}
 		if constexpr (MSU > 0) {
 			// construct the mask for the upper bits in the block that needs to move to the higher word
-			bt mask = 0xFFFFFFFFFFFFFFFF << (bitsInBlock - bitsToShift);
+			bt mask = bit_high_mask<bt>(bitsToShift, bitsInBlock);
 			for (unsigned i = MSU; i > 0; --i) {
 				_block[i] <<= bitsToShift;
 				// mix in the bits from the right

--- a/include/sw/universal/internal/blockfraction/blockfraction.hpp
+++ b/include/sw/universal/internal/blockfraction/blockfraction.hpp
@@ -301,7 +301,7 @@ public:
 		}
 		if constexpr (MSU > 0) {
 			// construct the mask for the upper bits in the block that need to move to the higher word
-			bt mask = 0xFFFFFFFFFFFFFFFF << (bitsInBlock - bitsToShift);
+			bt mask = bit_high_mask<bt>(bitsToShift, bitsInBlock);
 			for (unsigned i = MSU; i > 0; --i) {
 				_block[i] <<= bitsToShift;
 				// mix in the bits from the right

--- a/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
+++ b/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
@@ -333,7 +333,7 @@ public:
 		}
 		if constexpr (MSU > 0) {
 			// construct the mask for the upper bits in the block that need to move to the higher word
-			bt mask = 0xFFFFFFFFFFFFFFFF << (bitsInBlock - bitsToShift);
+			bt mask = bit_high_mask<bt>(bitsToShift, bitsInBlock);
 			for (unsigned i = MSU; i > 0; --i) {
 				_block[i] <<= bitsToShift;
 				// mix in the bits from the right

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -1891,7 +1891,7 @@ protected:
 			if (bitsToShift == 0) return;
 		}
 		// construct the mask for the upper bits in the block that need to move to the higher word
-		bt mask = 0xFFFFFFFFFFFFFFFF << (bitsInBlock - bitsToShift);
+		bt mask = bit_high_mask<bt>(bitsToShift, bitsInBlock);
 		for (unsigned i = MSU; i > 0; --i) {
 			_block[i] <<= bitsToShift;
 			// mix in the bits from the right

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -2450,7 +2450,7 @@ protected:
 		}
 		if constexpr (MSU > 0) {
 			// construct the mask for the upper bits in the block that need to move to the higher word
-			bt mask = 0xFFFFFFFFFFFFFFFF << (bitsInBlock - bitsToShift);
+			bt mask = bit_high_mask<bt>(bitsToShift, bitsInBlock);
 			for (unsigned i = MSU; i > 0; --i) {
 				_block[i] <<= bitsToShift;
 				// mix in the bits from the right

--- a/internal/blockbinary/api/bit_clear_mask.cpp
+++ b/internal/blockbinary/api/bit_clear_mask.cpp
@@ -1,4 +1,4 @@
-//  bit_clear_mask.cpp : test suite for the shared bit_clear_mask limb-mask helper (#1260)
+//  bit_clear_mask.cpp : test suite for the shared limb-mask helpers bit_clear_mask (#1260) and bit_high_mask (#1261)
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
@@ -40,13 +40,32 @@ namespace {
 		return nrOfFailures;
 	}
 
+	// bit_high_mask<bt>(count, bitsInBlock) must equal all-ones shifted left by
+	// (bitsInBlock - count): the highest `count` bits of the limb set.
+	template<typename bt>
+	int VerifyBitHighMask(const char* tag, bool reportTestCases) {
+		constexpr unsigned bitsInBlock = sizeof(bt) * 8u;
+		int nrOfFailures = 0;
+		for (unsigned count = 1; count < bitsInBlock; ++count) {   // callers early-return count(bitsToShift)==0
+			bt observed = bit_high_mask<bt>(count, bitsInBlock);
+			bt expected = static_cast<bt>(~(static_cast<std::uint64_t>(0)) << (bitsInBlock - count));
+			if (observed != expected) {
+				++nrOfFailures;
+				if (reportTestCases) std::cout << "    FAIL " << tag << " count=" << count
+					<< " observed=0x" << std::hex << static_cast<std::uint64_t>(observed)
+					<< " expected=0x" << static_cast<std::uint64_t>(expected) << std::dec << '\n';
+			}
+		}
+		return nrOfFailures;
+	}
+
 }  // anonymous namespace
 
 int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite  = "bit_clear_mask limb-mask helper (#1260)";
+	std::string test_suite  = "limb-mask helpers bit_clear_mask (#1260) / bit_high_mask (#1261)";
 	std::string test_tag    = "bit_clear_mask";
 	bool reportTestCases    = true;
 	int nrOfFailedTestCases = 0;
@@ -57,11 +76,19 @@ try {
 	static_assert(bit_clear_mask<std::uint8_t>(0, 8) == std::uint8_t(0xFE), "bit_clear_mask<uint8_t>(0) must be 0xFE");
 	static_assert(bit_clear_mask<std::uint8_t>(7, 8) == std::uint8_t(0x7F), "bit_clear_mask<uint8_t>(7) must be 0x7F");
 	static_assert(bit_clear_mask<std::uint16_t>(15, 16) == std::uint16_t(0x7FFF), "bit_clear_mask<uint16_t>(15)");
+	// bit_high_mask (#1261): the highest `count` bits of the limb
+	static_assert(bit_high_mask<std::uint8_t>(3, 8) == std::uint8_t(0xE0), "bit_high_mask<uint8_t>(3) must be 0xE0");
+	static_assert(bit_high_mask<std::uint8_t>(1, 8) == std::uint8_t(0x80), "bit_high_mask<uint8_t>(1) must be 0x80");
+	static_assert(bit_high_mask<std::uint16_t>(4, 16) == std::uint16_t(0xF000), "bit_high_mask<uint16_t>(4)");
 
 	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint8_t>("uint8_t", reportTestCases), "bit_clear_mask<uint8_t>", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint16_t>("uint16_t", reportTestCases), "bit_clear_mask<uint16_t>", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint32_t>("uint32_t", reportTestCases), "bit_clear_mask<uint32_t>", test_tag);
 	nrOfFailedTestCases += ReportTestResult(VerifyBitClearMask<std::uint64_t>("uint64_t", reportTestCases), "bit_clear_mask<uint64_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyBitHighMask<std::uint8_t>("uint8_t", reportTestCases), "bit_high_mask<uint8_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyBitHighMask<std::uint16_t>("uint16_t", reportTestCases), "bit_high_mask<uint16_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyBitHighMask<std::uint32_t>("uint32_t", reportTestCases), "bit_high_mask<uint32_t>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(VerifyBitHighMask<std::uint64_t>("uint64_t", reportTestCases), "bit_high_mask<uint64_t>", test_tag);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);


### PR DESCRIPTION
## Summary
The left-shift operators build the upper-bits mask as an unsuffixed 64-bit literal and implicitly narrow it to the limb type `bt`:
```cpp
bt mask = 0xFFFFFFFFFFFFFFFF << (bitsInBlock - bitsToShift);
```
so `-Wconversion` (GCC/Clang) and **C4244** (MSVC) fire at every instantiation. The literal's type is also platform-dependent (`unsigned long` LP64 vs `unsigned long long` Windows).

## Fix
Sibling of #1260 (same warning-clean Epic #1265), so I extended the same shared header. Added to `internal/bit_manipulation.hpp`:
```cpp
template<typename bt>
constexpr bt bit_high_mask(unsigned count, unsigned bitsInBlock) noexcept {
    return static_cast<bt>(static_cast<bt>(~bt(0)) << (bitsInBlock - count));
}
```
the highest `count` bits of a limb -- all-ones shifted left and narrowed **explicitly** (warning-free, platform-independent). All sites route through it.

**The issue listed 2 files; the idiom was actually in 5** (`blockbinary`, `blocksignificand`, `blockfraction`, `areal`, `cfloat`). The issue's proposed inline `ALL_ONES` fix would **not compile** for `areal`/`cfloat` (no `ALL_ONES` limb constant -- cfloat only has `ALL_ONES_FR`/`ALL_ONES_ES`), so the shared helper is the uniform fix and matches the Epic's intent. All 5 files already include `bit_manipulation.hpp` from #1260, so no new includes.

## Verification
- `bit_high_mask` is `-Wconversion -Werror` clean on gcc + clang and reproduces the original literal for **every shift** of uint8/16/32/64.
- `blockbinary<64,bt> <<= k` matches a `uint64` shift for all `bt` and all `k` (the exercised code path).
- Regression added to `internal/blockbinary/api/bit_clear_mask.cpp` (now covers both helpers, incl. `constexpr static_assert`s).
- `bb_api`, `cfloat_api`, `cfloat_assignment`, `areal_api`, `posit_api` PASS on both compilers; all consumers compile clean.

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Resolves #1261

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved left-shift behavior across supported numeric formats and block widths.
  - Ensured high-order bit masking works consistently without width-dependent limitations.

- **Tests**
  - Added comprehensive validation for high-bit mask generation across multiple integer sizes.
  - Added compile-time and runtime checks to verify shifting and masking results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->