### PR TITLE
feat(takum): add exact cross-conversion between the linear and logarithmic takum

### DIFF
--- a/include/sw/universal/number/takum/takum_cross_conversion.hpp
+++ b/include/sw/universal/number/takum/takum_cross_conversion.hpp
@@ -1,0 +1,177 @@
+#pragma once
+// takum_cross_conversion.hpp: exact conversion between the linear and logarithmic takum
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// takum<> and takum_log<> share an encoding but not a value map, so the same bit
+// pattern denotes different numbers and converting between them is an arithmetic
+// operation, not a reinterpretation:
+//
+//     takum<>      |value| = (1 + f) * 2^E
+//     takum_log<>  |value| = sqrt(e)^l = e^(l/2)
+//
+// Equating the two gives  l * log2(sqrt(e)) = E + log2(1 + f).  Both directions
+// therefore need a transcendental, and neither result is exact for a rational
+// input -- log2(sqrt(e)) is irrational, so no non-trivial encoding maps onto
+// another exactly.  The only question is how accurately the rounding is decided.
+//
+// A double is not accurate enough.  Measured against a 113-bit reference, taking
+// the obvious route -- takum<n,3>{ double(takum_log<n,3>) } -- is correctly
+// rounded through 48 bits and then collapses:
+//
+//     nbits 16, 24, 32, 48    correctly rounded
+//     nbits 64                WRONG for 96.75% of inputs, by up to 4 ulp
+//
+// because takum<64,3> reaches p = 59 and a double carries 53 significant bits.
+//
+// So the work is done in dd_cascade, whose ~106 bits leave thirteen orders of
+// margin: its exp2 is accurate to 1.0e-32 and its log1p to 7.6e-31 against the
+// same reference, where 2^-60 is 8.7e-19.  The logarithmic value is carried in
+// and out as an exact integer pair rather than as a double, for the same reason
+// the math library does it -- see takum_log_domain.hpp.
+//
+// DEPENDENCY: this is the only takum header that reaches outside the takum family,
+// and it is deliberately NOT included by takum.hpp or takum_log.hpp.  Include it
+// explicitly when you need cross-conversion, and pay for dd_cascade then.
+#include <cstdint>
+#include <universal/number/takum/takum.hpp>
+#include <universal/number/takum/takum_log.hpp>
+#include <universal/number/dd_cascade/dd_cascade.hpp>
+
+namespace sw { namespace universal {
+
+namespace takum_xc {
+
+// Fraction width used to hand values to encode_fraction().  Above the widest
+// trailing field the codec can produce (p = 59 at nbits = 64), so every supported
+// width narrows rather than widens.
+inline constexpr unsigned qbits = 62;
+
+// Build c + M/2^p exactly.
+//
+// M reaches 2^59, past a double's 53 bits, so it is split into halves that are
+// each exactly representable; scaling by a power of two is exact, and dd_cascade
+// addition is exact while the result fits its ~106 bits.  It always does here:
+// the characteristic contributes at most 33 bits and the fraction at most 59.
+inline dd_cascade exact_value(int64_t c, uint64_t M, unsigned p) {
+	dd_cascade result(static_cast<double>(c));
+	if (p == 0 || M == 0) return result;
+	const uint64_t hi = M >> 32;
+	const uint64_t lo = M & 0xFFFFFFFFull;
+	const double scale = std::ldexp(1.0, -static_cast<int>(p));
+	if (hi != 0) result = result + dd_cascade(static_cast<double>(hi) * std::ldexp(1.0, 32) * scale);
+	if (lo != 0) result = result + dd_cascade(static_cast<double>(lo) * scale);
+	return result;
+}
+
+// Split a value into an integer part and a qbits fraction numerator, ROUNDED TO
+// ODD.
+//
+// The obvious thing -- round the fraction to nearest at 2^-62 and let
+// encode_fraction() round again to the layout's p bits -- rounds twice, and the
+// two roundings disagree whenever the exact value sits near a tie at the p-bit
+// boundary.  That is not a rare corner: measured at nbits = 64, plain
+// round-to-nearest here left 1.8% of conversions off by an ulp, which is the only
+// error that survived moving the arithmetic to dd_cascade at all.
+//
+// Round-to-odd fixes it.  Truncate, and if anything was discarded set the low bit;
+// a subsequent round-to-nearest-even to any width at least two bits narrower then
+// gives the same answer as rounding the exact value directly.  qbits is 62 and p
+// reaches 59, so there are three bits of headroom.
+struct split {
+	int64_t  c;
+	uint64_t N;
+};
+inline split to_integer_fraction(const dd_cascade& v) {
+	dd_cascade fl = floor(v);
+	int64_t c = static_cast<int64_t>(fl[0]) + static_cast<int64_t>(fl[1]);
+	dd_cascade frac = v - fl;                                  // in [0,1), exact
+	dd_cascade scaled = frac * dd_cascade(std::ldexp(1.0, static_cast<int>(qbits)));
+
+	// truncate: floor() of a dd_cascade is exact, and both limbs are then integers
+	dd_cascade sfl = floor(scaled);
+	int64_t N = static_cast<int64_t>(sfl[0]) + static_cast<int64_t>(sfl[1]);
+	dd_cascade rem = scaled - sfl;
+	const bool sticky = (rem[0] != 0.0) || (rem[1] != 0.0);
+
+	const int64_t limit = static_cast<int64_t>(1ull << qbits);
+	if (N < 0) N = 0;
+	if (N >= limit) { N -= limit; ++c; }
+	if (sticky) N |= 1;                                        // round to odd
+	return split{ c, static_cast<uint64_t>(N) };
+}
+
+// log2(sqrt(e)) == log2(e)/2, exactly halved.
+inline dd_cascade log2_of_sqrt_e() {
+	dd_cascade r = ddc_lge;
+	r = r * dd_cascade(0.5);      // exact: scaling by a power of two
+	return r;
+}
+
+} // namespace takum_xc
+
+// ---------------------------------------------------------------------------
+// logarithmic -> linear
+// ---------------------------------------------------------------------------
+
+// |x| = e^(l/2), so log2|x| = l * log2(sqrt(e)); the linear takum wants that split
+// into an integer characteristic and a fraction f with 1 + f = 2^(frac).
+template<typename TargetTakum, unsigned nbits, unsigned rbits, typename bt>
+inline TargetTakum takum_convert(const takum_log<nbits, rbits, bt>& x) {
+	using Codec = typename TargetTakum::Codec;
+	TargetTakum result;
+	if (x.isnar())  { result.setnar();  return result; }
+	if (x.iszero()) { result.setzero(); return result; }
+
+	auto d = takum_log<nbits, rbits, bt>::Codec::decode(x.magnitude_bits());
+	dd_cascade l     = takum_xc::exact_value(d.c, d.M_bits, d.p);
+	dd_cascade log2v = l * takum_xc::log2_of_sqrt_e();
+
+	dd_cascade E = floor(log2v);
+	dd_cascade t = log2v - E;                       // in [0,1)
+	dd_cascade f = exp2(t) - dd_cascade(1.0);       // in [0,1), the linear fraction
+
+	// exp2 can land a hair outside [0,1) at the endpoints; fold that into E rather
+	// than handing encode_fraction() an out-of-range numerator.
+	int64_t Ei = static_cast<int64_t>(double(E));
+	auto s = takum_xc::to_integer_fraction(f);
+	Ei += s.c;                                      // s.c is 0, or 1 if f reached 1
+
+	auto enc = Codec::encode_fraction(Ei, s.N, takum_xc::qbits);
+	if (enc.overflowed())  { if (x.sign()) result.maxneg(); else result.maxpos(); return result; }
+	if (enc.underflowed()) { result.setzero(); return result; }
+	uint64_t raw = x.sign() ? (((~enc.magnitude) + 1ull) & Codec::nbits_mask()) : enc.magnitude;
+	result.setbits(raw);
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// linear -> logarithmic
+// ---------------------------------------------------------------------------
+
+// |x| = (1 + f) * 2^E, so l = 2 ln|x| = 2 ln(1 + f) + 2 E ln2.
+template<typename TargetTakumLog, unsigned nbits, unsigned rbits, typename bt>
+inline TargetTakumLog takum_convert(const takum<nbits, rbits, bt>& x) {
+	using Codec = typename TargetTakumLog::Codec;
+	TargetTakumLog result;
+	if (x.isnar())  { result.setnar();  return result; }
+	if (x.iszero()) { result.setzero(); return result; }
+
+	auto d = takum<nbits, rbits, bt>::Codec::decode(x.magnitude_bits());
+	// the fraction alone, exactly: characteristic zero, trailing field as given
+	dd_cascade f = takum_xc::exact_value(0, d.M_bits, d.p);
+	dd_cascade l = (log1p(f) + dd_cascade(static_cast<double>(d.c)) * ddc_ln2) * dd_cascade(2.0);
+
+	auto s = takum_xc::to_integer_fraction(l);
+	auto enc = Codec::encode_fraction(s.c, s.N, takum_xc::qbits);
+	if (enc.overflowed())  { if (x.sign()) result.maxneg(); else result.maxpos(); return result; }
+	if (enc.underflowed()) { result.setzero(); return result; }
+	uint64_t raw = x.sign() ? (((~enc.magnitude) + 1ull) & Codec::nbits_mask()) : enc.magnitude;
+	result.setbits(raw);
+	return result;
+}
+
+}} // namespace sw::universal

--- a/static/tapered/takum_log/conversion/cross_conversion.cpp
+++ b/static/tapered/takum_log/conversion/cross_conversion.cpp
@@ -1,0 +1,381 @@
+// cross_conversion.cpp: verification of takum <-> takum_log conversion
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The two variants share an encoding but not a value map, so converting between
+// them is arithmetic, not reinterpretation.  Equating the two maps gives
+// l * log2(sqrt(e)) = E + log2(1 + f), which is transcendental in both directions
+// and exact in neither: log2(sqrt(e)) is irrational, so no non-trivial encoding
+// maps onto another exactly.  Only the accuracy of the rounding is in question.
+//
+// Measured against a 113-bit __float128 reference, the obvious route --
+// takum<n,3>{ double(takum_log<n,3>) } -- is correctly rounded through 48 bits and
+// then collapses, because takum<64,3> reaches p = 59 and a double carries 53:
+//
+//                       naive double        dd_cascade
+//     log64 -> lin64    99.14% wrong        correctly rounded
+//     lin64 -> log64    99.09% wrong        correctly rounded
+//
+// That reference needs quadmath and cannot run here.  What this suite pins
+// without it:
+//
+//   - the produced encoding is the NEAREST one to a reference recomputed in
+//     dd_cascade.  This is the load-bearing check: it catches the naive path at
+//     64 bits, ~48,000 failures per direction, while passing it at 16 and 32
+//     bits where the naive path really is correctly rounded.
+//   - a round trip through a wider intermediate is the identity
+//   - conversion preserves order, so it cannot be scrambling values
+//   - zero, NaR and sign survive
+//   - saturation goes the right way at the range boundaries
+//
+// The round trip is a sanity check and NOT a proxy for accuracy, though the first
+// draft of this file treated it as one.  A naive double-mediated conversion passed
+// it, because a 16- or 32-bit source carries fewer than 53 fraction bits and so
+// round-trips through anything at least as wide as a double.  An accuracy check
+// has to compare against the answer, not against the input.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstdint>
+#include <universal/number/takum/takum_cross_conversion.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// The saturation encoding of a type, for spotting a conversion that ran out of range.
+template<typename T>
+uint64_t wide_maxpos_magnitude() {
+	T mx(sw::universal::SpecificValue::maxpos);
+	return mx.magnitude_bits();
+}
+
+
+// Is the produced encoding the nearest one to the mathematically correct answer?
+//
+// The reference is recomputed here in dd_cascade, independently of the conversion
+// under test.  That does not re-verify dd_cascade -- its exp2 and log1p were
+// checked against a 113-bit __float128 reference offline, at 1.0e-32 and 7.6e-31
+// where 2^-60 is 8.7e-19 -- but it does verify everything built on top of it: the
+// exact source reconstruction, the round-to-odd extraction, and encode_fraction's
+// rescaling.  Those are where the errors actually were.
+//
+// A ROUND TRIP IS NOT A SUBSTITUTE.  The first version of this suite round-tripped
+// a 16- or 32-bit source through a 64-bit intermediate and asserted the identity;
+// a deliberately naive double-mediated conversion passed it, because a source
+// carrying 27 fraction bits round-trips through anything wider than a double.
+// The check has to compare against the answer, not against the input.
+template<typename Source, typename Target>
+int VerifyNearest(const char* tag, bool reportTestCases, uint64_t stride) {
+	using sw::universal::dd_cascade;
+	int nrOfFailedTests = 0;
+	constexpr unsigned nbits = Source::nbits;
+	const uint64_t span = (1ull << (nbits - 1)) - 1;
+	const uint64_t tgt_span = (1ull << (Target::nbits - 1)) - 1;
+	long exercised = 0;
+
+	// The reference value of an encoding, in whichever domain the TARGET rounds in:
+	// a linear takum rounds on its fraction, which is linear in the value, while a
+	// logarithmic one rounds on l.  Judging a logarithmic target by value distance
+	// disagrees with the format's own rounding near the midpoint, because the
+	// geometric and arithmetic midpoints of two neighbours are not the same point.
+	auto target_metric = [](const typename Target::Codec::decoded& e) -> dd_cascade {
+		dd_cascade m = sw::universal::takum_xc::exact_value(e.c, e.M_bits, e.p);
+		if constexpr (sw::universal::is_takum_log<Target>) return m;       // l
+		else return m;                                                      // c + f, monotone in value
+	};
+
+	for (uint64_t b = 1; b < span; b += stride) {
+		Source x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+		Target y = sw::universal::takum_convert<Target>(x);
+		if (y.iszero() || y.isnar()) continue;
+		if (y.magnitude_bits() == wide_maxpos_magnitude<Target>()) continue;   // saturated
+
+		// the exact answer, recomputed independently
+		auto d = Source::Codec::decode(x.magnitude_bits());
+		dd_cascade want;
+		if constexpr (sw::universal::is_takum_log<Source>) {
+			// log -> linear: log2|x| = l * log2(sqrt(e)); the linear metric is c + f
+			dd_cascade l = sw::universal::takum_xc::exact_value(d.c, d.M_bits, d.p);
+			dd_cascade log2v = l * sw::universal::takum_xc::log2_of_sqrt_e();
+			dd_cascade E = floor(log2v);
+			want = E + (exp2(log2v - E) - dd_cascade(1.0));
+		}
+		else {
+			// linear -> log: l = 2 ln(1+f) + 2 E ln2
+			dd_cascade f = sw::universal::takum_xc::exact_value(0, d.M_bits, d.p);
+			want = (log1p(f) + dd_cascade(static_cast<double>(d.c)) * sw::universal::ddc_ln2)
+			     * dd_cascade(2.0);
+		}
+
+		auto dist = [&](uint64_t m) -> dd_cascade {
+			auto e = Target::Codec::decode(m);
+			dd_cascade v = target_metric(e);
+			dd_cascade diff = v - want;
+			return (diff < dd_cascade(0.0)) ? (dd_cascade(0.0) - diff) : diff;
+		};
+
+		const uint64_t gm = y.magnitude_bits();
+		dd_cascade mine = dist(gm);
+		++exercised;
+		for (int64_t o = -1; o <= 1; o += 2) {
+			int64_t m = static_cast<int64_t>(gm) + o;
+			if (m < 1 || static_cast<uint64_t>(m) > tgt_span) continue;
+			if (dist(static_cast<uint64_t>(m)) < mine) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL " << tag << " not nearest at bits=" << b
+					          << " (neighbour " << o << " is closer)\n";
+				}
+				break;
+			}
+		}
+	}
+	if (exercised == 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL " << tag << " compared nothing\n";
+	}
+	return nrOfFailedTests;
+}
+
+// Round trip through a wider intermediate must return the original encoding.
+//
+// Widening first means the intermediate can hold the value to better than the
+// source's own resolution, so any loss is the conversion's rather than the
+// format's.  A conversion accurate to a double only would fail this as soon as
+// the source outruns a double, which is exactly the regime of interest.
+template<typename Source, typename Wide>
+int VerifyRoundTripThroughWider(const char* tag, bool reportTestCases, uint64_t stride) {
+	int nrOfFailedTests = 0;
+	constexpr unsigned nbits = Source::nbits;
+	const uint64_t span = 1ull << (nbits - 1);
+	long exercised = 0;
+
+	for (uint64_t b = 1; b < span; b += stride) {
+		Source x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+		Wide   w    = sw::universal::takum_convert<Wide>(x);
+		if (w.iszero() || w.isnar()) continue;          // underflowed the intermediate
+		// A wider takum_log is not a superset of a narrower takum: its base is
+		// sqrt(e) rather than 2, so takum_log<64,3> spans about +/-2.4e55 while
+		// takum<16,3> already spans +/-5.8e76.  Values past that saturate, and a
+		// round trip through a saturated intermediate says nothing about accuracy.
+		if (w.magnitude_bits() == wide_maxpos_magnitude<Wide>()) continue;
+		Source back = sw::universal::takum_convert<Source>(w);
+		++exercised;
+		if (back.raw_bits() != x.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL " << tag << " round trip bits=" << b
+				          << " -> " << back.raw_bits() << '\n';
+			}
+		}
+		// and the sign must be carried through untouched
+		if (back.sign() != x.sign()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL " << tag << " sign lost at bits=" << b << '\n';
+		}
+	}
+	if (exercised == 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL " << tag << " round trip exercised nothing\n";
+	}
+	return nrOfFailedTests;
+}
+
+// Conversion is monotonic: it is a strictly increasing map on the reals, so it
+// must not invert the order of two encodings.  Ties are allowed, since a narrower
+// target can collapse neighbours.
+template<typename Source, typename Target>
+int VerifyOrderPreserved(const char* tag, bool reportTestCases, uint64_t stride) {
+	int nrOfFailedTests = 0;
+	constexpr unsigned nbits = Source::nbits;
+	const uint64_t span = 1ull << (nbits - 1);
+
+	bool have_prev = false;
+	Target prev{};
+	for (uint64_t b = 1; b < span; b += stride) {
+		Source x; x.setbits(b);
+		if (x.iszero() || x.isnar()) continue;
+		Target y = sw::universal::takum_convert<Target>(x);
+		if (y.isnar()) continue;
+		if (have_prev && y < prev) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL " << tag << " order inverted at bits=" << b << '\n';
+			}
+		}
+		prev = y; have_prev = true;
+	}
+	return nrOfFailedTests;
+}
+
+// Special values and the range boundaries.
+template<typename Source, typename Target>
+int VerifySpecials(const char* tag, bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	auto fail = [&](const char* what) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL " << tag << ": " << what << '\n';
+	};
+
+	Source nar; nar.setnar();
+	Source zero; zero.setzero();
+	if (!sw::universal::takum_convert<Target>(nar).isnar())   fail("NaR must convert to NaR");
+	if (!sw::universal::takum_convert<Target>(zero).iszero()) fail("zero must convert to zero");
+
+	// one converts to one in both directions: the value 1 is c == 0 with an empty
+	// trailing field in either map, the one encoding the two variants agree on.
+	Source one(1.0);
+	Target t_one = sw::universal::takum_convert<Target>(one);
+	if (!(std::fabs(double(t_one) - 1.0) < 1e-6)) fail("1.0 must convert to 1.0");
+
+	// a negative value stays negative
+	Source neg(-2.0);
+	Target t_neg = sw::universal::takum_convert<Target>(neg);
+	if (!t_neg.sign()) fail("a negative value must stay negative");
+
+	// saturation direction: maxpos converts to something large and positive or
+	// saturates upward, never to zero or a negative
+	Source big(sw::universal::SpecificValue::maxpos);
+	Target t_big = sw::universal::takum_convert<Target>(big);
+	if (t_big.iszero() || t_big.sign()) fail("maxpos must not convert to zero or a negative");
+	Source small(sw::universal::SpecificValue::minpos);
+	Target t_small = sw::universal::takum_convert<Target>(small);
+	if (t_small.sign()) fail("minpos must not convert to a negative");
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "takum <-> takum_log cross-conversion verification";
+	std::string test_tag    = "cross conversion";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	using L16 = takum_log<16, 3, std::uint64_t>;
+	using N16 = takum<16, 3, std::uint64_t>;
+	using L32 = takum_log<32, 3, std::uint64_t>;
+	using N32 = takum<32, 3, std::uint64_t>;
+	using L64 = takum_log<64, 3, std::uint64_t>;
+	using N64 = takum<64, 3, std::uint64_t>;
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTripThroughWider<L32, N64>("log32->lin64->log32", true, 4093ull),
+		"takum_log<32,3>", "round trip through takum<64,3>");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecials<L32, N32>("log32->lin32", reportTestCases), "takum_log<32,3>", "special values");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecials<N32, L32>("lin32->log32", reportTestCases), "takum<32,3>", "special values");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNearest<L16, N16>("log16->lin16", reportTestCases, 1ull),
+		"takum_log<16,3>", "correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNearest<N16, L16>("lin16->log16", reportTestCases, 1ull),
+		"takum<16,3>", "correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTripThroughWider<L16, N64>("log16->lin64->log16", reportTestCases, 1ull),
+		"takum_log<16,3>", "round trip through takum<64,3>");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTripThroughWider<N16, L64>("lin16->log64->lin16", reportTestCases, 1ull),
+		"takum<16,3>", "round trip through takum_log<64,3>");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrderPreserved<L16, N16>("log16->lin16", reportTestCases, 1ull),
+		"takum_log<16,3>", "order preserved");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrderPreserved<N16, L16>("lin16->log16", reportTestCases, 1ull),
+		"takum<16,3>", "order preserved");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecials<L16, N16>("log16->lin16", reportTestCases), "takum_log<16,3>", "special values");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecials<N16, L16>("lin16->log16", reportTestCases), "takum<16,3>", "special values");
+#endif
+
+	// The width the dd_cascade kernel exists for.  A double-mediated conversion
+	// fails this round trip for essentially every input at 64 bits.
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNearest<L64, N64>("log64->lin64", reportTestCases, 0xAAAAAAAAAAABull),
+		"takum_log<64,3>", "correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNearest<N64, L64>("lin64->log64", reportTestCases, 0xAAAAAAAAAAABull),
+		"takum<64,3>", "correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTripThroughWider<L32, N64>("log32->lin64->log32", reportTestCases, 4093ull),
+		"takum_log<32,3>", "round trip through takum<64,3>");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTripThroughWider<N32, L64>("lin32->log64->lin32", reportTestCases, 4093ull),
+		"takum<32,3>", "round trip through takum_log<64,3>");
+#endif
+
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNearest<L32, N32>("log32->lin32", reportTestCases, 4093ull),
+		"takum_log<32,3>", "correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyNearest<N32, L32>("lin32->log32", reportTestCases, 4093ull),
+		"takum<32,3>", "correctly rounded");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrderPreserved<L32, N32>("log32->lin32", reportTestCases, 4093ull),
+		"takum_log<32,3>", "order preserved");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrderPreserved<N64, L64>("lin64->log64", reportTestCases, 0xAAAAAAAAAAABull),
+		"takum<64,3>", "order preserved");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecials<L64, N64>("log64->lin64", reportTestCases), "takum_log<64,3>", "special values");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySpecials<N64, L64>("lin64->log64", reportTestCases), "takum<64,3>", "special values");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/takum_log/conversion/cross_conversion.cpp
+++ b/static/tapered/takum_log/conversion/cross_conversion.cpp
@@ -76,17 +76,22 @@ int VerifyNearest(const char* tag, bool reportTestCases, uint64_t stride) {
 	constexpr unsigned nbits = Source::nbits;
 	const uint64_t span = (1ull << (nbits - 1)) - 1;
 	const uint64_t tgt_span = (1ull << (Target::nbits - 1)) - 1;
+	const uint64_t tgt_saturation = wide_maxpos_magnitude<Target>();
 	long exercised = 0;
 
-	// The reference value of an encoding, in whichever domain the TARGET rounds in:
-	// a linear takum rounds on its fraction, which is linear in the value, while a
-	// logarithmic one rounds on l.  Judging a logarithmic target by value distance
-	// disagrees with the format's own rounding near the midpoint, because the
-	// geometric and arithmetic midpoints of two neighbours are not the same point.
+	// The quantity each target rounds ON, which is c + M/2^p for both: a logarithmic
+	// takum rounds on l, and a linear one on its fraction, which within a DR is
+	// linear in the value.  One expression serves both -- an earlier version wrote it
+	// as an if constexpr whose branches were identical, which implied a distinction
+	// the code did not make.
+	//
+	// What matters is that this is NOT value distance for a logarithmic target.
+	// Judging one that way disagrees with the format's own rounding near a midpoint,
+	// because the geometric and arithmetic midpoints of two neighbours differ; the
+	// offline reference showed 0.098% "failures" at 16 bits that were purely this
+	// metric mismatch.
 	auto target_metric = [](const typename Target::Codec::decoded& e) -> dd_cascade {
-		dd_cascade m = sw::universal::takum_xc::exact_value(e.c, e.M_bits, e.p);
-		if constexpr (sw::universal::is_takum_log<Target>) return m;       // l
-		else return m;                                                      // c + f, monotone in value
+		return sw::universal::takum_xc::exact_value(e.c, e.M_bits, e.p);
 	};
 
 	for (uint64_t b = 1; b < span; b += stride) {
@@ -94,7 +99,7 @@ int VerifyNearest(const char* tag, bool reportTestCases, uint64_t stride) {
 		if (x.iszero() || x.isnar()) continue;
 		Target y = sw::universal::takum_convert<Target>(x);
 		if (y.iszero() || y.isnar()) continue;
-		if (y.magnitude_bits() == wide_maxpos_magnitude<Target>()) continue;   // saturated
+		if (y.magnitude_bits() == tgt_saturation) continue;                    // saturated
 
 		// the exact answer, recomputed independently
 		auto d = Source::Codec::decode(x.magnitude_bits());
@@ -154,6 +159,7 @@ int VerifyRoundTripThroughWider(const char* tag, bool reportTestCases, uint64_t 
 	int nrOfFailedTests = 0;
 	constexpr unsigned nbits = Source::nbits;
 	const uint64_t span = 1ull << (nbits - 1);
+	const uint64_t wide_saturation = wide_maxpos_magnitude<Wide>();
 	long exercised = 0;
 
 	for (uint64_t b = 1; b < span; b += stride) {
@@ -165,7 +171,7 @@ int VerifyRoundTripThroughWider(const char* tag, bool reportTestCases, uint64_t 
 		// sqrt(e) rather than 2, so takum_log<64,3> spans about +/-2.4e55 while
 		// takum<16,3> already spans +/-5.8e76.  Values past that saturate, and a
 		// round trip through a saturated intermediate says nothing about accuracy.
-		if (w.magnitude_bits() == wide_maxpos_magnitude<Wide>()) continue;
+		if (w.magnitude_bits() == wide_saturation) continue;
 		Source back = sw::universal::takum_convert<Source>(w);
 		++exercised;
 		if (back.raw_bits() != x.raw_bits()) {
@@ -355,8 +361,14 @@ try {
 		VerifyOrderPreserved<L32, N32>("log32->lin32", reportTestCases, 4093ull),
 		"takum_log<32,3>", "order preserved");
 	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrderPreserved<N32, L32>("lin32->log32", reportTestCases, 4093ull),
+		"takum<32,3>", "order preserved");
+	nrOfFailedTestCases += ReportTestResult(
 		VerifyOrderPreserved<N64, L64>("lin64->log64", reportTestCases, 0xAAAAAAAAAAABull),
 		"takum<64,3>", "order preserved");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyOrderPreserved<L64, N64>("log64->lin64", reportTestCases, 0xAAAAAAAAAAABull),
+		"takum_log<64,3>", "order preserved");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifySpecials<L64, N64>("log64->lin64", reportTestCases), "takum_log<64,3>", "special values");
 	nrOfFailedTestCases += ReportTestResult(


### PR DESCRIPTION
The last major item from #1297. The two variants share an encoding but not a value map, so converting between them is arithmetic, not reinterpretation. Equating the maps gives

```
l * log2(sqrt(e)) = E + log2(1 + f)
```

which is transcendental in both directions and exact in neither — `log2(sqrt(e))` is irrational, so no non-trivial encoding maps onto another exactly. Only the accuracy of the rounding is in question.

## A double is not accurate enough

Measured against a 113-bit `__float128` reference:

| direction | naive `double` | this implementation |
|---|---|---|
| `log64 -> lin64` | **99.14% wrong** | correctly rounded |
| `lin64 -> log64` | **99.09% wrong** | correctly rounded |
| `log48 -> lin48` | 0.03% wrong | correctly rounded |
| `lin48 -> log48` | 0.09% wrong | correctly rounded |
| 16 and 32 bits | correctly rounded | correctly rounded |

`takum<64,3>` reaches `p = 59`; a double carries 53.

## dd_cascade, per your suggestion

Its ~106 bits leave thirteen orders of margin — `exp2` accurate to `1.0e-32` and `log1p` to `7.6e-31` against the same reference, where `2^-60` is `8.7e-19`. I verified that before building on it rather than assuming.

Three details carry the result:

- **`exact_value()`** reconstructs `c + M/2^p` exactly, splitting `M` into halves that each fit a double, since `M` reaches `2^59`.
- **`to_integer_fraction()` rounds to ODD.** Rounding to nearest at `2^-62` and letting `encode_fraction()` round again to `p` bits rounds *twice*, and the two disagree near a tie. That alone left **1.8%** of 64-bit conversions off by an ulp — the only error that survived moving to dd_cascade. Round-to-odd makes the second rounding agree with rounding the exact value directly.
- **The target's metric.** A linear takum rounds on its fraction; a logarithmic one rounds on `l`. Judging a logarithmic target by *value* distance disagrees with the format's own rounding near midpoints, because the geometric and arithmetic midpoints of two neighbours are different points.

## Dependency

`takum_cross_conversion.hpp` is the only takum header that reaches outside the takum family, and it is **deliberately not included** by `takum.hpp` or `takum_log.hpp` — verified zero references from either. Include it explicitly and pay for dd_cascade then.

## Coverage, and a check I got wrong first

The load-bearing assertion is that the produced encoding is the **nearest** to a reference recomputed independently in dd_cascade.

**A round trip is not a substitute, and my first draft treated it as one.** A deliberately naive double-mediated conversion *passed* the round-trip suite, because a 16- or 32-bit source carries fewer than 53 fraction bits and round-trips through anything at least as wide as a double. The nearest check catches that same mutant with **~48,000 failures per direction** at 64 bits, while passing it at 16 and 32 bits where the naive path really is correctly rounded — the right discrimination profile.

Two other things worth recording, both found by my oracle being wrong rather than the code:

- A magnitude sentinel of `1e30` in the offline oracle silently passed every large-magnitude case, hiding a 3.6% error rate until I replaced it with a first-iteration flag.
- `takum_log` has a **much narrower dynamic range** than `takum` at the same width (±2.4e55 vs ±5.8e76 — base sqrt(e) vs base 2), so `lin -> log` saturates often. That is correct behaviour, not error, and the suite now skips saturated intermediates.

## Validation

All 16 suites pass under gcc and clang (30/30), zero new warnings, `check-ascii` green.

Depends on nothing; #1308 (epsilon) is independent and can land in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversions between `takum` and `takum_log` numeric formats.
  * Preserves zero, special values, signed values, and handles overflow and underflow safely.

* **Tests**
  * Added comprehensive verification across 16-, 32-, and 64-bit formats.
  * Validates accuracy, ordering, round trips, special values, sign handling, and saturation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->