### PR TITLE
fix(quire): size cfloat quire radix_point from smallest normal LSB (#1202)

### DIFF
--- a/include/sw/universal/traits/quire_traits.hpp
+++ b/include/sw/universal/traits/quire_traits.hpp
@@ -81,17 +81,24 @@ struct quire_traits<posit<nbits, es, bt>> {
 // subnormals extend the negative exponent range far beyond the positive range.
 //
 // Scale bounds for individual values:
-//   bias      = 2^(es-1) - 1
-//   max_scale = bias     (or bias+1 if hasMaxExpValues)
-//   min_scale = 1 - bias - fbits  (if hasSubnormals)
-//             = 1 - bias          (if !hasSubnormals)
+//   bias         = 2^(es-1) - 1
+//   max_scale    = bias     (or bias+1 if hasMaxExpValues)     [scale of maxpos]
+//   min_lsb_scale = 1 - bias - fbits                           [scale of the LSB of the
+//                                                               smallest representable value]
+//
+// The smallest representable magnitude's LSB sits at scale (1 - bias - fbits) in BOTH
+// subnormal modes: without subnormals the smallest normal 2^(1-bias) still carries fbits
+// fraction bits down to 2^(1-bias-fbits); with subnormals the smallest subnormal IS exactly
+// 2^(1-bias-fbits). So radix_point does NOT depend on hasSubnormals. (#1202: the old
+// no-subnormals branch used |min_scale| of the value (bias-1) instead of |min_lsb_scale|,
+// dropping 2*fbits fraction bits and truncating exact dot products of small normal operands.)
 //
 // Product scale bounds:
-//   max_product_scale = 2*max_scale + 1   (maxpos^2 significand in [2,4))
-//   min_product_scale = 2*min_scale       (minpos^2)
+//   max_product_scale = 2*max_scale + 1     (maxpos^2 significand in [2,4))
+//   min_product_lsb   = 2*min_lsb_scale     (smallest product bit)
 //
 // Quire layout:
-//   radix_point = |min_product_scale|     -> minpos^2 lands on bit 0
+//   radix_point = |min_product_lsb| = 2*(bias + fbits - 1)  -> smallest product bit at bit 0
 //   upper_range = max_product_scale + 1   -> maxpos^2 MSB lands on bit range-1
 //   range       = radix_point + upper_range
 //
@@ -110,15 +117,14 @@ struct quire_traits<cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, isSatu
 	// Maximum scale of a representable value
 	static constexpr unsigned max_scale   = hasMaxExpValues ? (bias + 1u) : bias;
 
-	// |min_scale|: magnitude of the most negative scale
-	//   hasSubnormals:  min_scale = 1 - bias - fbits  ->  |min_scale| = bias + fbits - 1
-	//   !hasSubnormals: min_scale = 1 - bias           ->  |min_scale| = bias - 1
-	static constexpr unsigned abs_min_scale = hasSubnormals
-		? (bias + fbits - 1u)
-		: (bias >= 1u ? bias - 1u : 0u);
+	// |scale of the LSB of the smallest representable value| = bias + fbits - 1, in BOTH
+	// subnormal modes (see the note above; #1202). Matches the native float/double
+	// specializations below, which use bias + fbits - 1 unconditionally. The guard covers
+	// the degenerate bias + fbits == 0 case (e.g. cfloat<2,1>).
+	static constexpr unsigned abs_min_scale = (bias + fbits >= 1u) ? (bias + fbits - 1u) : 0u;
 
 	// Quire geometry derived from product scale bounds
-	static constexpr unsigned radix_point = 2u * abs_min_scale;   // minpos^2 at bit 0
+	static constexpr unsigned radix_point = 2u * abs_min_scale;   // smallest product bit at bit 0
 	static constexpr unsigned upper_range = 2u * max_scale + 2u;  // maxpos^2 MSB at bit range-1
 	static constexpr unsigned range       = radix_point + upper_range;
 

--- a/static/quire/api/cfloat.cpp
+++ b/static/quire/api/cfloat.cpp
@@ -1383,6 +1383,67 @@ int TestDifferentConfigs() {
 	return nrOfFailedTestCases;
 }
 
+// ============================================================================
+// TestExactDotSmallNormals (#1202)
+// quire_traits<cfloat>::radix_point must reserve 2*fbits fraction bits below
+// minpos^2 so the quire captures products of small NORMAL operands exactly, in
+// BOTH subnormal modes. The smallest normal 2^(1-bias) still carries fbits
+// fraction bits down to 2^(1-bias-fbits), so its square reaches
+// 2^(2-2*bias-2*fbits). Before the fix the no-subnormals quire truncated at
+// ~2^-2*(bias-1), silently dropping those low bits -- a cfloat<16,5> "exact"
+// dot was ~1e-9, worse than accumulating in double.
+// ============================================================================
+template<typename Scalar>
+int VerifyExactDotSmallNormals(const std::string& tag) {
+	using QT = quire_traits<Scalar>;
+	int fails = 0;
+	const int      bias = static_cast<int>(QT::bias);
+	const unsigned fbits = QT::fbits;
+	// smallest normal value 2^(1-bias) and its ULP 2^(1-bias-fbits)
+	const double base = std::ldexp(1.0, 1 - bias);
+	const double ulp  = std::ldexp(base, -static_cast<int>(fbits));
+
+	// near-minpos NORMAL operands with low fraction bits set. Each stays inside the
+	// smallest normal binade (8*ulp < base for fbits >= 4) and is exactly representable,
+	// so operands, their products, and the short sum all fit a double exactly -> the
+	// double dot is an independent exact oracle.
+	std::vector<Scalar> x, y;
+	for (unsigned k = 1; k <= 8; ++k) {
+		x.push_back(Scalar(base + double(k) * ulp));
+		y.push_back(Scalar(base + double(9u - k) * ulp));
+	}
+	double oracle = 0.0;
+	for (size_t i = 0; i < x.size(); ++i) oracle += double(x[i]) * double(y[i]);
+
+	// the quire must deliver the exact sum (convert_to<double> is lossless for this range)
+	quire<Scalar> q;
+	for (size_t i = 0; i < x.size(); ++i) q += quire_mul(x[i], y[i]);
+	const double delivered = q.template convert_to<double>();
+
+	if (delivered != oracle) {
+		std::cerr << "FAIL: " << tag << " exact small-normal dot: quire delivered "
+		          << std::setprecision(std::numeric_limits<double>::max_digits10) << delivered
+		          << ", exact " << oracle << " (radix_point=" << QT::radix_point << ")\n";
+		++fails;
+	}
+	return fails;
+}
+
+int TestExactDotSmallNormals() {
+	int f = 0;
+	// exactness must hold in BOTH subnormal modes (#1202)
+	f += VerifyExactDotSmallNormals<cfloat< 8, 2, uint8_t,  false, false, false>>("cfloat<8,2> no-sub");
+	f += VerifyExactDotSmallNormals<cfloat< 8, 2, uint8_t,  true,  false, false>>("cfloat<8,2> sub");
+	f += VerifyExactDotSmallNormals<cfloat<16, 5, uint16_t, false, false, false>>("cfloat<16,5> no-sub");
+	f += VerifyExactDotSmallNormals<cfloat<16, 5, uint16_t, true,  false, false>>("cfloat<16,5> sub");
+	// radix_point is now mode-independent and matches the documented layout
+	static_assert(quire_traits<cfloat<16, 5, uint16_t, false, false, false>>::radix_point == 48, "cfloat<16,5> no-sub");
+	static_assert(quire_traits<cfloat<16, 5, uint16_t, true,  false, false>>::radix_point == 48, "cfloat<16,5> sub");
+	static_assert(quire_traits<cfloat<8, 3>>::radix_point  == 12,  "cfloat<8,3> documented radix_point");
+	static_assert(quire_traits<cfloat<32, 8>>::radix_point == 298, "cfloat<32,8> documented radix_point");
+	return f;
+}
+
 }} // namespace sw::universal
 
 int main()
