### PR TITLE
fix(numeric): clear decimal.hpp narrowing + ignored-qualifier warnings (#1263)

### DIFF
--- a/include/sw/universal/number/support/decimal.hpp
+++ b/include/sw/universal/number/support/decimal.hpp
@@ -198,9 +198,9 @@ inline void add(decimal& lhs, const decimal& rhs) {
 	}
 	decimal::iterator lit = lhs.begin();
 	decimal::iterator rit = _rhs.begin();
-	char carry = 0;
+	uint8_t carry = 0;   // only ever 0 or 1; uint8_t avoids char's implementation-defined signedness
 	for (; lit != lhs.end() || rit != _rhs.end(); ++lit, ++rit) {
-		*lit += *rit + carry;
+		*lit = static_cast<uint8_t>(*lit + *rit + carry);   // sum promotes to int; the digit narrows back explicitly
 		if (*lit > 9) {
 			carry = 1;
 			*lit -= 10;
@@ -281,7 +281,7 @@ inline void mul(decimal& lhs, const decimal& rhs) {
 		for (sit = lhs.begin(); sit != lhs.end(); ++sit) {
 			decimal partial_sum; partial_sum.clear(); // TODO: this is silly, create and immediately destruct to make the insert work
 			partial_sum.insert(partial_sum.end(), r + position, 0);
-			decimal::iterator pit = partial_sum.begin() + static_cast<const int64_t>(position);
+			decimal::iterator pit = partial_sum.begin() + static_cast<int64_t>(position);
 			uint8_t carry = 0;
 			for (bit = rhs.begin(); bit != rhs.end() && pit != partial_sum.end(); ++bit, ++pit) {
 				uint8_t digit = uint8_t(*sit * *bit + carry);
@@ -299,7 +299,7 @@ inline void mul(decimal& lhs, const decimal& rhs) {
 		for (sit = rhs.begin(); sit != rhs.end(); ++sit) {
 			decimal partial_sum; partial_sum.clear(); // TODO: this is silly, create and immediately destruct to make the insert work
 			partial_sum.insert(partial_sum.end(), l + position, 0);
-			decimal::iterator pit = partial_sum.begin() + static_cast<const int64_t>(position);
+			decimal::iterator pit = partial_sum.begin() + static_cast<int64_t>(position);
 			uint8_t carry = 0;
 			for (bit = lhs.begin(); bit != lhs.end() && pit != partial_sum.end(); ++bit, ++pit) {
 				uint8_t digit = uint8_t(*sit * *bit + carry);


### PR DESCRIPTION
## Summary
Three warnings in `number/support/decimal.hpp` (warning-clean Epic #1265), reachable widely because `decimal.hpp` is pulled in through the number-system aggregators.

1. **`add()` digit accumulation narrows** `int -> uint8_t` (`-Wconversion`, line 203): `*lit += *rit + carry` promotes to `int` and the compound assignment narrows back. Made the truncation explicit and changed `char carry` -> `uint8_t carry` (it only ever holds 0/1; `char`'s implementation-defined signedness meant signed/unsigned mixing in digit arithmetic). This also makes `add()` consistent with `sub()`'s `uint8_t borrow` and `mul()`'s `uint8_t carry`.
2/3. **`mul()` `static_cast<const int64_t>(position)`** at two sites (`-Wignored-qualifiers`, lines 284/302): top-level `const` on a cast to a non-class type is meaningless -> dropped it.

Value-preserving: the casts state existing truncations, and `uint8_t carry` holds the same 0/1.

## Changes
- `include/sw/universal/number/support/decimal.hpp` -- the three fixes above.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| conversions_to_decimal | PASS | PASS |
| bt_decimal | PASS | PASS |
| fixpnt_mod_conversion | PASS | PASS |

`decimal.hpp` is now clean under `-Wconversion` / `-Wignored-qualifiers` on both compilers.

## Note (out of scope)
clang's `-Wconversion` (which includes `-Wsign-conversion`) surfaces one *additional*, isolated warning at line 386 (`if (v & mask)` -- signed `v` & unsigned `mask` in binary->decimal conversion). It's a different warning class not listed in #1263, and touches the negative-value path, so I left it out; happy to fold it in or file a follow-up for the Epic.

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Resolves #1263

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal addition and multiplication calculations to ensure more reliable arithmetic results.
  * Preserved existing normalization and accumulation behavior while strengthening numeric handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->