### PR TITLE
fix(interval): do not return a finite enclosure for an unbounded result

### DIFF
--- a/include/sw/universal/number/interval/exceptions.hpp
+++ b/include/sw/universal/number/interval/exceptions.hpp
@@ -24,6 +24,14 @@ struct interval_negative_sqrt_arg : public interval_arithmetic_exception {
 	interval_negative_sqrt_arg() : interval_arithmetic_exception("negative sqrt argument") {}
 };
 
+// The exact result is unbounded, but Scalar has no infinity with which to
+// represent it. Thrown instead of silently returning a finite interval, which
+// would claim to enclose values it does not contain.
+struct interval_unrepresentable_unbounded : public interval_arithmetic_exception {
+	interval_unrepresentable_unbounded() : interval_arithmetic_exception(
+		"unbounded result cannot be represented: Scalar has no infinity") {}
+};
+
 ///////////////////////////////////////////////////////////////
 // internal implementation exceptions
 

--- a/include/sw/universal/number/interval/interval_impl.hpp
+++ b/include/sw/universal/number/interval/interval_impl.hpp
@@ -192,6 +192,23 @@ class interval {
 public:
 	using value_type = Scalar;
 
+	/// Can this interval represent an UNBOUNDED result?
+	///
+	/// Division by an interval containing zero has an unbounded exact result set,
+	/// and the only way to enclose it is +/-infinity. Some Scalars have no
+	/// infinity to offer: posit has NaR instead, and
+	/// numeric_limits<posit>::infinity() returns maxpos -- a finite value
+	/// indistinguishable from ordinary data. lns likewise reports
+	/// has_infinity = false.
+	///
+	/// The flag is derived from what infinity() actually IS, not from the
+	/// has_infinity claim, because the two disagree for posit. When this is false
+	/// the unbounded case throws rather than returning a finite interval that
+	/// would claim to enclose values it does not contain.
+	static constexpr bool can_represent_unbounded =
+		std::numeric_limits<Scalar>::has_infinity &&
+		(std::numeric_limits<Scalar>::infinity() > std::numeric_limits<Scalar>::max());
+
 	// constructors
 	constexpr interval() noexcept : _lo{}, _hi{} {}
 
@@ -305,10 +322,23 @@ public:
 		}
 #else
 		if (rhs.contains_zero()) {
-			// Division by interval containing zero results in [-inf, inf]
-			_lo = -std::numeric_limits<Scalar>::infinity();
-			_hi = std::numeric_limits<Scalar>::infinity();
-			return *this;
+			// The exact result set is unbounded, and the only enclosure of it is
+			// [-inf, +inf]. That requires Scalar to HAVE an infinity.
+			//
+			// For posit it does not: numeric_limits<posit>::infinity() returns
+			// maxpos, so this used to produce the finite [-maxpos, maxpos] -- an
+			// interval claiming to enclose an unbounded set while excluding
+			// everything beyond maxpos. Silently returning a too-narrow enclosure
+			// is the one failure mode interval arithmetic must never have, so
+			// throw instead: there is no correct value to return.
+			if constexpr (!can_represent_unbounded) {
+				throw interval_unrepresentable_unbounded();
+			}
+			else {
+				_lo = -std::numeric_limits<Scalar>::infinity();
+				_hi = std::numeric_limits<Scalar>::infinity();
+				return *this;
+			}
 		}
 #endif
 		// Compute reciprocal of rhs: [1/d, 1/c]. EFT (fma residual) widens each endpoint