@@ -1395,6 +1456,7 @@ try {
 	std::cout << test_suite << '\n';
 	std::cout << std::string(60, '=') << '\n';
 
+	nrOfFailedTestCases += ReportTestResult(TestExactDotSmallNormals(), "cfloat quire", "small-normal dot #1202");
 	nrOfFailedTestCases += ReportTestResult(TestQuireMul(), "cfloat quire_mul", "unrounded product + limb placement");
 	nrOfFailedTestCases += ReportTestResult(TestSpecialValues(), "cfloat quire_mul", "special values");
 	nrOfFailedTestCases += ReportTestResult(TestLimbBoundaryCarryBorrow(), "cfloat quire", "limb-boundary carry/borrow");

--- a/static/quire/api/cfloat.cpp
+++ b/static/quire/api/cfloat.cpp
@@ -6,13 +6,11 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
 // Test structure:
-//   quire<cfloat<32,8>> with uint32_t limbs:
-//     qbits=592, radix_point=281 (in limb 8, bit 25 of that limb)
-//     limb boundaries at accumulator positions 0,32,64,...,576
+//   quire<cfloat<32,8>> with uint32_t limbs (quire_traits<> is the source of truth):
+//     radix_point=298, upper_range=256, range=554, qbits=584 (19 uint32 limbs)
+//     radix_point 298 -> limb 9 (bits 288..319), radix at bit 10 of that limb
 //     MUL blocktriple: bfbits=48, radix=46
-//     accu_base_offset = 281 + scale - 46 = 235 + scale
-//     So a product with scale S starts at accumulator bit (235+S)
-//     Limb crossings when (235+S+i) mod 32 == 0 for some significand bit i
+//     a product at scale S starts at accumulator bit (radix_point + S - 46) = 252 + S
 //
 #include <universal/utility/directives.hpp>
 #include <universal/number/cfloat/cfloat.hpp>
@@ -27,22 +25,17 @@ namespace sw { namespace universal {
 
 // ============================================================================
 // Key quire architectural constants for cfloat<32,8,uint32_t>
+// (derived by quire_traits<>; see include/sw/universal/traits/quire_traits.hpp)
 // ============================================================================
-//   radix_point   = 281
-//   limb size     = 32 bits
-//   limb of radix = 281/32 = limb 8 (bits 256..287), radix at bit 25 in limb
-//   qbits         = 592 (19 limbs: 0..18)
-//   MUL bfbits    = 48, MUL radix = 46
-//   base_offset   = 281 + scale - 46 = 235 + scale
+//   radix_point = 298   (limb 9, bit 10 of that limb)
+//   upper_range = 256,  range = 554,  qbits = 584  (19 uint32 limbs)
+//   MUL blocktriple: bfbits = 48, radix = 46
+//   base_offset = radix_point + scale - 46 = 252 + scale
+//   (a product at scale S occupies accumulator bits [252+S .. 252+S+47])
 //
-// To target limb boundary N*32, we need: 235 + scale + bit_in_sig = N*32
-// For the hidden-bit (bit 47 in 48-bit MUL significand):
-//   235 + scale + 47 = N*32  ->  scale = N*32 - 282
-// Limb  8: 256 -> scale = -26   (radix limb lower boundary)
-// Limb  9: 288 -> scale =   6   (radix limb upper boundary)
-// Limb 10: 320 -> scale =  38
-// Limb  7: 224 -> scale = -58
-// Limb  0:   0 -> scale = -282  (below quire range, would be clipped)
+// The per-limb scale->boundary table was removed: it is derivable from the
+// constants above and had drifted out of date (#1202). The carry/borrow tests
+// below validate the accumulator arithmetic independent of exact limb alignment.
 
 // Helper: compute the exact double-precision dot product of two cfloat vectors
 template<typename Scalar>

--- a/static/quire/api/cfloat_fdp.cpp
+++ b/static/quire/api/cfloat_fdp.cpp
@@ -6,13 +6,11 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
 // Test structure:
-//   quire<cfloat<32,8>> with uint32_t limbs:
-//     qbits=592, radix_point=281 (in limb 8, bit 25 of that limb)
-//     limb boundaries at accumulator positions 0,32,64,...,576
+//   quire<cfloat<32,8>> with uint32_t limbs (quire_traits<> is the source of truth):
+//     radix_point=298, upper_range=256, range=554, qbits=584 (19 uint32 limbs)
+//     radix_point 298 -> limb 9 (bits 288..319), radix at bit 10 of that limb
 //     MUL blocktriple: bfbits=48, radix=46
-//     accu_base_offset = 281 + scale - 46 = 235 + scale
-//     So a product with scale S starts at accumulator bit (235+S)
-//     Limb crossings when (235+S+i) mod 32 == 0 for some significand bit i
+//     a product at scale S starts at accumulator bit (radix_point + S - 46) = 252 + S
 //
 #include <universal/utility/directives.hpp>
 #include <universal/number/cfloat/cfloat.hpp>
@@ -27,22 +25,17 @@ namespace sw { namespace universal {
 
 // ============================================================================
 // Key quire architectural constants for cfloat<32,8,uint32_t>
+// (derived by quire_traits<>; see include/sw/universal/traits/quire_traits.hpp)
 // ============================================================================
-//   radix_point   = 281
-//   limb size     = 32 bits
-//   limb of radix = 281/32 = limb 8 (bits 256..287), radix at bit 25 in limb
-//   qbits         = 592 (19 limbs: 0..18)
-//   MUL bfbits    = 48, MUL radix = 46
-//   base_offset   = 281 + scale - 46 = 235 + scale
+//   radix_point = 298   (limb 9, bit 10 of that limb)
+//   upper_range = 256,  range = 554,  qbits = 584  (19 uint32 limbs)
+//   MUL blocktriple: bfbits = 48, radix = 46
+//   base_offset = radix_point + scale - 46 = 252 + scale
+//   (a product at scale S occupies accumulator bits [252+S .. 252+S+47])
 //
-// To target limb boundary N*32, we need: 235 + scale + bit_in_sig = N*32
-// For the hidden-bit (bit 47 in 48-bit MUL significand):
-//   235 + scale + 47 = N*32  ->  scale = N*32 - 282
-// Limb  8: 256 -> scale = -26   (radix limb lower boundary)
-// Limb  9: 288 -> scale =   6   (radix limb upper boundary)
-// Limb 10: 320 -> scale =  38
-// Limb  7: 224 -> scale = -58
-// Limb  0:   0 -> scale = -282  (below quire range, would be clipped)
+// The per-limb scale->boundary table was removed: it is derivable from the
+// constants above and had drifted out of date (#1202). The carry/borrow tests
+// below validate the accumulator arithmetic independent of exact limb alignment.
 
 // Helper: compute the exact double-precision dot product of two cfloat vectors
 template<typename Scalar>


### PR DESCRIPTION
## Summary
`quire_traits<cfloat>::radix_point` was undersized for **no-subnormals** cfloat
configs (the default), so fused dot products of small-but-normal operands were
truncated -- a `cfloat<16,5>` "exact" dot was ~1e-9 (worse than `double`), and
`cfloat<8,2>` had `radix_point == 0` (no fraction bits at all).

## Root cause
The no-subnormals branch derived `radix_point` from `|min value scale|`
(`bias-1`) -- the scale of the smallest normal's **hidden bit**. But that value
carries `fbits` fraction bits below it, down to `2^(1-bias-fbits)`, so its
square needs `2*(bias+fbits-1)` fraction bits. The old value `2*(bias-1)` was
`2*fbits` short.

The smallest representable magnitude's LSB is at scale `1-bias-fbits` in **both**
subnormal modes (without subnormals the smallest normal's fraction reaches
exactly as low as the smallest subnormal), so `radix_point` does not depend on
`hasSubnormals`.

## Fix
`abs_min_scale = bias + fbits - 1` (guarded for the degenerate `bias+fbits==0`
case), unifying both branches. This matches:
- the native `float`/`double` `quire_traits` specializations (which already use
  `bias + fbits - 1` unconditionally), and
- the file's own documented examples (`cfloat<8,3>=12`, `cfloat<32,8>=298`) --
  which the buggy code contradicted (it produced 4 and 252).

| config | old radix_point | new (this PR) |
|---|--:|--:|
| cfloat<16,5> no-sub | 28 | 48 |
| cfloat<8,2> no-sub  | 0  | 10 |
| cfloat<32,8> no-sub | 252 | 298 |

## Regression
`static/quire/api/cfloat.cpp::TestExactDotSmallNormals`: an exact quire dot over
near-minpos **normal** operands, delivered via `quire::convert_to<double>()`,
must be bit-exact vs an independent `double` oracle for `cfloat<8,2>` and
`cfloat<16,5>` in **both** subnormal modes; plus `static_assert`s on the
documented `radix_point` values. Fails on pre-fix headers (cfloat<8,2> delivered
8 vs exact 10.37; cfloat<16,5> ~1e-9 off), passes with the fix.

## Test Results (gcc + clang)
| Target | Result |
|--------|--------|
| quire_traits / cfloat / cfloat_fdp | PASS |
| aggregator_fdp / api / fixpnt_fdp / lns_fdp | PASS |
| new TestExactDotSmallNormals (both subnormal modes) | PASS |

The larger no-subnormals cfloat quire introduces no regressions (fixpnt/lns
specializations untouched).

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1202

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected quire scaling for `cfloat` values, including consistent handling of fraction bits and zero-scale edge cases.
  * Ensured radix-point calculations remain consistent whether subnormal values are enabled or disabled.

* **Tests**
  * Added coverage verifying exact fused dot-product results for values near the minimum normal range.
  * Confirmed consistent behavior across both subnormal modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->