### PR TITLE
feat(ucalc): register the logarithmic takum

### DIFF
--- a/tools/ucalc/README.md
+++ b/tools/ucalc/README.md
@@ -19,10 +19,17 @@ agents, supporting structured JSON/CSV output for automated workflows.
 
 `ucalc` is a REPL calculator and compute engine that:
 
-- Supports **42+ number types** out of the box: IEEE float/double, posit (8-64),
-  takum (8-64), cfloat (8-64), bfloat16, FP8 variants, fixed-point, decimal
-  fixed-point, LNS, integer, hexadecimal float, decimal float, rational,
-  double-double, quad-double, and cascaded variants.
+- Supports **46+ number types** out of the box: IEEE float/double, posit (8-64),
+  takum (8-64) in both the linear and the logarithmic encoding, cfloat (8-64),
+  bfloat16, FP8 variants, fixed-point, decimal fixed-point, LNS, integer,
+  hexadecimal float, decimal float, rational, double-double, quad-double, and
+  cascaded variants.
+
+  The two takum variants are worth a word: `takum8`..`takum64` and
+  `takum_log8`..`takum_log64` share an identical bit layout but map those bits to
+  different numbers -- `(1+f)*2^c` against `sqrt(e)^(c+m)` -- so the same input
+  prints different encodings under each. `diverge <expr> takum32 takum_log32
+  <tol> for <var> in [a, b]` finds where they first disagree.
 - Parses **infix arithmetic** with standard operator precedence, parentheses,
   variables, constants, and math functions.
 - Provides **20+ analysis commands** organized in three categories:

