### PR TITLE
test(takum_log): cover multiply and divide rounding at 64 bits

### DIFF
--- a/static/tapered/takum_log/arithmetic/multiplication.cpp
+++ b/static/tapered/takum_log/arithmetic/multiplication.cpp
@@ -58,7 +58,7 @@ template<unsigned nbits, unsigned rbits>
 int VerifyIdentities(bool reportTestCases) {
 	using TL = sw::universal::takum_log<nbits, rbits>;
 	int nrOfFailedTests = 0;
-	const uint64_t NR = 1ull << nbits;
+	const uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);   // no 64-bit shift
 	TL one(1.0), zero; zero.setzero();
 	TL nar; nar.setnar();
 
@@ -89,7 +89,7 @@ template<unsigned nbits, unsigned rbits>
 int VerifyCommutative(bool reportTestCases) {
 	using TL = sw::universal::takum_log<nbits, rbits>;
 	int nrOfFailedTests = 0;
-	const uint64_t NR = 1ull << nbits;
+	const uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);   // no 64-bit shift
 
 	for (uint64_t i = 0; i < NR; ++i) {
 		TL a; a.setbits(i);
@@ -113,12 +113,15 @@ int VerifyCommutative(bool reportTestCases) {
 // 67 that l needs, so the reference is exact for this purpose, and it is arrived
 // at independently of the operator's integer path.
 template<unsigned nbits, unsigned rbits>
-int VerifyCorrectlyRounded(bool divide, bool reportTestCases) {
+int VerifyCorrectlyRounded(bool divide, bool reportTestCases, uint64_t stride = 1) {
 	using sw::universal::dd_cascade;
 	using TL    = sw::universal::takum_log<nbits, rbits, std::uint64_t>;
 	using Codec = typename TL::Codec;
 	int nrOfFailedTests = 0;
-	const uint64_t NR = 1ull << nbits;
+	// 1ull << nbits is undefined at nbits == 64, and 64 is exactly the width this
+	// change exists for, so the bound is expressed without it.  stride > 1 samples
+	// rather than enumerating, since the sweep is over PAIRS.
+	const uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
 	const uint64_t span = (1ull << (nbits - 1)) - 1;
 	long exercised = 0;
 
@@ -135,10 +138,10 @@ int VerifyCorrectlyRounded(bool divide, bool reportTestCases) {
 		return l;
 	};
 
-	for (uint64_t i = 0; i < NR; ++i) {
+	for (uint64_t i = 0; i < NR && i + stride > i; i += stride) {
 		TL a; a.setbits(i);
 		if (a.isnar() || a.iszero()) continue;
-		for (uint64_t j = 0; j < NR; ++j) {
+		for (uint64_t j = 0; j < NR && j + stride > j; j += stride) {
 			TL b; b.setbits(j);
 			if (b.isnar() || b.iszero()) continue;
 
@@ -259,6 +262,18 @@ try {
 		VerifyCorrectlyRounded<8, 1>(true, reportTestCases), "takum_log<8,1>", "correctly rounded divide");
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyIdentities<14, 3>(reportTestCases), "takum_log<14,3>", "identities");
+	// The width this change exists for.  takum_log<64,3> reaches p = 58 and 59,
+	// past a double's 53, and the double-mediated operators it replaced were
+	// incorrectly rounded for 99% of products here.  Sampled with a stride
+	// coprime to the field structure so the sweep crosses every DR (about 225
+	// samples per operand, so ~50k pairs); enumerating
+	// pairs at 64 bits is obviously out of the question.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 3>(false, reportTestCases, 0x0123456789ABCDEFull),
+		"takum_log<64,3>", "correctly rounded multiply");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 3>(true, reportTestCases, 0x0123456789ABCDEFull),
+		"takum_log<64,3>", "correctly rounded divide");
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);


### PR DESCRIPTION
Closes the coverage gap I flagged when merging #1312, and the one CodeRabbit raised there.

## The gap

The correctly-rounded reference check ran at **8 and 10 bits only**, so the width that arithmetic exists for had no committed coverage. #1312 verified it against a 113-bit `__float128` oracle, but that needs quadmath and cannot ship — which left the headline claim (99.22% incorrectly rounded → 0.00% at `takum_log<64,3>`) resting on nothing in the tree.

## Two things had to change

**`1ull << nbits` is undefined at `nbits == 64`.** That is why the 64-bit case was not a one-line addition. It was dormant, since nothing instantiated it there, but the bound is now expressed without a 64-bit shift — and the same latent trap is removed from `VerifyIdentities` and `VerifyCommutative`, which are only instantiated narrow today but were built the same way.

**The sweep is over pairs, so it needed a stride.** My first attempt used one giving ~12,000 samples per operand — 151 million pairs, each doing several `dd_cascade` operations. It did not finish. At ~225 samples per operand the whole suite runs in **3.4 seconds**.

## Confirmed to discriminate

Removing the division borrow trips the new 64-bit case with **24,288 failures**, while correctly leaving multiplication passing, since that path does not borrow. Same mutation, same expected asymmetry as the 8- and 10-bit cases.

## Validation

Builds clean under gcc and clang, full suite passes in 3.4s, `check-ascii` green, no long lines.