--- a/static/range/interval/arithmetic/unbounded.cpp
+++ b/static/range/interval/arithmetic/unbounded.cpp
@@ -106,8 +106,13 @@ int VerifyOrdinaryDivisionUnaffected(bool reportTestCases) {
 	int nrOfFailures = 0;
 	try {
 		const I q = I(Scalar(1), Scalar(4)) / I(Scalar(2), Scalar(4));
-		// [1,4]/[2,4] = [0.25, 2]
-		if (!(q.lower() <= Scalar(0.25)) || !(q.upper() >= Scalar(2))) {
+		// [1,4]/[2,4] = [0.25, 2]; require a FINITE enclosure strictly inside +-max() so the
+		// test catches ordinary division being wrongly routed through the zero-divisor path
+		// (which would return an unbounded / +-max() interval that still encloses [0.25, 2]).
+		if (!q.isfinite() ||
+		    !(q.lower() <= Scalar(0.25)) || !(q.upper() >= Scalar(2)) ||
+		    !(q.lower() > -std::numeric_limits<Scalar>::max()) ||
+		    !(q.upper() < std::numeric_limits<Scalar>::max())) {
 			++nrOfFailures;
 			if (reportTestCases)
 				std::cerr << "FAIL: [1,4]/[2,4] = [" << double(q.lower()) << ", "

--- a/static/range/interval/arithmetic/unbounded.cpp
+++ b/static/range/interval/arithmetic/unbounded.cpp
@@ -1,0 +1,177 @@
+// unbounded.cpp: division by an interval containing zero, for Scalars with and
+// without an infinity
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Division by an interval containing zero has an UNBOUNDED exact result set, and
+// the only enclosure of it is [-inf, +inf]. That requires the Scalar to have an
+// infinity -- and not every Scalar does:
+//
+//   double, cfloat  : has_infinity, and infinity() > max()          -> can represent
+//   posit           : NaR instead of infinity; numeric_limits<posit>::infinity()
+//                     returns MAXPOS, a finite value indistinguishable from data
+//   lns             : has_infinity is correctly false
+//
+// Before the fix this produced the finite [-maxpos, maxpos] for posit: an
+// interval claiming to enclose an unbounded set while excluding everything beyond
+// maxpos. Silently returning a too-narrow enclosure is the one failure mode
+// interval arithmetic must never have -- there is no correct value to return, so
+// the operation now throws.
+//
+// interval<Scalar>::can_represent_unbounded is the compile-time query, derived
+// from what infinity() actually IS rather than from the has_infinity claim,
+// because the two disagree for posit.
+#include <universal/utility/directives.hpp>
+#include <iostream>
+#include <universal/number/posit/posit.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/number/lns/lns.hpp>
+#include <universal/number/interval/interval.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// Scalar HAS a usable infinity: the unbounded result must be representable, and
+// the returned interval must actually be unbounded.
+template<typename Scalar>
+int VerifyUnboundedRepresentable(bool reportTestCases) {
+	using namespace sw::universal;
+	using I = interval<Scalar>;
+	int nrOfFailures = 0;
+
+	if constexpr (!I::can_represent_unbounded) {
+		++nrOfFailures;
+		if (reportTestCases) std::cerr << "FAIL: expected can_represent_unbounded == true\n";
+	}
+	else {
+		try {
+			const I q = I(Scalar(1), Scalar(4)) / I(Scalar(-1), Scalar(1));
+			// A finite result here would be an enclosure that excludes part of the
+			// true (unbounded) result set.
+			if (!(q.lower() < -std::numeric_limits<Scalar>::max()) ||
+			    !(q.upper() >  std::numeric_limits<Scalar>::max())) {
+				++nrOfFailures;
+				if (reportTestCases)
+					std::cerr << "FAIL: [1,4]/[-1,1] returned a FINITE interval ["
+					          << double(q.lower()) << ", " << double(q.upper())
+					          << "] where the exact result set is unbounded\n";
+			}
+		}
+		catch (const interval_unrepresentable_unbounded&) {
+			++nrOfFailures;
+			if (reportTestCases)
+				std::cerr << "FAIL: threw although the Scalar has an infinity\n";
+		}
+	}
+	return nrOfFailures;
+}
+
+// Scalar has NO usable infinity: the operation must throw rather than return a
+// finite interval that claims to enclose an unbounded set.
+template<typename Scalar>
+int VerifyUnboundedThrows(bool reportTestCases) {
+	using namespace sw::universal;
+	using I = interval<Scalar>;
+	int nrOfFailures = 0;
+
+	if constexpr (I::can_represent_unbounded) {
+		++nrOfFailures;
+		if (reportTestCases) std::cerr << "FAIL: expected can_represent_unbounded == false\n";
+	}
+	else {
+		bool threw = false;
+		try {
+			const I q = I(Scalar(1), Scalar(4)) / I(Scalar(-1), Scalar(1));
+			if (reportTestCases)
+				std::cerr << "FAIL: returned [" << double(q.lower()) << ", " << double(q.upper())
+				          << "] instead of throwing; that interval excludes everything beyond max()\n";
+		}
+		catch (const interval_unrepresentable_unbounded&) {
+			threw = true;
+		}
+		if (!threw) ++nrOfFailures;
+	}
+	return nrOfFailures;
+}
+
+// The guard must fire ONLY for a zero-containing divisor: ordinary division is
+// untouched for every Scalar.
+template<typename Scalar>
+int VerifyOrdinaryDivisionUnaffected(bool reportTestCases) {
+	using namespace sw::universal;
+	using I = interval<Scalar>;
+	int nrOfFailures = 0;
+	try {
+		const I q = I(Scalar(1), Scalar(4)) / I(Scalar(2), Scalar(4));
+		// [1,4]/[2,4] = [0.25, 2]
+		if (!(q.lower() <= Scalar(0.25)) || !(q.upper() >= Scalar(2))) {
+			++nrOfFailures;
+			if (reportTestCases)
+				std::cerr << "FAIL: [1,4]/[2,4] = [" << double(q.lower()) << ", "
+				          << double(q.upper()) << "], expected to enclose [0.25, 2]\n";
+		}
+	}
+	catch (...) {
+		++nrOfFailures;
+		if (reportTestCases) std::cerr << "FAIL: ordinary division threw\n";
+	}
+	return nrOfFailures;
+}
+
+} // namespace
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "interval unbounded-result validation";
+	std::string test_tag    = "unbounded division";
+	bool reportTestCases    = true;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// Scalars with a real infinity.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyUnboundedRepresentable<float>(reportTestCases), "float", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyUnboundedRepresentable<double>(reportTestCases), "double", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyUnboundedRepresentable<cfloat<32, 8>>(reportTestCases)), "cfloat<32,8>", test_tag);
+
+	// Scalars without one: posit has NaR, lns reports has_infinity = false.
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyUnboundedThrows<posit<16, 2>>(reportTestCases)), "posit<16,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyUnboundedThrows<posit<32, 2>>(reportTestCases)), "posit<32,2>", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyUnboundedThrows<lns<32, 16>>(reportTestCases)), "lns<32,16>", test_tag);
+
+	// And nothing else changed.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrdinaryDivisionUnaffected<double>(reportTestCases), "double ordinary", test_tag);
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyOrdinaryDivisionUnaffected<posit<32, 2>>(reportTestCases)), "posit<32,2> ordinary", test_tag);
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Uncaught arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Division by an interval containing zero has an **unbounded** exact result set, and the only enclosure of it is `[-inf, +inf]`. `interval<Scalar>` signalled that with `±numeric_limits<Scalar>::infinity()`, which assumes every `Scalar` **has** an infinity. Not every one does:

