### PR TITLE
test: add the logic and conversion regression suites

### DIFF
--- a/static/tapered/takum_log/conversion/conversion.cpp
+++ b/static/tapered/takum_log/conversion/conversion.cpp
@@ -1,0 +1,316 @@
+// conversion.cpp: value conversion verification for the logarithmic takum
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// takum_log converts by way of its logarithmic value: encoding a real x means
+// finding the representable l nearest 2 ln|x|, and decoding means evaluating
+// sqrt(e)^l.  The properties worth pinning follow from that, and two of them are
+// specific enough to this format to be easy to get wrong:
+//
+//   decode-encode identity   every encoding must survive a round trip out to a
+//                            double and back, wherever a double can hold it
+//   monotonicity             encoding is order preserving, so a larger real must
+//                            never produce a smaller encoding
+//   saturation direction     a value past maxpos saturates UP and one below
+//                            minpos goes to zero -- and those two must not swap,
+//                            which is precisely the failure that made exp()
+//                            return zero for exp(maxpos) in #1305
+//   integers are not exact   an integer k is sqrt(e)^l only for irrational l, so
+//                            takum_log<32,3>(3) holds 2.99999999 and NO
+//                            configuration represents 3 exactly.  Tests that
+//                            assume otherwise fail for the wrong reason; this one
+//                            asserts the property instead.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstdint>
+#include <universal/number/takum/takum_log.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// Every encoding must survive encoding -> double -> encoding.
+template<unsigned nbits, unsigned rbits>
+int VerifyRoundTrip(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	const uint64_t NR = 1ull << nbits;
+	long exercised = 0;
+
+	for (uint64_t i = 0; i < NR; ++i) {
+		TL x; x.setbits(i);
+		if (x.isnar()) continue;
+		const double d = double(x);
+		// wide regime fields put minpos and maxpos outside a double's range; those
+		// encodings are valid, they just cannot be compared through one
+		if (!std::isfinite(d)) continue;
+		if (d == 0.0 && !x.iszero()) continue;
+
+		TL back(d);
+		++exercised;
+		if (back.raw_bits() != x.raw_bits()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL round trip bits=" << i << " value=" << d
+				          << " came back as " << back.raw_bits() << '\n';
+			}
+		}
+	}
+	if (exercised == 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL round trip exercised nothing\n";
+	}
+	return nrOfFailedTests;
+}
+
+// Encoding preserves order: a larger real never yields a smaller encoding.
+template<unsigned nbits, unsigned rbits>
+int VerifyMonotonic(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+
+	// sweep the representable span in the logarithmic domain, where the format is
+	// uniform, so the samples are spread evenly across the encodings
+	TL lo(sw::universal::SpecificValue::minpos);
+	TL hi(sw::universal::SpecificValue::maxpos);
+	const double dlo = double(lo), dhi = double(hi);
+	if (!std::isfinite(dlo) || !std::isfinite(dhi) || dlo <= 0.0) return 0;   // beyond double
+
+	const int N = 4000;
+	const double llo = std::log(dlo), lhi = std::log(dhi);
+	TL prev; bool have_prev = false;
+	for (int i = 0; i <= N; ++i) {
+		const double v = std::exp(llo + (lhi - llo) * (double(i) / double(N)));
+		if (!std::isfinite(v) || v == 0.0) continue;
+		TL x(v);
+		if (x.isnar()) continue;
+		if (have_prev && x < prev) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL monotonicity broken at " << v << '\n';
+			}
+		}
+		prev = x; have_prev = true;
+	}
+	// and the same on the negative side, where the ordering reverses in value
+	// but must still be consistent
+	TL nprev; bool have_nprev = false;
+	for (int i = N; i >= 0; --i) {
+		const double v = -std::exp(llo + (lhi - llo) * (double(i) / double(N)));
+		if (!std::isfinite(v)) continue;
+		TL x(v);
+		if (x.isnar()) continue;
+		if (have_nprev && x < nprev) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL negative monotonicity broken at " << v << '\n';
+		}
+		nprev = x; have_nprev = true;
+	}
+	return nrOfFailedTests;
+}
+
+// Saturation must go the right way at both ends, and the two must not swap.
+template<unsigned nbits, unsigned rbits>
+int VerifySaturation(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	auto fail = [&](const char* what) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL " << what << '\n';
+	};
+
+	TL maxpos(sw::universal::SpecificValue::maxpos);
+	TL minpos(sw::universal::SpecificValue::minpos);
+	const double dmax = double(maxpos), dmin = double(minpos);
+	if (!std::isfinite(dmax) || dmin <= 0.0) return 0;   // beyond double, cannot drive from one
+
+	// past the top saturates UP, not to zero
+	TL over(dmax * 16.0);
+	if (over.iszero())  fail("a value above maxpos must not become zero");
+	if (over.sign())    fail("a value above maxpos must stay positive");
+	TL under_neg(-dmax * 16.0);
+	if (under_neg.iszero()) fail("a value below maxneg must not become zero");
+	if (!under_neg.sign())  fail("a value below maxneg must stay negative");
+
+	// below the bottom goes to zero, not to maxpos
+	TL tiny(dmin / 16.0);
+	if (!tiny.iszero())     fail("a value below minpos must underflow to zero");
+	TL tiny_neg(-dmin / 16.0);
+	if (!tiny_neg.iszero()) fail("a negative value below minpos must underflow to zero");
+
+	// specials
+	TL zero(0.0);
+	if (!zero.iszero())                                    fail("0.0 must encode as zero");
+	TL nan(std::numeric_limits<double>::quiet_NaN());
+	if (!nan.isnar())                                      fail("NaN must encode as NaR");
+	TL inf(std::numeric_limits<double>::infinity());
+	if (!inf.isnar())                                      fail("infinity must encode as NaR");
+	TL ninf(-std::numeric_limits<double>::infinity());
+	if (!ninf.isnar())                                     fail("-infinity must encode as NaR");
+	return nrOfFailedTests;
+}
+
+// No integer is exactly representable, because k = sqrt(e)^l needs an irrational
+// l for every integer k except none at all.  This is the property that makes
+// naive expectations like "floor(TL(3)) == 3" fail, so assert it rather than
+// letting a future test trip over it.
+template<unsigned nbits, unsigned rbits>
+int VerifyIntegersInexact(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+
+	// 1 is the exception: l == 0, exactly representable.
+	TL one(1.0);
+	if (double(one) != 1.0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL 1.0 must be exact (l == 0)\n";
+	}
+	// The inexactness itself can only be OBSERVED through a double while the format
+	// is coarser than one.  At nbits = 64 the trailing field reaches 58 bits, finer
+	// than a double's 53, so double(TL(2)) rounds to exactly 2.0 even though the
+	// stored M is 111341769010871232 rather than 0.  Checking it there would assert
+	// a property of the yardstick, not of the format.
+	constexpr bool double_can_resolve = (nbits <= 32);
+	for (double k : { 2.0, 3.0, 5.0, 7.0, 10.0, 100.0 }) {
+		TL x(k);
+		if (x.iszero() || x.isnar()) continue;
+		if (double_can_resolve && double(x) == k) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL " << k << " came out exact; no integer but 1 should be\n";
+			}
+		}
+		// What IS checkable at every width: the encoding has a non-zero fraction.
+		// k = sqrt(e)^l needs l = 2 ln k, which is transcendental for every integer
+		// k except 1, so the trailing field can never be empty.
+		{
+			auto dk = TL::Codec::decode(x.magnitude_bits());
+			if (dk.p > 0 && dk.M_bits == 0) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL " << k << " encoded with an empty fraction,"
+					          << " implying an exact power of sqrt(e)\n";
+				}
+			}
+		}
+		// but it must still be close
+		const double rel = std::fabs((double(x) - k) / k);
+		if (!(rel < 1.0e-2)) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL " << k << " encoded too far off: relerr " << rel << '\n';
+			}
+		}
+	}
+	// and the powers of the value base ARE exact: e, 1/e, sqrt(e)
+	TL e_val(2.718281828459045235360287471352662497757);
+	auto d = TL::Codec::decode(e_val.magnitude_bits());
+	if (d.c != 2 || d.M_bits != 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) {
+			std::cout << "FAIL e should encode exactly as l == 2, got c=" << d.c
+			          << " M=" << d.M_bits << '\n';
+		}
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "takum_log conversion verification";
+	std::string test_tag    = "conversion";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<12, 3>(true), "takum_log<12,3>", "round trip");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySaturation<16, 3>(reportTestCases), "takum_log<16,3>", "saturation direction");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySaturation<32, 3>(reportTestCases), "takum_log<32,3>", "saturation direction");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIntegersInexact<32, 3>(reportTestCases), "takum_log<32,3>", "integers are inexact");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<12, 3>(reportTestCases), "takum_log<12,3>", "round trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<16, 3>(reportTestCases), "takum_log<16,3>", "round trip");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyMonotonic<16, 3>(reportTestCases), "takum_log<16,3>", "encoding is monotonic");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyMonotonic<32, 3>(reportTestCases), "takum_log<32,3>", "encoding is monotonic");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIntegersInexact<16, 3>(reportTestCases), "takum_log<16,3>", "integers are inexact");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<16, 1>(reportTestCases), "takum_log<16,1>", "round trip");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<18, 3>(reportTestCases), "takum_log<18,3>", "round trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifySaturation<12, 3>(reportTestCases), "takum_log<12,3>", "saturation direction");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyMonotonic<12, 3>(reportTestCases), "takum_log<12,3>", "encoding is monotonic");
+#endif
+
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyRoundTrip<20, 3>(reportTestCases), "takum_log<20,3>", "round trip");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIntegersInexact<64, 3>(reportTestCases), "takum_log<64,3>", "integers are inexact");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyMonotonic<64, 3>(reportTestCases), "takum_log<64,3>", "encoding is monotonic");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/takum_log/logic/logic.cpp
+++ b/static/tapered/takum_log/logic/logic.cpp
@@ -1,0 +1,243 @@
+// logic.cpp: comparison operator verification for the logarithmic takum
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Neither takum variant had a logic suite.  That matters more here than it would
+// for most formats, because takum comparison is not a value comparison: the
+// encoding is a two's-complement integer whose order IS the value order
+// (Proposition 4), so the operators work on bits and never decode.  Nothing was
+// checking that the shortcut agrees with the values it stands for.
+//
+// The two properties that make it work are checked separately:
+//
+//   ordering    for every pair of encodings, the bit comparison agrees with the
+//               comparison of the decoded values
+//   totality    exactly one of <, ==, > holds for any pair, and the relations are
+//               mutually consistent
+//
+// NaR is excluded from the ordering check and given its own.  It IS a normal
+// two's-complement encoding -- 0x8000 at 16 bits, the most negative word -- but
+// both variants deliberately give it IEEE NaN semantics in comparison: every
+// relation involving NaR returns false, including NaR == NaR.
+//
+// That is worth pinning precisely because the encoding and the semantics point
+// opposite ways.  x == x is false for NaR, trichotomy does not hold for it, and
+// nothing in the library was checking either.  An earlier draft of this file
+// asserted the opposite, on the reasoning that a two's-complement value ought to
+// compare like one; the implementation says otherwise, in both variants, and the
+// implementation is the specification here.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <cstdint>
+#include <universal/number/takum/takum_log.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// The bit comparison must agree with the value comparison, for every pair.
+// Exhaustive: at 10 and 12 bits that is a million pairs, which is cheap and
+// leaves no room for a lucky sample.
+template<unsigned nbits, unsigned rbits>
+int VerifyOrdering(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	const uint64_t NR = 1ull << nbits;
+
+	for (uint64_t i = 0; i < NR; ++i) {
+		TL a; a.setbits(i);
+		if (a.isnar()) continue;
+		const double da = double(a);
+		if (!std::isfinite(da)) continue;
+
+		for (uint64_t j = 0; j < NR; ++j) {
+			TL b; b.setbits(j);
+			if (b.isnar()) continue;
+			const double db = double(b);
+			if (!std::isfinite(db)) continue;
+
+			// Distinct encodings can share a double when the format outruns it,
+			// so only the strict relations are pinned against the value.
+			if (da < db && !(a < b)) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL " << da << " < " << db << " but encodings disagree\n";
+				}
+			}
+			if (da > db && !(a > b)) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL " << da << " > " << db << " but encodings disagree\n";
+				}
+			}
+			if (i == j && !(a == b)) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cout << "FAIL identical encodings are not equal\n";
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// Exactly one of <, ==, > must hold, and the derived relations must follow.
+template<unsigned nbits, unsigned rbits>
+int VerifyTotality(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	const uint64_t NR = 1ull << nbits;
+
+	for (uint64_t i = 0; i < NR; ++i) {
+		TL a; a.setbits(i);
+		if (a.isnar()) continue;
+		for (uint64_t j = 0; j < NR; ++j) {
+			TL b; b.setbits(j);
+			if (b.isnar()) continue;
+
+			const int trichotomy = (a < b ? 1 : 0) + (a == b ? 1 : 0) + (a > b ? 1 : 0);
+			if (trichotomy != 1) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL trichotomy broken for bits " << i << " and " << j << '\n';
+				}
+			}
+			if ((a != b) != !(a == b)) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cout << "FAIL != is not the negation of ==\n";
+			}
+			if ((a <= b) != (a < b || a == b)) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cout << "FAIL <= is not < or ==\n";
+			}
+			if ((a >= b) != (a > b || a == b)) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cout << "FAIL >= is not > or ==\n";
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// NaR is a normal two's-complement value, not an IEEE NaN, so it compares rather
+// than poisoning every relation.  Pin what it actually does.
+template<unsigned nbits, unsigned rbits>
+int VerifyNaR(bool reportTestCases) {
+	using TL = sw::universal::takum_log<nbits, rbits>;
+	int nrOfFailedTests = 0;
+	auto fail = [&](const char* what) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL " << what << '\n';
+	};
+
+	TL nar; nar.setnar();
+	TL zero; zero.setzero();
+	TL one(1.0);
+
+	if (!nar.isnar())            fail("setnar did not produce NaR");
+	// NaN semantics: every comparison against NaR is false, itself included.
+	if (nar == nar)              fail("NaR == NaR must be false (NaN semantics)");
+	if (!(nar != nar))           fail("NaR != NaR must be true");
+	if (nar == zero)             fail("NaR == zero must be false");
+	if (nar == one)              fail("NaR == one must be false");
+	if (nar < one)               fail("NaR < one must be false");
+	if (nar > one)               fail("NaR > one must be false");
+	if (one < nar)               fail("one < NaR must be false");
+	if (one > nar)               fail("one > NaR must be false");
+	if (nar <= nar)              fail("NaR <= NaR must be false");
+	if (nar >= nar)              fail("NaR >= NaR must be false");
+	// so trichotomy fails for NaR, which is why the ordering suites exclude it
+	if (((nar < one) ? 1 : 0) + ((nar == one) ? 1 : 0) + ((nar > one) ? 1 : 0) != 0) {
+		fail("no relation involving NaR should hold");
+	}
+	// zero and its negation are the same encoding
+	TL negzero = -zero;
+	if (!(negzero == zero))      fail("negated zero must equal zero");
+	if (!zero.iszero() || !negzero.iszero()) fail("negated zero must still be zero");
+	// ordering around zero
+	TL neg(-1.0);
+	if (!(neg < zero))           fail("-1 < 0");
+	if (!(zero < one))           fail("0 < 1");
+	if (!(neg < one))            fail("-1 < 1");
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "takum_log logic operator verification";
+	std::string test_tag    = "logic";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyOrdering<8, 3>(true), "takum_log<8,3>", "ordering");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyNaR<16, 3>(reportTestCases), "takum_log<16,3>", "NaR and zero");
+	nrOfFailedTestCases += ReportTestResult(VerifyNaR<32, 3>(reportTestCases), "takum_log<32,3>", "NaR and zero");
+	nrOfFailedTestCases += ReportTestResult(VerifyOrdering<8, 3>(reportTestCases), "takum_log<8,3>", "ordering");
+	nrOfFailedTestCases += ReportTestResult(VerifyTotality<8, 3>(reportTestCases), "takum_log<8,3>", "trichotomy");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyOrdering<10, 3>(reportTestCases), "takum_log<10,3>", "ordering");
+	nrOfFailedTestCases += ReportTestResult(VerifyTotality<10, 3>(reportTestCases), "takum_log<10,3>", "trichotomy");
+	nrOfFailedTestCases += ReportTestResult(VerifyOrdering<8, 1>(reportTestCases), "takum_log<8,1>", "ordering");
+	nrOfFailedTestCases += ReportTestResult(VerifyNaR<12, 3>(reportTestCases), "takum_log<12,3>", "NaR and zero");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyOrdering<12, 3>(reportTestCases), "takum_log<12,3>", "ordering");
+	nrOfFailedTestCases += ReportTestResult(VerifyTotality<12, 3>(reportTestCases), "takum_log<12,3>", "trichotomy");
+	nrOfFailedTestCases += ReportTestResult(VerifyOrdering<10, 2>(reportTestCases), "takum_log<10,2>", "ordering");
+#endif
+
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(VerifyOrdering<14, 3>(reportTestCases), "takum_log<14,3>", "ordering");
+	nrOfFailedTestCases += ReportTestResult(VerifyTotality<14, 3>(reportTestCases), "takum_log<14,3>", "trichotomy");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
Two of the three directories from #1297. **Arithmetic is deliberately not here** — see the end.

