### PR TITLE
ci(deps): bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -270,7 +270,7 @@ jobs:
       # sccache for Windows (Ninja generator invokes cl.exe through sccache)
       - name: Install and configure sccache
         if: runner.os == 'Windows'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Set sccache compiler launcher
         if: runner.os == 'Windows'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -20,7 +20,7 @@ jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: Universal ${{ github.ref_name }}
@@ -102,17 +102,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: stillwater/universal
           tags: |
@@ -120,7 +120,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.release
@@ -131,7 +131,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `release` workflow emits:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `softprops/action-gh-release@v2`.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` is doing its job -- it forces the Node 24 runtime and warns for any action whose `action.yml` still declares `using: node20`. The fix is to move to a ref that declares node24 natively. `softprops/action-gh-release@v2` still resolves to node20 even at its newest patch (`v2.6.2`); the `v2` line is deliberately pinned there for older self-hosted runners.

An audit of every `uses:` across `.github/workflows/` found eight more in the same state.

## Changes

| Workflow | Action | Before | After |
|---|---|---|---|
| release.yml | softprops/action-gh-release | v2 | v3 |
| release.yml | docker/setup-buildx-action | v3 | v4 |
| release.yml | docker/login-action | v3 | v4 |
| release.yml | docker/metadata-action | v5 | v6 |
| release.yml | docker/build-push-action | v5 | **v7** (v6 is still node20) |
| release.yml | peter-evans/dockerhub-description | v4 | v5 |
| codeql.yml | actions/checkout | v4 | v6 (matches rest of repo) |
| conventional-commits.yml | amannn/action-semantic-pull-request | v5 | v6 |
| cmake.yml | mozilla-actions/sccache-action | v0.0.9 | v0.0.11 |

## Verification

Every action reference in `.github/workflows/` was re-checked by fetching its `action.yml` at the pinned ref -- all now report `using: node24` (or `composite`), not inferred from changelogs. All ten workflow files still parse.

These are majors, not patches, so each was checked against our actual call sites:

- **build-push-action v7** removes `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS`. `grep -rn "DOCKER_BUILD_"` over the workflows returns nothing.
- **setup-buildx-action v4** removes deprecated inputs/outputs. Our step passes no `with:` at all.
- **metadata-action v6** changes `#` handling inside list inputs. Our `tags:` are plain `type=raw,value=...` with no `#`.
- **action-semantic-pull-request v6** is flagged BREAKING, but the note scopes it to the Node 24/ESM move. All five inputs we pass (`types`, `scopes`, `requireScope`, `subjectPattern`, `subjectPatternError`) are still declared in v6.
- The rest are runtime-only bumps.

All of these require **Actions Runner v2.327.1+**, satisfied by the GitHub-hosted runners this repo uses. Worth knowing if a job ever moves to self-hosted.

## Known gap

`ilammy/msvc-dev-cmd@v1` (`cmake.yml:268`) is left alone -- there is no Node 24 release. Latest tag is `v1.13.0` and even the default branch declares `using: node20`, so the Windows matrix keeps emitting that one warning until upstream ships a fix. Harmless while `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` holds; if GitHub drops the Node 20 runtime outright, the escape hatch is calling `vcvarsall.bat` directly.

## Testing note

CI on this PR exercises only the codeql / conventional-commits / cmake bumps. **`release.yml` triggers on `v[0-9]*` tag pushes only**, so six of the nine bumps -- including the whole Docker publish chain -- are not covered by a green check here. First real exercise is the next release tag. The `workflow_dispatch` + `docker_only: true` path would test them sooner, but it pushes `stillwater/universal:latest` to Docker Hub for real, so it is a deliberate call rather than routine validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, security scanning, pull request validation, and release workflows to use newer action versions.
  * Improved the reliability and maintainability of continuous integration and release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->