### PR TITLE
feat(takum): add takum_log, the logarithmic takum, on the shared codec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1133,6 +1133,7 @@ endif(UNIVERSAL_BUILD_NUMBER_QUIRES)
 
 if(UNIVERSAL_BUILD_NUMBER_TAKUMS)
 add_subdirectory("static/tapered/takum")
+add_subdirectory("static/tapered/takum_log")
 endif(UNIVERSAL_BUILD_NUMBER_TAKUMS)
 
 # reals with an uncertainty bit

--- a/include/sw/universal/number/takum/manipulators.hpp
+++ b/include/sw/universal/number/takum/manipulators.hpp
@@ -16,12 +16,13 @@ namespace sw { namespace universal {
 
 	// Generate a type tag for this takum
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string type_tag(const TakumType & = {}) {
 		std::stringstream s;
 		typename TakumType::BlockType bt{0};
-		s << "takum<"
+		// name the variant: the two share an encoding but are different number systems
+		s << (is_takum_log<TakumType> ? "takum_log<" : "takum<")
 			<< std::setw(3) << TakumType::nbits << ", "
 			<< std::setw(1) << TakumType::rbits << ", "
 			<< type_tag(bt) << ">";
@@ -29,7 +30,7 @@ namespace sw { namespace universal {
 	}
 
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string range(const TakumType & = {}) {
 		std::stringstream s;
@@ -39,7 +40,7 @@ namespace sw { namespace universal {
 	}
 
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline bool isInRange(double v) {
 		TakumType a{};
@@ -50,7 +51,7 @@ namespace sw { namespace universal {
 
 	// Generate a string representing the takum components
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string components(const TakumType& v) {
 		std::stringstream s;
@@ -71,7 +72,7 @@ namespace sw { namespace universal {
 	}
 
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string to_hex(const TakumType& v, bool nibbleMarker = false, bool hexPrefix = true) {
 		constexpr unsigned nbits = TakumType::nbits;
@@ -91,7 +92,7 @@ namespace sw { namespace universal {
 	}
 
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string hex_print(const TakumType& c) {
 		constexpr unsigned nbits = TakumType::nbits;
@@ -101,7 +102,7 @@ namespace sw { namespace universal {
 	}
 
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string pretty_print(const TakumType& number, bool nibbleMarker = false) {
 		constexpr unsigned nbits = TakumType::nbits;
@@ -140,14 +141,14 @@ namespace sw { namespace universal {
 	}
 
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string info_print(const TakumType& p, int printPrecision = 17) {
 		return std::string("TBD");
 	}
 
 	template<typename TakumType,
-		std::enable_if_t< is_takum<TakumType>, bool> = true
+		std::enable_if_t< is_any_takum<TakumType>, bool> = true
 	>
 	inline std::string color_print(const TakumType& number, bool nibbleMarker = false) {
 		constexpr unsigned nbits = TakumType::nbits;

--- a/include/sw/universal/number/takum/numeric_limits.hpp
+++ b/include/sw/universal/number/takum/numeric_limits.hpp
@@ -28,6 +28,24 @@ constexpr int takum_exponent_cast(std::int64_t c) noexcept {
 	return static_cast<int>((c < lo) ? lo : ((c > hi) ? hi : c));
 }
 
+// floor() as a constant expression.  The arguments here are characteristics scaled
+// by log2(sqrt(e)), at most ~3.1e9 in magnitude, so int64_t is ample.
+constexpr std::int64_t takum_exponent_floor(double x) noexcept {
+	std::int64_t t = static_cast<std::int64_t>(x);
+	return (x < 0.0 && static_cast<double>(t) != x) ? (t - 1) : t;
+}
+
+// log2(sqrt(e)): converts a takum_log characteristic, which counts powers of the
+// value base sqrt(e), into the power-of-two exponent numeric_limits must report.
+inline constexpr double takum_log2_of_sqrt_e = 0.7213475204444817;
+
+// floor(log2|value|) for a decoded takum_log magnitude, whose value is sqrt(e)^(c+m).
+template<typename Decoded>
+constexpr std::int64_t takum_log_exponent_of(const Decoded& d) noexcept {
+	return takum_exponent_floor(
+		(static_cast<double>(d.c) + d.template fraction<double>()) * takum_log2_of_sqrt_e);
+}
+
 }} // namespace sw::universal
 
 namespace std {
@@ -79,10 +97,23 @@ public:
 	static constexpr bool is_exact    = false;
 	static constexpr int radix        = 2;
 
-	// saturating: see takum_exponent_cast above
-	static constexpr int min_exponent   = sw::universal::takum_exponent_cast(TAKUM::min_characteristic());
+	// C++ specification: min_exponent is one more than the smallest negative power of
+	// the radix that is a normalized value, max_exponent one more than the largest
+	// integer power that is representable -- the +1 convention cfloat's specialization
+	// also documents.  A linear takum is (1 + f) * 2^c, so the exponent of an encoding
+	// is just its characteristic.
+	//
+	// Taken from the extreme ENCODINGS, magnitude 1 and magnitude_mask(), rather than
+	// from min/max_characteristic(): those are the range the format advertises, which
+	// the extremes need not attain.  takum<12,3> is the case in point -- its narrowest
+	// DR has no trailing field, so minpos sits at c == -254, not at the advertised
+	// -255.  Both agree with std::ilogb(minpos) + 1 and std::ilogb(maxpos) + 1.
+	// Saturating on the way to int: see takum_exponent_cast above.
+	static constexpr int min_exponent   = sw::universal::takum_exponent_cast(
+		TAKUM::Codec::decode(1ull).c + 1);
 	static constexpr int min_exponent10 = static_cast<int>(min_exponent * 0.301029995663981);
-	static constexpr int max_exponent   = sw::universal::takum_exponent_cast(TAKUM::max_characteristic());
+	static constexpr int max_exponent   = sw::universal::takum_exponent_cast(
+		TAKUM::Codec::decode(TAKUM::Codec::magnitude_mask()).c + 1);
 	static constexpr int max_exponent10 = static_cast<int>(max_exponent * 0.301029995663981);
 	static constexpr bool has_infinity = false;
 	static constexpr bool has_quiet_NaN = true;  // NaR serves as NaN
@@ -107,9 +138,9 @@ public:
 // static constexpr int and cannot express that.  Per the standard it describes
 // the radix of the integer representation of the significand, which here is the
 // base-2 fixed-point logarithmic value l, so it stays 2.  The value base is
-// exposed separately as takum_log<>::value_base.  Likewise min_exponent /
-// max_exponent below bound the characteristic c, which is in units of sqrt(e),
-// not a power of two.  See docs/takum-design.md.
+// exposed separately as takum_log<>::value_base.  Because radix is 2, the
+// exponent fields below are radix-2 exponents rather than characteristics --
+// the conversion is done where they are defined.  See docs/takum-design.md.
 template <unsigned nbits, unsigned rbits, typename bt>
 class numeric_limits< sw::universal::takum_log<nbits, rbits, bt> > {
 public:
@@ -146,12 +177,20 @@ public:
 	static constexpr bool is_exact    = false;
 	static constexpr int radix        = 2;  // representation radix; value base is sqrt(e)
 
-	// bounds on the characteristic c (units of sqrt(e), not powers of two),
-	// saturating: see takum_exponent_cast above
-	static constexpr int min_exponent   = sw::universal::takum_exponent_cast(TAKUMLOG::min_characteristic());
-	static constexpr int min_exponent10 = static_cast<int>(min_exponent * 0.217147240951626); // log10(sqrt(e))
-	static constexpr int max_exponent   = sw::universal::takum_exponent_cast(TAKUMLOG::max_characteristic());
-	static constexpr int max_exponent10 = static_cast<int>(max_exponent * 0.217147240951626);
+	// These are radix-2 exponents, as radix == 2 above requires, NOT characteristics.
+	// A takum_log characteristic counts powers of sqrt(e), so reporting it raw would
+	// overstate the range by 1/log2(sqrt(e)) ~ 1.39x.  Taken from the extreme encodings
+	// and converted, with the same +1 convention the linear specialization documents.
+	// Both agree with std::ilogb(minpos) + 1 and std::ilogb(maxpos) + 1.
+	static constexpr int min_exponent   = sw::universal::takum_exponent_cast(
+		sw::universal::takum_log_exponent_of(TAKUMLOG::Codec::decode(1ull)) + 1);
+	static constexpr int max_exponent   = sw::universal::takum_exponent_cast(
+		sw::universal::takum_log_exponent_of(
+			TAKUMLOG::Codec::decode(TAKUMLOG::Codec::magnitude_mask())) + 1);
+	// base 10 follows from the base-2 bounds above, so log10(2) -- not log10(sqrt(e)),
+	// which would apply the base conversion a second time
+	static constexpr int min_exponent10 = static_cast<int>(min_exponent * 0.301029995663981);
+	static constexpr int max_exponent10 = static_cast<int>(max_exponent * 0.301029995663981);
 	static constexpr bool has_infinity = false;
 	static constexpr bool has_quiet_NaN = true;   // NaR serves as NaN
 	static constexpr bool has_signaling_NaN = false;

--- a/include/sw/universal/number/takum/numeric_limits.hpp
+++ b/include/sw/universal/number/takum/numeric_limits.hpp
@@ -73,4 +73,68 @@ public:
 	static constexpr float_round_style round_style = round_toward_zero;
 };
 
+// numeric_limits for the LOGARITHMIC takum.
+//
+// Note on radix: this type's values are powers of sqrt(e), but radix is a
+// static constexpr int and cannot express that.  Per the standard it describes
+// the radix of the integer representation of the significand, which here is the
+// base-2 fixed-point logarithmic value l, so it stays 2.  The value base is
+// exposed separately as takum_log<>::value_base.  Likewise min_exponent /
+// max_exponent below bound the characteristic c, which is in units of sqrt(e),
+// not a power of two.  See docs/takum-design.md.
+template <unsigned nbits, unsigned rbits, typename bt>
+class numeric_limits< sw::universal::takum_log<nbits, rbits, bt> > {
+public:
+	using TAKUMLOG = sw::universal::takum_log<nbits, rbits, bt>;
+	static constexpr bool is_specialized = true;
+	static constexpr TAKUMLOG min() {
+		TAKUMLOG lminpos(sw::universal::SpecificValue::minpos);
+		return lminpos;
+	}
+	static constexpr TAKUMLOG max() {
+		TAKUMLOG lmaxpos(sw::universal::SpecificValue::maxpos);
+		return lmaxpos;
+	}
+	static constexpr TAKUMLOG lowest() {
+		TAKUMLOG lmaxneg(sw::universal::SpecificValue::maxneg);
+		return lmaxneg;
+	}
+	static constexpr TAKUMLOG epsilon() {
+		TAKUMLOG one{ 1.0f }, incr{ 1.0f };
+		++incr;
+		return incr - one;
+	}
+	static constexpr TAKUMLOG round_error() { return TAKUMLOG(0.5); }
+	static constexpr TAKUMLOG denorm_min()  { return min(); }  // no denormals
+	static constexpr TAKUMLOG infinity()    { return TAKUMLOG(INFINITY); }
+	static constexpr TAKUMLOG quiet_NaN()   { return TAKUMLOG(NAN); }
+	static constexpr TAKUMLOG signaling_NaN() { return TAKUMLOG(NAN); }
+
+	static constexpr int digits       = TAKUMLOG::maxCharBits + 1;
+	static constexpr int digits10     = static_cast<int>(digits * 0.301029995663981);
+	static constexpr int max_digits10 = static_cast<int>(digits * 0.301029995663981) + 2;
+	static constexpr bool is_signed   = true;
+	static constexpr bool is_integer  = false;
+	static constexpr bool is_exact    = false;
+	static constexpr int radix        = 2;  // representation radix; value base is sqrt(e)
+
+	// bounds on the characteristic c (units of sqrt(e), not powers of two)
+	static constexpr int min_exponent   = static_cast<int>(TAKUMLOG::min_characteristic());
+	static constexpr int min_exponent10 = static_cast<int>(min_exponent * 0.217147240951626); // log10(sqrt(e))
+	static constexpr int max_exponent   = static_cast<int>(TAKUMLOG::max_characteristic());
+	static constexpr int max_exponent10 = static_cast<int>(max_exponent * 0.217147240951626);
+	static constexpr bool has_infinity = false;
+	static constexpr bool has_quiet_NaN = true;   // NaR serves as NaN
+	static constexpr bool has_signaling_NaN = false;
+	static constexpr float_denorm_style has_denorm = denorm_absent;
+	static constexpr bool has_denorm_loss = false;
+
+	static constexpr bool is_iec559 = false;
+	static constexpr bool is_bounded = true;
+	static constexpr bool is_modulo = false;
+	static constexpr bool traps = false;
+	static constexpr bool tinyness_before = false;
+	static constexpr float_round_style round_style = round_toward_zero;
+};
+
 }

--- a/include/sw/universal/number/takum/numeric_limits.hpp
+++ b/include/sw/universal/number/takum/numeric_limits.hpp
@@ -5,6 +5,30 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstdint>
+#include <limits>
+
+namespace sw { namespace universal {
+
+// numeric_limits<>::min_exponent and max_exponent are int by standard mandate, but
+// a takum characteristic is int64_t.  The specification fixes rbits = 3, where the
+// range is [-255, 254] and the two agree; Universal also instantiates wider regime
+// fields, and at rbits = 5 the range is [1 - 2^32, 2^32 - 2], which does not fit.
+// Narrowing that silently wraps: takum<16,5> reported min_exponent == 1 and
+// max_exponent == -2, an inverted range, and gcc flagged it with -Woverflow.
+//
+// Saturate instead.  The reported bounds are then a conservative subset of the real
+// ones -- generic code that sizes a scratch exponent or picks a scaling strategy
+// from them stays correct, just pessimistic, rather than being handed a range with
+// the wrong sign.  Callers that need the exact bounds read min_characteristic() and
+// max_characteristic() off the type, which keep full int64_t width.
+constexpr int takum_exponent_cast(std::int64_t c) noexcept {
+	constexpr std::int64_t lo = static_cast<std::int64_t>((std::numeric_limits<int>::min)());
+	constexpr std::int64_t hi = static_cast<std::int64_t>((std::numeric_limits<int>::max)());
+	return static_cast<int>((c < lo) ? lo : ((c > hi) ? hi : c));
+}
+
+}} // namespace sw::universal
 
 namespace std {
 
@@ -55,9 +79,10 @@ public:
 	static constexpr bool is_exact    = false;
 	static constexpr int radix        = 2;
 
-	static constexpr int min_exponent   = TAKUM::min_characteristic();
+	// saturating: see takum_exponent_cast above
+	static constexpr int min_exponent   = sw::universal::takum_exponent_cast(TAKUM::min_characteristic());
 	static constexpr int min_exponent10 = static_cast<int>(min_exponent * 0.301029995663981);
-	static constexpr int max_exponent   = TAKUM::max_characteristic();
+	static constexpr int max_exponent   = sw::universal::takum_exponent_cast(TAKUM::max_characteristic());
 	static constexpr int max_exponent10 = static_cast<int>(max_exponent * 0.301029995663981);
 	static constexpr bool has_infinity = false;
 	static constexpr bool has_quiet_NaN = true;  // NaR serves as NaN
@@ -70,7 +95,10 @@ public:
 	static constexpr bool is_modulo = false;
 	static constexpr bool traps = false;
 	static constexpr bool tinyness_before = false;
-	static constexpr float_round_style round_style = round_toward_zero;
+	// takum_codec::encode_rounded() rounds the trailing field -- and, when the layout
+	// leaves none, the characteristic -- to nearest with ties to even.  Conversion
+	// never truncates toward zero.
+	static constexpr float_round_style round_style = round_to_nearest;
 };
 
 // numeric_limits for the LOGARITHMIC takum.
@@ -118,10 +146,11 @@ public:
 	static constexpr bool is_exact    = false;
 	static constexpr int radix        = 2;  // representation radix; value base is sqrt(e)
 
-	// bounds on the characteristic c (units of sqrt(e), not powers of two)
-	static constexpr int min_exponent   = static_cast<int>(TAKUMLOG::min_characteristic());
+	// bounds on the characteristic c (units of sqrt(e), not powers of two),
+	// saturating: see takum_exponent_cast above
+	static constexpr int min_exponent   = sw::universal::takum_exponent_cast(TAKUMLOG::min_characteristic());
 	static constexpr int min_exponent10 = static_cast<int>(min_exponent * 0.217147240951626); // log10(sqrt(e))
-	static constexpr int max_exponent   = static_cast<int>(TAKUMLOG::max_characteristic());
+	static constexpr int max_exponent   = sw::universal::takum_exponent_cast(TAKUMLOG::max_characteristic());
 	static constexpr int max_exponent10 = static_cast<int>(max_exponent * 0.217147240951626);
 	static constexpr bool has_infinity = false;
 	static constexpr bool has_quiet_NaN = true;   // NaR serves as NaN
@@ -134,7 +163,7 @@ public:
 	static constexpr bool is_modulo = false;
 	static constexpr bool traps = false;
 	static constexpr bool tinyness_before = false;
-	static constexpr float_round_style round_style = round_toward_zero;
+	static constexpr float_round_style round_style = round_to_nearest;  // as takum<>, same codec
 };
 
 }

--- a/include/sw/universal/number/takum/takum.hpp
+++ b/include/sw/universal/number/takum/takum.hpp
@@ -46,6 +46,7 @@
 #include <universal/number/takum/exceptions.hpp>
 #include <universal/number/takum/takum_fwd.hpp>
 #include <universal/number/takum/takum_impl.hpp>
+#include <universal/number/takum/takum_log_impl.hpp>
 #include <universal/number/takum/takum_traits.hpp>
 #include <universal/number/takum/numeric_limits.hpp>
 

--- a/include/sw/universal/number/takum/takum_codec.hpp
+++ b/include/sw/universal/number/takum/takum_codec.hpp
@@ -283,32 +283,37 @@ struct takum_codec {
 		unsigned dr = find_dr(c);
 		field_layout g = layout_of(dr);
 
-		// Characteristic bits.  When the format calls for more characteristic bits
-		// than this nbits can hold, the low bits are dropped with round-to-nearest-even.
+		// Characteristic bits.  When the format calls for more characteristic bits than
+		// this nbits can hold, the low ones are dropped; the value they carry is not
+		// rounded away here but folded into the residual below.  Note g.r > maxCharBits
+		// implies c_stored_bits == maxCharBits and therefore g.p == 0 (I1), so the two
+		// quantities below are consumed by exactly one rounding decision.
 		uint64_t C_full = static_cast<uint64_t>(c - dr_to_c_bias(dr));
 		uint64_t C_stored = C_full;
+		// The part of the value sitting above C_stored, and half of one stored step,
+		// both in characteristic units.  Without dropped bits a stored step spans one
+		// characteristic unit; with them it spans 2^shift.
+		double dropped_value = 0.0;
+		double step_half     = 0.5;
 		if (g.r > maxCharBits) {
 			unsigned shift = g.r - g.c_stored_bits;
-			C_stored = C_full >> shift;
-			uint64_t remainder = C_full & ((1ull << shift) - 1ull);
-			uint64_t half = 1ull << (shift - 1);
-			if (remainder > half || (remainder == half && (C_stored & 1ull))) ++C_stored;
-			if (C_stored >= (1ull << g.c_stored_bits)) {
-				if (dr + 1 >= nr_dr_values) return encoded{ magnitude_mask(), takum_encode_status::overflow };
-				++dr;
-				g = layout_of(dr);
-				C_stored = 0;
-				m_real = 0.0;
-			}
+			C_stored      = C_full >> shift;
+			dropped_value = static_cast<double>(C_full & ((1ull << shift) - 1ull));
+			step_half     = static_cast<double>(1ull << (shift - 1));
 		}
 
-		// When the layout leaves no trailing field, the fraction still carries value
+		// When the layout leaves no trailing field, the residual still carries value
 		// information and must round the CHARACTERISTIC -- discarding it would make
-		// conversion truncate rather than round to nearest, contradicting the
-		// format's rounding function.  Ties go to an even characteristic.
-		uint64_t M_bits = 0;
+		// conversion truncate rather than round to nearest, contradicting the format's
+		// rounding function.  Ties go to an even stored characteristic.
+		//
+		// The dropped characteristic bits and m are weighed together, in one decision.
+		// Rounding them separately is wrong twice over: it can carry into C_stored
+		// twice, and it measures a bare m against half a CHARACTERISTIC unit when a
+		// stored step is 2^shift of them.
 		if (g.p == 0) {
-			if (m_real > 0.5 || (m_real == 0.5 && (C_stored & 1ull))) {
+			double residual = dropped_value + m_real;
+			if (residual > step_half || (residual == step_half && (C_stored & 1ull))) {
 				++C_stored;
 				if (C_stored >= (1ull << g.c_stored_bits)) {
 					if (dr + 1 >= nr_dr_values) return encoded{ magnitude_mask(), takum_encode_status::overflow };
@@ -320,22 +325,21 @@ struct takum_codec {
 			return encoded{ pack(dr, C_stored, 0ull, g), takum_encode_status::ok };
 		}
 
-		// Trailing field, round-to-nearest-even.
-		if (g.p > 0) {
-			double scaled = m_real * static_cast<double>(1ull << g.p);
-			M_bits = static_cast<uint64_t>(scaled);
-			double remainder = scaled - static_cast<double>(M_bits);
-			if (remainder > 0.5 || (remainder == 0.5 && (M_bits & 1ull))) ++M_bits;
-			if (M_bits >= (1ull << g.p)) {
-				// Carry out of the trailing field into the characteristic.
-				M_bits = 0;
-				++C_stored;
-				if (C_stored >= (1ull << g.c_stored_bits)) {
-					if (dr + 1 >= nr_dr_values) return encoded{ magnitude_mask(), takum_encode_status::overflow };
-					++dr;
-					g = layout_of(dr);
-					C_stored = 0;
-				}
+		// Trailing field, round-to-nearest-even.  Reached only when g.p > 0, hence
+		// g.r <= maxCharBits, C_stored == C_full and no characteristic bits were dropped.
+		double scaled = m_real * static_cast<double>(1ull << g.p);
+		uint64_t M_bits = static_cast<uint64_t>(scaled);
+		double remainder = scaled - static_cast<double>(M_bits);
+		if (remainder > 0.5 || (remainder == 0.5 && (M_bits & 1ull))) ++M_bits;
+		if (M_bits >= (1ull << g.p)) {
+			// Carry out of the trailing field into the characteristic.
+			M_bits = 0;
+			++C_stored;
+			if (C_stored >= (1ull << g.c_stored_bits)) {
+				if (dr + 1 >= nr_dr_values) return encoded{ magnitude_mask(), takum_encode_status::overflow };
+				++dr;
+				g = layout_of(dr);
+				C_stored = 0;
 			}
 		}
 

--- a/include/sw/universal/number/takum/takum_codec.hpp
+++ b/include/sw/universal/number/takum/takum_codec.hpp
@@ -302,8 +302,25 @@ struct takum_codec {
 			}
 		}
 
-		// Trailing field, round-to-nearest-even.
+		// When the layout leaves no trailing field, the fraction still carries value
+		// information and must round the CHARACTERISTIC -- discarding it would make
+		// conversion truncate rather than round to nearest, contradicting the
+		// format's rounding function.  Ties go to an even characteristic.
 		uint64_t M_bits = 0;
+		if (g.p == 0) {
+			if (m_real > 0.5 || (m_real == 0.5 && (C_stored & 1ull))) {
+				++C_stored;
+				if (C_stored >= (1ull << g.c_stored_bits)) {
+					if (dr + 1 >= nr_dr_values) return encoded{ magnitude_mask(), takum_encode_status::overflow };
+					++dr;
+					g = layout_of(dr);
+					C_stored = 0;
+				}
+			}
+			return encoded{ pack(dr, C_stored, 0ull, g), takum_encode_status::ok };
+		}
+
+		// Trailing field, round-to-nearest-even.
 		if (g.p > 0) {
 			double scaled = m_real * static_cast<double>(1ull << g.p);
 			M_bits = static_cast<uint64_t>(scaled);

--- a/include/sw/universal/number/takum/takum_fwd.hpp
+++ b/include/sw/universal/number/takum/takum_fwd.hpp
@@ -18,5 +18,9 @@ template<unsigned nbits, unsigned rbits, typename bt>
 takum<nbits, rbits, bt> fma(const takum<nbits, rbits, bt>&, const takum<nbits, rbits, bt>&, const takum<nbits, rbits, bt>&);
 template<unsigned nbits, unsigned rbits, typename bt> takum<nbits, rbits, bt> sqrt(const takum<nbits, rbits, bt>&);
 
+// logarithmic takum: same codec, base sqrt(e) value map
+template<unsigned nbits, unsigned rbits, typename bt> class takum_log;
+template<unsigned nbits, unsigned rbits, typename bt> constexpr takum_log<nbits, rbits, bt> abs(const takum_log<nbits, rbits, bt>&) noexcept;
+
 }} // namespace sw::universal
 

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -157,10 +157,19 @@ public:
 		}
 	}
 
+	// Every type with an exact-match assignment operator below needs a matching
+	// constructor.  Without one, construction from that type is ambiguous -- it is a
+	// Conversion to each of int, long long, unsigned long long, float, double and
+	// long double alike, with nothing to break the tie -- while assignment keeps
+	// working, which makes the gap easy to miss.  char and unsigned short are the
+	// exceptions: they promote to int, and a Promotion outranks every Conversion.
 	constexpr takum(signed char initial_value)         noexcept : _block{} { *this = initial_value; }
 	constexpr takum(short initial_value)               noexcept : _block{} { *this = initial_value; }
 	constexpr takum(int initial_value)                 noexcept : _block{} { *this = initial_value; }
+	constexpr takum(long initial_value)                noexcept : _block{} { *this = initial_value; }
 	constexpr takum(long long initial_value)           noexcept : _block{} { *this = initial_value; }
+	constexpr takum(unsigned int initial_value)        noexcept : _block{} { *this = initial_value; }
+	constexpr takum(unsigned long initial_value)       noexcept : _block{} { *this = initial_value; }
 	constexpr takum(unsigned long long initial_value)  noexcept : _block{} { *this = initial_value; }
 	constexpr takum(float initial_value)               noexcept : _block{} { *this = initial_value; }
 	constexpr takum(double initial_value)              noexcept : _block{} { *this = initial_value; }

--- a/include/sw/universal/number/takum/takum_log.hpp
+++ b/include/sw/universal/number/takum/takum_log.hpp
@@ -1,0 +1,36 @@
+// arbitrary fixed-size logarithmic takum arithmetic type standard header
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+////////////////////////////////////////////////////////////////////////////////////////
+///  COMPILATION DIRECTIVES TO DIFFERENT COMPILERS
+#include <universal/utility/compiler.hpp>
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// required std libraries
+#include <iostream>
+#include <iomanip>
+
+////////////////////////////////////////////////////////////////////////////////////////
+///  BEHAVIORAL COMPILATION SWITCHES
+/// takum_log shares TAKUM_ENABLE_LITERALS and TAKUM_THROW_ARITHMETIC_EXCEPTION
+/// with the linear takum; takum.hpp defines them.
+
+///////////////////////////////////////////////////////////////////////////////////////
+// bring in the trait functions
+#include <universal/traits/number_traits.hpp>
+#include <universal/traits/arithmetic_traits.hpp>
+#include <universal/common/number_traits_reports.hpp>
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// INCLUDE FILES that make up the library
+/// The linear takum comes first: it defines the shared behavioral switches, the
+/// exception hierarchy and the shared codec that takum_log builds on.
+#include <universal/number/takum/takum.hpp>
+#include <universal/number/takum/takum_log_impl.hpp>

--- a/include/sw/universal/number/takum/takum_log_impl.hpp
+++ b/include/sw/universal/number/takum/takum_log_impl.hpp
@@ -129,10 +129,15 @@ public:
 		}
 	}
 
+	// The constructor set mirrors the assignment set below; see takum_impl.hpp for
+	// why a missing overload makes construction ambiguous while assignment still works.
 	constexpr takum_log(signed char initial_value)        noexcept : _block{} { *this = initial_value; }
 	constexpr takum_log(short initial_value)              noexcept : _block{} { *this = initial_value; }
 	constexpr takum_log(int initial_value)                noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(long initial_value)               noexcept : _block{} { *this = initial_value; }
 	constexpr takum_log(long long initial_value)          noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(unsigned int initial_value)       noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(unsigned long initial_value)      noexcept : _block{} { *this = initial_value; }
 	constexpr takum_log(unsigned long long initial_value) noexcept : _block{} { *this = initial_value; }
 	constexpr takum_log(float initial_value)              noexcept : _block{} { *this = initial_value; }
 	constexpr takum_log(double initial_value)             noexcept : _block{} { *this = initial_value; }
@@ -315,6 +320,18 @@ public:
 	// scale(): the integer power-of-two exponent, per the library-wide convention
 	// that scale() is base 2 for every number system.  The characteristic is in
 	// units of sqrt(e), so it is converted here rather than returned directly.
+	//
+	// Accuracy: sqrt(e)^l is a power of two only for l = 2k ln2, which is irrational
+	// for k != 0, so no encoding sits exactly on a boundary and the floor below is
+	// always well defined.  It is computed in double, though, which at |l| ~ 255
+	// leaves ~1e-13 of absolute slack; an encoding closer than that to a power of two
+	// can floor to the neighbouring exponent.  Deciding those cases needs the exact
+	// (c, M_bits) pair carried at more than double precision -- a follow-up if a
+	// caller ever needs it.  Note that std::ilogb(double(*this)) is NOT the fix: it
+	// agrees with this on every uniformly sampled encoding, is no better on the
+	// boundary set (both are coin flips there), and returns INT_MAX for the ~34% of
+	// wide-rbits encodings whose magnitude overflows a double -- which is precisely
+	// where attributes.hpp's minpos_scale() / maxpos_scale() land.
 	CONSTEXPRESSION int scale() const noexcept {
 		if (iszero() || isnar()) return 0;
 		double log2_magnitude = logarithmic_value() * log2_of_base;

--- a/include/sw/universal/number/takum/takum_log_impl.hpp
+++ b/include/sw/universal/number/takum/takum_log_impl.hpp
@@ -1,0 +1,591 @@
+#pragma once
+// takum_log_impl.hpp: implementation of the logarithmic takum number system
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// LOGARITHMIC takum encoding (Hunhold, 2024, arXiv:2404.18603, Definition 2;
+// restated as Definition 1 of arXiv:2408.10594, the hardware codec paper).
+//
+//   The takum specification defines two variants that share an identical bit
+//   layout and differ only in the value map:
+//     - logarithmic takum, base sqrt(e): 2404.18603 Def. 2 / 2408.10594 Def. 1
+//     - linear takum,      base 2:       2404.18603 Def. 8 / 2408.10594 Def. 2
+//   This type implements the LOGARITHMIC variant, which 2404.18603 Sec 4.7
+//   designates as the standard.  The naming follows the libtakum reference
+//   implementation, which uses takum_log for this variant and the bare name for
+//   the linear one.  See docs/takum-design.md.
+//
+// The bit layout, the (S, D, R, C, M) decode, the two's-complement ordering and
+// the zero / NaR encodings are all owned by takum_codec<nbits, rbits>, shared
+// verbatim with takum<>.  This class supplies only the value map:
+//
+//   m := 2^-p uint(M)  in [0,1)              (the mantissa)
+//   l := (-1)^S (c + m)  in (-255, 255)      (the logarithmic value)
+//   value := (-1)^S sqrt(e)^l
+//
+// Equivalently, for the positive representative reached by two's-complement
+// negation, |value| = sqrt(e)^(c + m) = e^((c + m) / 2).
+//
+// Properties that distinguish this from the linear takum (arXiv:2404.18603):
+//   - Proposition 7: incrementing the bit string yields the RECIPROCAL, so
+//     negation and inversion are both single integer operations.  The linear
+//     takum has no such bitwise inversion.
+//   - Proposition 11: machine precision lambda(p) = sqrt(e)^(2^-p-1) - 1, which
+//     is bounded by (2/3) of the linear takum's epsilon(p).
+//
+// PRECISION LIMITATION: like takum<>, conversion currently routes through
+// double.  The logarithmic value l needs about p + 9 bits to be represented
+// exactly, so for p > 44 or so (nbits beyond ~53) the double cannot carry the
+// full mantissa and conversion loses low bits.  The reference implementation
+// has the same constraint and uses long double for takum_log64.  Tracked with
+// the native-arithmetic work in #1297.
+
+#include <cassert>
+#include <limits>
+#include <cmath>
+
+#include <universal/native/ieee754.hpp>
+#include <universal/internal/blockbinary/blockbinary.hpp>
+#include <math/constexpr_math/exp.hpp>
+#include <math/constexpr_math/log.hpp>
+
+#include <universal/internal/bit_manipulation.hpp>
+#include <universal/number/takum/takum_codec.hpp>
+
+namespace sw {	namespace universal {
+
+// Forward definitions
+template<unsigned nbits, unsigned rbits, typename bt> class takum_log;
+
+// template class representing a logarithmic takum with two's complement encoding
+template<unsigned _nbits, unsigned _rbits = 3, typename bt = uint8_t>
+class takum_log {
+public:
+	typedef bt BlockType;
+
+	// The field codec shared with the linear takum.  It owns the bit layout, the
+	// DR/characteristic/mantissa geometry and the rounded encode path; this class
+	// supplies only the logarithmic value map.
+	using Codec = takum_codec<_nbits, _rbits>;
+
+	static constexpr unsigned nbits    = _nbits;
+	static constexpr unsigned rbits    = _rbits;
+	static constexpr unsigned overhead = Codec::overhead;
+
+	static constexpr unsigned dr_bits       = Codec::dr_bits;
+	static constexpr unsigned nr_dr_values  = Codec::nr_dr_values;
+	static constexpr unsigned max_r         = Codec::max_r;
+	static constexpr unsigned r_mask        = Codec::r_mask;
+	static constexpr unsigned dr_field_mask = Codec::dr_field_mask;
+	static constexpr unsigned maxCharBits   = Codec::maxCharBits;
+
+	// The base of the value map.  std::numeric_limits<>::radix is a
+	// static constexpr int and cannot express sqrt(e), so the value base is
+	// exposed here instead; numeric_limits keeps the integer representation
+	// radix.  See docs/takum-design.md.
+	static constexpr double value_base   = 1.6487212707001281468;  // sqrt(e)
+	static constexpr double log2_of_base = 0.7213475204444817;     // log2(sqrt(e)) == 1/(2 ln 2)
+
+	// Codec geometry, re-exported so takum_log<> and takum<> present the same surface
+	static constexpr unsigned dr_to_r(unsigned dr)      noexcept { return Codec::dr_to_r(dr); }
+	static constexpr int64_t  dr_to_c_bias(unsigned dr) noexcept { return Codec::dr_to_c_bias(dr); }
+	static constexpr unsigned find_dr(int64_t c)        noexcept { return Codec::find_dr(c); }
+	static constexpr int64_t  max_characteristic()      noexcept { return Codec::max_characteristic(); }
+	static constexpr int64_t  min_characteristic()      noexcept { return Codec::min_characteristic(); }
+
+	static constexpr unsigned bitsInByte  = 8ull;
+	static constexpr unsigned bitsInBlock = sizeof(bt) * bitsInByte;
+	static constexpr unsigned nrBlocks    = (1 + ((nbits - 1) / bitsInBlock));
+	static constexpr unsigned bitsInMSU   = (1 + ((nbits - 1) % bitsInBlock));
+	static constexpr uint64_t storageMask = (0xFFFFFFFFFFFFFFFFull >> (64 - bitsInBlock));
+	static constexpr unsigned MSU         = nrBlocks - 1;
+	static constexpr bt       MSU_MASK    = bt(bt(~0) >> (nrBlocks * bitsInBlock - nbits));
+	static constexpr bt       SIGN_BIT_MASK = bt(1ull << ((nbits - 1ull) % bitsInBlock));
+
+	using BlockBinary = blockbinary<nbits, bt, BinaryNumberType::Unsigned>;
+
+	takum_log() = default;
+	takum_log(const takum_log&) = default;
+	takum_log(takum_log&&) = default;
+	takum_log& operator=(const takum_log&) = default;
+	takum_log& operator=(takum_log&&) = default;
+
+	constexpr takum_log(const SpecificValue code) noexcept : _block{} {
+		switch (code) {
+		case SpecificValue::maxpos: maxpos(); break;
+		case SpecificValue::minpos: minpos(); break;
+		case SpecificValue::zero:
+		default:                    zero();   break;
+		case SpecificValue::minneg: minneg(); break;
+		case SpecificValue::maxneg: maxneg(); break;
+		case SpecificValue::infpos:
+		case SpecificValue::infneg:
+		case SpecificValue::nar:
+		case SpecificValue::qnan:
+		case SpecificValue::snan:   setnar();  break;
+		}
+	}
+
+	constexpr takum_log(signed char initial_value)        noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(short initial_value)              noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(int initial_value)                noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(long long initial_value)          noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(unsigned long long initial_value) noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(float initial_value)              noexcept : _block{} { *this = initial_value; }
+	constexpr takum_log(double initial_value)             noexcept : _block{} { *this = initial_value; }
+
+	constexpr takum_log& operator=(signed char rhs)        noexcept { return convert_signed(rhs); }
+	constexpr takum_log& operator=(short rhs)              noexcept { return convert_signed(rhs); }
+	constexpr takum_log& operator=(int rhs)                noexcept { return convert_signed(rhs); }
+	constexpr takum_log& operator=(long rhs)               noexcept { return convert_signed(rhs); }
+	constexpr takum_log& operator=(long long rhs)          noexcept { return convert_signed(rhs); }
+	constexpr takum_log& operator=(char rhs)               noexcept { return convert_unsigned(rhs); }
+	constexpr takum_log& operator=(unsigned short rhs)     noexcept { return convert_unsigned(rhs); }
+	constexpr takum_log& operator=(unsigned int rhs)       noexcept { return convert_unsigned(rhs); }
+	constexpr takum_log& operator=(unsigned long rhs)      noexcept { return convert_unsigned(rhs); }
+	constexpr takum_log& operator=(unsigned long long rhs) noexcept { return convert_unsigned(rhs); }
+	CONSTEXPRESSION takum_log& operator=(float rhs)        noexcept { return convert_ieee754(rhs); }
+	CONSTEXPRESSION takum_log& operator=(double rhs)       noexcept { return convert_ieee754(rhs); }
+
+	explicit CONSTEXPRESSION operator int()       const noexcept { return to_signed<int>(); }
+	explicit CONSTEXPRESSION operator long()      const noexcept { return to_signed<long>(); }
+	explicit CONSTEXPRESSION operator long long() const noexcept { return to_signed<long long>(); }
+	explicit CONSTEXPRESSION operator float()     const noexcept { return to_ieee754<float>(); }
+	explicit CONSTEXPRESSION operator double()    const noexcept { return to_ieee754<double>(); }
+
+#if LONG_DOUBLE_SUPPORT
+	CONSTEXPRESSION takum_log(long double initial_value)   noexcept : _block{} { *this = initial_value; }
+	CONSTEXPRESSION takum_log& operator=(long double rhs)  noexcept { return convert_ieee754(rhs); }
+	explicit CONSTEXPRESSION operator long double()  const noexcept { return to_ieee754<long double>(); }
+#endif
+
+	// prefix negation: two's complement negate (Proposition 6, shared with takum<>)
+	constexpr takum_log operator-() const noexcept {
+		if (iszero() || isnar()) return *this;
+		takum_log result;
+		result.setbits(((~raw_bits()) + 1ull) & nbits_mask());
+		return result;
+	}
+
+	// Exact reciprocal (Proposition 7), unique to the logarithmic variant.
+	//
+	// value = (-1)^S sqrt(e)^l with l = (-1)^S (c + m), so 1/value keeps the sign
+	// and negates l.  Negating l with S fixed means negating (c + m), which is the
+	// two's complement of the D:R:C:M field -- the sign bit is left alone.  That
+	// makes negation (two's complement of the whole word, Prop. 6) and inversion
+	// (two's complement of everything but the sign) symmetric bit operations.
+	//
+	// The linear takum has no such inversion; see docs/takum-design.md.
+	constexpr takum_log reciprocal() const noexcept {
+		if (isnar()) return *this;
+		if (iszero()) { takum_log r; r.setnar(); return r; }
+		constexpr uint64_t field_mask = (1ull << (nbits - 1)) - 1ull;
+		uint64_t raw   = raw_bits();
+		uint64_t sign  = raw & (1ull << (nbits - 1));
+		uint64_t field = raw & field_mask;
+		takum_log result;
+		result.setbits(sign | (((~field) + 1ull) & field_mask));
+		return result;
+	}
+
+	// in-place arithmetic via double conversion, matching takum<>'s current
+	// approach.  Native logarithmic arithmetic -- where multiply/divide become
+	// fixed-point add/subtract on l -- is tracked in #1297.
+	CONSTEXPRESSION takum_log& operator+=(const takum_log& rhs) {
+		if (isnar() || rhs.isnar()) { setnar(); return *this; }
+		return convert_ieee754(double(*this) + double(rhs));
+	}
+	CONSTEXPRESSION takum_log& operator+=(double rhs) { return *this += takum_log(rhs); }
+	CONSTEXPRESSION takum_log& operator-=(const takum_log& rhs) {
+		if (isnar() || rhs.isnar()) { setnar(); return *this; }
+		return convert_ieee754(double(*this) - double(rhs));
+	}
+	CONSTEXPRESSION takum_log& operator-=(double rhs) { return *this -= takum_log(rhs); }
+	CONSTEXPRESSION takum_log& operator*=(const takum_log& rhs) {
+		if (isnar() || rhs.isnar()) { setnar(); return *this; }
+		return convert_ieee754(double(*this) * double(rhs));
+	}
+	CONSTEXPRESSION takum_log& operator*=(double rhs) { return *this *= takum_log(rhs); }
+	CONSTEXPRESSION takum_log& operator/=(const takum_log& rhs) {
+		if (isnar() || rhs.isnar()) { setnar(); return *this; }
+		if (rhs.iszero()) {
+#if TAKUM_THROW_ARITHMETIC_EXCEPTION
+			if (!std::is_constant_evaluated()) throw takum_divide_by_zero();
+#endif
+			setnar();
+			return *this;
+		}
+		return convert_ieee754(double(*this) / double(rhs));
+	}
+	CONSTEXPRESSION takum_log& operator/=(double rhs) { return *this /= takum_log(rhs); }
+
+	constexpr takum_log& operator++() noexcept {
+		if (isnar()) return *this;
+		uint64_t raw = raw_bits(), mask = nbits_mask();
+		if (raw == (mask >> 1)) return *this;   // already maxpos
+		setbits((raw + 1ull) & mask);
+		return *this;
+	}
+	constexpr takum_log operator++(int) noexcept { takum_log tmp(*this); operator++(); return tmp; }
+	constexpr takum_log& operator--() noexcept {
+		if (isnar()) return *this;
+		uint64_t raw = raw_bits();
+		if (raw == ((1ull << (nbits - 1)) | 1ull)) return *this;  // already maxneg
+		setbits((raw - 1ull) & nbits_mask());
+		return *this;
+	}
+	constexpr takum_log operator--(int) noexcept { takum_log tmp(*this); operator--(); return tmp; }
+
+	// modifiers
+	constexpr void clear()                           noexcept { _block.clear(); }
+	constexpr void setzero()                         noexcept { _block.clear(); }
+	constexpr void setnar()                          noexcept { _block.clear(); setbit(nbits - 1); }
+	constexpr void setnan(bool sign = false)         noexcept { (void)sign; setnar(); }
+	constexpr void setinf(bool sign)                 noexcept { (sign ? maxneg() : maxpos()); }
+	constexpr void setsign(bool s = true)            noexcept { setbit(nbits - 1, s); }
+	constexpr void setbit(unsigned i, bool v = true) noexcept {
+		unsigned blockIndex = i / bitsInBlock;
+		if (i < nbits) {
+			bt block = _block[blockIndex];
+			bt null  = bit_clear_mask<bt>(i, bitsInBlock);
+			bt bit   = bt(v ? 1 : 0);
+			bt mask  = bt(bit << (i % bitsInBlock));
+			_block.setblock(blockIndex, bt((block & null) | mask));
+		}
+	}
+	constexpr void setbits(uint64_t value) noexcept {
+		if constexpr (1 == nrBlocks) {
+			_block.setblock(0, value & storageMask);
+		}
+		else if constexpr (1 < nrBlocks) {
+			for (unsigned i = 0; i < nrBlocks; ++i) {
+				_block.setblock(i, value & storageMask);
+				value >>= bitsInBlock;
+			}
+		}
+		_block.setblock(MSU, static_cast<bt>(_block[MSU] & MSU_MASK));
+	}
+
+	constexpr takum_log& maxpos() noexcept { clear(); flip(); setbit(nbits - 1, false); return *this; }
+	constexpr takum_log& minpos() noexcept { clear(); setbit(0, true); return *this; }
+	constexpr takum_log& zero()   noexcept { clear(); return *this; }
+	constexpr takum_log& minneg() noexcept { clear(); flip(); return *this; }
+	constexpr takum_log& maxneg() noexcept { clear(); setbit(nbits - 1, true); setbit(0, true); return *this; }
+
+	// selectors
+	constexpr bool iszero() const noexcept { return _block.iszero(); }
+	constexpr bool isneg()  const noexcept { return _block.test(nbits - 1) && !isnar(); }
+	constexpr bool ispos()  const noexcept { return !_block.test(nbits - 1) && !iszero(); }
+	constexpr bool isinf()  const noexcept { return false; }
+	constexpr bool isnan()  const noexcept { return isnar(); }
+	constexpr bool isnar()  const noexcept {
+		if (!_block.test(nbits - 1)) return false;
+		for (unsigned i = 0; i < nrBlocks; ++i) {
+			bt expected = (i == MSU) ? SIGN_BIT_MASK : bt(0);
+			if (_block[i] != expected) return false;
+		}
+		return true;
+	}
+	constexpr bool sign() const noexcept { return _block.test(nbits - 1); }
+
+	constexpr bool direct() const noexcept {
+		return static_cast<bool>((magnitude_bits() >> (nbits - 2)) & 1);
+	}
+	constexpr unsigned regime() const noexcept {
+		return static_cast<unsigned>((magnitude_bits() >> (nbits - overhead)) & r_mask);
+	}
+	constexpr unsigned dr_field() const noexcept {
+		return static_cast<unsigned>((magnitude_bits() >> (nbits - overhead)) & dr_field_mask);
+	}
+	// The takum characteristic c: the integer part of the logarithmic value of
+	// the magnitude, in units of the value base sqrt(e) -- NOT a power of two.
+	constexpr int64_t characteristic() const noexcept {
+		if (iszero() || isnar()) return 0;
+		return Codec::characteristic_of(magnitude_bits());
+	}
+	// The logarithmic value l of the magnitude: |value| == sqrt(e)^l.
+	CONSTEXPRESSION double logarithmic_value() const noexcept {
+		if (iszero() || isnar()) return 0.0;
+		auto d = Codec::decode(magnitude_bits());
+		return static_cast<double>(d.c) + d.fraction();
+	}
+	// scale(): the integer power-of-two exponent, per the library-wide convention
+	// that scale() is base 2 for every number system.  The characteristic is in
+	// units of sqrt(e), so it is converted here rather than returned directly.
+	CONSTEXPRESSION int scale() const noexcept {
+		if (iszero() || isnar()) return 0;
+		double log2_magnitude = logarithmic_value() * log2_of_base;
+		int    s = static_cast<int>(log2_magnitude);
+		if (log2_magnitude < 0.0 && static_cast<double>(s) != log2_magnitude) --s;  // floor
+		return s;
+	}
+
+	constexpr bool at(unsigned bitIndex) const noexcept {
+		if (bitIndex >= nbits) return false;
+		bt word = _block[bitIndex / bitsInBlock];
+		bt mask = bt(1ull << (bitIndex % bitsInBlock));
+		return (word & mask);
+	}
+	constexpr bt block(unsigned b) const noexcept { return (b < nrBlocks) ? _block[b] : bt(0); }
+	constexpr uint8_t nibble(unsigned n) const noexcept {
+		if (n < (1 + ((nbits - 1) >> 2))) {
+			bt word = _block[(n * 4) / bitsInBlock];
+			int nibbleIndexInWord = int(n % (bitsInBlock >> 2ull));
+			bt mask = bt(0xF << (nibbleIndexInWord * 4));
+			bt nibblebits = bt(mask & word);
+			return uint8_t(nibblebits >> (nibbleIndexInWord * 4));
+		}
+		return 0;
+	}
+
+	constexpr uint64_t raw_bits() const noexcept {
+		uint64_t raw = 0;
+		for (unsigned i = 0; i < nrBlocks; ++i) raw |= (static_cast<uint64_t>(_block[i]) << (i * bitsInBlock));
+		return raw;
+	}
+	constexpr uint64_t magnitude_bits() const noexcept {
+		uint64_t raw = raw_bits();
+		if (raw & (1ull << (nbits - 1))) raw = ((~raw) + 1) & nbits_mask();
+		return raw;
+	}
+
+protected:
+	constexpr takum_log& flip() noexcept {
+		for (unsigned i = 0; i < nrBlocks; ++i) _block.setblock(i, bt(~_block[i]));
+		_block.setblock(MSU, bt(_block[MSU] & MSU_MASK));
+		return *this;
+	}
+	static constexpr uint64_t nbits_mask() noexcept { return Codec::nbits_mask(); }
+
+	template<typename SignedInt>
+	CONSTEXPRESSION takum_log& convert_signed(SignedInt rhs) noexcept { return convert_ieee754(double(rhs)); }
+	template<typename UnsignedInt>
+	CONSTEXPRESSION takum_log& convert_unsigned(UnsignedInt rhs) noexcept { return convert_ieee754(double(rhs)); }
+
+	/// Convert an IEEE-754 value to the logarithmic takum encoding.
+	///
+	/// |x| = sqrt(e)^l  =>  l = log_sqrt(e)|x| = 2 ln|x|.  The pair (c, m) with
+	/// c = floor(l) and m = l - c is exactly what the shared codec encodes, so
+	/// everything from here -- rounding, carry, saturation -- is common with the
+	/// linear takum.
+	template<typename Real>
+	CONSTEXPRESSION takum_log& convert_ieee754(Real rhs) noexcept {
+		static_assert(nbits <= 64, "takum_log > 64 bits not yet supported");
+
+		if (rhs != rhs) { setnar(); return *this; }
+		if constexpr (std::numeric_limits<Real>::has_infinity) {
+			if (rhs ==  std::numeric_limits<Real>::infinity()) { setnar(); return *this; }
+			if (rhs == -std::numeric_limits<Real>::infinity()) { setnar(); return *this; }
+		}
+		if (rhs == Real(0)) { setzero(); return *this; }
+
+		bool s = (rhs < Real(0));
+		double abs_v = static_cast<double>(s ? -rhs : rhs);
+
+		// l = 2 ln|x|, the logarithmic value in units of the base sqrt(e).
+		// std::log is not constexpr, so constant evaluation uses the library's
+		// constexpr log; at runtime std::log is both available and more accurate.
+		double l;
+		if (std::is_constant_evaluated()) {
+			l = 2.0 * sw::math::constexpr_math::log(abs_v);
+		}
+		else {
+			l = 2.0 * std::log(abs_v);
+		}
+
+		// Split into characteristic and mantissa: c = floor(l), m = l - c in [0,1)
+		int64_t c = static_cast<int64_t>(l);
+		if (l < 0.0 && static_cast<double>(c) != l) --c;          // floor toward -inf
+		double m = l - static_cast<double>(c);
+		if (m < 0.0) m = 0.0;                                      // guard against fp drift
+		if (m >= 1.0) { m = 0.0; ++c; }
+
+		// Evaluating 2 ln|x| carries roughly |l| * 2^-52 of absolute error, so a
+		// value sitting exactly on a characteristic boundary can land a hair below
+		// it and be truncated to the previous characteristic.  Snap to the boundary
+		// when within that error.  The tolerance stays far below the smallest
+		// resolvable mantissa step 2^-p for every p a double can actually carry, so
+		// this cannot absorb a genuinely distinct value.
+		const double tol = ((l < 0.0) ? -l : l) * 4e-16 + 4e-16;
+		if (m > 1.0 - tol) { m = 0.0; ++c; }
+		else if (m < tol)  { m = 0.0; }
+
+		auto enc = Codec::encode_rounded(c, m);
+		if (enc.overflowed()) {
+			if (s) maxneg(); else maxpos();
+			return *this;
+		}
+		if (enc.underflowed()) { setzero(); return *this; }
+
+		// The codec never sets the sign bit (I4); two's-complement negate here.
+		setbits(s ? (((~enc.magnitude) + 1ull) & nbits_mask()) : enc.magnitude);
+		return *this;
+	}
+
+	template<typename SignedInt>
+	CONSTEXPRESSION typename std::enable_if<std::is_integral<SignedInt>::value && std::is_signed<SignedInt>::value, SignedInt>::type
+		to_signed() const noexcept { return SignedInt(to_ieee754<double>()); }
+	template<typename UnsignedInt>
+	CONSTEXPRESSION typename std::enable_if<std::is_integral<UnsignedInt>::value && std::is_unsigned<UnsignedInt>::value, UnsignedInt>::type
+		to_unsigned() const noexcept { return UnsignedInt(to_ieee754<double>()); }
+
+	/// Decode to an IEEE-754 value: |x| = sqrt(e)^l = e^(l/2).
+	template<typename TargetFloat>
+	CONSTEXPRESSION TargetFloat to_ieee754() const noexcept {
+		if (iszero()) return TargetFloat(0);
+		if (isnar())  return std::numeric_limits<TargetFloat>::quiet_NaN();
+		static_assert(nbits <= 64, "takum_log > 64 bits not yet supported");
+
+		bool s = sign();
+
+		// Shared codec: magnitude -> (c, m).  Only the value map below is
+		// specific to the logarithmic takum.
+		auto d = Codec::decode(magnitude_bits());
+		double l = static_cast<double>(d.c) + d.fraction();
+
+		// LOGARITHMIC value map: |value| = sqrt(e)^l = e^(l/2).
+		// As in convert_ieee754, std::exp is not constexpr, so constant evaluation
+		// uses the library's constexpr exp and runtime uses the more accurate one.
+		double magnitude;
+		if (std::is_constant_evaluated()) {
+			magnitude = sw::math::constexpr_math::exp(l * 0.5);
+		}
+		else {
+			magnitude = std::exp(l * 0.5);
+		}
+		TargetFloat value = static_cast<TargetFloat>(magnitude);
+		if (s) value = -value;
+		return value;
+	}
+
+private:
+	BlockBinary _block;
+
+	template<unsigned nn, unsigned nr, typename nb>
+	friend std::ostream& operator<< (std::ostream& ostr, const takum_log<nn, nr, nb>& r);
+	template<unsigned nn, unsigned nr, typename nb>
+	friend std::istream& operator>> (std::istream& istr, takum_log<nn, nr, nb>& r);
+	template<unsigned nn, unsigned nr, typename nb>
+	friend constexpr bool operator==(const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept;
+	template<unsigned nn, unsigned nr, typename nb>
+	friend constexpr bool operator< (const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept;
+};
+
+// return the Unit in the Last Position
+template<unsigned nbits, unsigned rbits, typename bt>
+inline CONSTEXPRESSION takum_log<nbits, rbits, bt> ulp(const takum_log<nbits, rbits, bt>& a) {
+	takum_log<nbits, rbits, bt> b(a);
+	return ++b - a;
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+std::string to_binary(const takum_log<nbits, rbits, bt>& number, bool nibbleMarker = false) {
+	using T = takum_log<nbits, rbits, bt>;
+	std::stringstream s;
+	uint64_t mag = number.magnitude_bits();
+
+	s << "0b";
+	s << (number.sign() ? "1." : "0.");
+	bool D = static_cast<bool>((mag >> (nbits - 2)) & 1);
+	s << (D ? "1." : "0.");
+
+	unsigned regime = static_cast<unsigned>((mag >> (nbits - T::overhead)) & T::r_mask);
+	for (int i = static_cast<int>(rbits) - 1; i >= 0; --i) s << ((regime >> i) & 1 ? '1' : '0');
+	s << '.';
+
+	auto g = T::Codec::layout_of(number.dr_field());
+	int bit = static_cast<int>(nbits) - static_cast<int>(T::overhead) - 1;
+	for (unsigned i = 0; i < g.c_stored_bits && bit >= 0; ++i) {
+		s << ((mag >> bit) & 1 ? '1' : '0');
+		--bit;
+		if (i < g.c_stored_bits - 1 && ((g.c_stored_bits - 1 - i) % 4) == 0 && nibbleMarker) s << '\'';
+	}
+	s << '.';
+	for (unsigned i = 0; i < g.p && bit >= 0; ++i) {
+		s << ((mag >> bit) & 1 ? '1' : '0');
+		if (bit > 0 && (bit % 4) == 0 && nibbleMarker) s << '\'';
+		--bit;
+	}
+	return s.str();
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+std::string to_native(const takum_log<nbits, rbits, bt>& number, bool nibbleMarker = false) {
+	return to_binary(number, nibbleMarker);
+}
+
+////////////////////// operators
+template<unsigned nn, unsigned nr, typename nb>
+inline std::ostream& operator<<(std::ostream& ostr, const takum_log<nn, nr, nb>& v) { ostr << double(v); return ostr; }
+template<unsigned nn, unsigned nr, typename nb>
+inline std::istream&
+operator>>(std::istream& istr, takum_log<nn, nr, nb>& v) {
+	double d; istr >> d; v = d; return istr;
+}
+
+template<unsigned nn, unsigned nr, typename nb>
+inline constexpr bool operator==(const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept {
+	if (lhs.isnar() || rhs.isnar()) return false;
+	return (lhs._block == rhs._block);
+}
+template<unsigned nn, unsigned nr, typename nb>
+inline constexpr bool operator!=(const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept {
+	if (lhs.isnar() || rhs.isnar()) return true;
+	return !operator==(lhs, rhs);
+}
+template<unsigned nn, unsigned nr, typename nb>
+inline constexpr bool operator< (const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept {
+	if (lhs.isnar() || rhs.isnar()) return false;
+	// Two's-complement ordering equals value ordering for real encodings (Prop. 4).
+	uint64_t l = lhs.raw_bits(), r = rhs.raw_bits();
+	uint64_t sign_ext = (nn < 64) ? ~((1ull << nn) - 1) : 0ull;
+	int64_t ls = (l & (1ull << (nn - 1))) ? static_cast<int64_t>(l | sign_ext) : static_cast<int64_t>(l);
+	int64_t rs = (r & (1ull << (nn - 1))) ? static_cast<int64_t>(r | sign_ext) : static_cast<int64_t>(r);
+	return ls < rs;
+}
+template<unsigned nn, unsigned nr, typename nb>
+inline constexpr bool
+operator> (const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept {
+	return operator< (rhs, lhs);
+}
+template<unsigned nn, unsigned nr, typename nb>
+inline constexpr bool operator<=(const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept {
+	if (lhs.isnar() || rhs.isnar()) return false;
+	return !operator>(lhs, rhs);
+}
+template<unsigned nn, unsigned nr, typename nb>
+inline constexpr bool operator>=(const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept {
+	if (lhs.isnar() || rhs.isnar()) return false;
+	return !operator<(lhs, rhs);
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline CONSTEXPRESSION takum_log<nbits, rbits, bt> operator+(const takum_log<nbits, rbits, bt>& lhs,
+	const takum_log<nbits, rbits, bt>& rhs) {
+	takum_log<nbits, rbits, bt> sum(lhs); sum += rhs; return sum;
+}
+template<unsigned nbits, unsigned rbits, typename bt>
+inline CONSTEXPRESSION takum_log<nbits, rbits, bt> operator-(const takum_log<nbits, rbits, bt>& lhs,
+	const takum_log<nbits, rbits, bt>& rhs) {
+	takum_log<nbits, rbits, bt> diff(lhs); diff -= rhs; return diff;
+}
+template<unsigned nbits, unsigned rbits, typename bt>
+inline CONSTEXPRESSION takum_log<nbits, rbits, bt> operator*(const takum_log<nbits, rbits, bt>& lhs,
+	const takum_log<nbits, rbits, bt>& rhs) {
+	takum_log<nbits, rbits, bt> mul(lhs); mul *= rhs; return mul;
+}
+template<unsigned nbits, unsigned rbits, typename bt>
+inline CONSTEXPRESSION takum_log<nbits, rbits, bt> operator/(const takum_log<nbits, rbits, bt>& lhs,
+	const takum_log<nbits, rbits, bt>& rhs) {
+	takum_log<nbits, rbits, bt> ratio(lhs); ratio /= rhs; return ratio;
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+constexpr takum_log<nbits, rbits, bt> abs(const takum_log<nbits, rbits, bt>& v) noexcept {
+	return v.isneg() ? -v : v;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/takum/takum_log_impl.hpp
+++ b/include/sw/universal/number/takum/takum_log_impl.hpp
@@ -321,6 +321,13 @@ public:
 	// that scale() is base 2 for every number system.  The characteristic is in
 	// units of sqrt(e), so it is converted here rather than returned directly.
 	//
+	// Returns int64_t, as takum<>::scale() does.  An int cannot hold the result: at
+	// rbits = 5 the characteristic reaches ~2^32, so takum_log<16,5> maxpos scales to
+	// ~3.1e9 and the narrowing conversion is undefined behaviour -- UBSan reported
+	// maxpos as INT_MIN and minpos as INT_MAX, an inverted range.  Widening the return
+	// type removes the conversion rather than clamping it, and manipulators.hpp's
+	// components() reaches this for every takum_log configuration.
+	//
 	// Accuracy: sqrt(e)^l is a power of two only for l = 2k ln2, which is irrational
 	// for k != 0, so no encoding sits exactly on a boundary and the floor below is
 	// always well defined.  It is computed in double, though, which at |l| ~ 255
@@ -330,12 +337,11 @@ public:
 	// caller ever needs it.  Note that std::ilogb(double(*this)) is NOT the fix: it
 	// agrees with this on every uniformly sampled encoding, is no better on the
 	// boundary set (both are coin flips there), and returns INT_MAX for the ~34% of
-	// wide-rbits encodings whose magnitude overflows a double -- which is precisely
-	// where attributes.hpp's minpos_scale() / maxpos_scale() land.
-	CONSTEXPRESSION int scale() const noexcept {
+	// wide-rbits encodings whose magnitude overflows a double.
+	CONSTEXPRESSION int64_t scale() const noexcept {
 		if (iszero() || isnar()) return 0;
-		double log2_magnitude = logarithmic_value() * log2_of_base;
-		int    s = static_cast<int>(log2_magnitude);
+		double  log2_magnitude = logarithmic_value() * log2_of_base;
+		int64_t s = static_cast<int64_t>(log2_magnitude);
 		if (log2_magnitude < 0.0 && static_cast<double>(s) != log2_magnitude) --s;  // floor
 		return s;
 	}

--- a/include/sw/universal/number/takum/takum_traits.hpp
+++ b/include/sw/universal/number/takum/takum_traits.hpp
@@ -28,4 +28,32 @@ namespace sw { namespace universal {
 	template<typename _Ty>
 	using enable_if_takum = std::enable_if_t<is_takum<_Ty>, _Ty>;
 
+	// define a trait for the logarithmic takum, which shares takum's codec but is a
+	// distinct number system: same bit layout, base sqrt(e) instead of base 2.
+	template<typename _Ty>
+	struct is_takum_log_trait
+		: false_type
+	{
+	};
+
+	template<unsigned nbits, unsigned rbits, typename BlockType>
+	struct is_takum_log_trait< takum_log<nbits, rbits, BlockType> >
+		: true_type
+	{
+	};
+
+	template<typename _Ty>
+	constexpr bool is_takum_log = is_takum_log_trait<_Ty>::value;
+
+	template<typename _Ty>
+	using enable_if_takum_log = std::enable_if_t<is_takum_log<_Ty>, _Ty>;
+
+	// either variant: use for code that only touches the shared encoding, such as
+	// the bit-level manipulators.  Value-level code should pick one.
+	template<typename _Ty>
+	constexpr bool is_any_takum = is_takum<_Ty> || is_takum_log<_Ty>;
+
+	template<typename _Ty>
+	using enable_if_any_takum = std::enable_if_t<is_any_takum<_Ty>, _Ty>;
+
 }} // namespace sw::universal

--- a/static/tapered/takum/api/codec.cpp
+++ b/static/tapered/takum/api/codec.cpp
@@ -432,7 +432,12 @@ int VerifyTruncatedRounding(bool reportTestCases) {
 					int64_t c = base + k * step + off;
 					if (c < Codec::min_characteristic() || c > Codec::max_characteristic()) continue;
 					auto e = Codec::encode_rounded(c, m);
-					if (!e.ok()) continue;
+					if (!e.ok()) {
+						// c was range checked above and k+1 still fits the stored field,
+						// so saturation here is a defect, not an expected outcome.
+						report_fail(dr, "truncated rounded encode", reportTestCases, nrOfFailedTests);
+						continue;
+					}
 					++exercised;
 
 					// Where the value actually sits above k stored steps, and the

--- a/static/tapered/takum/api/codec.cpp
+++ b/static/tapered/takum/api/codec.cpp
@@ -391,6 +391,77 @@ int VerifyTruncatedCharacteristic(bool reportTestCases) {
 	return nrOfFailedTests;
 }
 
+// Dropped characteristic bits TOGETHER WITH a fraction.
+//
+// VerifyTruncatedCharacteristic above always passes m = 0, so it only ever sees
+// one of the two quantities that live below a stored characteristic step.  When
+// r > maxCharBits the layout leaves p == 0, so the dropped low bits of C and the
+// caller's m both fall inside the same step and must be weighed on the same scale
+// in a single round-to-nearest-even decision.
+//
+// Rounding them independently is wrong twice over: it can carry into C_stored
+// twice, and it compares a bare m against half a CHARACTERISTIC unit when a
+// stored step spans 2^shift of them.  Both errors move the result by whole steps,
+// not one ulp, so drive the combination directly.
+template<unsigned nbits, unsigned rbits>
+int VerifyTruncatedRounding(bool reportTestCases) {
+	using Codec = sw::universal::takum_codec<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	int exercised = 0;
+
+	for (unsigned dr = 0; dr < Codec::nr_dr_values; ++dr) {
+		auto g = Codec::layout_of(dr);
+		if (g.r <= Codec::maxCharBits) continue;      // not a truncating layout
+		unsigned shift = g.r - g.c_stored_bits;
+		if (shift == 0 || shift >= 63) continue;
+		if (g.c_stored_bits < 2) continue;            // need room for k and k+1
+		int64_t base = Codec::dr_to_c_bias(dr);
+		int64_t step = static_cast<int64_t>(1ull << shift);
+		double  half = static_cast<double>(step) / 2.0;
+
+		// Two adjacent stored steps, so both tie-to-even parities are exercised.
+		const int64_t mid = static_cast<int64_t>(1ull << (g.c_stored_bits - 1));
+		for (int64_t k : { mid, mid + 1 }) {
+			// Offsets bracketing the midpoint of one stored step.
+			const int64_t offsets[] = {
+				0, 1, step / 4, (step / 2) - 1, step / 2, (step / 2) + 1, (3 * step) / 4, step - 1,
+			};
+			for (int64_t off : offsets) {
+				if (off < 0 || off >= step) continue;
+				for (double m : { 0.0, 0.25, 0.5, 0.75 }) {
+					int64_t c = base + k * step + off;
+					if (c < Codec::min_characteristic() || c > Codec::max_characteristic()) continue;
+					auto e = Codec::encode_rounded(c, m);
+					if (!e.ok()) continue;
+					++exercised;
+
+					// Where the value actually sits above k stored steps, and the
+					// single nearest-even decision that follows from it.
+					double  residual = static_cast<double>(off) + m;
+					int64_t want_k   = k;
+					if (residual > half || (residual == half && (k & 1))) ++want_k;
+
+					int64_t want_c = base + want_k * step;
+					int64_t got_c  = Codec::decode(e.magnitude).c;
+					if (got_c != want_c) {
+						++nrOfFailedTests;
+						if (reportTestCases) {
+							std::cout << "FAIL truncated rounding dr=" << dr << " step=" << step
+							          << " asked c=" << c << " m=" << m
+							          << " got c=" << got_c << " want c=" << want_c << '\n';
+						}
+					}
+				}
+			}
+		}
+	}
+	if (exercised == 0) {
+		++nrOfFailedTests;   // the configuration was supposed to reach this path
+		if (reportTestCases) std::cout << "FAIL truncated-rounding path never exercised\n";
+	}
+	return nrOfFailedTests;
+}
+
 } // anonymous namespace
 
 int main()
@@ -514,6 +585,22 @@ try {
 		VerifyTruncatedCharacteristic<16, 5>(reportTestCases), "codec<16,5>", "truncated characteristic");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyTruncatedCharacteristic<24, 5>(reportTestCases), "codec<24,5>", "truncated characteristic");
+
+	// ----------------------------------------------------------------------------
+	// Dropped characteristic bits combined with a fraction: the two quantities that
+	// share a stored step must be rounded once, together.  codec<11,3> is the
+	// narrowest spec-regime configuration that drops characteristic bits at all.
+	// ----------------------------------------------------------------------------
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyTruncatedRounding<11, 3>(reportTestCases), "codec<11,3>", "truncated rounding");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyTruncatedRounding<12, 4>(reportTestCases), "codec<12,4>", "truncated rounding");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyTruncatedRounding<12, 5>(reportTestCases), "codec<12,5>", "truncated rounding");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyTruncatedRounding<16, 5>(reportTestCases), "codec<16,5>", "truncated rounding");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyTruncatedRounding<24, 5>(reportTestCases), "codec<24,5>", "truncated rounding");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/static/tapered/takum_log/CMakeLists.txt
+++ b/static/tapered/takum_log/CMakeLists.txt
@@ -1,0 +1,11 @@
+file (GLOB API_SRC "./api/*.cpp")
+file (GLOB CONVERSION_SRC "./conversion/*.cpp")
+file (GLOB LOGIC_SRC "./logic/*.cpp")
+file (GLOB ARITHMETIC_SRC "./arithmetic/*.cpp")
+file (GLOB MATH_SRC "./math/*.cpp")
+
+compile_all("true" "tkml" "Number Systems/static/floating-point/tapered/takum_log/api" "${API_SRC}")
+compile_all("true" "tkml" "Number Systems/static/floating-point/tapered/takum_log/conversion" "${CONVERSION_SRC}")
+compile_all("true" "tkml" "Number Systems/static/floating-point/tapered/takum_log/logic" "${LOGIC_SRC}")
+compile_all("true" "tkml" "Number Systems/static/floating-point/tapered/takum_log/arithmetic" "${ARITHMETIC_SRC}")
+compile_all("true" "tkml" "Number Systems/static/floating-point/tapered/takum_log/math" "${MATH_SRC}")

--- a/static/tapered/takum_log/api/api.cpp
+++ b/static/tapered/takum_log/api/api.cpp
@@ -158,11 +158,16 @@ int VerifyRoundTrip(bool reportTestCases) {
 // power-of-two exponent of the value actually stored.  takum_log's characteristic
 // is in units of sqrt(e), so scale() has to convert; std::ilogb gives the exact
 // reference exponent.
-template<unsigned nbits, unsigned rbits>
-int VerifyScaleConvention(bool reportTestCases) {
-	using TL = sw::universal::takum_log<nbits, rbits>;
+//
+// stride > 1 samples instead of enumerating, so that the widest configurations,
+// whose encoding space is far too large to walk, are still covered.  It is
+// deliberately coprime with the encoding structure so the sample sweeps every DR.
+template<unsigned nbits, unsigned rbits, typename bt = std::uint8_t>
+int VerifyScaleConvention(bool reportTestCases, uint64_t stride = 1) {
+	using TL = sw::universal::takum_log<nbits, rbits, bt>;
 	int nrOfFailedTests = 0;
-	for (uint64_t b = 0; b < (1ull << nbits); ++b) {
+	const uint64_t limit = (nbits >= 64) ? ~0ull : (1ull << nbits);
+	for (uint64_t b = 0; b < limit && b + stride > b; b += stride) {
 		TL x; x.setbits(b);
 		if (!comparable(x)) continue;
 		int want = std::ilogb(double(x));
@@ -237,6 +242,20 @@ int VerifySharedEncoding(bool reportTestCases) {
 }
 
 } // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
 
 int main()
 try {
@@ -334,43 +353,79 @@ try {
 		if (!(double(lim::lowest()) < 0.0)) { ++nrOfFailedTestCases; std::cout << "FAIL lowest should be negative\n"; }
 	}
 
+#if MANUAL_TESTING
+
+	// Scratch space for investigating a single configuration.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyInversion<12, 3>(true), "takum_log<12,3>", "inversion (Prop. 7)");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;   // ignore failures while iterating manually
+#else
+
 	// ----------------------------------------------------------------------------
-	// Exhaustive structural properties
+	// Level 1: the defining structural properties, exhaustive over the two narrow
+	// configurations.  takum_log<12,3> is the narrowest layout that still has a
+	// trailing field; <16,3> is the spec regime at a practical width.
 	// ----------------------------------------------------------------------------
+#if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyNegation<12, 3>(reportTestCases), "takum_log<12,3>", "negation (Prop. 6)");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyNegation<16, 3>(reportTestCases), "takum_log<16,3>", "negation (Prop. 6)");
-
-	nrOfFailedTestCases += ReportTestResult(
 		VerifyInversion<12, 3>(reportTestCases), "takum_log<12,3>", "inversion (Prop. 7)");
-	nrOfFailedTestCases += ReportTestResult(
-		VerifyInversion<16, 3>(reportTestCases), "takum_log<16,3>", "inversion (Prop. 7)");
-
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyOrdering<12, 3>(reportTestCases), "takum_log<12,3>", "ordering (Prop. 4)");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyOrdering<16, 3>(reportTestCases), "takum_log<16,3>", "ordering (Prop. 4)");
-
-	nrOfFailedTestCases += ReportTestResult(
 		VerifyRoundTrip<12, 3>(reportTestCases), "takum_log<12,3>", "double round-trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyScaleConvention<12, 3>(reportTestCases), "takum_log<12,3>", "scale() base-2 convention");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySharedEncoding<12, 3>(reportTestCases), "takum_log<12,3>", "shared codec with takum<>");
+#endif
+
+	// ----------------------------------------------------------------------------
+	// Level 2: the same properties at 16 bits, plus a narrower regime field.
+	// ----------------------------------------------------------------------------
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNegation<16, 3>(reportTestCases), "takum_log<16,3>", "negation (Prop. 6)");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyInversion<16, 3>(reportTestCases), "takum_log<16,3>", "inversion (Prop. 7)");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrdering<16, 3>(reportTestCases), "takum_log<16,3>", "ordering (Prop. 4)");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyRoundTrip<16, 3>(reportTestCases), "takum_log<16,3>", "double round-trip");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyRoundTrip<16, 1>(reportTestCases), "takum_log<16,1>", "double round-trip");
-
-	nrOfFailedTestCases += ReportTestResult(
-		VerifyScaleConvention<12, 3>(reportTestCases), "takum_log<12,3>", "scale() base-2 convention");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyScaleConvention<16, 3>(reportTestCases), "takum_log<16,3>", "scale() base-2 convention");
-
-	nrOfFailedTestCases += ReportTestResult(
-		VerifySharedEncoding<12, 3>(reportTestCases), "takum_log<12,3>", "shared codec with takum<>");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifySharedEncoding<16, 3>(reportTestCases), "takum_log<16,3>", "shared codec with takum<>");
+#endif
+
+	// ----------------------------------------------------------------------------
+	// Level 3: 32 bits.  Too wide to enumerate, so the encoding space is sampled
+	// with a stride coprime to the field structure, which sweeps every DR.
+	// ----------------------------------------------------------------------------
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyScaleConvention<32, 3>(reportTestCases, 5749ull), "takum_log<32,3>", "scale() base-2 convention");
+#endif
+
+	// ----------------------------------------------------------------------------
+	// Level 4: 64 bits, where the trailing field runs past a double's 53 significand
+	// bits and scale() has the least headroom.  64-bit limbs, so the sample does not
+	// pay for byte-at-a-time block access.
+	// ----------------------------------------------------------------------------
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyScaleConvention<64, 3, std::uint64_t>(reportTestCases, 0x2AAAAAAAABull),
+		"takum_log<64,3>", "scale() base-2 convention");
+#endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
 }
 catch (char const* msg) {
 	std::cerr << msg << std::endl;

--- a/static/tapered/takum_log/api/api.cpp
+++ b/static/tapered/takum_log/api/api.cpp
@@ -1,0 +1,386 @@
+// api.cpp: application programming interface tests for the logarithmic takum
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// takum_log<nbits, rbits, bt> is the LOGARITHMIC takum: arXiv:2404.18603
+// Definition 2, restated as Definition 1 of arXiv:2408.10594.  It shares the
+// entire (S, D, R, C, M) encoding with the linear takum<> through
+// takum_codec<nbits, rbits> and differs only in the value map:
+//
+//     takum<>      |value| = (1 + f) * 2^c
+//     takum_log<>  |value| = sqrt(e)^(c + m)
+//
+// This suite pins the properties that make it a distinct number system rather
+// than a reinterpretation, in particular the two the paper singles out:
+//
+//   Proposition 6   negation is the two's complement of the whole word
+//                   (shared with the linear takum)
+//   Proposition 7   INVERSION is the two's complement of everything but the
+//                   sign bit -- exact, and absent from the linear takum
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstdint>
+#include <universal/number/takum/takum_log.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// Values whose magnitude leaves double's range are unusable for a
+// double-mediated comparison.  This is a property of wide rbits configurations
+// (rbits=5 pushes the characteristic to ~2^32) and affects the linear takum
+// equally; the specification fixes rbits=3, where everything is representable.
+template<typename TL>
+bool comparable(const TL& v) {
+	if (v.iszero() || v.isnar()) return false;
+	double d = double(v);
+	return std::isfinite(d) && d != 0.0;
+}
+
+// Proposition 6: negating the two's complement integer negates the value.
+template<unsigned nbits, unsigned rbits>
+int VerifyNegation(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	for (uint64_t b = 0; b < (1ull << nbits); ++b) {
+		TL x; x.setbits(b);
+		if (!comparable(x)) continue;
+		TL n = -x;
+		if (double(n) != -double(x)) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL Prop6 bits=" << b << " x=" << double(x) << " -x=" << double(n) << '\n';
+			}
+		}
+		if ((-n).raw_bits() != x.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL Prop6 not involutive bits=" << b << '\n';
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// Proposition 7: inversion is a bit operation and is EXACT.  This is the
+// property the linear takum lacks, so it is the sharpest test that takum_log is
+// really the logarithmic format and not a mislabelled takum<>.
+template<unsigned nbits, unsigned rbits>
+int VerifyInversion(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	for (uint64_t b = 0; b < (1ull << nbits); ++b) {
+		TL x; x.setbits(b);
+		if (x.isnar()) continue;
+		if (x.iszero()) {
+			// 1/0 is NaR by the proposition
+			if (!x.reciprocal().isnar()) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cout << "FAIL Prop7 1/0 must be NaR\n";
+			}
+			continue;
+		}
+		TL r = x.reciprocal();
+		// involution: 1/(1/x) == x, exactly, at the bit level
+		if (r.reciprocal().raw_bits() != x.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL Prop7 not involutive bits=" << b << '\n';
+		}
+		if (!comparable(x) || !comparable(r)) continue;
+		double want = 1.0 / double(x);
+		double rel  = std::fabs((double(r) - want) / want);
+		// the encoding is exact; only the double round-trip introduces error
+		if (rel > 1e-12) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL Prop7 bits=" << b << " x=" << double(x)
+				          << " 1/x=" << double(r) << " want=" << want << " rel=" << rel << '\n';
+			}
+		}
+		// sign is preserved by inversion, unlike negation
+		if (x.sign() != r.sign()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL Prop7 sign changed bits=" << b << '\n';
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// Proposition 4: two's complement integer ordering equals value ordering.
+template<unsigned nbits, unsigned rbits>
+int VerifyOrdering(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	double prev = 0.0;
+	bool have_prev = false;
+	// walk the signed integer range in increasing order, skipping NaR
+	for (int64_t i = -(1ll << (nbits - 1)); i < (1ll << (nbits - 1)); ++i) {
+		TL x; x.setbits(static_cast<uint64_t>(i) & ((1ull << nbits) - 1));
+		if (x.isnar()) continue;
+		double d = double(x);
+		if (!std::isfinite(d)) { have_prev = false; continue; }
+		if (have_prev && !(d > prev)) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL Prop4 ordering at i=" << i << " prev=" << prev << " cur=" << d << '\n';
+			}
+		}
+		prev = d; have_prev = true;
+	}
+	return nrOfFailedTests;
+}
+
+// Conversion round-trip: every representable value must survive
+// takum_log -> double -> takum_log unchanged.
+template<unsigned nbits, unsigned rbits>
+int VerifyRoundTrip(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	for (uint64_t b = 0; b < (1ull << nbits); ++b) {
+		TL x; x.setbits(b);
+		if (!comparable(x)) continue;
+		TL back{ double(x) };
+		if (back.raw_bits() != x.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL round-trip bits=" << b << " value=" << double(x)
+				          << " came back as bits=" << back.raw_bits() << '\n';
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// scale() must follow the library-wide base-2 convention: the integer
+// power-of-two exponent of the value actually stored.  takum_log's characteristic
+// is in units of sqrt(e), so scale() has to convert; std::ilogb gives the exact
+// reference exponent.
+template<unsigned nbits, unsigned rbits>
+int VerifyScaleConvention(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	for (uint64_t b = 0; b < (1ull << nbits); ++b) {
+		TL x; x.setbits(b);
+		if (!comparable(x)) continue;
+		int want = std::ilogb(double(x));
+		if (x.scale() != want) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL scale bits=" << b << " value=" << double(x)
+				          << " scale()=" << x.scale() << " ilogb=" << want << '\n';
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// The two variants must agree bit-for-bit on the shared encoding: same special
+// values, same field geometry, same ordering structure -- and disagree on value.
+template<unsigned nbits, unsigned rbits>
+int VerifySharedEncoding(bool reportTestCases) {
+	using TLIN = sw::universal::takum<nbits, rbits>;
+	using TLOG = sw::universal::takum_log<nbits, rbits>;
+	using sw::universal::SpecificValue;
+	int nrOfFailedTests = 0;
+
+	auto same_bits = [&](const char* what, uint64_t a, uint64_t b) {
+		if (a != b) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL shared encoding: " << what << " differs\n";
+		}
+	};
+	same_bits("zero",   TLIN(SpecificValue::zero).raw_bits(),   TLOG(SpecificValue::zero).raw_bits());
+	same_bits("nar",    TLIN(SpecificValue::nar).raw_bits(),    TLOG(SpecificValue::nar).raw_bits());
+	same_bits("minpos", TLIN(SpecificValue::minpos).raw_bits(), TLOG(SpecificValue::minpos).raw_bits());
+	same_bits("maxpos", TLIN(SpecificValue::maxpos).raw_bits(), TLOG(SpecificValue::maxpos).raw_bits());
+	same_bits("minneg", TLIN(SpecificValue::minneg).raw_bits(), TLOG(SpecificValue::minneg).raw_bits());
+	same_bits("maxneg", TLIN(SpecificValue::maxneg).raw_bits(), TLOG(SpecificValue::maxneg).raw_bits());
+
+	// same characteristic decode for every bit pattern -- it comes from one codec
+	for (uint64_t b = 0; b < (1ull << nbits); ++b) {
+		TLIN a; a.setbits(b);
+		TLOG c; c.setbits(b);
+		if (a.characteristic() != c.characteristic()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL shared codec: characteristic differs at bits=" << b << '\n';
+			break;
+		}
+		if (a.dr_field() != c.dr_field()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL shared codec: dr_field differs at bits=" << b << '\n';
+			break;
+		}
+	}
+
+	// ...and the value maps must genuinely differ wherever the characteristic is
+	// non-zero: 2^c versus sqrt(e)^c.  At c == 0 with m == 0 both give 1.0, and
+	// agreeing there is correct rather than a defect, so seek a pattern with c != 0.
+	{
+		bool found_divergence = false, found_c_nonzero = false;
+		for (uint64_t b = 1; b < (1ull << (nbits - 1)); ++b) {
+			TLIN a; a.setbits(b);
+			TLOG c; c.setbits(b);
+			if (a.characteristic() == 0) continue;
+			found_c_nonzero = true;
+			double da = double(a), dc = double(c);
+			if (std::isfinite(da) && std::isfinite(dc) && da != dc) { found_divergence = true; break; }
+		}
+		if (!found_c_nonzero || !found_divergence) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL the two value maps never diverged\n";
+		}
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "takum_log (logarithmic takum) API verification";
+	std::string test_tag    = "api";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// ----------------------------------------------------------------------------
+	// Compile-time: takum_log shares the codec with takum and re-exports the same
+	// geometry, so generic code can treat the encoding uniformly.
+	// ----------------------------------------------------------------------------
+	{
+		using TL16 = takum_log<16, 3, std::uint8_t>;
+		using T16  = takum<16, 3, std::uint8_t>;
+		static_assert(std::is_same_v<TL16::Codec, T16::Codec>, "both variants share one codec");
+		static_assert(TL16::nbits == 16u && TL16::rbits == 3u, "template parameters");
+		static_assert(TL16::overhead == T16::overhead,             "shared overhead");
+		static_assert(TL16::maxCharBits == T16::maxCharBits,       "shared maxCharBits");
+		static_assert(TL16::max_characteristic() == T16::max_characteristic(), "shared characteristic range");
+		static_assert(TL16::min_characteristic() == T16::min_characteristic(), "shared characteristic range");
+
+		// the traits separate them despite the shared encoding
+		static_assert(is_takum_log<TL16>,  "takum_log satisfies is_takum_log");
+		static_assert(!is_takum<TL16>,     "takum_log is NOT a linear takum");
+		static_assert(is_takum<T16>,       "takum satisfies is_takum");
+		static_assert(!is_takum_log<T16>,  "takum is NOT a logarithmic takum");
+		static_assert(is_any_takum<TL16> && is_any_takum<T16>, "both satisfy is_any_takum");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Special values and the value base
+	// ----------------------------------------------------------------------------
+	{
+		using TL = takum_log<32, 3>;
+		TL z(SpecificValue::zero), n(SpecificValue::nar);
+		if (!z.iszero()) { ++nrOfFailedTestCases; std::cout << "FAIL zero\n"; }
+		if (!n.isnar())  { ++nrOfFailedTestCases; std::cout << "FAIL nar\n"; }
+		if (double(TL(1.0)) != 1.0) { ++nrOfFailedTestCases; std::cout << "FAIL exact 1.0\n"; }
+
+		// sqrt(e) is the value base, so it must land exactly on c=1, m=0
+		TL base(TL::value_base);
+		if (base.characteristic() != 1) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL value_base should encode as characteristic 1, got " << base.characteristic() << '\n';
+		}
+		// scale() follows the library-wide base-2 convention even though the value
+		// base is sqrt(e).  Note that a power of two is generally NOT representable
+		// here, so the contract is about the stored value: scale() == floor(log2|v|),
+		// which std::ilogb computes exactly.
+		if (TL(1.0).scale() != 0) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL scale(1.0) should be 0, got " << TL(1.0).scale() << '\n';
+		}
+	}
+
+	// ----------------------------------------------------------------------------
+	// Dynamic range: the logarithmic variant trades range for uniform precision.
+	// takum<32,3> spans ~1e+-77 (base 2), takum_log<32,3> ~1e+-55 (base sqrt(e)).
+	// ----------------------------------------------------------------------------
+	{
+		double lin_max = double(takum<32, 3>(SpecificValue::maxpos));
+		double log_max = double(takum_log<32, 3>(SpecificValue::maxpos));
+		if (!(log_max < lin_max)) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL expected the logarithmic range to be narrower: log=" << log_max
+			          << " linear=" << lin_max << '\n';
+		}
+		if (!(log_max > 1e50 && log_max < 1e60)) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL takum_log<32,3> maxpos out of expected 1e50..1e60 band: " << log_max << '\n';
+		}
+	}
+
+	// ----------------------------------------------------------------------------
+	// numeric_limits
+	// ----------------------------------------------------------------------------
+	{
+		using TL  = takum_log<32, 3>;
+		using lim = std::numeric_limits<TL>;
+		if (!lim::is_specialized)  { ++nrOfFailedTestCases; std::cout << "FAIL numeric_limits not specialized\n"; }
+		if (lim::has_infinity)     { ++nrOfFailedTestCases; std::cout << "FAIL takum_log has no infinity\n"; }
+		if (!lim::has_quiet_NaN)   { ++nrOfFailedTestCases; std::cout << "FAIL NaR serves as quiet NaN\n"; }
+		if (lim::radix != 2) {
+			++nrOfFailedTestCases;
+			std::cout << "FAIL radix is the integer representation radix\n";
+		}
+		if (!(double(lim::min()) > 0.0 && double(lim::max()) > double(lim::min()))) {
+			++nrOfFailedTestCases; std::cout << "FAIL min/max ordering\n";
+		}
+		if (!(double(lim::lowest()) < 0.0)) { ++nrOfFailedTestCases; std::cout << "FAIL lowest should be negative\n"; }
+	}
+
+	// ----------------------------------------------------------------------------
+	// Exhaustive structural properties
+	// ----------------------------------------------------------------------------
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNegation<12, 3>(reportTestCases), "takum_log<12,3>", "negation (Prop. 6)");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNegation<16, 3>(reportTestCases), "takum_log<16,3>", "negation (Prop. 6)");
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyInversion<12, 3>(reportTestCases), "takum_log<12,3>", "inversion (Prop. 7)");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyInversion<16, 3>(reportTestCases), "takum_log<16,3>", "inversion (Prop. 7)");
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrdering<12, 3>(reportTestCases), "takum_log<12,3>", "ordering (Prop. 4)");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrdering<16, 3>(reportTestCases), "takum_log<16,3>", "ordering (Prop. 4)");
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<12, 3>(reportTestCases), "takum_log<12,3>", "double round-trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<16, 3>(reportTestCases), "takum_log<16,3>", "double round-trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<16, 1>(reportTestCases), "takum_log<16,1>", "double round-trip");
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyScaleConvention<12, 3>(reportTestCases), "takum_log<12,3>", "scale() base-2 convention");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyScaleConvention<16, 3>(reportTestCases), "takum_log<16,3>", "scale() base-2 convention");
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySharedEncoding<12, 3>(reportTestCases), "takum_log<12,3>", "shared codec with takum<>");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySharedEncoding<16, 3>(reportTestCases), "takum_log<16,3>", "shared codec with takum<>");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/takum_log/api/api.cpp
+++ b/static/tapered/takum_log/api/api.cpp
@@ -170,7 +170,7 @@ int VerifyScaleConvention(bool reportTestCases, uint64_t stride = 1) {
 	for (uint64_t b = 0; b < limit && b + stride > b; b += stride) {
 		TL x; x.setbits(b);
 		if (!comparable(x)) continue;
-		int want = std::ilogb(double(x));
+		int64_t want = std::ilogb(double(x));
 		if (x.scale() != want) {
 			++nrOfFailedTests;
 			if (reportTestCases) {
@@ -178,6 +178,52 @@ int VerifyScaleConvention(bool reportTestCases, uint64_t stride = 1) {
 				          << " scale()=" << x.scale() << " ilogb=" << want << '\n';
 			}
 		}
+	}
+	return nrOfFailedTests;
+}
+
+// scale() where a double cannot follow.
+//
+// VerifyScaleConvention checks against std::ilogb(double(x)), so it can only see
+// encodings whose magnitude a double can hold.  At rbits = 5 the characteristic
+// reaches ~2^32 and about a third of all encodings overflow a double, so that
+// entire region went unchecked -- which is how scale() came to narrow a ~3.1e9
+// result to int.  That is undefined behaviour, and it silently returned INT_MIN
+// for maxpos and INT_MAX for minpos, an inverted range, without any suite noticing.
+//
+// Check the properties that survive without a double oracle: scale() is
+// non-decreasing in the magnitude, and it separates the extremes in the right
+// order.  Either one alone catches the inversion.
+template<unsigned nbits, unsigned rbits, typename bt = std::uint8_t>
+int VerifyWideScale(bool reportTestCases, uint64_t stride = 1) {
+	using TL = sw::universal::takum_log<nbits, rbits, bt>;
+	int nrOfFailedTests = 0;
+
+	TL lo(sw::universal::SpecificValue::minpos), hi(sw::universal::SpecificValue::maxpos);
+	if (!(lo.scale() < hi.scale())) {
+		++nrOfFailedTests;
+		if (reportTestCases) {
+			std::cout << "FAIL scale(minpos)=" << lo.scale()
+			          << " must be below scale(maxpos)=" << hi.scale() << '\n';
+		}
+	}
+
+	// Positive magnitudes only, so increasing bits means increasing value (Prop. 4).
+	const uint64_t limit = 1ull << (nbits - 1);
+	int64_t prev = 0;
+	bool have_prev = false;
+	for (uint64_t b = 1; b < limit; b += stride) {
+		TL x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+		int64_t s = x.scale();
+		if (have_prev && s < prev) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL scale not monotonic at bits=" << b
+				          << ": " << s << " after " << prev << '\n';
+			}
+		}
+		prev = s; have_prev = true;
 	}
 	return nrOfFailedTests;
 }
@@ -379,6 +425,12 @@ try {
 		VerifyRoundTrip<12, 3>(reportTestCases), "takum_log<12,3>", "double round-trip");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyScaleConvention<12, 3>(reportTestCases), "takum_log<12,3>", "scale() base-2 convention");
+	// rbits=5 puts a third of the encodings out of a double's reach, so scale() there
+	// is only checkable structurally.  Cheap, and it is the configuration that broke.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyWideScale<16, 5>(reportTestCases), "takum_log<16,5>", "scale() beyond double range");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyWideScale<16, 4>(reportTestCases), "takum_log<16,4>", "scale() beyond double range");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifySharedEncoding<12, 3>(reportTestCases), "takum_log<12,3>", "shared codec with takum<>");
 #endif


### PR DESCRIPTION
Implements the second half of #1297, on the codec extracted in #1299.

`takum_log<nbits, rbits, bt>` is the **logarithmic** takum -- Definition 2 of [arXiv:2404.18603](https://arxiv.org/abs/2404.18603), restated as Definition 1 of [arXiv:2408.10594](https://arxiv.org/abs/2408.10594) -- the variant the paper designates as the standard.

## The seam works

It shares the entire `(S, D, R, C, M)` encoding with `takum<>` through `takum_codec` and supplies only the value map:

| | value map |
|---|---|
| `takum<>` | `\|value\| = (1 + f) * 2^c` |
| `takum_log<>` | `\|value\| = sqrt(e)^(c + m)` |

Conversion in is `l = 2 ln\|x\|` split into `c = floor(l)`, `m = l - c` -- exactly the pair the codec encodes, so **all** rounding, carry and saturation logic is shared. This is what the design assessment argued for and what libtakum does.

## Proposition 7: the property that justifies two types

The paper singles out bitwise inversion as the reason to prefer a logarithmic significand. `reciprocal()` implements it: `1/x` is the two's complement of everything **except** the sign bit -- one integer operation, exact, and impossible in the linear takum. Verified exhaustively, including involution at the bit level.

That, plus Prop. 6 (negation) and Prop. 4 (ordering), is now pinned by tests.

## Three things worth reviewer attention

**1. `scale()` converts to base 2.** The library-wide convention is that `scale()` is the integer power-of-two exponent. `takum_log`'s characteristic is in units of `sqrt(e)`, so returning it directly would have silently violated the convention every other Universal type follows and broken generic test suites. It converts, and the new suite pins it against `std::ilogb` exhaustively. Note a consequence: powers of two are generally *not* representable in base `sqrt(e)`, so `takum_log(1024.0).scale()` is legitimately 9, not 10 -- the stored value sits just below 1024.

**2. `numeric_limits::radix` stays 2.** It is a `static constexpr int` and cannot express `sqrt(e)`; per the standard it is the radix of the integer representation, which here is the base-2 fixed-point `l`. The value base is exposed as `takum_log<>::value_base`. This is the contract the design doc called for.

**3. Conversion accuracy.** Runtime uses `std::log`/`std::exp`, constant evaluation uses the `constexpr_math` versions. The constexpr log is accurate to 1.8e-16 relative, which at `l = 161` is enough absolute error to land just below a characteristic boundary and truncate, so conversion also snaps to a boundary when within the error of `2 ln|x|`.

## The first commit changes `takum<>` behavior -- please read it separately

`d7a9ef6f` fixes a **pre-existing** defect in the shared codec that #1299 preserved faithfully: `encode_rounded` discarded the fraction when the DR layout left `p == 0`, so conversion truncated instead of rounding to nearest, contradicting the format's rounding function. `takum<12,3>` converted `1.9 * 2^-254` to characteristic -254 rather than the nearer -253.

Bounded and strictly an improvement:

- **decode is untouched** -- every bit pattern still denotes the same value; only the encoding chosen for a given double changes
- only configurations with a `p == 0` layout are affected. At the spec's `rbits = 3` that is **`nbits == 12` alone** (`p == 0` needs `r >= nbits - 5`, and `r` caps at 7)
- measured over a 194,100-line sweep of six configurations: 9,408 encodings change, all in the encode direction, confined to `takum<12,3>` and `takum<12,5>`. `takum<8,2>`, `takum<16,3>` and `takum<12,1>` are untouched

Most visible improvement: a value that should round to minpos previously **collapsed to zero** -- `takum<12,3>` encoded `1.571 * 2^-255` as the zero bit pattern and now encodes minpos.

## Heads-up on Codacy

The new header will likely draw ~9 `noExplicitConstructor` findings. They are the library's deliberate plug-in-replacement design -- making the converting constructors explicit would break `takum_log<32,3> x = 1.0;` and generic kernels -- and `takum_impl.hpp` produces the identical 9 under the same cppcheck flags. They are only "new" because Codacy diffs per PR. This may need a pattern exclusion on your side; I did not contort the design for it.

## Scope

Deferred to follow-ups on #1297: mathlib specializations (where the logarithmic variant makes `sqrt`/`pow`/`exp`/`log` nearly free), constant tables, cross-conversion between variants, and the arithmetic/logic/conversion regression directories. Arithmetic routes through `double`, as `takum<>` does.

## Verification

Full takum and takum_log suites pass on **gcc and clang**, no warnings, `-DNDEBUG` as well; `check-ascii` passes. New suite is exhaustive over every bit pattern for negation, inversion, ordering, round-trip, `scale()`, and codec sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logarithmic Takum support, including arithmetic, comparisons, conversions, formatting, reciprocals, scaling, and special-value handling.
  * Added numeric limits and type detection for logarithmic Takum values.
  * Extended inspection utilities and integer conversion support across Takum variants.
* **Bug Fixes**
  * Improved round-to-nearest-even behavior, carry handling, and overflow detection during encoding.
* **Tests**
  * Added comprehensive validation for conversions, ordering, limits, dynamic range, special values, rounding, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->