## Logic

Neither takum variant had a logic suite, and it matters more here than for most formats: **takum comparison is not a value comparison.** The encoding is a two's-complement integer whose order *is* the value order (Prop. 4), so the operators work on bits and never decode. Nothing was checking that the shortcut agrees with the values it stands for. Ordering and trichotomy are now exhaustive over every pair up to 14 bits.

**The NaR semantics were worth pinning, and I had them backwards at first.** NaR is a perfectly normal two's-complement encoding — `0x8000` at 16 bits — so I wrote the suite expecting it to compare like a value. Both variants deliberately give it IEEE NaN semantics instead: every relation involving NaR is false, `NaR == NaR` included, and trichotomy therefore does not hold for it. The implementation is the specification here, and the suite now says so.

## Conversion

Round trip through a double, monotonicity of the encoding, and the **saturation direction** — a value past maxpos must saturate up and one below minpos must go to zero, and those two must not swap. That is exactly the failure that made `exp()` return zero for `exp(maxpos)` in #1305, so it is checked rather than assumed.

It also asserts that **no integer but 1 is exactly representable**: `k = sqrt(e)^l` needs `l = 2 ln k`, transcendental for every integer except 1. That property is what makes naive expectations like `floor(TL(3)) == 3` fail, and it has now caught me out twice, so it is written down.

