### PR TITLE
fix: drop gratuitous ull in posit index arithmetic; lns scale() casts to int (#1264)

### DIFF
--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -444,7 +444,7 @@ public:
 	constexpr int  scale()  const noexcept {
 		ExponentBlockBinary exp(_block);
 		exp >>= rbits;
-		return long(exp);
+		return static_cast<int>(exp);   // scale() returns int (matches posit/cfloat convention); long(exp) narrowed on LP64
 	}
 	constexpr blockbinary<nbits+2, std::uint32_t, BinaryNumberType::Unsigned> fraction() const noexcept {
 		blockbinary<nbits + 2, std::uint32_t, BinaryNumberType::Unsigned> bb{ 0 };

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -380,10 +380,10 @@ constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const bl
 		pt_bits |= fraction;
 		pt_bits |= sticky_bit;
 
-		unsigned len = 1 + std::max<unsigned>((nbits + 1ull), (2u + run + es));
+		unsigned len = 1 + std::max<unsigned>((nbits + 1u), (2u + run + es));
 		bool blast = pt_bits.test(len - nbits);
-		bool bafter = pt_bits.test(len - nbits - 1ull);
-		bool bsticky = pt_bits.anyAfter(len - nbits - 1ull);
+		bool bafter = pt_bits.test(len - nbits - 1u);      // len >= nbits + 2, so this is >= 1 (no unsigned wrap)
+		bool bsticky = pt_bits.anyAfter(len - nbits - 1u); // 1u (not 1ull) keeps the index expression unsigned
 
 		bool rb = (blast & bafter) | (bafter & bsticky);
 


### PR DESCRIPTION
## Summary
Two independent one-line narrowings (warning-clean Epic #1265).

1. **posit** `posit_impl.hpp::convert_()`: the rounding bit-tests `test(len - nbits - 1ull)` / `anyAfter(len - nbits - 1ull)` (lines 385/386) promoted an unsigned index expression to 64 bits only to narrow it straight back to `unsigned` -> `-Wconversion`. `len`/`nbits` are `unsigned` and `test`/`anyAfter` take `unsigned`, so use `1u`. Also cleaned the gratuitous `nbits + 1ull` (line 383 -- constant that fits, didn't warn, but same idiom). `len >= nbits + 2` by construction, so `len - nbits - 1u >= 1` (no unsigned wrap).
2. **lns** `lns_impl.hpp::scale()`: returned `long(exp)` from an `int`-returning function -> `-Wconversion` (`long` is 64-bit on LP64, 32-bit on MSVC -- hence the asymmetric CI reports). **Confirmed** `int` is the `scale()` convention across the number systems (posit/cfloat return `int`), so the cast was the mistake -> `static_cast<int>`.

## Changes
- `include/sw/universal/number/posit/posit_impl.hpp` -- `1ull` -> `1u` (3 sites)
- `include/sw/universal/number/lns/lns_impl.hpp` -- `long(exp)` -> `static_cast<int>(exp)`

## Verification
The flagged lines are clean under `-Wconversion` on **gcc + clang**. Value-preserving.

| Target | gcc | clang |
|--------|-----|-------|
| posit_addition | PASS | PASS |
| posit_multiplication | PASS | PASS |
| lns_api | PASS | PASS |
| lns_conversion | PASS | PASS |

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Resolves #1264

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric conversion reliability by making narrowing conversions explicit.
  * Corrected rounding and guard-bit calculations to prevent edge-case errors during posit number conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->