### PR TITLE
fix(native): setFields(long double) reconstructs the explicit integer bit (#1262)

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -67,6 +67,7 @@ jobs:
             efloat
             ereal
             elreal
+            native
             internal
             blockbinary
             blockdecimal

--- a/include/sw/universal/native/set_fields.hpp
+++ b/include/sw/universal/native/set_fields.hpp
@@ -95,9 +95,25 @@ namespace sw { namespace universal {
 	// specialization to set fields on a long double
 	inline void setFields(long double& value, bool s, uint64_t rawExponentBits, uint64_t rawFractionBits) noexcept {
 		long_double_decoder decoder;
+		const uint64_t exponent = rawExponentBits & 0x7FFF;
 		decoder.parts.sign = s;
-		decoder.parts.exponent = rawExponentBits & 0x7FFF;
+		decoder.parts.exponent = exponent;
+#if defined(UNIVERSAL_ARCH_X86_64) || defined(UNIVERSAL_ARCH_RISCV)
+		// x86/RISC-V 80-bit extended: `fraction` is a 63-bit field (bits 62-0) and the
+		// integer part of the significand lives in an EXPLICIT `bit63` field that is 1 for
+		// every value with a nonzero exponent (normals, inf, NaN) and 0 for zero/subnormals.
+		// setFields' inputs carry only the 63-bit fraction (extractFields returns
+		// parts.fraction), so the integer bit must be reconstructed here -- without it every
+		// normal value decoded to a NaN (#1262). The 0x7FFF... mask also states the
+		// truncation to the field width explicitly; the old 0xFFFF... mask was a no-op that
+		// narrowed implicitly (-Wconversion / MSVC C4244).
+		decoder.parts.fraction = rawFractionBits & 0x7FFF'FFFF'FFFF'FFFF;
+		decoder.parts.bit63 = (exponent != 0) ? 1u : 0u;
+#else
+		// other long double layouts (binary128 / double-double) have an implicit integer
+		// bit like float/double and no `bit63` field; preserve the original assignment.
 		decoder.parts.fraction = rawFractionBits & 0xFFFF'FFFF'FFFF'FFFF;
+#endif
 		value = decoder.ld;
 	}
 
@@ -183,9 +199,25 @@ namespace sw { namespace universal {
 	// specialization to extract fields from a long double
 	inline void setFields(long double& value, bool s, uint64_t rawExponentBits, uint64_t rawFractionBits) noexcept {
 		long_double_decoder decoder;
+		const uint64_t exponent = rawExponentBits & 0x7FFF;
 		decoder.parts.sign = s;
-		decoder.parts.exponent = rawExponentBits & 0x7FFF;
+		decoder.parts.exponent = exponent;
+#if defined(UNIVERSAL_ARCH_X86_64) || defined(UNIVERSAL_ARCH_RISCV)
+		// x86/RISC-V 80-bit extended: `fraction` is a 63-bit field (bits 62-0) and the
+		// integer part of the significand lives in an EXPLICIT `bit63` field that is 1 for
+		// every value with a nonzero exponent (normals, inf, NaN) and 0 for zero/subnormals.
+		// setFields' inputs carry only the 63-bit fraction (extractFields returns
+		// parts.fraction), so the integer bit must be reconstructed here -- without it every
+		// normal value decoded to a NaN (#1262). The 0x7FFF... mask also states the
+		// truncation to the field width explicitly; the old 0xFFFF... mask was a no-op that
+		// narrowed implicitly (-Wconversion / MSVC C4244).
+		decoder.parts.fraction = rawFractionBits & 0x7FFF'FFFF'FFFF'FFFF;
+		decoder.parts.bit63 = (exponent != 0) ? 1u : 0u;
+#else
+		// other long double layouts (binary128 / double-double) have an implicit integer
+		// bit like float/double and no `bit63` field; preserve the original assignment.
 		decoder.parts.fraction = rawFractionBits & 0xFFFF'FFFF'FFFF'FFFF;
+#endif
 		value = decoder.ld;
 	}
 #endif // LONG_DOUBLE_DOWNCAST

--- a/static/native/float/ieee754.cpp
+++ b/static/native/float/ieee754.cpp
@@ -709,6 +709,14 @@ try {
 	std::cout << "\nField round-trip tests\n";
 	nrOfFailedTestCases += ReportTestResult(VerifyFieldRoundTrip<float>(reportTestCases), "float", "field round-trip");
 	nrOfFailedTestCases += ReportTestResult(VerifyFieldRoundTrip<double>(reportTestCases), "double", "field round-trip");
+#if LONG_DOUBLE_SUPPORT && !defined(LONG_DOUBLE_DOWNCAST) && (defined(UNIVERSAL_ARCH_X86_64) || defined(UNIVERSAL_ARCH_RISCV))
+	// 80-bit extended long double (#1262): setFields must reconstruct the explicit integer
+	// bit, else every normal value round-trips to NaN. Scoped to the x86/RISC-V 63-bit-
+	// fraction layout: it is skipped where setFields downcasts to double (lossy for
+	// >53-bit values) and on binary128 layouts (112-bit fraction does not fit the uint64
+	// field interface, so the round-trip is inherently lossy there, independent of #1262).
+	nrOfFailedTestCases += ReportTestResult(VerifyFieldRoundTrip<long double>(reportTestCases), "long double", "field round-trip");
+#endif
 
 #endif
 


### PR DESCRIPTION
## Summary
On the x86/RISC-V 80-bit extended path, `setFields(long double)` had two problems:
1. **No-op mask**: `rawFractionBits & 0xFFFF'FFFF'FFFF'FFFF` (64 ones) while the target `parts.fraction` is a **`:63`** bitfield -> the assignment truncated implicitly (`-Wconversion` / MSVC C4244).
2. **The real defect**: it never set the **explicit integer bit** `parts.bit63` (must be 1 for any nonzero exponent). So `extractFields -> setFields` produced **NaN for every normal value** (verified: `1.0L`, `2.0L`, `pi`, ... all decoded to NaN before the fix).

## Confirming the issue's open question
The field is **not** too narrow -- the x86 decoder has a *separate* `bit63` field for the integer part, and `extractFields` returns only the 63-bit `parts.fraction`. So `setFields` (which takes only the 63-bit fraction) must reconstruct the integer bit itself. The fix belongs in `setFields`, not the decoder.

## Fix
Both non-DOWNCAST copies: mask the fraction to 63 bits explicitly and set `parts.bit63 = (exponent != 0)`. Guarded to the layouts that actually have the `:63`+`bit63` fields (`UNIVERSAL_ARCH_X86_64` / `_RISCV`); binary128 / double-double layouts (no `bit63` field) keep the original assignment unchanged, so ARM64/POWER are unaffected.

## Regression
`static/native/float/ieee754.cpp` already had a generic `VerifyFieldRoundTrip<Real>` (tests `1.0`, `pi`, `max`, `min`, `denorm_min`, `inf`, `NaN`, ...). Instantiated it for `long double`, scoped to the 80-bit x86/RISC-V path (the `uint64` field interface cannot round-trip a 128-bit fraction, and the DOWNCAST path is lossy for >53-bit values -- both independent of #1262).

## Test Results (both compilers non-DOWNCAST on x86_64 here)
| Target | gcc | clang |
|--------|-----|-------|
| native_float_ieee754 (float/double/long double round-trip) | PASS | PASS |

## Test plan
- [ ] Fast CI passes (incl. ARM64/POWER/RISC-V cross builds -- guarded so they compile unchanged)
- [ ] Promote to ready when satisfied

Resolves #1262

Generated with [Claude Code](https://claude.com/claude-code)