Observing it is width-limited, which took a failing test to notice. At `nbits = 64` the trailing field reaches 58 bits, finer than a double's 53, so `double(TL(2))` rounds to exactly `2.0` while the stored `M` is `111341769010871232` rather than `0`. The double comparison now runs only where a double can resolve the difference; the encoding-level check — a non-empty trailing field — runs everywhere.

## Verified by mutation

- negating `operator<` trips ordering and trichotomy with **67M** and **402M** failures
- swapping the saturation directions in `convert_ieee754` trips the conversion suite at every width

A first attempt at the `operator<` mutation silently failed to apply and the suite reported PASS. A mutation that does not fail is not evidence, and I re-ran it properly.

## Why arithmetic is held

`takum_log`'s operators are double-mediated. Measured against a 113-bit reference, that stops being correctly rounded at 64 bits:

| configuration | `a+b` incorrectly rounded |
|---|---|
| `takum<16,3>`, `<32,3>` | 0.00% |
| `takum<64,3>` | **75.60%** |
| `takum_log<16,3>`, `<32,3>` | 0.00% |
| `takum_log<64,3>` | **99.22%** |

That is what #1300 tracks. Written now, the arithmetic suite would need a survey-mode carve-out documenting the defect; written after #1300, it asserts correct rounding unconditionally at every width — one rule instead of two, and written once.

The measurement is [posted to #1300](https://github.com/stillwater-sc/universal/issues/1300#issuecomment-5296860249), along with two things that issue did not capture: it applies to `takum_log` as well and more severely, and the `dd_cascade` plumbing it needs (exact operand reconstruction, round-to-odd extraction, `encode_fraction`) already landed with #1309.

## Validation

Both suites pass under gcc and clang, zero non-pre-existing warnings, `check-ascii` green, no long lines.