### PR TITLE
fix(numeric): decimal integer conversion is UB (and hangs) for LLONG_MIN (#1273)

### DIFF
--- a/include/sw/universal/number/support/decimal.hpp
+++ b/include/sw/universal/number/support/decimal.hpp
@@ -52,7 +52,8 @@ public:
 	}
 	inline void setvalue(long long v) {
 		setzero();
-		uint64_t absValue = (v < 0) ? static_cast<uint64_t>(-v) : static_cast<uint64_t>(v);
+		// unsigned negation for the magnitude: -v is UB for LLONG_MIN (#1273)
+		uint64_t absValue = (v < 0) ? (0ull - static_cast<uint64_t>(v)) : static_cast<uint64_t>(v);
 
 		uint64_t mask = 1ull;
 		support::decimal multiplier;
@@ -369,25 +370,25 @@ inline decimal div(const decimal& lhs, const decimal& rhs) {
 inline void convert_to_decimal(long long v, decimal& d) {
 	using namespace std;
 	d.setzero();
-	bool sign = false;
 	if (v == 0) return;
-	if (v < 0) {
-		sign = true; // negative number
-		// transform to sign-magnitude on positive side
-		v *= -1;
-	}
+	bool sign = (v < 0);
+	// magnitude in the UNSIGNED domain: negating a signed long long is UB for LLONG_MIN
+	// (its magnitude 2^63 is not representable in long long -- the old `v *= -1` left v
+	// negative and the loop below spun forever). Unsigned negation is well-defined and
+	// yields 2^63 for LLONG_MIN (#1273).
+	uint64_t magnitude = sign ? (0ull - static_cast<uint64_t>(v)) : static_cast<uint64_t>(v);
 	uint64_t mask = 0x1;
-	// IMPORTANT: can't use initializer or assignment operator as it would yield 
+	// IMPORTANT: can't use initializer or assignment operator as it would yield
 	// an infinite loop calling convert_to_decimal. So we need to construct the
 	// decimal from first principals
 	decimal base; // can't use base(1) semantics here as it would cause an infinite loop
 	base.setdigit(1);
-	while (v) { // minimum loop iterations; exits when no bits left
-		if (static_cast<uint64_t>(v) & mask) {   // v is non-negative here (magnitude); cast avoids -Wsign-conversion (#1270)
+	while (magnitude) { // minimum loop iterations; exits when no bits left
+		if (magnitude & mask) {
 			add(d, base);
 		}
 		add(base, base);
-		v >>= 1;
+		magnitude >>= 1;
 	}
 	// finally set the sign
 	d.setsign(sign);

--- a/static/conversions/decimal_boundary.cpp
+++ b/static/conversions/decimal_boundary.cpp
@@ -1,0 +1,82 @@
+// decimal_boundary.cpp: boundary regression for support::decimal integer conversion (#1273)
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// LLONG_MIN used to trigger signed-overflow UB: convert_to_decimal did `v *= -1` and
+// setvalue did `-v`, whose magnitude 2^63 is not representable in long long. In
+// convert_to_decimal that left v negative and the bit loop spun forever (a hang); the
+// fix negates in the unsigned domain (#1273).
+#include <universal/utility/directives.hpp>
+#include <climits>
+#include <sstream>
+#include <string>
+#include <iostream>
+
+#include <universal/number/support/decimal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	using sw::universal::support::decimal;
+
+	std::string toStr(const decimal& d) { std::stringstream ss; ss << d; return ss.str(); }
+
+	int VerifyDecimalConversion(bool reportTestCases) {
+		int nrOfFailures = 0;
+		struct Case { long long v; const char* expected; };
+		const Case cases[] = {
+			{ LLONG_MIN,     "-9223372036854775808" },   // the UB / infinite-loop case
+			{ LLONG_MIN + 1, "-9223372036854775807" },
+			{ LLONG_MAX,      "9223372036854775807" },
+			{ 0,   "0" }, { -1, "-1" }, { 1, "1" }, { -1000000, "-1000000" }, { 123456789, "123456789" },
+		};
+		for (const auto& c : cases) {
+			decimal a; sw::universal::support::convert_to_decimal(c.v, a);
+			if (toStr(a) != c.expected) {
+				++nrOfFailures;
+				if (reportTestCases) std::cout << "    FAIL convert_to_decimal(" << c.v << ") = " << toStr(a)
+					<< " expected " << c.expected << '\n';
+			}
+			decimal b; b.setvalue(c.v);
+			if (toStr(b) != c.expected) {
+				++nrOfFailures;
+				if (reportTestCases) std::cout << "    FAIL setvalue(" << c.v << ") = " << toStr(b)
+					<< " expected " << c.expected << '\n';
+			}
+		}
+		return nrOfFailures;
+	}
+
+}  // anonymous namespace
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite = "support::decimal integer conversion boundaries (#1273)";
+	bool reportTestCases = true;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	nrOfFailedTestCases += ReportTestResult(VerifyDecimalConversion(reportTestCases),
+		"convert_to_decimal / setvalue (incl. LLONG_MIN)", "decimal");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << '\n';
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << '\n';
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << '\n';
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary
`number/support/decimal.hpp` computed a magnitude by negating a signed `long long`, which is **UB for `LLONG_MIN`** (its magnitude `2^63` is not representable in `long long`):

- **`convert_to_decimal`**: `v *= -1` left `v == LLONG_MIN` (still negative); the bit loop then did `v >>= 1` on a negative value, which **sticks at `-1` forever -> infinite loop** (confirmed hang).
- **`setvalue`**: `-v` is the same overflow UB (its fixed 64-iteration loop hid the symptom, but the negation is still UB / UBSan-flagged).

## Fix
Negate in the **unsigned domain** (`0ull - static_cast<uint64_t>(v)`), which is well-defined and yields `2^63` for `LLONG_MIN`. `convert_to_decimal` now loops over a `uint64_t magnitude` (which also retires the `-Wsign-conversion` cast added in #1270 at that line).

## Changes
- `include/sw/universal/number/support/decimal.hpp` -- unsigned negation in `setvalue` and `convert_to_decimal`.
- `static/conversions/decimal_boundary.cpp` -- new regression (LLONG_MIN / LLONG_MIN+1 / LLONG_MAX / 0 / +-small); **hangs on the old code, PASSes on the fix**.

## Verification
- Correct decimal for `LLONG_MIN` (`-9223372036854775808`), terminates, **UBSan-clean** (no signed overflow).

| Target | gcc | clang |
|--------|-----|-------|
| conversions_decimal_boundary | PASS | PASS |
| bt_decimal | PASS | PASS |

## Test plan
- [ ] Fast CI passes (and the ASan/UBSan tier, given the UB nature)
- [ ] Promote to ready when satisfied

Resolves #1273
Relates to #1270

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of the minimum signed 64-bit integer and other negative values to decimal text.
  * Prevented incorrect results or hangs when processing boundary integer values.

* **Tests**
  * Added regression coverage for minimum and maximum limits, zero, negative values, and representative integers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->