--- a/tools/ucalc/registry.hpp
+++ b/tools/ucalc/registry.hpp
@@ -183,6 +183,16 @@ inline TypeRegistry build_default_registry() {
 	reg.add("takum32",  register_type<takum<32, 3, uint32_t>>("takum32"));
 	reg.add("takum64",  register_type<takum<64, 3, uint64_t>>("takum64"));
 
+	// Takum, logarithmic encoding.  Same bit layout as the linear takum above and
+	// the same rbits = 3 the specification fixes, but a different value map:
+	// sqrt(e)^(c+m) rather than (1+f)*2^c.  The same input therefore prints
+	// different bits under takum32 and takum_log32, which is the point of having
+	// both in the calculator.
+	reg.add("takum_log8",  register_type<takum_log<8, 3, uint8_t>>("takum_log8"));
+	reg.add("takum_log16", register_type<takum_log<16, 3, uint16_t>>("takum_log16"));
+	reg.add("takum_log32", register_type<takum_log<32, 3, uint32_t>>("takum_log32"));
+	reg.add("takum_log64", register_type<takum_log<64, 3, uint64_t>>("takum_log64"));
+
 	// Decimal fixed-point (BCD encoding, Modulo arithmetic)
 	reg.add("dfixpnt8_4",  register_type<dfixpnt<8, 4>>("dfixpnt8_4"));
 	reg.add("dfixpnt16_8", register_type<dfixpnt<16, 8>>("dfixpnt16_8"));

--- a/tools/ucalc/regression.cpp
+++ b/tools/ucalc/regression.cpp
@@ -454,6 +454,47 @@ try {
 	}
 
 	// ================================================================
+	// Takum, both variants
+	// ================================================================
+	// The family had no coverage here at all before takum_log was registered.
+	{
+		check_value(reg, "takum32",     "1 + 1",     2.0, 0.0,   "takum32 add");
+		check_value(reg, "takum_log32", "1 + 1",     2.0, 1e-7,  "takum_log32 add");
+		check_value(reg, "takum32",     "sqrt(4)",   2.0, 1e-7,  "takum32 sqrt");
+		check_value(reg, "takum_log32", "sqrt(4)",   2.0, 1e-7,  "takum_log32 sqrt");
+		check_value(reg, "takum_log32", "2 * 3",     6.0, 1e-7,  "takum_log32 mul");
+		check_value(reg, "takum_log32", "1 / 4",     0.25, 1e-7, "takum_log32 div");
+		check_value(reg, "takum_log32", "pi",        3.14159265358979324, 1e-7, "takum_log32 pi");
+		check_value(reg, "takum_log32", "exp(0)",    1.0, 1e-7,  "takum_log32 exp(0)");
+		check_value(reg, "takum_log32", "log(1)",    0.0, 1e-7,  "takum_log32 log(1)");
+		check_value(reg, "takum_log16", "1 + 1",     2.0, 1e-3,  "takum_log16 add");
+		check_value(reg, "takum_log64", "1 + 1",     2.0, 1e-12, "takum_log64 add");
+		check_value(reg, "takum_log8",  "1 + 1",     2.0, 0.2,   "takum_log8 add");
+
+		// e is exactly representable in the logarithmic takum and in no binary
+		// floating-point format: the value base is sqrt(e), so e is sqrt(e)^2 and
+		// its logarithmic value is the integer 2.
+		check_value(reg, "takum_log32", "e", 2.71828182845904524, 1e-9, "takum_log32 e");
+
+		// The two variants share a bit layout but not a value map, so the same
+		// number must land on DIFFERENT bits.  That is the reason both are
+		// registered, and a registration that silently aliased one to the other
+		// would pass every check above.
+		Value lin = eval_in(reg, "takum32",     "3.0");
+		Value log = eval_in(reg, "takum_log32", "3.0");
+		if (lin.binary_rep == log.binary_rep) {
+			std::cerr << "FAIL: takum32 and takum_log32 produced identical encodings for 3.0: "
+			          << lin.binary_rep << "\n";
+			++nrOfFailedTests;
+		}
+		if (lin.type_name == log.type_name) {
+			std::cerr << "FAIL: takum32 and takum_log32 report the same type tag: "
+			          << lin.type_name << "\n";
+			++nrOfFailedTests;
+		}
+	}
+
+	// ================================================================
 	// Report
 	// ================================================================
 	if (nrOfFailedTests > 0) {


### PR DESCRIPTION
Next item from #1297. `takum_log` was absent from the calculator, so the thing it is most useful for — seeing that the two variants disagree — could not be done there.

## Registration alone was enough

`ucalc.cpp` already includes `takum.hpp`, which pulls in `takum_log_impl.hpp`, and the generic `register_type<T>` detects capabilities through SFINAE and ADL rather than requiring a specialization. All four widths work through the existing paths — `show`, `bits`, `range`, `precision`, `ulp`, `compare`, `diverge` — with no changes to the dispatch layer.

The interesting one is `diverge`, which now spans the two encodings:

```
> diverge x*x takum32 takum_log32 1e-9 for x in [1,2]
  first divergence at x = 1.0000169297250676
  takum32       1.000033855
  takum_log32   1.000033863
  ulp diff:     2.154 ULPs
```

and the same value lands on different bits, as it must:

```
takum32      3.0 -> 0b0.1.001.0.10000000000000000000000000
takum_log32  3.0 -> 0b0.1.001.1.00110010011111010100111101
```

Same DR field, different C and M — one encoding, two value maps.

## Coverage

The takum family had **no coverage in ucalc's regression at all**, so this adds it for both variants: arithmetic, `sqrt`, constants, and the widths from 8 to 64.

Two checks exist specifically to catch a registration that compiles but is wrong. A registration that silently aliased `takum_log32` to `takum32` would satisfy every value check — both types compute `1+1` — so the suite also asserts the two produce **different encodings** and **different type tags** for the same input.

Verified by mutation: aliasing the registration trips three checks — those two, plus `e`, which is exactly representable in the logarithmic takum and in no binary floating-point format, because the value base is `sqrt(e)`.

One note on that mutation test: my first attempt reported PASS against the mutant, which turned out to be the harness rather than the check — `#include "registry.hpp"` resolves relative to `regression.cpp`'s own directory, so it picked up the real registry instead of the patched one. Re-run correctly, all three checks fire.

## Validation

`ucalc` and `regression` both build clean under gcc and clang, regression passes on both, README type count updated, `check-ascii` green, no new long lines.