### PR TITLE
docs(lns): document scale() int-truncation limit for wide configurations (#1274)

### DIFF
--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -444,11 +444,12 @@ public:
 	// scale(): the integer power-of-two exponent (the integer part of the lns exponent).
 	// Returns int by the library-wide scale() convention (posit/cfloat/... all return int).
 	// LIMITATION (#1274): the lns exponent field is nbits-rbits-1 bits wide, so for
-	// astronomically wide configurations (e.g. lns<64,11> ~ 2^52, lns<128,15> ~ 2^111)
-	// the scale exceeds int range and this accessor truncates. lns ARITHMETIC is
-	// unaffected -- it operates on the full fixed-point exponent, not on scale(); only this
-	// metadata accessor saturates. If a use needs the full scale for such configs, read the
-	// exponent field directly rather than through scale().
+	// astronomically wide configurations (e.g. lns<64,11> ~ 2^52, lns<128,15> ~ 2^111) the
+	// scale exceeds int range. operator int() keeps at most the low 64 bits and the C++20
+	// int64->int conversion then reduces modulo 2^32 (well-defined, but not the true scale).
+	// lns ARITHMETIC is unaffected -- it operates on the full fixed-point exponent, not on
+	// scale(); only this metadata accessor loses the high bits. There is currently no public
+	// full-width scale() alternative for such configurations.
 	constexpr int  scale()  const noexcept {
 		ExponentBlockBinary exp(_block);
 		exp >>= rbits;

--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -441,10 +441,18 @@ public:
 	constexpr bool sign()   const noexcept { 
 		return (SIGN_BIT_MASK & _block[MSU]) != 0;
 	}
+	// scale(): the integer power-of-two exponent (the integer part of the lns exponent).
+	// Returns int by the library-wide scale() convention (posit/cfloat/... all return int).
+	// LIMITATION (#1274): the lns exponent field is nbits-rbits-1 bits wide, so for
+	// astronomically wide configurations (e.g. lns<64,11> ~ 2^52, lns<128,15> ~ 2^111)
+	// the scale exceeds int range and this accessor truncates. lns ARITHMETIC is
+	// unaffected -- it operates on the full fixed-point exponent, not on scale(); only this
+	// metadata accessor saturates. If a use needs the full scale for such configs, read the
+	// exponent field directly rather than through scale().
 	constexpr int  scale()  const noexcept {
 		ExponentBlockBinary exp(_block);
 		exp >>= rbits;
-		return static_cast<int>(exp);   // scale() returns int (matches posit/cfloat convention); long(exp) narrowed on LP64
+		return static_cast<int>(exp);   // int by convention; wide configs truncate (see note above, #1274)
 	}
 	constexpr blockbinary<nbits+2, std::uint32_t, BinaryNumberType::Unsigned> fraction() const noexcept {
 		blockbinary<nbits + 2, std::uint32_t, BinaryNumberType::Unsigned> bb{ 0 };


### PR DESCRIPTION
## Summary
Per the #1274 decision (**document the limit**), add a doc note on `lns::scale()`.

`scale()` returns `int` by the library-wide convention (posit/cfloat/... all return `int`), and that convention is baked into the arithmetic engine (`blocktriple`/`blocksignificand` consume `int` scale) and ~499 call sites -- widening it is an Epic-scale rearchitecture. A `static_assert` was rejected because the wide configs are legitimately used (`lns<128,15>` inside the lns math library, `lns<64,11>`/`<128,15>` in perf tests).

`lns` is the one type whose exponent field (`nbits-rbits-1` bits) can exceed `int`, so `scale()` truncates for astronomically wide configs (`lns<64,11>` ~ 2^52, `lns<128,15>` ~ 2^111). The note records this and clarifies that lns **arithmetic is unaffected** (it operates on the full fixed-point exponent; only this metadata accessor saturates).

## Changes
- `include/sw/universal/number/lns/lns_impl.hpp` -- doc comment on `scale()`. **No behavior change.**

## Verification
| Target | gcc | clang |
|--------|-----|-------|
| lns_api | PASS | PASS |

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Resolves #1274

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `lns::scale()` returns an `int` by library convention.
  * Documented that values may be truncated when the exponent exceeds the `int` range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->