### PR TITLE
fix(native): restore inline exponent mask in setFields (-Wconversion regression) (#1265)

### DIFF
--- a/include/sw/universal/native/set_fields.hpp
+++ b/include/sw/universal/native/set_fields.hpp
@@ -95,9 +95,11 @@ namespace sw { namespace universal {
 	// specialization to set fields on a long double
 	inline void setFields(long double& value, bool s, uint64_t rawExponentBits, uint64_t rawFractionBits) noexcept {
 		long_double_decoder decoder;
-		const uint64_t exponent = rawExponentBits & 0x7FFF;
 		decoder.parts.sign = s;
-		decoder.parts.exponent = exponent;
+		// inline the 0x7FFF mask so the compiler sees the value fits the 15-bit exponent
+		// field: assigning a masked expression is warning-free, whereas assigning a uint64_t
+		// local is a narrowing to :15 (-Wconversion). (Regression from #1262's local, #1265.)
+		decoder.parts.exponent = rawExponentBits & 0x7FFF;
 #if defined(UNIVERSAL_ARCH_X86_64) || defined(UNIVERSAL_ARCH_RISCV)
 		// x86/RISC-V 80-bit extended: `fraction` is a 63-bit field (bits 62-0) and the
 		// integer part of the significand lives in an EXPLICIT `bit63` field that is 1 for
@@ -108,7 +110,7 @@ namespace sw { namespace universal {
 		// truncation to the field width explicitly; the old 0xFFFF... mask was a no-op that
 		// narrowed implicitly (-Wconversion / MSVC C4244).
 		decoder.parts.fraction = rawFractionBits & 0x7FFF'FFFF'FFFF'FFFF;
-		decoder.parts.bit63 = (exponent != 0) ? 1u : 0u;
+		decoder.parts.bit63 = ((rawExponentBits & 0x7FFF) != 0) ? 1u : 0u;
 #else
 		// other long double layouts (binary128 / double-double) have an implicit integer
 		// bit like float/double and no `bit63` field; preserve the original assignment.
@@ -199,9 +201,11 @@ namespace sw { namespace universal {
 	// specialization to extract fields from a long double
 	inline void setFields(long double& value, bool s, uint64_t rawExponentBits, uint64_t rawFractionBits) noexcept {
 		long_double_decoder decoder;
-		const uint64_t exponent = rawExponentBits & 0x7FFF;
 		decoder.parts.sign = s;
-		decoder.parts.exponent = exponent;
+		// inline the 0x7FFF mask so the compiler sees the value fits the 15-bit exponent
+		// field: assigning a masked expression is warning-free, whereas assigning a uint64_t
+		// local is a narrowing to :15 (-Wconversion). (Regression from #1262's local, #1265.)
+		decoder.parts.exponent = rawExponentBits & 0x7FFF;
 #if defined(UNIVERSAL_ARCH_X86_64) || defined(UNIVERSAL_ARCH_RISCV)
 		// x86/RISC-V 80-bit extended: `fraction` is a 63-bit field (bits 62-0) and the
 		// integer part of the significand lives in an EXPLICIT `bit63` field that is 1 for
@@ -212,7 +216,7 @@ namespace sw { namespace universal {
 		// truncation to the field width explicitly; the old 0xFFFF... mask was a no-op that
 		// narrowed implicitly (-Wconversion / MSVC C4244).
 		decoder.parts.fraction = rawFractionBits & 0x7FFF'FFFF'FFFF'FFFF;
-		decoder.parts.bit63 = (exponent != 0) ? 1u : 0u;
+		decoder.parts.bit63 = ((rawExponentBits & 0x7FFF) != 0) ? 1u : 0u;
 #else
 		// other long double layouts (binary128 / double-double) have an implicit integer
 		// bit like float/double and no `bit63` field; preserve the original assignment.


### PR DESCRIPTION
## Summary
Closes the last residual `-Wconversion` site in the #1265 inventory, which was a regression from #1262.

#1262 extracted `const uint64_t exponent = rawExponentBits & 0x7FFF;` into a local and assigned it to the **15-bit** `parts.exponent` bitfield. That broke gcc's range tracking: the inline `& 0x7FFF` proved the value fits `:15` (no warning), but a `uint64_t` local can hold values that don't, so `parts.exponent = exponent` became a narrowing (`-Wconversion` at `set_fields.hpp:100`).

Fix: inline the mask at the exponent assignment again and derive `bit63` from the same masked expression. **Behavior unchanged** (identical value); this only restores the compiler's view that the truncation is safe.

## Result
With this, **all 8 headers in the #1265 inventory are clean under gcc `-Wconversion` / `-Wfloat-conversion`**.

## Changes
- `include/sw/universal/native/set_fields.hpp` -- inline the exponent mask (both non-DOWNCAST copies).

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| native_float_ieee754 (incl. long double round-trip) | PASS | PASS |

Relates to #1262, #1265

Generated with [Claude Code](https://claude.com/claude-code)