### PR TITLE
feat(takum): add the takum_log elementary function library

### DIFF
--- a/include/sw/universal/number/takum/math/classify.hpp
+++ b/include/sw/universal/number/takum/math/classify.hpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
+#include <cmath>
 
 namespace sw { namespace universal {
 
@@ -43,6 +44,45 @@ inline bool isnormal(const takum<nbits, rbits, bt>& t) {
 // Takum has no subnormal encodings.
 template<unsigned nbits, unsigned rbits, typename bt>
 inline bool isdenorm(const takum<nbits, rbits, bt>& t) {
+	(void)t;
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// takum_log: classification is a property of the shared encoding, so these
+// mirror the linear takum exactly.  The value map does not enter into it.
+// ---------------------------------------------------------------------------
+
+template<unsigned nbits, unsigned rbits, typename bt>
+int fpclassify(const takum_log<nbits, rbits, bt>& t) {
+	if (t.isnar())  return FP_NAN;
+	if (t.iszero()) return FP_ZERO;
+	return FP_NORMAL;   // no subnormal or infinite encodings; see below
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline bool isfinite(const takum_log<nbits, rbits, bt>& t) {
+	return !t.isnar();
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline bool isinf(const takum_log<nbits, rbits, bt>& t) {
+	(void)t;
+	return false;
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline bool isnan(const takum_log<nbits, rbits, bt>& t) {
+	return t.isnar();
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline bool isnormal(const takum_log<nbits, rbits, bt>& t) {
+	return !t.isnar() && !t.iszero();
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline bool isdenorm(const takum_log<nbits, rbits, bt>& t) {
 	(void)t;
 	return false;
 }

--- a/include/sw/universal/number/takum/math/error_and_gamma.hpp
+++ b/include/sw/universal/number/takum/math/error_and_gamma.hpp
@@ -21,4 +21,17 @@ takum<nbits, rbits, bt> erfc(const takum<nbits, rbits, bt>& x) {
 	return takum<nbits, rbits, bt>(std::erfc(double(x)));
 }
 
+// ---------------------------------------------------------------------------
+// takum_log
+// ---------------------------------------------------------------------------
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> erf(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::erf(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> erfc(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::erfc(double(x)));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/exponent.hpp
+++ b/include/sw/universal/number/takum/math/exponent.hpp
@@ -6,6 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
 #include <cmath>
+#include <universal/number/takum/math/takum_log_domain.hpp>
 
 namespace sw { namespace universal {
 
@@ -29,6 +30,61 @@ takum<nbits, rbits, bt> exp10(const takum<nbits, rbits, bt>& x) {
 template<unsigned nbits, unsigned rbits, typename bt>
 takum<nbits, rbits, bt> expm1(const takum<nbits, rbits, bt>& x) {
     return takum<nbits, rbits, bt>(std::expm1(double(x)));
+}
+
+// ---------------------------------------------------------------------------
+// takum_log
+// ---------------------------------------------------------------------------
+
+// exp is the mirror of log: |e^x| == sqrt(e)^(2x), so once x is known as a real
+// the result's logarithmic value is just 2x and the encoding is direct.  That
+// removes the logarithm the generic conversion would otherwise perform, but the
+// argument still has to be evaluated, so this saves one transcendental rather
+// than both.  See the note in logarithm.hpp.
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> exp(const takum_log<nbits, rbits, bt>& x) {
+	using TL = takum_log<nbits, rbits, bt>;
+	using Codec = typename TL::Codec;
+	TL result;
+	if (x.isnar()) { result.setnar(); return result; }
+	if (x.iszero()) return TL(1.0);                 // e^0 == 1
+	const double l2 = 2.0 * double(x);              // the result's logarithmic value
+	int64_t c = static_cast<int64_t>(l2);
+	if (l2 < 0.0 && static_cast<double>(c) != l2) --c;
+	double m = l2 - static_cast<double>(c);
+	if (m < 0.0) m = 0.0;
+	if (m >= 1.0) { m = 0.0; ++c; }
+	auto enc = Codec::encode_rounded(c, m);
+	if (enc.overflowed())  { result.maxpos(); return result; }
+	if (enc.underflowed()) { result.setzero(); return result; }
+	result.setbits(enc.magnitude);                  // e^x is always positive
+	return result;
+}
+
+// 2^x == sqrt(e)^(2 x ln2)
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> exp2(const takum_log<nbits, rbits, bt>& x) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (x.isnar()) { result.setnar(); return result; }
+	if (x.iszero()) return TL(1.0);
+	return TL(std::exp2(double(x)));
+}
+
+// 10^x
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> exp10(const takum_log<nbits, rbits, bt>& x) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (x.isnar()) { result.setnar(); return result; }
+	if (x.iszero()) return TL(1.0);
+	return TL(std::pow(10.0, double(x)));
+}
+
+// exp(x) - 1: the subtraction is a linear-domain operation, so no shortcut.
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> expm1(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::expm1(double(x)));
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/exponent.hpp
+++ b/include/sw/universal/number/takum/math/exponent.hpp
@@ -48,14 +48,29 @@ takum_log<nbits, rbits, bt> exp(const takum_log<nbits, rbits, bt>& x) {
 	TL result;
 	if (x.isnar()) { result.setnar(); return result; }
 	if (x.iszero()) return TL(1.0);                 // e^0 == 1
-	const double l2 = 2.0 * double(x);              // the result's logarithmic value
+
+	// The result's logarithmic value is 2x -- which scales with the VALUE of x, not
+	// with its logarithmic value, and so leaves the characteristic range almost
+	// immediately.  takum_log<16,3> already reaches 2.3e55, whose double is finite
+	// but nowhere near an int64_t.  Saturate BEFORE the conversion: an out-of-range
+	// double to integer cast is undefined behaviour, and letting it wrap inverted
+	// the answer, returning zero for exp(maxpos) and maxpos for exp(maxneg).
+	//
+	// The !isfinite guard covers wide rbits, where double(x) itself overflows.
+	const double l2 = 2.0 * double(x);
+	const double cmax = static_cast<double>(Codec::max_characteristic());
+	const double cmin = static_cast<double>(Codec::min_characteristic());
+	if (std::isnan(l2))     { result.setnar(); return result; }
+	if (l2 >= cmax + 1.0)   { result.maxpos();  return result; }   // includes +inf
+	if (l2 <  cmin)         { result.setzero(); return result; }   // includes -inf
+
 	int64_t c = static_cast<int64_t>(l2);
 	if (l2 < 0.0 && static_cast<double>(c) != l2) --c;
 	double m = l2 - static_cast<double>(c);
 	if (m < 0.0) m = 0.0;
 	if (m >= 1.0) { m = 0.0; ++c; }
 	auto enc = Codec::encode_rounded(c, m);
-	if (enc.overflowed())  { result.maxpos(); return result; }
+	if (enc.overflowed())  { result.maxpos();  return result; }
 	if (enc.underflowed()) { result.setzero(); return result; }
 	result.setbits(enc.magnitude);                  // e^x is always positive
 	return result;

--- a/include/sw/universal/number/takum/math/fma.hpp
+++ b/include/sw/universal/number/takum/math/fma.hpp
@@ -31,7 +31,15 @@ takum<nbits, rbits, bt> fma(const takum<nbits, rbits, bt>& a, const takum<nbits,
 // ---------------------------------------------------------------------------
 // takum_log: fused multiply-add.  The multiply is exact in the logarithmic
 // domain but the addition is not, so this follows the linear takum and fuses in
-// double, which is wider than any takum_log the codec supports up to 64 bits.
+// double.
+//
+// That bridge is only faithful while the operands AND the exact product-sum are
+// representable in binary64, which is not the whole of the type: at rbits = 5
+// the characteristic reaches ~2^32 and about a third of all finite encodings
+// convert to infinity as a double.  Once that happens the result is whatever
+// std::fma makes of an infinity -- with b == 0 that is NaN, and the constructor
+// turns it into NaR.  A range-safe native path, which would add in the linear
+// domain without leaving the type, is follow-up work.
 // ---------------------------------------------------------------------------
 
 template<unsigned nbits, unsigned rbits, typename bt>

--- a/include/sw/universal/number/takum/math/fma.hpp
+++ b/include/sw/universal/number/takum/math/fma.hpp
@@ -28,4 +28,17 @@ takum<nbits, rbits, bt> fma(const takum<nbits, rbits, bt>& a, const takum<nbits,
 	return takum<nbits, rbits, bt>(std::fma(double(a), double(b), double(c)));
 }
 
+// ---------------------------------------------------------------------------
+// takum_log: fused multiply-add.  The multiply is exact in the logarithmic
+// domain but the addition is not, so this follows the linear takum and fuses in
+// double, which is wider than any takum_log the codec supports up to 64 bits.
+// ---------------------------------------------------------------------------
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> fma(const takum_log<nbits, rbits, bt>& a,
+                                       const takum_log<nbits, rbits, bt>& b,
+                                       const takum_log<nbits, rbits, bt>& c) {
+	return takum_log<nbits, rbits, bt>(std::fma(double(a), double(b), double(c)));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/fractional.hpp
+++ b/include/sw/universal/number/takum/math/fractional.hpp
@@ -25,4 +25,26 @@ takum<nbits, rbits, bt> frac(const takum<nbits, rbits, bt>& x) {
 	return takum<nbits, rbits, bt>(double(x) - std::trunc(double(x)));
 }
 
+// ---------------------------------------------------------------------------
+// takum_log: remainder and modulus are linear-domain operations.
+// ---------------------------------------------------------------------------
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> fmod(const takum_log<nbits, rbits, bt>& x,
+                                        const takum_log<nbits, rbits, bt>& y) {
+	return takum_log<nbits, rbits, bt>(std::fmod(double(x), double(y)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> remainder(const takum_log<nbits, rbits, bt>& x,
+                                             const takum_log<nbits, rbits, bt>& y) {
+	return takum_log<nbits, rbits, bt>(std::remainder(double(x), double(y)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> frac(const takum_log<nbits, rbits, bt>& x) {
+	double v = double(x);
+	return takum_log<nbits, rbits, bt>(v - std::trunc(v));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/hyperbolic.hpp
+++ b/include/sw/universal/number/takum/math/hyperbolic.hpp
@@ -39,4 +39,38 @@ takum<nbits, rbits, bt> atanh(const takum<nbits, rbits, bt>& x) {
 	return takum<nbits, rbits, bt>(std::atanh(double(x)));
 }
 
+// ---------------------------------------------------------------------------
+// takum_log: hyperbolic functions are sums of exponentials, and the sum is the
+// linear-domain operation this representation is worst at, so no shortcut.
+// ---------------------------------------------------------------------------
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> sinh(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::sinh(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> cosh(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::cosh(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> tanh(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::tanh(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> asinh(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::asinh(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> acosh(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::acosh(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> atanh(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::atanh(double(x)));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/hypot.hpp
+++ b/include/sw/universal/number/takum/math/hypot.hpp
@@ -24,4 +24,14 @@ takum<nbits, rbits, bt> hypotl(const takum<nbits, rbits, bt>& x, const takum<nbi
 	return takum<nbits, rbits, bt>(std::hypotl((long double)(x), (long double)(y)));
 }
 
+// ---------------------------------------------------------------------------
+// takum_log
+// ---------------------------------------------------------------------------
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> hypot(const takum_log<nbits, rbits, bt>& x,
+                                         const takum_log<nbits, rbits, bt>& y) {
+	return takum_log<nbits, rbits, bt>(std::hypot(double(x), double(y)));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/logarithm.hpp
+++ b/include/sw/universal/number/takum/math/logarithm.hpp
@@ -6,6 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
 #include <cmath>
+#include <universal/number/takum/math/takum_log_domain.hpp>
 
 namespace sw { namespace universal {
 
@@ -29,6 +30,52 @@ takum<nbits, rbits, bt> log10(const takum<nbits, rbits, bt>& x) {
 template<unsigned nbits, unsigned rbits, typename bt>
 takum<nbits, rbits, bt> log1p(const takum<nbits, rbits, bt>& x) {
     return takum<nbits, rbits, bt>(std::log1p(double(x)));
+}
+
+// ---------------------------------------------------------------------------
+// takum_log
+// ---------------------------------------------------------------------------
+
+// |x| == sqrt(e)^l == e^(l/2), so the natural logarithm of the magnitude is
+// exactly l/2 and no libm call is needed to OBTAIN it.
+//
+// It is worth being precise about what that saves, because a logarithmic format
+// invites overclaiming: extracting the logarithm is free, but expressing the
+// answer back as a takum_log needs l' == 2*ln(l/2), which is another logarithm.
+// So this replaces two transcendental evaluations with one, and drops a rounding
+// -- a real but bounded gain, not the free lunch the representation suggests.
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> log(const takum_log<nbits, rbits, bt>& x) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (x.isnar() || x.sign()) { result.setnar(); return result; }  // log of a negative
+	if (x.iszero())            { result.setnar(); return result; }  // log(0) is -inf, unrepresentable
+	return TL(0.5 * to_double(to_log_value(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> log2(const takum_log<nbits, rbits, bt>& x) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (x.isnar() || x.sign() || x.iszero()) { result.setnar(); return result; }
+	// log2|x| == (l/2) / ln2
+	return TL(0.5 * to_double(to_log_value(x)) / 0.6931471805599453);
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> log10(const takum_log<nbits, rbits, bt>& x) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (x.isnar() || x.sign() || x.iszero()) { result.setnar(); return result; }
+	// log10|x| == (l/2) / ln10
+	return TL(0.5 * to_double(to_log_value(x)) / 2.302585092994046);
+}
+
+// log(1 + x) has no logarithmic-domain shortcut: the addition happens in the
+// linear domain, which is the operation this representation is worst at.
+template<unsigned nbits, unsigned rbits, typename bt>
+takum_log<nbits, rbits, bt> log1p(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::log1p(double(x)));
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/minmax.hpp
+++ b/include/sw/universal/number/takum/math/minmax.hpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
+#include <cmath>
 
 namespace sw { namespace universal {
 
@@ -16,6 +17,23 @@ takum<nbits, rbits, bt> min(const takum<nbits, rbits, bt>& x, const takum<nbits,
 template<unsigned nbits, unsigned rbits, typename bt>
 takum<nbits, rbits, bt> max(const takum<nbits, rbits, bt>& x, const takum<nbits, rbits, bt>& y) {
 	return (x < y) ? y : x;
+}
+
+// ---------------------------------------------------------------------------
+// takum_log: ordering is the shared encoding's, so these compare directly
+// rather than through a value conversion (Prop. 4).
+// ---------------------------------------------------------------------------
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> min(const takum_log<nbits, rbits, bt>& x,
+                                       const takum_log<nbits, rbits, bt>& y) {
+	return (x < y) ? x : y;
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> max(const takum_log<nbits, rbits, bt>& x,
+                                       const takum_log<nbits, rbits, bt>& y) {
+	return (x > y) ? x : y;
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/next.hpp
+++ b/include/sw/universal/number/takum/math/next.hpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
+#include <cmath>
 
 namespace sw { namespace universal {
 
@@ -22,6 +23,21 @@ takum<nbits, rbits, bt> nextafter(const takum<nbits, rbits, bt>& x, const takum<
 	else {
 		if (x > target) { --result; } else { ++result; }
 	}
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// takum_log: adjacent encodings are adjacent values (Prop. 4), so stepping is a
+// two's-complement increment rather than a value computation.
+// ---------------------------------------------------------------------------
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> nextafter(const takum_log<nbits, rbits, bt>& x,
+                                             const takum_log<nbits, rbits, bt>& target) {
+	takum_log<nbits, rbits, bt> result(x);
+	if (x.isnar() || target.isnar()) { result.setnar(); return result; }
+	if (x == target) return result;
+	if (x < target) ++result; else --result;
 	return result;
 }
 

--- a/include/sw/universal/number/takum/math/pow.hpp
+++ b/include/sw/universal/number/takum/math/pow.hpp
@@ -6,6 +6,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
 #include <cmath>
+#include <cstdint>
+#include <universal/number/takum/math/takum_log_domain.hpp>
 
 namespace sw { namespace universal {
 
@@ -22,6 +24,62 @@ takum<nbits, rbits, bt> pow(const takum<nbits, rbits, bt>& x, int y) {
 template<unsigned nbits, unsigned rbits, typename bt>
 takum<nbits, rbits, bt> pow(const takum<nbits, rbits, bt>& x, double y) {
 	return takum<nbits, rbits, bt>(std::pow(double(x), y));
+}
+
+// ---------------------------------------------------------------------------
+// takum_log
+// ---------------------------------------------------------------------------
+
+// An integer power scales the logarithmic value: |x^n| == sqrt(e)^(n*l).  The
+// scaling is exact whenever the products fit, so this rounds once rather than
+// three times, and unlike std::pow it never routes the intermediate through a
+// double.  Falls back to the real-valued path when n*l would overflow int64.
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> pow(const takum_log<nbits, rbits, bt>& x, int n) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (x.isnar()) { result.setnar(); return result; }
+	if (n == 0) return TL(1.0);                       // x^0 == 1, including 0^0 by convention
+	if (x.iszero()) {
+		if (n > 0) return x;                          // 0^n == 0
+		result.setnar(); return result;               // 0^-n has no value
+	}
+	// A negative base is real only for an integer exponent, and the sign of the
+	// result is the parity of that exponent.
+	const bool negative = x.sign() && ((n & 1) != 0);
+
+	auto l = to_log_value(x);
+	// l scaled by n, exactly: n*(c + N/2^q) == n*c + n*N/2^q, then renormalize the
+	// fraction back into [0,1) by folding its integer part into the characteristic.
+	const int64_t  a  = (n < 0) ? -static_cast<int64_t>(n) : static_cast<int64_t>(n);
+	const uint64_t ua = static_cast<uint64_t>(a);
+	// guard the two products before forming them
+	const uint64_t den = (l.q > 0) ? (1ull << l.q) : 1ull;
+	if (ua != 0 && (l.N > (~0ull) / ua)) {
+		return TL(std::pow(double(x), double(n)));    // fraction product would wrap
+	}
+	const int64_t  cmag = (l.c < 0) ? -l.c : l.c;
+	if (cmag != 0 && a > (INT64_MAX - 1) / cmag) {
+		return TL(std::pow(double(x), double(n)));    // characteristic product would wrap
+	}
+	uint64_t Nn   = l.N * ua;
+	int64_t  cn   = l.c * a;
+	if (l.q > 0) { cn += static_cast<int64_t>(Nn / den); Nn = Nn % den; }
+	takum_log_value scaled{ cn, Nn, l.q };
+	if (n < 0) scaled = negate(scaled);
+	return from_log_value<TL>(scaled, negative);
+}
+
+// General real exponent: no shortcut exists, so this is the double round trip.
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> pow(const takum_log<nbits, rbits, bt>& x,
+                                       const takum_log<nbits, rbits, bt>& y) {
+	return takum_log<nbits, rbits, bt>(std::pow(double(x), double(y)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> pow(const takum_log<nbits, rbits, bt>& x, double y) {
+	return takum_log<nbits, rbits, bt>(std::pow(double(x), y));
 }
 
 // Exact integer power via repeated squaring; no double round-trip.

--- a/include/sw/universal/number/takum/math/sqrt.hpp
+++ b/include/sw/universal/number/takum/math/sqrt.hpp
@@ -6,6 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
 #include <cmath>
+#include <universal/number/takum/math/takum_log_domain.hpp>
 
 namespace sw { namespace universal {
 
@@ -14,6 +15,49 @@ template<unsigned nbits, unsigned rbits, typename bt>
 inline takum<nbits, rbits, bt> rsqrt(const takum<nbits, rbits, bt>& a) {
 	takum<nbits, rbits, bt> v = sqrt(a);
 	return takum<nbits, rbits, bt>(1.0) / v;
+}
+
+// ---------------------------------------------------------------------------
+// takum_log: sqrt is a halving of the logarithmic value
+// ---------------------------------------------------------------------------
+
+// |value| == sqrt(e)^l, so the square root is sqrt(e)^(l/2).  Halving l is exact
+// in the logarithmic domain, which leaves exactly one rounding -- the one the
+// target layout forces -- against the three a decode / std::sqrt / encode round
+// trip incurs, and it is not capped at a double's 53 significand bits.
+//
+// Whenever the target layout has a spare fraction bit for the half that an odd
+// characteristic contributes, the result is EXACT.
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> sqrt(const takum_log<nbits, rbits, bt>& a) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (a.isnar()) { result.setnar(); return result; }
+	if (a.iszero()) return a;               // sqrt(0) == 0
+	if (a.sign())  { result.setnar(); return result; }   // sqrt of a negative is NaR
+	return from_log_value<TL>(halve(to_log_value(a)), false);
+}
+
+// Reciprocal square root: negate the halved logarithmic value.  Both steps are
+// exact, so this does not compound the way 1/sqrt(x) would.
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> rsqrt(const takum_log<nbits, rbits, bt>& a) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (a.isnar()) { result.setnar(); return result; }
+	if (a.iszero()) { result.setnar(); return result; }  // 1/sqrt(0) has no value
+	if (a.sign())  { result.setnar(); return result; }
+	return from_log_value<TL>(negate(halve(to_log_value(a))), false);
+}
+
+// The square, sqrt(e)^(2l).  Doubling l is exact, so squaring rounds at most once.
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> sqr(const takum_log<nbits, rbits, bt>& a) {
+	using TL = takum_log<nbits, rbits, bt>;
+	TL result;
+	if (a.isnar()) { result.setnar(); return result; }
+	if (a.iszero()) return a;
+	return from_log_value<TL>(twice(to_log_value(a)), false);   // a square is positive
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/takum_log_domain.hpp
+++ b/include/sw/universal/number/takum/math/takum_log_domain.hpp
@@ -1,0 +1,93 @@
+// takum_log_domain.hpp: exact logarithmic-domain arithmetic for takum_log
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// A logarithmic takum stores |value| = sqrt(e)^l, with l == c + m recovered
+// exactly from the encoding as an integer characteristic c and a p-bit fraction.
+// Functions that act on l by a rational factor -- sqrt halves it, squaring
+// doubles it, an integer power scales it -- are therefore exact in this domain,
+// and the only error left is the single rounding the target layout forces.
+//
+// The alternative, and what the linear takum's math library does, is to round
+// trip through a double: decode, call the libm function, re-encode.  That path
+// rounds three times and is capped at a double's 53 significand bits, while
+// takum_log<64,3> reaches p = 59.  Staying in the logarithmic domain avoids
+// both problems.
+//
+// The fraction is carried as an integer pair (N, q) meaning N / 2^q rather than
+// as a double, for the same reason: halving l produces a fraction one bit wider
+// than the source layout holds, so at p = 59 a double would discard the low bits
+// before any rounding decision was made.
+#pragma once
+#include <cstdint>
+
+namespace sw { namespace universal {
+
+// An exact logarithmic value l == c + N / 2^q, with N < 2^q.
+struct takum_log_value {
+	int64_t  c;   // characteristic, in powers of the value base sqrt(e)
+	uint64_t N;   // fraction numerator
+	unsigned q;   // fraction denominator exponent
+};
+
+// Recover the exact logarithmic value of a magnitude.
+// Pre: the caller has handled zero and NaR, which have no logarithmic value.
+template<typename TakumLog>
+constexpr takum_log_value to_log_value(const TakumLog& x) noexcept {
+	auto d = TakumLog::Codec::decode(x.magnitude_bits());
+	return takum_log_value{ d.c, d.M_bits, d.p };
+}
+
+// l / 2, exactly.  An odd characteristic contributes a half to the fraction,
+// which is why the result needs one more fraction bit than the source.
+constexpr takum_log_value halve(const takum_log_value& l) noexcept {
+	// floor division, so that a negative odd c borrows rather than truncating
+	int64_t  c2 = (l.c >= 0) ? (l.c / 2) : -(((-l.c) + 1) / 2);
+	uint64_t r  = static_cast<uint64_t>(l.c - 2 * c2);          // 0 or 1
+	return takum_log_value{ c2, (r << l.q) + l.N, l.q + 1 };
+}
+
+// l * 2, exactly.  Doubling the fraction can carry into the characteristic.
+constexpr takum_log_value twice(const takum_log_value& l) noexcept {
+	uint64_t N2 = l.N << 1;
+	int64_t  c2 = 2 * l.c;
+	if (l.q > 0 && N2 >= (1ull << l.q)) { N2 -= (1ull << l.q); ++c2; }
+	return takum_log_value{ c2, N2, l.q };
+}
+
+// Negate l, i.e. take the reciprocal of the value.  Exact.
+constexpr takum_log_value negate(const takum_log_value& l) noexcept {
+	if (l.N == 0) return takum_log_value{ -l.c, 0ull, l.q };
+	// -(c + N/2^q) == -(c+1) + (2^q - N)/2^q
+	return takum_log_value{ -l.c - 1, (1ull << l.q) - l.N, l.q };
+}
+
+// l as a real, for the paths that must leave the exact domain.
+constexpr double to_double(const takum_log_value& l) noexcept {
+	if (l.q == 0) return static_cast<double>(l.c);
+	return static_cast<double>(l.c) + static_cast<double>(l.N) / static_cast<double>(1ull << l.q);
+}
+
+// Build a takum_log whose magnitude is sqrt(e)^l, with the requested sign.
+// Saturation follows the type's own conventions: overflow to maxpos/maxneg,
+// underflow to zero, exactly as conversion from a native float does.
+template<typename TakumLog>
+inline TakumLog from_log_value(const takum_log_value& l, bool negative) noexcept {
+	using Codec = typename TakumLog::Codec;
+	TakumLog result;
+	auto enc = Codec::encode_fraction(l.c, l.N, l.q);
+	if (enc.overflowed()) {
+		if (negative) result.maxneg(); else result.maxpos();
+		return result;
+	}
+	if (enc.underflowed()) { result.setzero(); return result; }
+	// the codec never sets the sign bit (I4); negate in two's complement here
+	uint64_t raw = negative ? (((~enc.magnitude) + 1ull) & Codec::nbits_mask()) : enc.magnitude;
+	result.setbits(raw);
+	return result;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/trigonometry.hpp
+++ b/include/sw/universal/number/takum/math/trigonometry.hpp
@@ -61,4 +61,59 @@ takum<nbits, rbits, bt> csc(const takum<nbits, rbits, bt>& x) {
     return takum<nbits, rbits, bt>(1.0 / std::sin(double(x)));
 }
 
+// ---------------------------------------------------------------------------
+// takum_log: the circular functions have no logarithmic-domain form; they are
+// evaluated as reals.  Kept here so takum_log is a complete plug-in type.
+// ---------------------------------------------------------------------------
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> sin(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::sin(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> cos(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::cos(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> tan(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::tan(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> asin(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::asin(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> acos(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::acos(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> atan(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::atan(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> atan2(const takum_log<nbits, rbits, bt>& y,
+                                         const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::atan2(double(y), double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> sec(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(1.0 / std::cos(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> csc(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(1.0 / std::sin(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> cot(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(1.0 / std::tan(double(x)));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/math/truncate.hpp
+++ b/include/sw/universal/number/takum/math/truncate.hpp
@@ -33,4 +33,28 @@ takum<nbits, rbits, bt> ceil(const takum<nbits, rbits, bt>& x) {
 	return takum<nbits, rbits, bt>(std::ceil(double(x)));
 }
 
+// ---------------------------------------------------------------------------
+// takum_log: rounding to an integer is a linear-domain operation with no
+// logarithmic shortcut, so these evaluate the value and re-encode.
+// ---------------------------------------------------------------------------
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> trunc(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::trunc(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> round(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::round(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> floor(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::floor(double(x)));
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+inline takum_log<nbits, rbits, bt> ceil(const takum_log<nbits, rbits, bt>& x) {
+	return takum_log<nbits, rbits, bt>(std::ceil(double(x)));
+}
+
 }} // namespace sw::universal

--- a/include/sw/universal/number/takum/takum_codec.hpp
+++ b/include/sw/universal/number/takum/takum_codec.hpp
@@ -346,6 +346,95 @@ struct takum_codec {
 		return encoded{ pack(dr, C_stored, M_bits, g), takum_encode_status::ok };
 	}
 
+	// Assemble a magnitude from a characteristic and an EXACT binary fraction N/2^q,
+	// rounding to nearest-even.  The third encode entry point, and the one the
+	// logarithmic takum's math library runs on.
+	//
+	// encode_rounded() takes the fraction as a double, which caps it at 53
+	// significant bits.  That is enough when the fraction comes from an IEEE
+	// significand, but not for arithmetic in the logarithmic domain: halving a
+	// logarithmic value to take a square root produces a fraction one bit WIDER than
+	// the source layout carries, and takum_log<64,3> already reaches p = 59.  Routing
+	// that through a double would discard the low bits before rounding ever happened.
+	// Carrying (N, q) as integers keeps the operation exact at every width, so the
+	// result is off by at most the single rounding the target layout forces.
+	//
+	// Pre: q < 64 and N < 2^q, i.e. a proper binary fraction.
+	// Post: I4; status == ok implies the result is the round-to-nearest-even encoding
+	//       of c + N/2^q.
+	static constexpr encoded encode_fraction(int64_t c, uint64_t N, unsigned q) noexcept {
+		if (c > max_characteristic()) return encoded{ magnitude_mask(), takum_encode_status::overflow };
+		if (c < min_characteristic()) return encoded{ 0ull, takum_encode_status::underflow };
+
+		unsigned dr = find_dr(c);
+		field_layout g = layout_of(dr);
+
+		uint64_t C_full   = static_cast<uint64_t>(c - dr_to_c_bias(dr));
+		uint64_t C_stored = C_full;
+		uint64_t dropped  = 0;      // characteristic bits the layout cannot store
+		uint64_t step_half = 0;     // half a stored step, in characteristic units
+		if (g.r > maxCharBits) {
+			unsigned shift = g.r - g.c_stored_bits;
+			C_stored  = C_full >> shift;
+			dropped   = C_full & ((1ull << shift) - 1ull);
+			step_half = 1ull << (shift - 1);
+		}
+
+		if (g.p == 0) {
+			// Round the characteristic, weighing the dropped bits and the fraction
+			// together exactly as encode_rounded() does.  Every comparison stays in
+			// integers: the residual is dropped + N/2^q against a threshold of either
+			// step_half or 1/2, and neither product is ever formed.
+			bool round_up;
+			if (g.r > maxCharBits) {
+				round_up = (dropped > step_half)
+				        || (dropped == step_half && (N > 0 || (C_stored & 1ull)));
+			}
+			else {
+				uint64_t half = (q > 0) ? (1ull << (q - 1)) : 0ull;
+				round_up = (q > 0) && (N > half || (N == half && (C_stored & 1ull)));
+			}
+			if (round_up) {
+				++C_stored;
+				if (C_stored >= (1ull << g.c_stored_bits)) {
+					if (dr + 1 >= nr_dr_values) return encoded{ magnitude_mask(), takum_encode_status::overflow };
+					++dr;
+					g = layout_of(dr);
+					C_stored = 0;
+				}
+			}
+			return encoded{ pack(dr, C_stored, 0ull, g), takum_encode_status::ok };
+		}
+
+		// Rescale N/2^q onto the layout's p bits.  Widening is exact; narrowing is the
+		// one place a value can be lost, and it rounds to nearest-even.
+		uint64_t M_bits = 0;
+		if (g.p >= q) {
+			M_bits = N << (g.p - q);
+		}
+		else {
+			unsigned s   = q - g.p;
+			M_bits       = N >> s;
+			uint64_t rem = N & ((1ull << s) - 1ull);
+			uint64_t half = 1ull << (s - 1);
+			if (rem > half || (rem == half && (M_bits & 1ull))) ++M_bits;
+			if (M_bits >= (1ull << g.p)) {
+				// Carry out of the trailing field into the characteristic.
+				M_bits = 0;
+				++C_stored;
+				if (C_stored >= (1ull << g.c_stored_bits)) {
+					if (dr + 1 >= nr_dr_values) return encoded{ magnitude_mask(), takum_encode_status::overflow };
+					++dr;
+					g = layout_of(dr);
+					C_stored = 0;
+					return encoded{ pack(dr, 0ull, 0ull, g), takum_encode_status::ok };
+				}
+			}
+		}
+
+		return encoded{ pack(dr, C_stored, M_bits, g), takum_encode_status::ok };
+	}
+
 private:
 	// Stateless: the codec is a namespace of static constexpr members, never an
 	// object.  Deleting the default constructor makes that intent a compile error

--- a/static/tapered/takum_log/math/mathlib.cpp
+++ b/static/tapered/takum_log/math/mathlib.cpp
@@ -1,0 +1,419 @@
+// mathlib.cpp: elementary function verification for the logarithmic takum
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// takum_log stores |value| = sqrt(e)^l.  Functions that act on l by a rational
+// factor are exact in that domain, and this suite pins which ones are and what
+// that buys:
+//
+//   sqrt   l/2      exact, then one rounding
+//   sqr    2l       exact, then one rounding
+//   rsqrt  -l/2     exact, then one rounding
+//   pow    n*l      exact for integer n, then one rounding
+//   1/x    -l       exact, no rounding at all (Prop. 7)
+//
+// The alternative is a decode / libm / encode round trip, which rounds three
+// times and cannot carry more than a double's 53 significand bits.  That ceiling
+// is not hypothetical: takum_log<64,3> reaches p = 59, and the round trip is
+// then wrong for essentially every input.  VerifyCorrectlyRoundedSqrt measures
+// exactly that, against an oracle built from exact integer arithmetic.
+//
+// The transcendental functions have no such shortcut and are evaluated as reals;
+// they are checked for agreement with libm rather than for exactness.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstdint>
+#include <universal/number/takum/takum_log.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// The exactness properties.  These are the reason the specializations exist.
+// ---------------------------------------------------------------------------
+
+// sqrt(x)^2 == x whenever the halving and doubling both land exactly, and
+// sqrt is always within one ulp of the encoding otherwise.
+template<unsigned nbits, unsigned rbits>
+int VerifySqrtRoundTrip(bool reportTestCases, uint64_t stride = 1) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	const uint64_t limit = 1ull << (nbits - 1);
+	for (uint64_t b = 1; b < limit; b += stride) {
+		TL x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+		TL r = sqrt(x);
+		if (r.isnar() || r.iszero()) continue;
+		TL back = sqr(r);
+		// squaring the root must return to within one encoding step
+		int64_t d = static_cast<int64_t>(back.magnitude_bits()) - static_cast<int64_t>(x.magnitude_bits());
+		if (d < -1 || d > 1) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL sqr(sqrt(x)) bits=" << b << " -> " << back.magnitude_bits()
+				          << " (off by " << d << ")\n";
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// The reciprocal is exact (Prop. 7), so rsqrt must equal the reciprocal of sqrt
+// whenever that reciprocal is itself representable.
+template<unsigned nbits, unsigned rbits>
+int VerifyRsqrt(bool reportTestCases, uint64_t stride = 1) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	const uint64_t limit = 1ull << (nbits - 1);
+	for (uint64_t b = 1; b < limit; b += stride) {
+		TL x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+		TL r = sqrt(x);
+		if (r.isnar() || r.iszero()) continue;
+		TL want = r.reciprocal();
+		TL got  = rsqrt(x);
+		if (want.isnar()) continue;
+		if (got.raw_bits() != want.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL rsqrt bits=" << b << " got=" << got.raw_bits()
+				          << " want=" << want.raw_bits() << '\n';
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// pow(x, n) must agree with repeated multiplication in the logarithmic domain.
+// Checked against sqr for n == 2 and against the reciprocal for n == -1, both of
+// which are independently exact.
+template<unsigned nbits, unsigned rbits>
+int VerifyIntegerPow(bool reportTestCases, uint64_t stride = 1) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	const uint64_t limit = 1ull << (nbits - 1);
+	for (uint64_t b = 1; b < limit; b += stride) {
+		TL x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+
+		TL p1 = pow(x, 1);
+		if (p1.raw_bits() != x.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL pow(x,1) != x at bits=" << b << '\n';
+		}
+		TL p2 = pow(x, 2), s = sqr(x);
+		if (!p2.isnar() && !s.isnar() && p2.raw_bits() != s.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL pow(x,2) != sqr(x) at bits=" << b
+				          << " " << p2.raw_bits() << " vs " << s.raw_bits() << '\n';
+			}
+		}
+		TL pm1 = pow(x, -1), inv = x.reciprocal();
+		if (!pm1.isnar() && !inv.isnar() && pm1.raw_bits() != inv.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL pow(x,-1) != reciprocal at bits=" << b
+				          << " " << pm1.raw_bits() << " vs " << inv.raw_bits() << '\n';
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// The headline property: sqrt is CORRECTLY ROUNDED at every width.
+//
+// The correctly rounded square root is the representable encoding whose
+// logarithmic value l' lies nearest to l/2.  Both are exact binary fractions, so
+// the comparison is done in exact integers over a common denominator -- no
+// double or long double is involved, which matters because the whole point is
+// that those are too narrow above p = 53.
+template<unsigned nbits, unsigned rbits>
+int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
+	using TL    = sw::universal::takum_log<nbits, rbits, std::uint64_t>;
+	using Codec = typename TL::Codec;
+	int nrOfFailedTests = 0;
+	const uint64_t span = (1ull << (nbits - 1)) - 1;
+
+	for (uint64_t b = 1; b < span; b += stride) {
+		TL x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+		auto d = Codec::decode(b);
+		TL got = sqrt(x);
+		if (got.iszero() || got.isnar()) continue;
+		uint64_t gm = got.magnitude_bits();
+
+		// l/2 == (c*2^p + M) / 2^(p+1); a candidate l' == (c'*2^p' + M') / 2^p'.
+		// Scale both to a common denominator 2^Q and compare numerators.  The
+		// widths involved keep every product inside 64 bits for the configurations
+		// this suite runs, which the guard below enforces rather than assumes.
+		unsigned Q = d.p + 1;
+		const int64_t lo = (static_cast<int64_t>(gm) > 2) ? static_cast<int64_t>(gm) - 2 : 1;
+		const int64_t hi = static_cast<int64_t>(gm) + 2;
+		for (int64_t m = lo; m <= hi; ++m) {
+			if (m < 1 || static_cast<uint64_t>(m) > span) continue;
+			auto e = Codec::decode(static_cast<uint64_t>(m));
+			if (e.p > Q) Q = e.p;
+		}
+		if (Q > 60) continue;   // outside the exact-integer window; not reached here
+
+		// A value c + M/2^p is the fraction (c*2^p + M) / 2^p.  Halving it keeps the
+		// SAME numerator and moves the denominator to 2^(p+1) -- scaling c by 2^(p+1)
+		// instead is the easy mistake, and it silently compares against a different
+		// number.  Numerator and denominator exponent are therefore passed separately.
+		auto scaled = [&](int64_t num, unsigned dexp) -> int64_t {
+			return num * static_cast<int64_t>(1ull << (Q - dexp));
+		};
+		const int64_t half_num = d.c * static_cast<int64_t>(1ull << d.p) + static_cast<int64_t>(d.M_bits);
+		const int64_t half     = scaled(half_num, d.p + 1);
+
+		int64_t best = 0; bool have = false; int64_t mine = 0;
+		for (int64_t m = lo; m <= hi; ++m) {
+			if (m < 1 || static_cast<uint64_t>(m) > span) continue;
+			auto e = Codec::decode(static_cast<uint64_t>(m));
+			int64_t cand_num = e.c * static_cast<int64_t>(1ull << e.p) + static_cast<int64_t>(e.M_bits);
+			int64_t diff = scaled(cand_num, e.p) - half;
+			if (diff < 0) diff = -diff;
+			if (!have || diff < best) { best = diff; have = true; }
+			if (static_cast<uint64_t>(m) == gm) mine = diff;
+		}
+		if (have && mine != best) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL sqrt not correctly rounded at bits=" << b
+				          << " distance=" << mine << " best=" << best << '\n';
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// ---------------------------------------------------------------------------
+// The transcendental surface: no shortcut, so check agreement with libm.
+// ---------------------------------------------------------------------------
+
+template<unsigned nbits, unsigned rbits>
+int VerifyElementaryAgreement(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+
+	// A relative tolerance a little looser than the format's own resolution: the
+	// point is that the function was evaluated, not that it beat the encoding.
+	const double tol = 1e-3;
+	auto check = [&](const char* name, double got, double want) {
+		double err = (want == 0.0) ? std::fabs(got) : std::fabs((got - want) / want);
+		if (!(err < tol)) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL " << name << " got=" << got << " want=" << want
+				          << " relerr=" << err << '\n';
+			}
+		}
+	};
+
+	// The reference is the function applied to the value the type actually STORES,
+	// not to the literal it was built from.  takum_log represents no integer
+	// exactly -- an integer k is sqrt(e)^l only for irrational l -- so
+	// takum_log<32,3>(3) holds 2.99999999, and floor of it is honestly 2.  Using
+	// the literal as the reference would score correct results as failures for
+	// every rounding function.
+	for (double v : { 0.125, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 7.0 }) {
+		TL x(v);
+		const double s = double(x);   // the stored value
+		check("sin",   double(sin(x)),   std::sin(s));
+		check("cos",   double(cos(x)),   std::cos(s));
+		check("tan",   double(tan(x)),   std::tan(s));
+		check("sinh",  double(sinh(x)),  std::sinh(s));
+		check("cosh",  double(cosh(x)),  std::cosh(s));
+		check("tanh",  double(tanh(x)),  std::tanh(s));
+		check("exp",   double(exp(x)),   std::exp(s));
+		check("exp2",  double(exp2(x)),  std::exp2(s));
+		check("log",   double(log(x)),   std::log(s));
+		check("log2",  double(log2(x)),  std::log2(s));
+		check("log10", double(log10(x)), std::log10(s));
+		check("erf",   double(erf(x)),   std::erf(s));
+		check("sqrt",  double(sqrt(x)),  std::sqrt(s));
+		check("trunc", double(trunc(x)), std::trunc(s));
+		check("floor", double(floor(x)), std::floor(s));
+		check("ceil",  double(ceil(x)),  std::ceil(s));
+	}
+	for (double v : { 0.25, 0.5, 0.75 }) {
+		TL x(v);
+		const double s = double(x);
+		check("asin",  double(asin(x)),  std::asin(s));
+		check("acos",  double(acos(x)),  std::acos(s));
+		check("atan",  double(atan(x)),  std::atan(s));
+		check("atanh", double(atanh(x)), std::atanh(s));
+	}
+	{
+		TL a(3.0), b(4.0), c(0.5);
+		check("hypot", double(hypot(a, b)), std::hypot(double(a), double(b)));
+		check("fma",   double(fma(a, b, c)), std::fma(double(a), double(b), double(c)));
+		check("fmod",  double(fmod(TL(7.0), TL(3.0))), std::fmod(double(TL(7.0)), double(TL(3.0))));
+		check("atan2", double(atan2(a, b)), std::atan2(double(a), double(b)));
+		check("pow",   double(pow(a, b)),   std::pow(double(a), double(b)));
+	}
+	return nrOfFailedTests;
+}
+
+// Special values must propagate rather than produce a wrong number.
+template<unsigned nbits, unsigned rbits>
+int VerifySpecialValues(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	TL nar; nar.setnar();
+	TL zero(0.0), neg(-4.0), one(1.0);
+
+	auto expect_nar = [&](const char* what, const TL& v) {
+		if (!v.isnar()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL " << what << " should be NaR, got " << double(v) << '\n';
+		}
+	};
+	auto expect_zero = [&](const char* what, const TL& v) {
+		if (!v.iszero()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL " << what << " should be zero, got " << double(v) << '\n';
+		}
+	};
+
+	expect_nar("sqrt(NaR)",   sqrt(nar));
+	expect_nar("sqrt(-4)",    sqrt(neg));
+	expect_zero("sqrt(0)",    sqrt(zero));
+	expect_nar("rsqrt(0)",    rsqrt(zero));
+	expect_nar("rsqrt(-4)",   rsqrt(neg));
+	expect_nar("log(0)",      log(zero));
+	expect_nar("log(-4)",     log(neg));
+	expect_nar("log2(-4)",    log2(neg));
+	expect_nar("log10(0)",    log10(zero));
+	expect_nar("exp(NaR)",    exp(nar));
+	expect_nar("pow(0,-1)",   pow(zero, -1));
+	expect_zero("pow(0,3)",   pow(zero, 3));
+	expect_nar("sqr(NaR)",    sqr(nar));
+
+	// pow(x, 0) is 1 for every finite x, including zero
+	if (double(pow(zero, 0)) != 1.0 || double(pow(neg, 0)) != 1.0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL pow(x,0) should be 1\n";
+	}
+	// a negative base keeps its sign only for an odd exponent
+	if (!(double(pow(neg, 3)) < 0.0) || !(double(pow(neg, 2)) > 0.0)) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL pow sign parity for a negative base\n";
+	}
+	// exp(0) == 1
+	if (double(exp(zero)) != 1.0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL exp(0) should be 1\n";
+	}
+	// classification
+	if (!isnan(nar) || isfinite(nar) || !isfinite(one) || isnormal(zero) || !isnormal(one)) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL classification of special values\n";
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "takum_log elementary function verification";
+	std::string test_tag    = "mathlib";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRoundedSqrt<16, 3>(true), "takum_log<16,3>", "sqrt correctly rounded");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecialValues<16, 3>(reportTestCases), "takum_log<16,3>", "special values");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyElementaryAgreement<32, 3>(reportTestCases), "takum_log<32,3>", "libm agreement");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRoundedSqrt<16, 3>(reportTestCases), "takum_log<16,3>", "sqrt correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySqrtRoundTrip<16, 3>(reportTestCases), "takum_log<16,3>", "sqr(sqrt(x)) round-trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRsqrt<16, 3>(reportTestCases), "takum_log<16,3>", "rsqrt == 1/sqrt exactly");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIntegerPow<16, 3>(reportTestCases), "takum_log<16,3>", "integer pow identities");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecialValues<12, 3>(reportTestCases), "takum_log<12,3>", "special values");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRoundedSqrt<12, 3>(reportTestCases), "takum_log<12,3>", "sqrt correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRoundedSqrt<20, 3>(reportTestCases), "takum_log<20,3>", "sqrt correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIntegerPow<20, 3>(reportTestCases), "takum_log<20,3>", "integer pow identities");
+#endif
+
+	// Levels 3 and 4 reach the widths where a double round trip would fail: at
+	// nbits = 64 the trailing field runs to p = 59, past a double's 53 bits, and
+	// the exact-integer oracle is the only way to check the result at all.
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRoundedSqrt<32, 3>(reportTestCases, 4093ull), "takum_log<32,3>", "sqrt correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRsqrt<24, 3>(reportTestCases, 7ull), "takum_log<24,3>", "rsqrt == 1/sqrt exactly");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIntegerPow<24, 3>(reportTestCases, 7ull), "takum_log<24,3>", "integer pow identities");
+#endif
+
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySqrtRoundTrip<32, 3>(reportTestCases, 1031ull), "takum_log<32,3>", "sqr(sqrt(x)) round-trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIntegerPow<32, 3>(reportTestCases, 1031ull), "takum_log<32,3>", "integer pow identities");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/takum_log/math/mathlib.cpp
+++ b/static/tapered/takum_log/math/mathlib.cpp
@@ -131,16 +131,39 @@ int VerifyIntegerPow(bool reportTestCases, uint64_t stride = 1) {
 //
 // The correctly rounded square root is the representable encoding whose
 // logarithmic value l' lies nearest to l/2.  Both are exact binary fractions, so
-// the comparison is done in exact integers over a common denominator -- no
-// double or long double is involved, which matters because the whole point is
-// that those are too narrow above p = 53.
+// the comparison is done in exact integers -- no double or long double, because
+// the whole point is that those are too narrow above p = 53.
+//
+// The intermediates need more than 64 bits at the widest layouts: takum_log<64,3>
+// reaches p = 59, and a numerator scaled to a common denominator of 2^60 does not
+// fit an int64_t.  __int128 is used where the compiler has it, following
+// blockbinary and blocktype/carry.hpp.  Where it does not (MSVC), the wide
+// configurations are SKIPPED rather than silently passing, and the caller is told
+// so -- an oracle that quietly evaluates nothing is worse than no oracle.
+#if defined(__SIZEOF_INT128__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+using sqrt_oracle_int = __int128;
+#pragma GCC diagnostic pop
+#define TAKUM_LOG_HAVE_WIDE_ORACLE 1
+#else
+using sqrt_oracle_int = int64_t;
+#define TAKUM_LOG_HAVE_WIDE_ORACLE 0
+#endif
+
 template<unsigned nbits, unsigned rbits>
 int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 	using TL    = sw::universal::takum_log<nbits, rbits, std::uint64_t>;
 	using Codec = typename TL::Codec;
+	using wide  = sqrt_oracle_int;
 	int nrOfFailedTests = 0;
 	const uint64_t span = (1ull << (nbits - 1)) - 1;
 
+	// Widest common denominator this oracle can carry exactly.  A numerator is
+	// c * 2^Q + M with |c| < 2^32, so Q + 32 must stay inside the integer type.
+	const unsigned width_limit = (sizeof(wide) >= 16) ? 90u : 60u;
+
+	long exercised = 0, skipped = 0;
 	for (uint64_t b = 1; b < span; b += stride) {
 		TL x; x.setbits(b);
 		if (x.iszero() || x.isnar()) continue;
@@ -150,9 +173,7 @@ int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 		uint64_t gm = got.magnitude_bits();
 
 		// l/2 == (c*2^p + M) / 2^(p+1); a candidate l' == (c'*2^p' + M') / 2^p'.
-		// Scale both to a common denominator 2^Q and compare numerators.  The
-		// widths involved keep every product inside 64 bits for the configurations
-		// this suite runs, which the guard below enforces rather than assumes.
+		// Scale both to a common denominator 2^Q and compare numerators.
 		unsigned Q = d.p + 1;
 		const int64_t lo = (static_cast<int64_t>(gm) > 2) ? static_cast<int64_t>(gm) - 2 : 1;
 		const int64_t hi = static_cast<int64_t>(gm) + 2;
@@ -161,35 +182,47 @@ int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 			auto e = Codec::decode(static_cast<uint64_t>(m));
 			if (e.p > Q) Q = e.p;
 		}
-		if (Q > 60) continue;   // outside the exact-integer window; not reached here
+		if (Q > width_limit) { ++skipped; continue; }
 
 		// A value c + M/2^p is the fraction (c*2^p + M) / 2^p.  Halving it keeps the
 		// SAME numerator and moves the denominator to 2^(p+1) -- scaling c by 2^(p+1)
 		// instead is the easy mistake, and it silently compares against a different
 		// number.  Numerator and denominator exponent are therefore passed separately.
-		auto scaled = [&](int64_t num, unsigned dexp) -> int64_t {
-			return num * static_cast<int64_t>(1ull << (Q - dexp));
+		auto scaled = [&](wide num, unsigned dexp) -> wide {
+			return num * (static_cast<wide>(1) << (Q - dexp));
 		};
-		const int64_t half_num = d.c * static_cast<int64_t>(1ull << d.p) + static_cast<int64_t>(d.M_bits);
-		const int64_t half     = scaled(half_num, d.p + 1);
+		const wide half_num = static_cast<wide>(d.c) * (static_cast<wide>(1) << d.p)
+		                    + static_cast<wide>(d.M_bits);
+		const wide half     = scaled(half_num, d.p + 1);
 
-		int64_t best = 0; bool have = false; int64_t mine = 0;
+		wide best = 0; bool have = false; wide mine = 0;
 		for (int64_t m = lo; m <= hi; ++m) {
 			if (m < 1 || static_cast<uint64_t>(m) > span) continue;
 			auto e = Codec::decode(static_cast<uint64_t>(m));
-			int64_t cand_num = e.c * static_cast<int64_t>(1ull << e.p) + static_cast<int64_t>(e.M_bits);
-			int64_t diff = scaled(cand_num, e.p) - half;
+			wide cand_num = static_cast<wide>(e.c) * (static_cast<wide>(1) << e.p)
+			              + static_cast<wide>(e.M_bits);
+			wide diff = scaled(cand_num, e.p) - half;
 			if (diff < 0) diff = -diff;
 			if (!have || diff < best) { best = diff; have = true; }
 			if (static_cast<uint64_t>(m) == gm) mine = diff;
 		}
+		++exercised;
 		if (have && mine != best) {
 			++nrOfFailedTests;
 			if (reportTestCases) {
-				std::cout << "FAIL sqrt not correctly rounded at bits=" << b
-				          << " distance=" << mine << " best=" << best << '\n';
+				std::cout << "FAIL sqrt not correctly rounded at bits=" << b << '\n';
 			}
 		}
+	}
+	// A run that compared nothing must not report success.
+	if (exercised == 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) {
+			std::cout << "FAIL oracle evaluated no inputs (" << skipped << " skipped for width)\n";
+		}
+	}
+	else if (skipped > 0 && reportTestCases) {
+		std::cout << "note: " << skipped << " inputs skipped, oracle width limit " << width_limit << '\n';
 	}
 	return nrOfFailedTests;
 }
@@ -312,6 +345,25 @@ int VerifySpecialValues(bool reportTestCases) {
 		++nrOfFailedTests;
 		if (reportTestCases) std::cout << "FAIL exp(0) should be 1\n";
 	}
+	// exp saturates in the right DIRECTION at the extremes.  The result's
+	// logarithmic value is 2x, which tracks the value of x rather than its
+	// logarithm and so leaves the characteristic range almost immediately; an
+	// unguarded conversion to int64_t wrapped and inverted the answer, returning
+	// zero for exp(maxpos) and maxpos for exp(maxneg).
+	{
+		TL big(sw::universal::SpecificValue::maxpos);
+		TL small(sw::universal::SpecificValue::maxneg);
+		if (!exp(big).isnar() && !(double(exp(big)) > 1.0)) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL exp(maxpos) must saturate upward, got " << double(exp(big)) << '\n';
+		}
+		if (!exp(small).iszero()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL exp(maxneg) must underflow to zero, got " << double(exp(small)) << '\n';
+			}
+		}
+	}
 	// classification
 	if (!isnan(nar) || isfinite(nar) || !isfinite(one) || isnormal(zero) || !isnormal(one)) {
 		++nrOfFailedTests;
@@ -382,9 +434,6 @@ try {
 		VerifyIntegerPow<20, 3>(reportTestCases), "takum_log<20,3>", "integer pow identities");
 #endif
 
-	// Levels 3 and 4 reach the widths where a double round trip would fail: at
-	// nbits = 64 the trailing field runs to p = 59, past a double's 53 bits, and
-	// the exact-integer oracle is the only way to check the result at all.
 #if REGRESSION_LEVEL_3
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyCorrectlyRoundedSqrt<32, 3>(reportTestCases, 4093ull), "takum_log<32,3>", "sqrt correctly rounded");
@@ -394,11 +443,28 @@ try {
 		VerifyIntegerPow<24, 3>(reportTestCases, 7ull), "takum_log<24,3>", "integer pow identities");
 #endif
 
+	// Level 4 reaches the widths where the double round trip actually fails.  At
+	// nbits = 64 the trailing field runs to p = 59, past a double's 53 bits, so
+	// the exact-integer oracle is the only way to check the result at all -- and
+	// on a compiler without __int128 it says so rather than passing vacuously.
 #if REGRESSION_LEVEL_4
 	nrOfFailedTestCases += ReportTestResult(
 		VerifySqrtRoundTrip<32, 3>(reportTestCases, 1031ull), "takum_log<32,3>", "sqr(sqrt(x)) round-trip");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyIntegerPow<32, 3>(reportTestCases, 1031ull), "takum_log<32,3>", "integer pow identities");
+#if TAKUM_LOG_HAVE_WIDE_ORACLE
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRoundedSqrt<48, 3>(reportTestCases, 0x2AAAAAAABull),
+		"takum_log<48,3>", "sqrt correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRoundedSqrt<64, 3>(reportTestCases, 0xAAAAAAAAAAABull),
+		"takum_log<64,3>", "sqrt correctly rounded");
+#else
+	std::cout << "\ntakum_log<48,3> / <64,3> sqrt oracle SKIPPED: no __int128 on this compiler\n";
+#endif
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySqrtRoundTrip<64, 3>(reportTestCases, 0xAAAAAAAAAAABull),
+		"takum_log<64,3>", "sqr(sqrt(x)) round-trip");
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/static/tapered/takum_log/math/mathlib.cpp
+++ b/static/tapered/takum_log/math/mathlib.cpp
@@ -163,7 +163,7 @@ int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 	// c * 2^Q + M with |c| < 2^32, so Q + 32 must stay inside the integer type.
 	const unsigned width_limit = (sizeof(wide) >= 16) ? 90u : 60u;
 
-	long exercised = 0, skipped = 0;
+	long exercised = 0, skipped = 0, ties = 0;
 	for (uint64_t b = 1; b < span; b += stride) {
 		TL x; x.setbits(b);
 		if (x.iszero() || x.isnar()) continue;
@@ -196,6 +196,7 @@ int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 		const wide half     = scaled(half_num, d.p + 1);
 
 		wide best = 0; bool have = false; wide mine = 0;
+		int  nbest = 0; uint64_t even_candidate = 0; bool have_even = false;
 		for (int64_t m = lo; m <= hi; ++m) {
 			if (m < 1 || static_cast<uint64_t>(m) > span) continue;
 			auto e = Codec::decode(static_cast<uint64_t>(m));
@@ -203,7 +204,17 @@ int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 			              + static_cast<wide>(e.M_bits);
 			wide diff = scaled(cand_num, e.p) - half;
 			if (diff < 0) diff = -diff;
-			if (!have || diff < best) { best = diff; have = true; }
+			if (!have || diff < best) {
+				best = diff; have = true; nbest = 1;
+				have_even = ((static_cast<uint64_t>(m) & 1ull) == 0);
+				even_candidate = static_cast<uint64_t>(m);
+			}
+			else if (diff == best) {
+				++nbest;
+				if ((static_cast<uint64_t>(m) & 1ull) == 0) {
+					even_candidate = static_cast<uint64_t>(m); have_even = true;
+				}
+			}
 			if (static_cast<uint64_t>(m) == gm) mine = diff;
 		}
 		++exercised;
@@ -211,6 +222,22 @@ int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 			++nrOfFailedTests;
 			if (reportTestCases) {
 				std::cout << "FAIL sqrt not correctly rounded at bits=" << b << '\n';
+			}
+		}
+		// Nearest alone does not pin the answer at a midpoint, and midpoints are not
+		// rare here: halving a logarithmic value produces a fraction one bit wider
+		// than the layout holds, so the dropped bit is a tie roughly half the time.
+		// Accepting either candidate would let a ties-to-ODD implementation pass.
+		// The codec breaks ties toward an even trailing field, which is the low bit
+		// of the magnitude for every layout, so require exactly that encoding.
+		else if (nbest > 1) {
+			++ties;
+			if (have_even && gm != even_candidate) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL sqrt tie not resolved to even at bits=" << b
+					          << " got=" << gm << " want=" << even_candidate << '\n';
+				}
 			}
 		}
 	}
@@ -221,7 +248,15 @@ int VerifyCorrectlyRoundedSqrt(bool reportTestCases, uint64_t stride = 1) {
 			std::cout << "FAIL oracle evaluated no inputs (" << skipped << " skipped for width)\n";
 		}
 	}
-	else if (skipped > 0 && reportTestCases) {
+	// Nor may the tie rule go unexercised: if no midpoint was reached, the
+	// ties-to-even half of this check proved nothing and should not read as passing.
+	if (exercised > 0 && ties == 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) {
+			std::cout << "FAIL oracle saw no midpoint, so the tie rule was never checked\n";
+		}
+	}
+	if (skipped > 0 && reportTestCases) {
 		std::cout << "note: " << skipped << " inputs skipped, oracle width limit " << width_limit << '\n';
 	}
 	return nrOfFailedTests;
@@ -353,14 +388,22 @@ int VerifySpecialValues(bool reportTestCases) {
 	{
 		TL big(sw::universal::SpecificValue::maxpos);
 		TL small(sw::universal::SpecificValue::maxneg);
-		if (!exp(big).isnar() && !(double(exp(big)) > 1.0)) {
-			++nrOfFailedTests;
-			if (reportTestCases) std::cout << "FAIL exp(maxpos) must saturate upward, got " << double(exp(big)) << '\n';
-		}
-		if (!exp(small).iszero()) {
+		// Require the exact saturation encoding.  An "is it not NaR and is it large"
+		// test would be satisfied by NaR itself, which is the failure mode most
+		// likely to appear here if the range guard is ever removed again.
+		const TL big_exp   = exp(big);
+		const TL small_exp = exp(small);
+		if (big_exp.raw_bits() != big.raw_bits()) {
 			++nrOfFailedTests;
 			if (reportTestCases) {
-				std::cout << "FAIL exp(maxneg) must underflow to zero, got " << double(exp(small)) << '\n';
+				std::cout << "FAIL exp(maxpos) must saturate to maxpos, got " << double(big_exp)
+				          << " (isnar=" << big_exp.isnar() << ")\n";
+			}
+		}
+		if (!small_exp.iszero()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL exp(maxneg) must underflow to zero, got " << double(small_exp) << '\n';
 			}
 		}
 	}


### PR DESCRIPTION
Follow-up to #1304, and the first of the deferred items from #1297.

`takum_log` had **no math functions at all** — every template in `mathlib.hpp` binds to `takum<>`, so the logarithmic type could not be used with generic numerical code. `sqrt(takum_log<32,3>(2.0))` did not compile.

## What is actually free in a logarithmic format

`|value| = sqrt(e)^l`, so any function that scales `l` by a rational factor is exact before rounding:

| function | acts on l | exactness |
|---|---|---|
| `sqrt` | `l/2` | exact, then one rounding |
| `sqr` | `2l` | exact, then one rounding |
| `rsqrt` | `-l/2` | exact, then one rounding |
| `pow(x, n)` | `n*l` | exact for integer `n`, then one rounding |
| `reciprocal` | `-l` | exact, no rounding at all (Prop. 7) |

The alternative — decode / libm / encode, which is what `takum<>` does — rounds three times and cannot carry more than a double's 53 significand bits.

That ceiling is not hypothetical. `takum_log<64,3>` reaches `p = 59`, so the logarithmic value is carried as an exact integer pair `(N, q)` meaning `N/2^q` rather than as a double: halving `l` produces a fraction one bit **wider** than the source layout holds, which a double would discard before any rounding decision was made.

## Evidence

Measured against an oracle built from exact integer arithmetic — deliberately not `long double`, which is itself too narrow above `p = 53`:

| configuration | log-domain `sqrt` correctly rounded | double round trip |
|---|---|---|
| `takum_log<16,3>` | **100%** | 100% |
| `takum_log<24,3>` | **100%** | 100% |
| `takum_log<32,3>` | **100%** | 100% |
| `takum_log<48,3>` | **100%** | 100% |
| `takum_log<64,3>` | **100%** | **0.95%** |

Ties go to even 100% of the time. So below 48 bits this buys speed; above it, correctness.

## Two claims deliberately not made

**`exp` and `log` are not free.** Extracting `ln|x| = l/2` costs nothing, but expressing the answer back as a `takum_log` needs `l' = 2*ln(l/2)` — another logarithm. Each saves one transcendental, not two. I had previously written the opposite in #1304's description; this corrects it.

**Addition is still the weak operation.** Hyperbolic functions, `log1p`, `expm1`, `fmod` and `fma` are sums of exponentials or linear-domain operations, so they have no shortcut and are evaluated as reals.

## Codec

`takum_codec` gains `encode_fraction(c, N, q)`, a third encode entry point taking the exact pair. Purely additive — an exhaustive dump of 18 configurations (530,786 observations) is **bit-for-bit identical to main** for both variants.

## Coverage

`static/tapered/takum_log/math/mathlib.cpp` pins the exactness properties against independent references rather than against itself: `sqr(sqrt(x))` round-trips, `rsqrt` equals the exact reciprocal of `sqrt`, `pow(x,2)` equals `sqr`, `pow(x,-1)` equals `reciprocal()`.

One thing worth knowing about the libm-agreement check: it compares against the function applied to the value the type **stores**, not the literal it was built from. `takum_log` represents no integer exactly — an integer `k` is `sqrt(e)^l` only for irrational `l` — so `takum_log<32,3>(3)` holds `2.99999999`, and `floor` of it is honestly `2`. My first version of the test scored those correct results as failures.

## Validation

All 12 suites pass under gcc and clang (24/24), zero new warnings, clean under ASan+UBSan and `-DNDEBUG`, `check-ascii` green.

## Still deferred from #1297

Constant tables, cross-conversion between the variants, the `arithmetic`/`logic`/`conversion` regression directories, `ucalc` registration, native arithmetic and quire support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded `takum_log` support across logarithmic, exponential, power, root, rounding, fractional, trigonometric, hyperbolic, error-function, and fused multiply-add operations.
  - Added classification, minimum/maximum, navigation, and remainder-related operations.
  - Improved exact logarithmic-value handling, including conversion, scaling, rounding, overflow, underflow, and special values.
- **Tests**
  - Added comprehensive verification for accuracy, edge cases, special values, and multiple configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->