| Scalar | situation |
|---|---|
| `double`, `cfloat` | `has_infinity`, and `infinity() > max()` — can represent |
| `posit` | NaR instead of infinity; `numeric_limits<posit>::infinity()` returns **maxpos**, a finite value indistinguishable from ordinary data |
| `lns` | `has_infinity` is correctly `false`, but `interval` called `infinity()` without consulting the flag |

So `interval<posit<32,2>>` returned the **finite** `[-1.329e+36, 1.329e+36]` for a division whose exact result set is unbounded — an enclosure that excludes everything beyond maxpos while claiming to contain it.

Silently returning a too-narrow enclosure is the one failure mode interval arithmetic must never have. Every other error is conservative; this one is not.

## Fix

There is no correct value to return, so the operation now throws `interval_unrepresentable_unbounded`. That converts silent unsoundness into a loud, catchable failure.

```
interval<posit<32,2>>, [1,4]/[-1,1]:
  before   returned [-1.32923e+36, 1.32923e+36]    (finite, unsound)
  after    throws "unbounded result cannot be represented: Scalar has no infinity"
```

Adds `interval<Scalar>::can_represent_unbounded`, a compile-time query derived from what `infinity()` **actually is** rather than from the `has_infinity` claim, because the two disagree for posit:

```cpp
static constexpr bool can_represent_unbounded =
    numeric_limits<Scalar>::has_infinity &&
    (numeric_limits<Scalar>::infinity() > numeric_limits<Scalar>::max());
```

Callers can branch on it to skip element types that cannot express the answer, rather than discovering it at runtime.

## Scope

The guard fires **only** for a zero-containing divisor. Ordinary division is untouched for every Scalar (asserted in the test), as is every other operator.

## Testing

`static/range/interval/arithmetic/unbounded.cpp` covers both directions:

- `float` / `double` / `cfloat<32,8>` — must represent the unbounded result, **and** the returned interval must actually be unbounded (a finite return fails)
- `posit<16,2>` / `posit<32,2>` / `lns<32,16>` — must throw
- ordinary division for `double` and `posit<32,2>` — so the guard cannot creep

Verified against a downstream consumer: **stillwater-sc/mp-blas builds clean and all 16 of its tests pass** against this branch, including its interval BLAS suite (which exercises interval `dot`, `gemv`, `gemm`, `rot`, `nrm2`, and a naive interval `trsv`).

## Follow-up, deliberately not in this PR

A fuller fix would give `interval` an explicit **"entire"** state so the unbounded result is *representable* for every Scalar rather than merely refused. That means new state on a core class propagated through every operator — a larger change worth designing separately. This commit closes the unsoundness; the enhancement can restore the capability.

Related: stillwater-sc/mp-blas#12, where this was found while building an interval BLAS. Also stillwater-sc/universal#1236, which recorded the `numeric_limits<posit>` half of the diagnosis.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved interval division when the divisor contains zero.
  * Unbounded results are now represented using infinity when supported by the numeric type.
  * Clear exceptions are raised when unbounded results cannot be represented.

* **Tests**
  * Added validation across supported floating-point and specialized numeric types.
  * Confirmed ordinary interval division continues to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->