### PR TITLE
fix(posit): clear -Wsign-conversion in posit_impl convert_ (#1281)

### DIFF
--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -356,7 +356,7 @@ constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const bl
 		regime.setbit(0, 1 ^ r);
 		for (unsigned i = 1; i <= run; ++i) regime.setbit(i, r);
 
-		exponent = e % (1ull << es);
+		exponent = static_cast<unsigned long long>(e) % (1ull << es);
 		int nbits_plus_one = static_cast<int>(nbits) + 1;
 		int sign_regime_es = static_cast<int>(2ull + run + es);
 		unsigned nrFbits = static_cast<unsigned>(std::max<int>(0, (nbits_plus_one - sign_regime_es)));
@@ -370,8 +370,8 @@ constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const bl
 
 		// construct the untruncated posit
 		// pt    = BitOr[BitShiftLeft[reg, es + nf + 1], BitShiftLeft[esval, nf + 1], BitShiftLeft[fv, 1], sb];
-		regime <<= es + nrFbits + 1u;
-		exponent <<= nrFbits + 1u;
+		regime <<= static_cast<int>(es + nrFbits + 1u);
+		exponent <<= static_cast<int>(nrFbits + 1u);
 		fraction <<= 1u;
 		sticky_bit.setbit(0, sb);
 
@@ -388,7 +388,7 @@ constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const bl
 		bool rb = (blast & bafter) | (bafter & bsticky);
 
 		blockbinary<nbits, bt> ptt{0};
-		pt_bits <<= pt_len - len;
+		pt_bits <<= static_cast<int>(pt_len - len);
 		truncate(pt_bits, ptt);
 		if (rb) ++ptt;
 		if (s) ptt = ptt.twosComplement();


### PR DESCRIPTION
## Summary
Sub-issue of Epic #1279 (`-Wsign-conversion` cleanup). Four sites in the
posit encode/rounding path (`convert_`), all value-preserving.

## Changes (`include/sw/universal/number/posit/posit_impl.hpp`)
- `exponent = e % (1ull << es)`: the signed scale `e` was already promoted
  to `unsigned long long` by the modulo (`1ull` operand); made explicit.
  Correct for a power-of-two modulus -- `2^64 mod 2^es == 0`, so the
  unsigned reinterpretation of a two's-complement negative `e` yields
  exactly the low `es` bits = the posit exponent field (consistent with the
  arithmetic-shift regime split `e >> es`).
- `regime <<= es + nrFbits + 1u`, `exponent <<= nrFbits + 1u`,
  `pt_bits <<= pt_len - len`: unsigned shift-amount / left-align distance
  into `operator<<=(int)`; each `>= 1` and small by construction -> explicit
  `static_cast<int>`.

The dead `convert_to_bb` (inside `#ifdef TBD`, never defined, never called)
shares the idiom but does not compile, so it's intentionally left untouched.

## Proof of behavior-neutrality
Optimized assembly (`g++ -O2 -g0`) of a TU instantiating `convert_` across
`posit<8,0>/<16,1>/<32,2>/<64,3>` is **byte-for-byte identical** (16290
lines) before and after -- the casts are explicit forms of conversions the
compiler already did implicitly.

## Test Results
| Target | gcc | clang |
|--------|-----|-------|
| posit conversion | PASS | PASS |
| posit assignment | PASS | PASS |
| posit multiplication | PASS | PASS |
| posit_impl `-Wsign-conversion` / `-Wconversion` | clean | clean |

> Note: `posit<64,2..4>` **division** fails on this branch, but it fails
> **identically on main** (random-sampled, counts vary run-to-run) -- a
> pre-existing issue unrelated to this PR and out of scope. Flagged
> separately.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1281
Relates to #1279

Generated with [Claude Code](https://claude.com/claude-code)