### PR TITLE
fix: resolve Apple Clang warnings without reducing test coverage

### DIFF
--- a/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
+++ b/benchmark/performance/arithmetic/lns/log_add_algorithms.cpp
@@ -296,7 +296,6 @@ try {
 
 	// Throughput iterations per config: scale down for the larger lns sizes
 	// so the benchmark completes in seconds rather than minutes.
-	constexpr std::size_t TPUT_TINY   = 1'000'000;
 	constexpr std::size_t TPUT_SMALL  =    75'000;
 	constexpr std::size_t TPUT_MEDIUM =    50'000;
 	constexpr std::size_t TPUT_LARGE  =    25'000;

--- a/elastic/efloat/arithmetic/division.cpp
+++ b/elastic/efloat/arithmetic/division.cpp
@@ -89,8 +89,6 @@ namespace {
 		// --- IEEE 754 special values ---
 		double qnan = std::numeric_limits<double>::quiet_NaN();
 		double pinf = std::numeric_limits<double>::infinity();
-		double ninf = -pinf;
-
 		if (reportTestCases) std::cout << "  NaN / finite...\n";
 		{
 			efloat<16> a(1.0), n(qnan);

--- a/elastic/efloat/arithmetic/division.cpp
+++ b/elastic/efloat/arithmetic/division.cpp
@@ -88,8 +88,8 @@ namespace {
 
 		// --- IEEE 754 special values ---
 		double qnan = std::numeric_limits<double>::quiet_NaN();
-		double pinf = std::numeric_limits<double>::infinity();
-		if (reportTestCases) std::cout << "  NaN / finite...\n";
+	    double pinf = std::numeric_limits<double>::infinity();
+	    if (reportTestCases) std::cout << "  NaN / finite...\n";
 		{
 			efloat<16> a(1.0), n(qnan);
 			if (!(n / a).isnan()) { if (reportTestCases) std::cout << "    FAIL\n"; ++nrOfFailedTestCases; }

--- a/elastic/efloat/arithmetic/multiplication.cpp
+++ b/elastic/efloat/arithmetic/multiplication.cpp
@@ -80,8 +80,8 @@ namespace {
 		}
 		// --- IEEE 754 special values ---
 		double qnan = std::numeric_limits<double>::quiet_NaN();
-		double pinf = std::numeric_limits<double>::infinity();
-		if (reportTestCases) std::cout << "  NaN * finite...\n";
+	    double pinf = std::numeric_limits<double>::infinity();
+	    if (reportTestCases) std::cout << "  NaN * finite...\n";
 		{
 			efloat<16> a(1.0), n(qnan);
 			if (!(n * a).isnan()) { if (reportTestCases) std::cout << "    FAIL\n"; ++nrOfFailedTestCases; }

--- a/elastic/efloat/arithmetic/multiplication.cpp
+++ b/elastic/efloat/arithmetic/multiplication.cpp
@@ -81,8 +81,6 @@ namespace {
 		// --- IEEE 754 special values ---
 		double qnan = std::numeric_limits<double>::quiet_NaN();
 		double pinf = std::numeric_limits<double>::infinity();
-		double ninf = -pinf;
-
 		if (reportTestCases) std::cout << "  NaN * finite...\n";
 		{
 			efloat<16> a(1.0), n(qnan);

--- a/elastic/efloat/arithmetic/subtraction.cpp
+++ b/elastic/efloat/arithmetic/subtraction.cpp
@@ -71,8 +71,8 @@ namespace {
 
 		// --- IEEE 754 special values ---
 		double qnan = std::numeric_limits<double>::quiet_NaN();
-		double pinf = std::numeric_limits<double>::infinity();
-		if (reportTestCases) std::cout << "  NaN - finite...\n";
+	    double pinf = std::numeric_limits<double>::infinity();
+	    if (reportTestCases) std::cout << "  NaN - finite...\n";
 		{
 			efloat<16> a(1.0), n(qnan);
 			if (!(n - a).isnan()) { if (reportTestCases) std::cout << "    FAIL\n"; ++nrOfFailedTestCases; }

--- a/elastic/efloat/arithmetic/subtraction.cpp
+++ b/elastic/efloat/arithmetic/subtraction.cpp
@@ -72,8 +72,6 @@ namespace {
 		// --- IEEE 754 special values ---
 		double qnan = std::numeric_limits<double>::quiet_NaN();
 		double pinf = std::numeric_limits<double>::infinity();
-		double ninf = -pinf;
-
 		if (reportTestCases) std::cout << "  NaN - finite...\n";
 		{
 			efloat<16> a(1.0), n(qnan);

--- a/include/sw/universal/number/efloat/efloat_impl.hpp
+++ b/include/sw/universal/number/efloat/efloat_impl.hpp
@@ -993,7 +993,6 @@ protected:
 		}
 
 		if constexpr (std::is_same_v<Real, float>) {
-			constexpr unsigned S_bits = 1;
 			constexpr unsigned F_bits = 23;
 			constexpr unsigned E_bits = 8;
 			constexpr int E_max = 127;
@@ -1132,7 +1131,6 @@ protected:
 			return sw::bit_cast<float>(bits);
 
 		} else if constexpr (std::is_same_v<Real, double>) {
-			constexpr unsigned S_bits = 1;
 			constexpr unsigned F_bits = 52;
 			constexpr unsigned E_bits = 11;
 			constexpr int E_max = 1023;

--- a/include/sw/universal/number/efloat/math/truncate.hpp
+++ b/include/sw/universal/number/efloat/math/truncate.hpp
@@ -167,40 +167,19 @@ constexpr efloat<nlimbs> round(const efloat<nlimbs>& x) {
 	}
 
 	bool guard = false;
-	bool sticky = false;
-
 	if (exp < 0) {
 		guard = (exp == -1);
-		for (size_t i = 0; i < limbs.size(); ++i) {
-			uint32_t val = limbs[i];
-			if (i == 0) {
-				if ((val & 0x7FFFFFFF) != 0) sticky = true;
-			} else {
-				if (val != 0) sticky = true;
-			}
-		}
 	} else {
 		size_t full_limbs = static_cast<size_t>(exp / 32);
 		unsigned bit_idx = static_cast<unsigned>(exp % 32);
 
 		if (bit_idx < 31) {
 			guard = (limbs[full_limbs] & (1u << (30u - bit_idx))) != 0;
-			if ((limbs[full_limbs] & ((1u << (30u - bit_idx)) - 1u)) != 0) {
-				sticky = true;
-			}
 		} else {
 			// bit_idx == 31, guard is MSB of next limb!
 			if (full_limbs + 1 < limbs.size()) {
 				guard = (limbs[full_limbs + 1] & 0x80000000u) != 0;
-				if ((limbs[full_limbs + 1] & 0x7FFFFFFFu) != 0) {
-					sticky = true;
-				}
 			}
-		}
-		// check any subsequent limbs (including full_limbs + 1 if bit_idx < 31)
-		const size_t first_extra_limb = (bit_idx < 31) ? full_limbs + 1 : full_limbs + 2;
-		for (size_t i = first_extra_limb; i < limbs.size(); ++i) {
-			if (limbs[i] != 0) sticky = true;
 		}
 	}
 

--- a/include/sw/universal/verification/lns_test_suite.hpp
+++ b/include/sw/universal/verification/lns_test_suite.hpp
@@ -152,7 +152,9 @@ int VerifyDivision(bool reportTestCases) {
 	constexpr size_t NR_ENCODINGS = (1ull << nbits);
 
 	int     nrOfFailedTestCases = 0;
+#if LNS_THROW_ARITHMETIC_EXCEPTION
 	bool    firstTime           = true;
+#endif
 	LnsType a{}, b{}, c{}, cref{};
 	double  ref{};
 	if (reportTestCases)

--- a/static/conversions/to_decimal.cpp
+++ b/static/conversions/to_decimal.cpp
@@ -6,10 +6,11 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <iostream>
 #include <string>
+// configure the integer arithmetic class
+#define INTEGER_THROW_ARITHMETIC_EXCEPTION 1
 // configure the posit arithmetic
 #include <universal/number/posit/posit.hpp>
 // configure the integer arithmetic class
-#define INTEGER_THROW_ARITHMETIC_EXCEPTION 1
 #include <universal/number/integer/integer.hpp>
 #include <universal/number/edecimal/edecimal.hpp>
 #include <universal/verification/test_suite.hpp>

--- a/static/conversions/to_string.cpp
+++ b/static/conversions/to_string.cpp
@@ -7,10 +7,11 @@
 #include <universal/utility/directives.hpp>
 #include <iostream>
 #include <string>
+// configure the integer arithmetic class
+#define INTEGER_THROW_ARITHMETIC_EXCEPTION 1
 // configure the posit arithmetic
 #include <universal/number/posit/posit.hpp>
 // configure the integer arithmetic class
-#define INTEGER_THROW_ARITHMETIC_EXCEPTION 1
 #include <universal/number/integer/integer.hpp>
 #include <universal/number/fixpnt/fixpnt.hpp>
 #include <universal/verification/test_suite.hpp>

--- a/static/fixpnt/binary/api/constexpr.cpp
+++ b/static/fixpnt/binary/api/constexpr.cpp
@@ -198,7 +198,6 @@ try {
 		static_assert(a >= b,    "constexpr 42 >= 7");
 
 		// Cross-check via runtime; use to_long() for value comparison
-		Q32 ra(42), rb(7);
 		Q32 r49(49), r294(294), r6(6), r0(0), r_neg42(-42), r168(168), r10(10);
 		auto check = [&](const char* name, bool ok) {
 			if (!ok) { ++nrOfFailedTestCases; std::cout << "FAIL " << name << '\n'; }

--- a/static/fixpnt/binary/api/constexpr.cpp
+++ b/static/fixpnt/binary/api/constexpr.cpp
@@ -198,10 +198,18 @@ try {
 		static_assert(a >= b,    "constexpr 42 >= 7");
 
 		// Cross-check via runtime; use to_long() for value comparison
+		Q32 ra(42), rb(7);
 		Q32 r49(49), r294(294), r6(6), r0(0), r_neg42(-42), r168(168), r10(10);
 		auto check = [&](const char* name, bool ok) {
 			if (!ok) { ++nrOfFailedTestCases; std::cout << "FAIL " << name << '\n'; }
 		};
+		check("runtime Q32 42 construction", ra == a);
+		check("runtime Q32 7 construction", rb == b);
+		check("runtime 42+7 matches constexpr +", (ra + rb) == cx_sum);
+		check("runtime 42-7 matches constexpr -", (ra - rb) == cx_diff);
+		check("runtime 42*7 matches constexpr *", (ra * rb) == cx_prod);
+		check("runtime 42/7 matches constexpr /", (ra / rb) == cx_quot);
+		check("runtime 42%7 matches constexpr %", (ra % rb) == cx_rem);
 		check("constexpr 42+7  == 49",  cx_sum  == r49);
 		check("constexpr 42*7  == 294", cx_prod == r294);
 		check("constexpr 42/7  == 6",   cx_quot == r6);
@@ -211,7 +219,6 @@ try {
 		check("constexpr 42>>2 == 10",  cx_shr  == r10);
 		check("constexpr += matches +", cx_addeq == r49);
 		check("constexpr *= matches *", cx_muleq == r294);
-		(void)cx_diff;
 
 		// Multi-limb constexpr: fixpnt<128, 64> via uint32 limbs.
 		using Q128_64 = fixpnt<128, 64, Modulo, std::uint32_t>;

--- a/static/float/cfloat/arithmetic/nonsaturating/subnormal/fma.cpp
+++ b/static/float/cfloat/arithmetic/nonsaturating/subnormal/fma.cpp
@@ -86,10 +86,6 @@ int main() try {
 	bool        reportTestCases     = false;
 	int         nrOfFailedTestCases = 0;
 
-	constexpr bool hasSubnormals   = false;
-	constexpr bool hasMaxExpValues = false;
-	constexpr bool isSaturating    = false;
-
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
 #if MANUAL_TESTING
@@ -113,8 +109,6 @@ int main() try {
 
 #	if REGRESSION_LEVEL_1
 	using fp24    = cfloat<24, 5, uint16_t, true, false, false>;
-	using fp32    = cfloat<32, 8, uint32_t, true, false, false>;
-
 	nrOfFailedTestCases += ReportTestResult(VerifyFma<fp24>(nrSamples), type_tag(fp24{}), "fma");
 	nrOfFailedTestCases += ReportTestResult(VerifyResidual<cfloat<24, 5, uint16_t, true, false, false>>(nrSamples),
 	                                        type_tag(fp24{}), "residual");

--- a/static/float/cfloat/arithmetic/nonsaturating/subnormal/fma.cpp
+++ b/static/float/cfloat/arithmetic/nonsaturating/subnormal/fma.cpp
@@ -108,7 +108,7 @@ int main() try {
 	int nrSamples = 1000000;
 
 #	if REGRESSION_LEVEL_1
-	using fp24    = cfloat<24, 5, uint16_t, true, false, false>;
+	using fp24 = cfloat<24, 5, uint16_t, true, false, false>;
 	nrOfFailedTestCases += ReportTestResult(VerifyFma<fp24>(nrSamples), type_tag(fp24{}), "fma");
 	nrOfFailedTestCases += ReportTestResult(VerifyResidual<cfloat<24, 5, uint16_t, true, false, false>>(nrSamples),
 	                                        type_tag(fp24{}), "residual");

--- a/static/float/hfloat/arithmetic/addition.cpp
+++ b/static/float/hfloat/arithmetic/addition.cpp
@@ -120,7 +120,7 @@ try {
 	std::cout << "+---------    Truncation rounding behavior\n";
 	{
 		// In hfloat, the result is truncated (never rounds up)
-		HfloatShort a(1.0), b(1.0);
+		HfloatShort a(1.0);
 		HfloatShort third = a / HfloatShort(3);
 		double d3 = double(third);
 		// truncation: 1/3 should be <= exact 1/3

--- a/static/quire/api/lns_fdp.cpp
+++ b/static/quire/api/lns_fdp.cpp
@@ -466,9 +466,7 @@ int TestCatastrophicCancellation() {
 	{
 		Scalar a(32.0);
 		Scalar one(1.0);
-		// Find the closest lns value to -1 that isn't exactly -1
-		Scalar neg_one(-1.0);
-		// Use the next representable value
+		// Use a nearby representable value.
 		Scalar almost_neg_one(-0.9375);  // -15/16 in lns approximation
 		std::vector<Scalar> x(1024, a);
 		std::vector<Scalar> y(1024);

--- a/static/quire/api/lns_fdp.cpp
+++ b/static/quire/api/lns_fdp.cpp
@@ -467,7 +467,13 @@ int TestCatastrophicCancellation() {
 		Scalar a(32.0);
 		Scalar one(1.0);
 		// Use a nearby representable value.
+		Scalar neg_one(-1.0);
 		Scalar almost_neg_one(-0.9375);  // -15/16 in lns approximation
+		Scalar zero(0.0);
+		if (!(almost_neg_one > neg_one && almost_neg_one < zero)) {
+			std::cerr << "FAIL: nearby negative operand should lie between -1 and 0\n";
+			++nrOfFailedTestCases;
+		}
 		std::vector<Scalar> x(1024, a);
 		std::vector<Scalar> y(1024);
 		double expected = 0.0;

--- a/static/range/areal/api/constexpr.cpp
+++ b/static/range/areal/api/constexpr.cpp
@@ -120,8 +120,8 @@ namespace areal_constexpr_contract {
 	static_assert(!(two_dbl != two_dbl), "operator!= should be constexpr");
 	static_assert( two_dbl <  three_dbl, "operator<  should be constexpr (2.0 < 3.0)");
 	static_assert( three_dbl > two_dbl,  "operator>  should be constexpr (3.0 > 2.0)");
-	static_assert( one_int < two_dbl,    "signed int construction should be constexpr");
-	static_assert( two_dbl <= three_dbl, "operator<= should be constexpr");
+    static_assert(one_int < two_dbl, "signed int construction should be constexpr");
+    static_assert( two_dbl <= three_dbl, "operator<= should be constexpr");
 	static_assert( three_dbl >= two_dbl, "operator>= should be constexpr");
 
 	// Unary negation: must be constexpr and yield a strictly smaller value.

--- a/static/range/areal/api/constexpr.cpp
+++ b/static/range/areal/api/constexpr.cpp
@@ -120,6 +120,7 @@ namespace areal_constexpr_contract {
 	static_assert(!(two_dbl != two_dbl), "operator!= should be constexpr");
 	static_assert( two_dbl <  three_dbl, "operator<  should be constexpr (2.0 < 3.0)");
 	static_assert( three_dbl > two_dbl,  "operator>  should be constexpr (3.0 > 2.0)");
+	static_assert( one_int < two_dbl,    "signed int construction should be constexpr");
 	static_assert( two_dbl <= three_dbl, "operator<= should be constexpr");
 	static_assert( three_dbl >= two_dbl, "operator>= should be constexpr");
 


### PR DESCRIPTION
# Summary

This resolves the project-owned Apple Clang warnings found in a comprehensive Debug build with UNIVERSAL_BUILD_ALL=ON.

The initial build produced 126 warning instances across 19 source locations. The changes address the underlying causes rather than suppressing diagnostics.

Most were stale locals, constants, aliases, or computations, but reviewing the cleanup also identified two unused test constructions that represented implicit test intent. Those have been retained and converted into explicit assertions instead of simply being removed.

# Changes

* Remove unused S_bits constants from efloat IEEE conversion paths.
* Remove the unused sticky-bit computation from efloat::round(). The calculation did not participate in the function’s rounding decision; rint() retains its separate sticky-bit logic where required.
* Remove genuinely stale test, benchmark, and example locals and aliases.
* Scope firstTime to the LNS exception-enabled path where it is used.
* Turn the existing areal signed-integer constexpr construction into an explicit static_assert.
* Move INTEGER_THROW_ARITHMETIC_EXCEPTION before the related includes so the intended configuration is expressed without macro-redefinition ambiguity.
* Make previously implicit fixpnt runtime construction/arithmetic coverage explicit by comparing runtime Q32 operations with the corresponding constexpr results.
* Make the LNS near--1 cancellation setup explicit by checking that the selected nearby negative operand lies between -1 and 0.

No warning suppressions, -Wno-* options, diagnostic pragmas, or casts added merely to silence the compiler are included.

### Test-coverage review

A follow-up semantic audit specifically examined whether executing any of the removed “unused” expressions could itself have constituted useful test coverage.

### Two cases were retained and made explicit:

* Q32 runtime construction and arithmetic checks
* the exact -1 LNS construction used by the catastrophic-cancellation setup

Temporary mutation tests confirmed that deliberately breaking either new check causes its corresponding test to fail.

Other removed constructions were verified to be redundant or side-effect-free for their existing test context.

# Validation

Validated on Intel macOS with Apple Clang 21:

* Clean comprehensive Debug build with UNIVERSAL_ENABLE_TESTS=ON and UNIVERSAL_BUILD_ALL=ON
* 0 compiler warnings
* Focused affected tests: 14/14 passed
* Complete Debug CTest suite: 1033/1033 passed
* git diff --check passed
* Changed lines formatted with git clang-format

Focused GNU GCC 13.3 validation on Ubuntu 24.04 also passed without new warnings in the affected targets.

## AI-assisted development disclosure

OpenAI Codex performed the warning inventory, repository investigation, implementation, semantic audit, mutation checks, and most test execution.

ChatGPT reviewed the changes and raised the concern that some apparently unused test constructions might themselves represent test coverage. That prompted the additional audit in which Codex identified two such cases and converted their implicit coverage into explicit assertions.

I reviewed the resulting changes and validation before submitting them for maintainer review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fractional rounding behavior by simplifying guard-bit handling while preserving away-from-zero rounding.
  - Strengthened validation for catastrophic cancellation and special numeric values.

- **Tests**
  - Added runtime checks comparing fixed-point arithmetic with constexpr results.
  - Expanded compile-time coverage for signed integer ordering.
  - Improved division and conversion verification under configured arithmetic-exception modes.

- **Chores**
  - Removed unused benchmark, test, and conversion configuration elements.
  - Clarified numeric test setups without changing supported public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->