### PR TITLE
fix(posit): encoding() calls blockbinary::to_ull(), not to_ullong()

### DIFF
--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -950,7 +950,7 @@ public:
 	constexpr bool isinteger() const noexcept { return true; } // TODO: return (floor(*this) == *this) ? true : false; }
 
 	blockbinary<nbits, bt, BinaryNumberType::Signed> bits() const noexcept { return _block; }
-	unsigned long long encoding() const noexcept { return _block.to_ullong(); }
+	unsigned long long encoding() const noexcept { return _block.to_ull(); }
 
 	// Modifiers
 	constexpr void clear() noexcept { _block.clear(); }


### PR DESCRIPTION
## Summary

`posit<nbits,es,bt>::encoding()` (posit_impl.hpp:953) calls `_block.to_ullong()`,
but `blockbinary` has no `to_ullong()` — its accessor is `to_ull()`. So **any**
instantiation of `encoding()` fails to compile:

```
error: 'const class sw::universal::blockbinary<16, unsigned char, ...>'
       has no member named 'to_ullong'; did you mean 'to_ull'?
```

`blockbinary`'s own unsigned-integer conversion operators already use `to_ull()`
(blockbinary.hpp:178-180), so this aligns `encoding()` with the real API.

## Change

```diff
-unsigned long long encoding() const noexcept { return _block.to_ullong(); }
+unsigned long long encoding() const noexcept { return _block.to_ull(); }
```

## How it was found

Binding `posit<n,2>` to a NumPy dtype in
[stillwater-sc/universal_dtypes](https://github.com/stillwater-sc/universal_dtypes)
needs a posit's raw bit pattern. `encoding()` was the natural accessor but didn't
compile; the dtype currently works around it via `bits().to_ull()`. This fixes the
intended accessor.

## Test plan
- [ ] `encoding()` now instantiates (e.g. `posit<16,2>{1.0}.encoding()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated internal number encoding compatibility without changing observable encoding behavior.
  * Existing posit values continue to produce the same encoded results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->