### PR TITLE
fix(integer): clear -Wsign-conversion in integer/primes/lns (#1283)

### DIFF
--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -764,8 +764,11 @@ public:
 		}
 		if constexpr (MSU > 0) {
 			bt mask = ALL_ONES;
-			mask >>= (bitsInBlock - static_cast<unsigned>(bitsToShift)); // this is a mask for the lower bits in the block that need to move to the lower word
-			for (unsigned i = 0; i < MSU; ++i) {  // TODO: can this be improved? we should not have to work on the upper blocks in case we block shifted
+			// mask for the lower bits in the block that need to move to the lower word
+			mask >>= (bitsInBlock - static_cast<unsigned>(bitsToShift));
+			// TODO: can this be improved? we should not have to work on the upper
+			// blocks in case we block shifted
+			for (unsigned i = 0; i < MSU; ++i) {
 				_block[i] >>= bitsToShift;
 				// mix in the bits from the left
 				bt bits = bt(mask & _block[i + 1]);
@@ -1313,7 +1316,7 @@ public:
 		constexpr unsigned argbits = sizeof(rhs);
 		unsigned upper = (nbits <= _nbits ? nbits : argbits);
 		for (unsigned i = 0; i < upper; ++i) {
-			if ((v & 1) != 0) setbit(i);   // low-bit test; & with signed 1 avoids int64->uint64
+			if (v & 0x1ull) setbit(i);
 			v >>= 1;
 		}
 		return *this;
@@ -1887,10 +1890,12 @@ inline std::ostream& operator<<(std::ostream& ostr, const integer<nbits, BlockTy
 	std::streamsize width = ostr.width();
 	if (width > static_cast<std::streamsize>(s.size())) {
 		char fill = ostr.fill();
+		// width > s.size() here, so the subtraction stays non-negative
+		std::string::size_type pad = static_cast<std::string::size_type>(width) - s.size();
 		if ((ostr.flags() & std::ios_base::left) == std::ios_base::left)
-			s.append(static_cast<std::string::size_type>(width) - s.size(), fill);
+			s.append(pad, fill);
 		else
-			s.insert(static_cast<std::string::size_type>(0), static_cast<std::string::size_type>(width) - s.size(), fill);
+			s.insert(static_cast<std::string::size_type>(0), pad, fill);
 	}
 	return ostr << s;
 }

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -701,7 +701,7 @@ public:
 				_block[i] = bt(0);
 			}
 			// adjust the shift
-			bitsToShift -= static_cast<int>(blockShift * bitsInBlock);
+			bitsToShift -= static_cast<int>(static_cast<unsigned>(blockShift) * bitsInBlock);
 			if (bitsToShift == 0) {
 				_block[MSU] &= MSU_MASK;
 				return *this;
@@ -709,12 +709,15 @@ public:
 		}
 		if constexpr (MSU > 0) {
 			// construct the mask for the upper bits in the block that needs to move to the higher word
-			bt mask = 0xFFFFFFFFFFFFFFFFull << (bitsInBlock - bitsToShift);
+			// bitsToShift is > 0 here (guarded above); the shared helper also states the
+			// mask truncation explicitly (bit_high_mask, #1261) and the cast removes the
+			// unsigned/int mixing in the index arithmetic (#1283).
+			bt mask = bit_high_mask<bt>(static_cast<unsigned>(bitsToShift), bitsInBlock);
 			for (unsigned i = MSU; i > 0; --i) {
 				_block[i] <<= bitsToShift;
 				// mix in the bits from the right
 				bt bits = bt(mask & _block[i - 1]);
-				_block[i] |= (bits >> (bitsInBlock - bitsToShift));
+				_block[i] |= (bits >> (bitsInBlock - static_cast<unsigned>(bitsToShift)));
 			}
 		}
 		_block[0] <<= bitsToShift;	
@@ -731,7 +734,7 @@ public:
 		bool signext = sign();
 		unsigned blockShift = 0;
 		if (bitsToShift >= static_cast<int>(bitsInBlock)) {
-			blockShift = bitsToShift / bitsInBlock;
+			blockShift = static_cast<unsigned>(bitsToShift) / bitsInBlock;
 			if (MSU >= blockShift) {
 				// shift by blocks
 				for (unsigned i = 0; i <= MSU - blockShift; ++i) {
@@ -745,14 +748,14 @@ public:
 				if (signext) {
 					// bitsToShift is guaranteed to be less than nbits
 					bitsToShift += static_cast<int>(blockShift * bitsInBlock);
-					for (unsigned i = nbits - bitsToShift; i < nbits; ++i) {
+					for (unsigned i = nbits - static_cast<unsigned>(bitsToShift); i < nbits; ++i) {
 						setbit(i);
 					}
 				}
 				else {
 					// clean up the blocks we have shifted clean
 					bitsToShift += static_cast<int>(blockShift * bitsInBlock);
-					for (unsigned i = nbits - bitsToShift; i < nbits; ++i) {
+					for (unsigned i = nbits - static_cast<unsigned>(bitsToShift); i < nbits; ++i) {
 						setbit(i, false);
 					}
 				}
@@ -761,12 +764,12 @@ public:
 		}
 		if constexpr (MSU > 0) {
 			bt mask = ALL_ONES;
-			mask >>= (bitsInBlock - bitsToShift); // this is a mask for the lower bits in the block that need to move to the lower word
+			mask >>= (bitsInBlock - static_cast<unsigned>(bitsToShift)); // this is a mask for the lower bits in the block that need to move to the lower word
 			for (unsigned i = 0; i < MSU; ++i) {  // TODO: can this be improved? we should not have to work on the upper blocks in case we block shifted
 				_block[i] >>= bitsToShift;
 				// mix in the bits from the left
 				bt bits = bt(mask & _block[i + 1]);
-				_block[i] |= (bits << (bitsInBlock - bitsToShift));
+				_block[i] |= (bits << (bitsInBlock - static_cast<unsigned>(bitsToShift)));
 			}
 		}
 		_block[MSU] >>= bitsToShift;
@@ -775,14 +778,14 @@ public:
 		if (signext) {
 			// bitsToShift is guaranteed to be less than nbits
 			bitsToShift += static_cast<int>(blockShift * bitsInBlock);
-			for (unsigned i = nbits - bitsToShift; i < nbits; ++i) {
+			for (unsigned i = nbits - static_cast<unsigned>(bitsToShift); i < nbits; ++i) {
 				setbit(i);
 			}
 		}
 		else {
 			// clean up the blocks we have shifted clean
 			bitsToShift += static_cast<int>(blockShift * bitsInBlock);
-			for (unsigned i = nbits - bitsToShift; i < nbits; ++i) {
+			for (unsigned i = nbits - static_cast<unsigned>(bitsToShift); i < nbits; ++i) {
 				setbit(i, false);
 			}
 		}
@@ -1278,7 +1281,7 @@ public:
 
 		int64_t v = rhs;
 		for (unsigned i = 0; i < nbits && v != 0; ++i) {
-			if (v & 0x1ull) setbit(i);
+			if ((v & 1) != 0) setbit(i);   // low-bit test; & with signed 1 avoids int64->uint64
 			v >>= 1;
 		}
 		if constexpr (nbits > 64) {
@@ -1310,7 +1313,7 @@ public:
 		constexpr unsigned argbits = sizeof(rhs);
 		unsigned upper = (nbits <= _nbits ? nbits : argbits);
 		for (unsigned i = 0; i < upper; ++i) {
-			if (v & 0x1ull) setbit(i);
+			if ((v & 1) != 0) setbit(i);   // low-bit test; & with signed 1 avoids int64->uint64
 			v >>= 1;
 		}
 		return *this;
@@ -1885,9 +1888,9 @@ inline std::ostream& operator<<(std::ostream& ostr, const integer<nbits, BlockTy
 	if (width > static_cast<std::streamsize>(s.size())) {
 		char fill = ostr.fill();
 		if ((ostr.flags() & std::ios_base::left) == std::ios_base::left)
-			s.append(static_cast<std::string::size_type>(width - s.size()), fill);
+			s.append(static_cast<std::string::size_type>(width) - s.size(), fill);
 		else
-			s.insert(static_cast<std::string::size_type>(0), static_cast<std::string::size_type>(width - s.size()), fill);
+			s.insert(static_cast<std::string::size_type>(0), static_cast<std::string::size_type>(width) - s.size(), fill);
 	}
 	return ostr << s;
 }

--- a/include/sw/universal/number/integer/primes.hpp
+++ b/include/sw/universal/number/integer/primes.hpp
@@ -173,7 +173,7 @@ void printPrimes(const std::vector< IntegerType >& v) {
 		number /= 10;
 	}
 	std::cout << "largest prime: " << v[nrPrimes - 1] << " is " << COL_WIDTH - 1 << " decades\n";
-	int column = 1;
+	size_t column = 1;
 	for (auto p : v) {
 		std::cout << std::setw(COL_WIDTH) << p;
 		if (column * COL_WIDTH < PAGE_WIDTH) {

--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -745,7 +745,7 @@ protected:
 				// we need to project the bits we have on the fixpnt
 				for (unsigned i = 0; i < ieee754_parameter<Real>::fbits + 1; ++i) {
 					if (rawFraction & 0x01) {
-						lnsExponent.setbit(i + shiftLeft);
+						lnsExponent.setbit(i + static_cast<unsigned>(shiftLeft));
 					}
 					rawFraction >>= 1;
 				}


### PR DESCRIPTION
## Summary
Sub-issue of Epic #1279 (`-Wsign-conversion` cleanup) covering the
`integer` + `primes` + `lns` headers. Every change is value-preserving:
each cast targets a value already proven non-negative / in-range at the
site, or swaps a signedness-changing literal for a signed one.

## Changes
- `include/sw/universal/number/integer/integer_impl.hpp`
  - `operator<<=` / `operator>>=`: guard the block-shift index arithmetic
    where `int` `bitsToShift`/`blockShift` mixes with `unsigned`
    `bitsInBlock`/`nbits`/`MSU` (all `> 0` past the guards, so the casts
    are exact); upper-block mask now uses the shared `bit_high_mask<bt>`
    helper (#1261), which also states the truncation explicitly instead
    of a raw 64-bit literal shift that narrowed implicitly.
  - `assign(int64_t)`: low-bit test `v & 0x1ull` -> `(v & 1) != 0` (masks
    in `int64`, correct for negative `v`, no promotion to `uint64`).
  - `operator<<`: width padding casts `std::streamsize width` (guarded
    `width > s.size()`) before subtracting the string size.
- `include/sw/universal/number/integer/primes.hpp` -- `printPrimes`
  column counter `int` -> `size_t`.
- `include/sw/universal/number/lns/lns_impl.hpp` -- `setbit(i + shiftLeft)`
  cast (`shiftLeft` is a `>= 0` left-shift count on that path).

## Test Results
| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| integer shift_left | OK | PASS | OK | PASS |
| integer shift_right | OK | PASS | OK | PASS |
| integer division | OK | PASS | OK | PASS |
| integer remainder | OK | PASS | OK | PASS |
| lns conversion | OK | PASS | OK | PASS |

Also verified: all three headers compile `-Wsign-conversion` clean on gcc
**and** clang, and no new `-Wconversion` was introduced. A shift-roundtrip
correctness harness (`<<=`/`>>=` across block boundaries for 128-bit
`integer`, plus div/mod/lns/prime-factorization) passes on both.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied: `gh pr ready`

Resolves #1283
Relates to #1279

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integer shift, mask, bit-count, and index calculations for more consistent behavior across signed and unsigned values.
  * Corrected stream padding calculations for safer formatting.
  * Improved bit-index handling during logarithmic number conversions.
  * Updated prime-number output formatting to use appropriate size-based counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->