### PR TITLE
fix(numeric): explicit cast in convert_to_decimal bit-test (-Wsign-conversion) (#1270)

### DIFF
--- a/include/sw/universal/number/support/decimal.hpp
+++ b/include/sw/universal/number/support/decimal.hpp
@@ -383,7 +383,7 @@ inline void convert_to_decimal(long long v, decimal& d) {
 	decimal base; // can't use base(1) semantics here as it would cause an infinite loop
 	base.setdigit(1);
 	while (v) { // minimum loop iterations; exits when no bits left
-		if (v & mask) {
+		if (static_cast<uint64_t>(v) & mask) {   // v is non-negative here (magnitude); cast avoids -Wsign-conversion (#1270)
 			add(d, base);
 		}
 		add(base, base);


### PR DESCRIPTION
## Summary
Follow-up to #1263 (same file, warning-clean Epic #1265). `if (v & mask)` in `convert_to_decimal(long long v, decimal&)` implicitly promoted the signed `long long v` to `unsigned long long` (`mask` is `uint64_t`) -> `-Wsign-conversion`.

`v` is **non-negative** at that point (the function transforms negatives to positive magnitude via `v *= -1` up front), so the bit-test is semantically correct. Made the intent explicit with `static_cast<uint64_t>(v)`, matching the existing `decimal::setvalue` idiom (`if (absValue & mask)`).

## Changes
- `include/sw/universal/number/support/decimal.hpp` -- one-line explicit cast.

## Verification
`decimal.hpp` is now clean under `-Wconversion` / `-Wsign-conversion` / `-Wignored-qualifiers` on **gcc + clang**.

| Target | gcc | clang |
|--------|-----|-------|
| conversions_to_decimal | PASS | PASS |
| bt_decimal | PASS | PASS |

Value-preserving (`v >= 0` here).

## Note
The pre-existing `v *= -1` is UB for `LLONG_MIN` (negation overflow); flagged in #1270 as a possible separate correctness issue, out of scope for this hygiene fix.

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Resolves #1270

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal conversion reliability for large integer values, including values with high-order bits set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->