### PR TITLE
fix(takum): evaluate wide-configuration arithmetic exactly in integers

### DIFF
--- a/include/sw/universal/number/takum/math/fma.hpp
+++ b/include/sw/universal/number/takum/math/fma.hpp
@@ -6,15 +6,23 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
-// takum has no extended-precision blocktriple product path, so fma widens the
-// operands to double, forms a*b + c with std::fma (one IEEE rounding to double),
-// and rounds the result once into takum via the value constructor. A takum's
-// significand precision is well under double's 53 bits for the practical
-// configurations, so double(x) is the exact represented value, the product is
-// exact in double, and the subsequent double -> takum rounding is the single
-// rounding that determines the result -- the double intermediate carries far more
-// precision than the takum target. takum's non-real state (NaR) absorbs the IEEE
-// specials: inf*0 -> NaN -> NaR, and any inf / NaN operand -> NaR.
+// For configurations NARROWER than 54 + rbits bits, fma widens the operands to
+// double, forms a*b + c with std::fma (one IEEE rounding to double), and rounds
+// the result once into takum via the value constructor. A takum's significand is
+// 1 + p bits with p reaching nbits - 2 - rbits, so below that threshold -- which
+// is 57 bits for the specified rbits = 3 -- it stays under double's 53, and
+// double(x) is the exact represented value, the product is exact in double, and
+// the subsequent double -> takum rounding is the single rounding that determines
+// the result. takum's non-real state (NaR) absorbs the IEEE specials:
+// inf*0 -> NaN -> NaR, and any inf / NaN operand -> NaR.
+//
+// AT AND ABOVE that threshold the reasoning fails, and it fails before the fma
+// begins: takum<64,3> carries a 60-bit significand, so double(a) is already a
+// rounded operand and std::fma then delivers an exact product of the wrong
+// numbers. Those configurations take the exact integer path instead
+// (takum_wide_arithmetic.hpp): the significand product is exact in 128 bits, c is
+// aligned into the same window, and the single rounding happens once at the end
+// in the codec -- which is what fma is FOR. Issue #1300.
 //
 // Sub-issue of #1189 (universal fma, linear takum epic #592). Relates to #1195.
 
@@ -25,7 +33,21 @@ namespace sw { namespace universal {
 template<unsigned nbits, unsigned rbits, typename bt>
 takum<nbits, rbits, bt> fma(const takum<nbits, rbits, bt>& a, const takum<nbits, rbits, bt>& b,
                             const takum<nbits, rbits, bt>& c) {
-	return takum<nbits, rbits, bt>(std::fma(double(a), double(b), double(c)));
+	using Takum = takum<nbits, rbits, bt>;
+	if constexpr (Takum::wide_significand) {
+		Takum result;
+		if (a.isnar() || b.isnar() || c.isnar()) { result.setnar(); return result; }
+		// takum has no signed zero, so a vanishing product is simply absent from
+		// the sum and there is no -0 + 0 sign convention to preserve.
+		if (a.iszero() || b.iszero()) return c;
+		auto product = takum_wide::multiply(a.to_wide_operand(), b.to_wide_operand());
+		if (c.iszero()) return result.assign_wide(product);
+		return result.assign_wide(
+			takum_wide::sum(product, takum_wide::widen(c.to_wide_operand()), false));
+	}
+	else {
+		return Takum(std::fma(double(a), double(b), double(c)));
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/include/sw/universal/number/takum/math/fma.hpp
+++ b/include/sw/universal/number/takum/math/fma.hpp
@@ -6,17 +6,18 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
-// For configurations NARROWER than 54 + rbits bits, fma widens the operands to
+// For configurations with nbits <= 54 + rbits, fma widens the operands to
 // double, forms a*b + c with std::fma (one IEEE rounding to double), and rounds
 // the result once into takum via the value constructor. A takum's significand is
-// 1 + p bits with p reaching nbits - 2 - rbits, so below that threshold -- which
-// is 57 bits for the specified rbits = 3 -- it stays under double's 53, and
-// double(x) is the exact represented value, the product is exact in double, and
-// the subsequent double -> takum rounding is the single rounding that determines
-// the result. takum's non-real state (NaR) absorbs the IEEE specials:
-// inf*0 -> NaN -> NaR, and any inf / NaN operand -> NaR.
+// 1 + p bits with p reaching nbits - 2 - rbits, so up to and including that
+// threshold -- 57 bits for the specified rbits = 3, where the significand is
+// exactly 53 -- it still fits a double, and double(x) is the exact represented
+// value, the product is exact in double, and the subsequent double -> takum
+// rounding is the single rounding that determines the result. takum's non-real
+// state (NaR) absorbs the IEEE specials: inf*0 -> NaN -> NaR, and any inf / NaN
+// operand -> NaR.
 //
-// AT AND ABOVE that threshold the reasoning fails, and it fails before the fma
+// ABOVE that threshold the reasoning fails, and it fails before the fma
 // begins: takum<64,3> carries a 60-bit significand, so double(a) is already a
 // rounded operand and std::fma then delivers an exact product of the wrong
 // numbers. Those configurations take the exact integer path instead

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -50,6 +50,7 @@
 
 #include <universal/internal/bit_manipulation.hpp>
 #include <universal/number/takum/takum_codec.hpp>
+#include <universal/number/takum/takum_wide_arithmetic.hpp>
 
 namespace sw {	namespace universal {
 
@@ -106,6 +107,17 @@ public:
 
 	// Maximum characteristic bits available for this nbits
 	static constexpr unsigned maxCharBits = Codec::maxCharBits;
+
+	// Does the significand outrun a double?  A takum significand is 1 + p bits and
+	// p reaches maxCharBits, so this is true exactly when nbits > 54 + rbits: 57
+	// for the specified rbits = 3, which puts takum<64,3> and its 60-bit
+	// significand on the wrong side of a double's 53.  Those configurations
+	// evaluate their arithmetic exactly in integers (takum_wide_arithmetic.hpp)
+	// rather than through a double that would quantize both operands before the
+	// operation ever happened -- issue #1300.  Everything narrower keeps the
+	// double path, where the operands ARE exact doubles and one rounding decides
+	// the result.
+	static constexpr bool wide_significand = (maxCharBits + 1u) > 53u;
 
 	// Codec geometry, re-exported so that the public surface of takum<> is
 	// unchanged by the codec extraction (manipulators, numeric_limits and the
@@ -221,26 +233,45 @@ public:
 		return result;
 	}
 
-	// in-place arithmetic via double conversion.  CONSTEXPRESSION because
-	// the underlying convert_ieee754 / to_ieee754 path becomes constexpr only
-	// when sw::bit_cast is constexpr (BIT_CAST_IS_CONSTEXPR=true) and the
-	// constexpr_math::exp2 helper is constant-evaluable.
+	// in-place arithmetic.  Narrow configurations evaluate in a double, where both
+	// operands are exact and the conversion back is the single rounding that
+	// decides the result; wide ones (see wide_significand) evaluate exactly in
+	// integers instead.  CONSTEXPRESSION because the underlying convert_ieee754 /
+	// to_ieee754 path becomes constexpr only when sw::bit_cast is constexpr
+	// (BIT_CAST_IS_CONSTEXPR=true) and the constexpr_math::exp2 helper is
+	// constant-evaluable; the integer path is constexpr throughout.
 	CONSTEXPRESSION takum& operator+=(const takum& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
-		double result = double(*this) + double(rhs);
-		return convert_ieee754(result);
+		if constexpr (wide_significand) {
+			return wide_sum(rhs, false);
+		}
+		else {
+			double result = double(*this) + double(rhs);
+			return convert_ieee754(result);
+		}
 	}
 	CONSTEXPRESSION takum& operator+=(double rhs) { return *this += takum(rhs); }
 	CONSTEXPRESSION takum& operator-=(const takum& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
-		double result = double(*this) - double(rhs);
-		return convert_ieee754(result);
+		if constexpr (wide_significand) {
+			return wide_sum(rhs, true);
+		}
+		else {
+			double result = double(*this) - double(rhs);
+			return convert_ieee754(result);
+		}
 	}
 	CONSTEXPRESSION takum& operator-=(double rhs) { return *this -= takum(rhs); }
 	CONSTEXPRESSION takum& operator*=(const takum& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
-		double result = double(*this) * double(rhs);
-		return convert_ieee754(result);
+		if constexpr (wide_significand) {
+			if (iszero() || rhs.iszero()) { setzero(); return *this; }
+			return assign_wide(takum_wide::multiply(to_wide_operand(), rhs.to_wide_operand()));
+		}
+		else {
+			double result = double(*this) * double(rhs);
+			return convert_ieee754(result);
+		}
 	}
 	CONSTEXPRESSION takum& operator*=(double rhs) { return *this *= takum(rhs); }
 	CONSTEXPRESSION takum& operator/=(const takum& rhs) {
@@ -255,10 +286,40 @@ public:
 			return *this;
 #endif
 		}
-		double result = double(*this) / double(rhs);
-		return convert_ieee754(result);
+		if constexpr (wide_significand) {
+			if (iszero()) { setzero(); return *this; }
+			return assign_wide(takum_wide::divide(to_wide_operand(), rhs.to_wide_operand()));
+		}
+		else {
+			double result = double(*this) / double(rhs);
+			return convert_ieee754(result);
+		}
 	}
 	CONSTEXPRESSION takum& operator/=(double rhs) { return *this /= takum(rhs); }
+
+	// Exact-arithmetic surface, public so that fma() -- which is a free function
+	// and cannot reach a private member -- shares this decode and this rounding
+	// tail rather than reimplementing either.  Both are well defined at every
+	// width; it is simply that configurations with wide_significand == false never
+	// reach them.
+
+	// Decode to  value = (-1)^sign * S * 2^e.  Pre: neither zero nor NaR.
+	constexpr takum_wide::operand to_wide_operand() const noexcept {
+		return takum_wide::decode_operand<Codec>(sign(), magnitude_bits());
+	}
+
+	// Round a fully evaluated exact result into this takum.  A zero V is the
+	// genuine zero the codec cannot express; saturation follows conversion from a
+	// native float and lands on maxpos / maxneg / zero.
+	CONSTEXPRESSION takum& assign_wide(const takum_wide::wide_value& r) noexcept {
+		if (takum_wide::iszero(r.V)) { setzero(); return *this; }
+		auto enc = takum_wide::encode<Codec>(r);
+		if (enc.overflowed()) { if (r.sign) maxneg(); else maxpos(); return *this; }
+		if (enc.underflowed()) { setzero(); return *this; }
+		// The codec never sets the sign bit (I4); two's-complement negate here.
+		setbits(r.sign ? (((~enc.magnitude) + 1ull) & nbits_mask()) : enc.magnitude);
+		return *this;
+	}
 
 	// prefix/postfix increment: advance to next/previous representable value
 	constexpr takum& operator++() noexcept {
@@ -452,6 +513,18 @@ protected:
 	}
 
 	static constexpr uint64_t nbits_mask() noexcept { return Codec::nbits_mask(); }
+
+	// Exact addition / subtraction for wide configurations.  The zero cases are
+	// peeled off here because takum_wide::sum() decodes a significand and a zero
+	// has none; they are also the cases issue #1300 opened on -- x + 0 came back
+	// quantized to a double rather than as x.
+	CONSTEXPRESSION takum& wide_sum(const takum& rhs, bool subtract) noexcept {
+		if (rhs.iszero()) return *this;
+		if (iszero()) { *this = (subtract ? -rhs : rhs); return *this; }
+		return assign_wide(takum_wide::sum(takum_wide::widen(to_wide_operand()),
+		                                   takum_wide::widen(rhs.to_wide_operand()),
+		                                   subtract));
+	}
 
 	//////////////////////////////////////////////////////
 	/// conversion routines from native types

--- a/include/sw/universal/number/takum/takum_log_impl.hpp
+++ b/include/sw/universal/number/takum/takum_log_impl.hpp
@@ -196,9 +196,21 @@ public:
 		return result;
 	}
 
-	// in-place arithmetic via double conversion, matching takum<>'s current
-	// approach.  Native logarithmic arithmetic -- where multiply/divide become
-	// fixed-point add/subtract on l -- is tracked in #1297.
+	// Addition and subtraction still evaluate in a double.  They have no
+	// logarithmic shortcut -- unlike the multiply and divide below -- so an exact
+	// path has to leave the logarithmic domain and come back, which costs a
+	// transcendental per operand at the working width.
+	//
+	// That double is a single rounding only while the operands themselves are
+	// exact doubles.  The fraction of l is p bits wide with p reaching
+	// maxCharBits, so takum_log<64,3> carries 59 against a double's 53 and both
+	// operands are quantized before the addition: measured against a 113-bit
+	// reference, 99.22% of 64-bit sums come back incorrectly rounded, against
+	// 0.00% at 16 and 32 bits.  The linear takum resolved the same defect by
+	// evaluating in integers (takum_wide_arithmetic.hpp), which works there
+	// because its values are dyadic and its sums are not transcendental.  The
+	// remaining half of #1300.  Native logarithmic arithmetic more broadly is
+	// tracked in #1297.
 	CONSTEXPRESSION takum_log& operator+=(const takum_log& rhs) {
 		if (isnar() || rhs.isnar()) { setnar(); return *this; }
 		return convert_ieee754(double(*this) + double(rhs));

--- a/include/sw/universal/number/takum/takum_wide_arithmetic.hpp
+++ b/include/sw/universal/number/takum/takum_wide_arithmetic.hpp
@@ -1,0 +1,329 @@
+#pragma once
+// takum_wide_arithmetic.hpp: exact integer evaluation path for the linear takum
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// WHY THIS EXISTS
+//
+// takum<>'s arithmetic operators evaluated in a double.  That is a single rounding
+// -- and therefore correct -- only while the operands themselves are exactly
+// representable as doubles, which stops being true at the wide end of the format:
+// a takum<nbits, rbits> significand is 1 + p bits with p reaching
+// nbits - 2 - rbits, so takum<64,3> carries 60 bits against a double's 53 and both
+// operands were quantized BEFORE the operation.  Adding zero was not a no-op
+// there.  Issue #1300.
+//
+// WHAT IT DOES INSTEAD
+//
+// Everything a linear takum denotes is a dyadic rational:
+//
+//     |value| = (1 + M/2^p) * 2^c = S * 2^e     with  S = 2^p + M,  e = c - p
+//
+// so S is an integer below 2^62 and the arithmetic is integer arithmetic.  The
+// four operations produce an exact (or exactly-tracked) 128-bit result:
+//
+//     multiply   the 124-bit integer product of the two significands, exact
+//     divide     128 quotient bits developed by restoring division, plus a
+//                sticky remainder
+//     add / sub  both terms aligned into a 128-bit window, with a sticky bit for
+//                whatever falls below it
+//
+// and all three then take the SAME tail: normalize, round to odd at qbits, and
+// hand the result to takum_codec::encode_fraction(), which performs the one
+// rounding the target layout actually calls for.
+//
+// WHY ROUND TO ODD
+//
+// The tail narrows twice -- 128 bits to qbits here, qbits to p in the codec -- and
+// two roundings to nearest disagree with one whenever the exact value sits near a
+// tie at the p-bit boundary.  That is not a corner case; the same double rounding
+// left 1.8% of cross-conversions off by an ulp before takum_cross_conversion.hpp
+// adopted round-to-odd.  Truncating and forcing the low bit instead makes the
+// subsequent round-to-nearest-even agree with rounding the exact value directly,
+// provided qbits >= p + 2 (see qbits below).
+//
+// WHY NOT A DOUBLE-DOUBLE
+//
+// #1300 first proposed evaluating in dd_cascade.  Its ~106 bits restore + - /, but
+// the exact product of two 60-bit significands is 120 bits, and while an exact TIE
+// is safe there (a tie needs exactly p+1 significant bits, which dd holds exactly)
+// a NEAR-tie is not: the exact product can sit 2^-120 from a tie point, below
+// dd_cascade's own 2^-104 error.  Integers have no such hole, cost no dependency
+// in the core header, and stay usable in a constant-evaluated context.  This is
+// the same argument that made takum_log's multiply and divide exact in #1312.
+//
+// NOT A GENERAL-PURPOSE 128-BIT LIBRARY
+//
+// u128 below carries exactly the operations this path needs, with the
+// preconditions this path guarantees.  It is not a substitute for
+// internal/uint128.hpp or for blockbinary<>.
+
+#include <cassert>
+#include <cstdint>
+
+namespace sw { namespace universal { namespace takum_wide {
+
+// ---------------------------------------------------------------------------
+// u128: a 128-bit unsigned integer, hi:lo
+// ---------------------------------------------------------------------------
+
+struct u128 {
+	uint64_t hi;
+	uint64_t lo;
+};
+
+constexpr u128 make_u128(uint64_t v) noexcept { return u128{ 0ull, v }; }
+
+constexpr bool iszero(const u128& v) noexcept { return (v.hi | v.lo) == 0ull; }
+
+constexpr bool less(const u128& a, const u128& b) noexcept {
+	return (a.hi != b.hi) ? (a.hi < b.hi) : (a.lo < b.lo);
+}
+
+// Pre: the sum fits 128 bits.  Every caller reserves a bit for the carry.
+constexpr u128 add(const u128& a, const u128& b) noexcept {
+	u128 r{ a.hi + b.hi, a.lo + b.lo };
+	if (r.lo < a.lo) ++r.hi;
+	return r;
+}
+
+// Pre: a >= b.
+constexpr u128 sub(const u128& a, const u128& b) noexcept {
+	u128 r{ a.hi - b.hi, a.lo - b.lo };
+	if (a.lo < b.lo) --r.hi;
+	return r;
+}
+
+// Pre: s < 128, and no significant bit is shifted out.
+constexpr u128 shift_left(const u128& v, unsigned s) noexcept {
+	if (s == 0u) return v;
+	if (s >= 64u) return u128{ v.lo << (s - 64u), 0ull };
+	return u128{ (v.hi << s) | (v.lo >> (64u - s)), v.lo << s };
+}
+
+// Pre: s < 128.  Bits shifted out are lost; ask any_low_bits() first if they matter.
+constexpr u128 shift_right(const u128& v, unsigned s) noexcept {
+	if (s == 0u) return v;
+	if (s >= 64u) return u128{ 0ull, v.hi >> (s - 64u) };
+	return u128{ v.hi >> s, (v.lo >> s) | (v.hi << (64u - s)) };
+}
+
+// Is any of the low s bits set?  This is the sticky bit of a right shift by s.
+constexpr bool any_low_bits(const u128& v, unsigned s) noexcept {
+	if (s == 0u) return false;
+	if (s >= 128u) return !iszero(v);
+	if (s >= 64u) {
+		if (v.lo != 0ull) return true;
+		const unsigned t = s - 64u;
+		return (t == 0u) ? false : ((v.hi & ((1ull << t) - 1ull)) != 0ull);
+	}
+	return (v.lo & ((1ull << s) - 1ull)) != 0ull;
+}
+
+constexpr bool bit_at(const u128& v, unsigned i) noexcept {
+	return (i >= 64u) ? (((v.hi >> (i - 64u)) & 1ull) != 0ull)
+	                  : (((v.lo >> i) & 1ull) != 0ull);
+}
+
+// Index of the highest set bit.  Pre: v != 0.
+constexpr unsigned msb_index(const u128& v) noexcept {
+	uint64_t w    = (v.hi != 0ull) ? v.hi : v.lo;
+	unsigned base = (v.hi != 0ull) ? 64u : 0u;
+	unsigned k    = 0;
+	while (w > 1ull) { w >>= 1; ++k; }
+	return base + k;
+}
+
+// The exact 128-bit product of two 64-bit values, via 32-bit halves.  No
+// __int128 and no intrinsic, so this is portable and constant-evaluable.
+constexpr u128 mul64(uint64_t a, uint64_t b) noexcept {
+	const uint64_t a0 = a & 0xFFFFFFFFull, a1 = a >> 32;
+	const uint64_t b0 = b & 0xFFFFFFFFull, b1 = b >> 32;
+	const uint64_t p00 = a0 * b0;
+	const uint64_t p01 = a0 * b1;
+	const uint64_t p10 = a1 * b0;
+	const uint64_t p11 = a1 * b1;
+	const uint64_t mid = (p00 >> 32) + (p01 & 0xFFFFFFFFull) + (p10 & 0xFFFFFFFFull);
+	const uint64_t lo  = (p00 & 0xFFFFFFFFull) | (mid << 32);
+	const uint64_t hi  = p11 + (p01 >> 32) + (p10 >> 32) + (mid >> 32);
+	return u128{ hi, lo };
+}
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+// A decoded takum operand:  value = (-1)^sign * S * 2^e,
+// with S = 2^p + M in [2^p, 2^(p+1)) -- the significand with its implicit bit
+// restored -- and e = c - p.  S < 2^62 for every supported configuration.
+struct operand {
+	uint64_t S;
+	int64_t  e;
+	bool     sign;
+};
+
+// A partially evaluated result:  value = (-1)^sign * (V + theta) * 2^e,
+// with theta in [0,1) and theta > 0 exactly when inexact is set.
+//
+// Carrying the residue as a flag rather than a value is all round-to-odd needs:
+// it asks only whether anything was discarded, never how much.
+struct wide_value {
+	u128     V;
+	int64_t  e;
+	bool     sign;
+	bool     inexact;
+};
+
+template<typename Codec>
+constexpr operand decode_operand(bool sign, uint64_t magnitude) noexcept {
+	const auto d = Codec::decode(magnitude);
+	return operand{ (1ull << d.p) | d.M_bits,
+	                d.c - static_cast<int64_t>(d.p),
+	                sign };
+}
+
+constexpr wide_value widen(const operand& x) noexcept {
+	return wide_value{ make_u128(x.S), x.e, x.sign, false };
+}
+
+// ---------------------------------------------------------------------------
+// The three producers
+// ---------------------------------------------------------------------------
+
+// Exact: the integer product of the significands, at most 124 bits.
+constexpr wide_value multiply(const operand& a, const operand& b) noexcept {
+	return wide_value{ mul64(a.S, b.S), a.e + b.e, a.sign != b.sign, false };
+}
+
+// S_a / S_b developed to 128 quotient bits with a sticky remainder.
+// Pre: b.S != 0 (the caller has already turned x/0 into NaR).
+constexpr wide_value divide(const operand& a, const operand& b) noexcept {
+	// (S_a << 64) / S_b by restoring division.  The running remainder stays below
+	// the divisor, which is under 2^62, so doubling it cannot overflow a uint64_t.
+	// The quotient is at most (2^62 << 64) / 1 = 2^126 and cannot overflow either.
+	const u128 num = shift_left(make_u128(a.S), 64u);
+	u128 q{ 0ull, 0ull };
+	uint64_t rem = 0ull;
+	for (int i = 127; i >= 0; --i) {
+		rem = (rem << 1) | (bit_at(num, static_cast<unsigned>(i)) ? 1ull : 0ull);
+		q = shift_left(q, 1u);
+		if (rem >= b.S) { rem -= b.S; q.lo |= 1ull; }
+	}
+	return wide_value{ q, a.e - b.e - 64, a.sign != b.sign, rem != 0ull };
+}
+
+// Align two exact terms into a 128-bit window and combine them.  Handles addition,
+// subtraction (subtract == true negates b), and the accumulate step of fma, whose
+// first term is a 124-bit product rather than a bare significand.
+//
+// Pre: neither V is zero, and both terms are exact.  An inexact input would break
+// the "at most one term is truncated" argument the subtraction path rests on.
+constexpr wide_value sum(const wide_value& a, const wide_value& b0, bool subtract) noexcept {
+	assert(!iszero(a.V) && !iszero(b0.V));
+	assert(!a.inexact && !b0.inexact);
+
+	wide_value b = b0;
+	if (subtract) b.sign = !b.sign;
+
+	// Anchor the window on whichever term has the higher leading bit and let it
+	// land on bit 126, leaving bit 127 free so a magnitude sum cannot carry out.
+	const unsigned ka   = msb_index(a.V);
+	const unsigned kb   = msb_index(b.V);
+	const int64_t  topA = a.e + static_cast<int64_t>(ka);
+	const int64_t  topB = b.e + static_cast<int64_t>(kb);
+	const int64_t  top  = (topA >= topB) ? topA : topB;
+	const int64_t  base = top - 126;
+
+	// Bring both terms onto the common base.  A term shifts left by
+	// (its top) - base, which is at most 126 and therefore loses nothing; only a
+	// term whose top is strictly below `top` can shift right.  So the truncated
+	// term, when there is one, is strictly the smaller of the two in magnitude:
+	// its leading bit sits below the other's, and both are positioned exactly.
+	auto place = [base](const wide_value& t, bool& lost) -> u128 {
+		const int64_t s = t.e - base;
+		if (s >= 0) { lost = false; return shift_left(t.V, static_cast<unsigned>(s)); }
+		if (-s >= 128) { lost = true; return u128{ 0ull, 0ull }; }
+		const unsigned r = static_cast<unsigned>(-s);
+		lost = any_low_bits(t.V, r);
+		return shift_right(t.V, r);
+	};
+	bool lostA = false, lostB = false;
+	const u128 A = place(a, lostA);
+	const u128 B = place(b, lostB);
+
+	if (a.sign == b.sign) {
+		return wide_value{ add(A, B), base, a.sign, lostA || lostB };
+	}
+
+	// Magnitudes subtract.  Order them first: equal tops mean both were placed
+	// exactly and a direct comparison decides, including the exactly-cancelling
+	// case; unequal tops decide it outright.
+	bool aLarger = true;
+	if (topA == topB) {
+		if (less(A, B))      aLarger = false;
+		else if (less(B, A)) aLarger = true;
+		else return wide_value{ u128{ 0ull, 0ull }, base, false, false };  // exact cancellation
+	}
+	else {
+		aLarger = (topA > topB);
+	}
+
+	const u128 L       = aLarger ? A : B;
+	const u128 S       = aLarger ? B : A;
+	const bool inexact = aLarger ? lostB : lostA;   // only the smaller term can be truncated
+
+	// The subtrahend's discarded residue theta lies in (0,1), so the exact
+	// difference is (L - S - 1) + (1 - theta): one less than the integer
+	// difference, and still inexact.
+	u128 V = sub(L, S);
+	if (inexact) {
+		// L - S - 1 cannot underflow.  L's leading bit is at 126 and the truncated
+		// term carries at most 124 significant bits below bit 125, so
+		// S <= 2^126 - 4 while L >= 2^126.
+		assert(!iszero(V));
+		V = sub(V, make_u128(1ull));
+	}
+	return wide_value{ V, base, aLarger ? a.sign : b.sign, inexact };
+}
+
+// ---------------------------------------------------------------------------
+// The shared tail
+// ---------------------------------------------------------------------------
+
+// Fraction width handed to encode_fraction().  Two bits wider than the widest
+// trailing field any supported layout produces -- p reaches maxCharBits, which is
+// nbits - 2 - rbits and therefore 61 at nbits = 64, rbits = 1 -- which is exactly
+// the headroom round-to-odd needs to be equivalent to a single rounding.
+inline constexpr unsigned qbits = 63;
+
+// Normalize, round to odd at qbits, and let the codec perform the one rounding
+// the layout calls for.  Pre: r.V != 0 (zero has no (c, m) and is the caller's
+// business, since the codec owns no storage).
+template<typename Codec>
+constexpr typename Codec::encoded encode(const wide_value& r) noexcept {
+	assert(!iszero(r.V));
+
+	const unsigned k = msb_index(r.V);
+	const int64_t  c = r.e + static_cast<int64_t>(k);
+
+	// The bits below the leading one, as a qbits numerator.
+	uint64_t N    = 0ull;
+	bool     lost = r.inexact;
+	if (k >= qbits) {
+		const unsigned drop = k - qbits;
+		lost = lost || any_low_bits(r.V, drop);
+		N = shift_right(r.V, drop).lo & ((1ull << qbits) - 1ull);  // strip the leading one
+	}
+	else {
+		// k < qbits < 64, so the whole value sits in the low word
+		N = (r.V.lo & ((1ull << k) - 1ull)) << (qbits - k);
+	}
+	if (lost) N |= 1ull;   // round to odd
+
+	return Codec::encode_fraction(c, N, qbits);
+}
+
+}}} // namespace sw::universal::takum_wide

--- a/include/sw/universal/number/takum/takum_wide_arithmetic.hpp
+++ b/include/sw/universal/number/takum/takum_wide_arithmetic.hpp
@@ -97,7 +97,13 @@ constexpr u128 sub(const u128& a, const u128& b) noexcept {
 	return r;
 }
 
-// Pre: s < 128, and no significant bit is shifted out.
+// Pre: s < 128, and no significant bit is shifted out of the 128-bit value.
+//
+// The low word's own overflow is intended and is not that: `v.lo << s` drops the
+// bits the `v.hi` term simultaneously carries up, which is what makes this a
+// 128-bit shift rather than two 64-bit ones.  Unsigned overflow is defined, so
+// this is clean under -fsanitize=undefined; -fsanitize=integer reports it, since
+// that group flags defined wraparound too.
 constexpr u128 shift_left(const u128& v, unsigned s) noexcept {
 	if (s == 0u) return v;
 	if (s >= 64u) return u128{ v.lo << (s - 64u), 0ull };

--- a/static/tapered/takum/api/constexpr.cpp
+++ b/static/tapered/takum/api/constexpr.cpp
@@ -327,6 +327,43 @@ try {
 			"constexpr c_min for rbits=5 below int min");
 	}
 
+	// ----------------------------------------------------------------------------
+	// Wide configurations evaluate their arithmetic in integers rather than in a
+	// double (issue #1300).  That path has to stay constant-evaluable: the double
+	// path it replaced was constexpr, so losing it here would be a silent
+	// regression in what callers can write, and nothing else in the suite would
+	// notice.  These are static_asserts precisely so the compiler is the check.
+	// ----------------------------------------------------------------------------
+	{
+		using tk64 = takum<64, 3, std::uint64_t>;
+		static_assert(tk64::wide_significand, "takum<64,3> takes the exact integer path");
+
+		constexpr tk64 two(2.0), three(3.0);
+
+		constexpr tk64 sum  = two + three;
+		constexpr tk64 diff = two - three;
+		constexpr tk64 prod = two * three;
+		constexpr tk64 quot = tk64(6.0) / three;
+		static_assert(static_cast<double>(sum)  ==  5.0, "constexpr takum<64,3> 2+3 == 5");
+		static_assert(static_cast<double>(diff) == -1.0, "constexpr takum<64,3> 2-3 == -1");
+		static_assert(static_cast<double>(prod) ==  6.0, "constexpr takum<64,3> 2*3 == 6");
+		static_assert(static_cast<double>(quot) ==  2.0, "constexpr takum<64,3> 6/3 == 2");
+
+		// The reported symptom of #1300, decided at compile time: one encoding step
+		// above 1.0 plus zero is that same encoding, not a value quantized to a
+		// double on the way in.
+		constexpr tk64 eps = [] {
+			tk64 e;
+			e.setbits(tk64(1.0).raw_bits() + 1ull);
+			return e;
+		}();
+		constexpr tk64 zero{};
+		static_assert((eps + zero).raw_bits() == eps.raw_bits(),
+			"constexpr takum<64,3> eps + 0 == eps");
+		static_assert((eps - zero).raw_bits() == eps.raw_bits(),
+			"constexpr takum<64,3> eps - 0 == eps");
+	}
+
 	std::cout << "takum constexpr verification: "
 	          << (nrOfFailedTestCases == 0 ? "PASS\n" : "FAIL\n");
 

--- a/static/tapered/takum/arithmetic/wide_arithmetic.cpp
+++ b/static/tapered/takum/arithmetic/wide_arithmetic.cpp
@@ -29,9 +29,18 @@
 // and 32 bits, which is the whole shape of the defect.  Disabling the round-to-odd
 // step in the shared tail fails a further 834 cases, all of them at 64 bits.
 //
-// Exact ties are accepted either way: the check fails only on a strictly closer
-// neighbour, so it never reports a correct implementation for a tie-break
-// convention it was not told about.
+// Exact ties are decided, not waved through.  The format rounds to nearest-even,
+// so at a tie the chosen encoding must carry an even trailing field; accepting
+// either side would leave tie-breaking unverified, and ties are precisely what the
+// round-to-odd intermediate width exists to get right.  They are not rare enough
+// to ignore: an addition sweep at 64 bits hits about 1100 of them.  Confirmed by
+// mutation -- flipping encode_fraction() to break ties towards odd fails this,
+// and fails NOTHING else in the sweep, since a mis-broken tie is by definition
+// equidistant and invisible to a nearest-neighbour comparison.
+//
+// Coverage is a checked property, not an assumption: report_coverage() fails the
+// sweep if it compared nothing, or if any pair was skipped because the exact
+// reference could not reach it.
 //
 // Saturated results -- zero, maxpos, maxneg -- are skipped.  Those are range
 // decisions the format makes on the caller's behalf, not rounding decisions, and
@@ -165,11 +174,30 @@ constexpr std::int64_t neighbour_margin(unsigned maxCharBits) noexcept {
 	return static_cast<std::int64_t>(maxCharBits) + 2;
 }
 
+// What a single comparison established.
+struct tally {
+	long skipped = 0;   // the exact reference could not be formed; NOT a pass
+	long ties    = 0;   // the exact value fell exactly between two encodings
+	long tiesTested = 0;  // ...and the two shared a layout, so the rule was checked
+};
+
 // Is `got` at least as close to num/den as both of its neighbours?  num and den
 // are exact, den > 0, and every value is scaled by the same 2^base, so comparing
 // |num - value(candidate) * den| across candidates decides it outright.
+//
+// An EXACT TIE is decided too, not waved through.  The format rounds to
+// nearest-even -- encode_fraction() breaks a tie towards an even trailing field --
+// so at a tie the chosen encoding must have an even M.  Accepting either side, as
+// an earlier draft did, left the entire tie-breaking path unverified, and ties are
+// the whole reason the shared tail rounds to odd at an intermediate width: they
+// are the case it exists to get right.
+//
+// The rule is only checked when the two tied encodings share a trailing width.
+// Across a DR boundary the candidates carry different p and "even M" is not a
+// statement about the same quantity, so those are counted and reported rather than
+// judged.
 template<typename T>
-bool nearest(const T& got, const BigInt& num, const BigInt& den, std::int64_t base, bool& skipped) {
+bool nearest(const T& got, const BigInt& num, const BigInt& den, std::int64_t base, tally& t) {
 	auto distance = [&](const T& cand, bool& ok) -> BigInt {
 		fields f = decode(cand);
 		if (f.zero) { ok = true; return babs(num); }
@@ -180,17 +208,65 @@ bool nearest(const T& got, const BigInt& num, const BigInt& den, std::int64_t ba
 
 	bool ok = false;
 	const BigInt mine = distance(got, ok);
-	if (!ok) { skipped = true; return true; }
+	if (!ok) { ++t.skipped; return true; }
 
 	const std::int64_t g = signed_bits(got);
 	for (int k = -1; k <= 1; k += 2) {
 		T nb;
 		if (!neighbour<T>(g + k, nb)) continue;
 		const BigInt d = distance(nb, ok);
-		if (!ok) { skipped = true; return true; }
+		if (!ok) { ++t.skipped; return true; }
 		if (d < mine) return false;
+		if (d == mine && !nb.iszero() && !got.iszero()) {
+			++t.ties;
+			const auto dg = T::Codec::decode(got.magnitude_bits());
+			const auto dn = T::Codec::decode(nb.magnitude_bits());
+			if (dg.p == dn.p && dg.p > 0) {
+				++t.tiesTested;
+				if ((dg.M_bits & 1ull) != 0ull) return false;   // tie went to odd
+			}
+		}
 	}
 	return true;
+}
+
+// Did the sweep actually verify anything, and did it verify everything it walked?
+//
+// A sweep that compares nothing and a sweep that compares everything report the
+// same PASS, so the coverage has to be a checked property rather than an assumed
+// one.  Two ways it can quietly evaporate:
+//
+//   exercised == 0   nothing was compared at all
+//   skipped > 0      individual pairs fell outside the exact reference's reach and
+//                    were passed over.  Every configuration in this suite is sized
+//                    to fit, so any skip at all is a defect in the suite -- either
+//                    BigInt is too narrow or neighbour_margin() is wrong -- and
+//                    NOT something to absorb silently.  A deliberately span-limited
+//                    configuration would have to relax this, loudly.
+//
+// Ties are reported rather than required: they are rare, and a sweep that happens
+// to produce none is not thereby broken.  Reporting them is what tells a reader
+// whether the tie rule was actually exercised or merely available.
+int report_coverage(const char* what, unsigned nbits, unsigned rbits,
+                    long exercised, const tally& t, bool reportTestCases) {
+	int failures = 0;
+	if (exercised == 0) {
+		++failures;
+		std::cout << "FAIL " << what << " takum<" << nbits << ',' << rbits
+		          << "> compared nothing\n";
+	}
+	if (t.skipped != 0) {
+		++failures;
+		std::cout << "FAIL " << what << " takum<" << nbits << ',' << rbits << "> skipped "
+		          << t.skipped << " of " << (exercised + t.skipped)
+		          << " pairs: the exact reference did not reach them\n";
+	}
+	if (reportTestCases) {
+		std::cout << "      takum<" << nbits << ',' << rbits << "> " << what
+		          << ": exercised " << exercised << ", ties " << t.ties
+		          << " (" << t.tiesTested << " with the rule checked)\n";
+	}
+	return failures;
 }
 
 // ---------------------------------------------------------------------------
@@ -201,6 +277,7 @@ int VerifyCorrectlyRounded(Op op, unsigned samples, bool reportTestCases) {
 	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
 	int nrOfFailedTests = 0;
 	long exercised = 0;
+	tally t;
 	const std::uint64_t LAST   = last_encoding(nbits);
 	const std::uint64_t stride = sample_stride(LAST, samples);
 
@@ -229,11 +306,10 @@ int VerifyCorrectlyRounded(Op op, unsigned samples, bool reportTestCases) {
 			const fields fg = decode(got);
 			BigInt num(0), den(1);
 			std::int64_t base = 0;
-			bool skipped = false;
 
 			if (op == Op::add || op == Op::sub) {
 				base = std::min(std::min(fa.e, fb.e), fg.e) - neighbour_margin(T::maxCharBits);
-				if (!fits(fa.e, base) || !fits(fb.e, base)) continue;
+				if (!fits(fa.e, base) || !fits(fb.e, base)) { ++t.skipped; continue; }
 				const BigInt A = scaled(fa.S, fa.e, fa.sign, base);
 				const BigInt B = scaled(fb.S, fb.e, (op == Op::sub) ? !fb.sign : fb.sign, base);
 				num = A + B;
@@ -241,7 +317,7 @@ int VerifyCorrectlyRounded(Op op, unsigned samples, bool reportTestCases) {
 			else if (op == Op::mul) {
 				const std::int64_t ep = fa.e + fb.e;
 				base = std::min(ep, fg.e) - neighbour_margin(T::maxCharBits);
-				if (!fits(ep, base)) continue;
+				if (!fits(ep, base)) { ++t.skipped; continue; }
 				BigInt P(fa.S);
 				P = P * BigInt(fb.S);
 				P <<= static_cast<int>(ep - base);
@@ -250,13 +326,14 @@ int VerifyCorrectlyRounded(Op op, unsigned samples, bool reportTestCases) {
 			else {
 				const std::int64_t eq = fa.e - fb.e;
 				base = std::min(eq, fg.e) - neighbour_margin(T::maxCharBits);
-				if (!fits(eq, base)) continue;
+				if (!fits(eq, base)) { ++t.skipped; continue; }
 				num = scaled(fa.S, eq, fa.sign != fb.sign, base);
 				den = BigInt(fb.S);
 			}
 
-			const bool ok = nearest(got, num, den, base, skipped);
-			if (skipped) continue;
+			const long skipsBefore = t.skipped;
+			const bool ok = nearest(got, num, den, base, t);
+			if (t.skipped != skipsBefore) continue;
 			++exercised;
 			if (!ok) {
 				++nrOfFailedTests;
@@ -268,10 +345,7 @@ int VerifyCorrectlyRounded(Op op, unsigned samples, bool reportTestCases) {
 			}
 		}
 	}
-	if (exercised == 0) {
-		++nrOfFailedTests;
-		if (reportTestCases) std::cout << "FAIL correctly-rounded check compared nothing\n";
-	}
+	nrOfFailedTests += report_coverage("correctly rounded", nbits, rbits, exercised, t, reportTestCases);
 	return nrOfFailedTests;
 }
 
@@ -287,6 +361,7 @@ int VerifyFmaCorrectlyRounded(unsigned samples, bool reportTestCases) {
 	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
 	int nrOfFailedTests = 0;
 	long exercised = 0;
+	tally t;
 	const std::uint64_t LAST   = last_encoding(nbits);
 	const std::uint64_t stride = sample_stride(LAST, samples);
 	// a third operand from the same sweep, offset so it is not a repeat of a or b
@@ -311,7 +386,7 @@ int VerifyFmaCorrectlyRounded(unsigned samples, bool reportTestCases) {
 			const fields fg = decode(got);
 			const std::int64_t ep = fa.e + fb.e;
 			const std::int64_t base = std::min(std::min(ep, fc.e), fg.e) - neighbour_margin(T::maxCharBits);
-			if (!fits(ep, base) || !fits(fc.e, base)) continue;
+			if (!fits(ep, base) || !fits(fc.e, base)) { ++t.skipped; continue; }
 
 			BigInt P(fa.S);
 			P = P * BigInt(fb.S);
@@ -319,9 +394,9 @@ int VerifyFmaCorrectlyRounded(unsigned samples, bool reportTestCases) {
 			if (fa.sign != fb.sign) P = -P;
 			const BigInt num = P + scaled(fc.S, fc.e, fc.sign, base);
 
-			bool skipped = false;
-			const bool ok = nearest(got, num, BigInt(1), base, skipped);
-			if (skipped) continue;
+			const long skipsBefore = t.skipped;
+			const bool ok = nearest(got, num, BigInt(1), base, t);
+			if (t.skipped != skipsBefore) continue;
 			++exercised;
 			if (!ok) {
 				++nrOfFailedTests;
@@ -333,10 +408,7 @@ int VerifyFmaCorrectlyRounded(unsigned samples, bool reportTestCases) {
 			}
 		}
 	}
-	if (exercised == 0) {
-		++nrOfFailedTests;
-		if (reportTestCases) std::cout << "FAIL fma correctly-rounded check compared nothing\n";
-	}
+	nrOfFailedTests += report_coverage("correctly rounded fma", nbits, rbits, exercised, t, reportTestCases);
 	return nrOfFailedTests;
 }
 

--- a/static/tapered/takum/arithmetic/wide_arithmetic.cpp
+++ b/static/tapered/takum/arithmetic/wide_arithmetic.cpp
@@ -1,0 +1,513 @@
+// wide_arithmetic.cpp: correct-rounding verification for wide takum configurations
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// A takum significand is 1 + p bits with p reaching nbits - 2 - rbits, so from
+// nbits > 54 + rbits it no longer fits a double -- takum<64,3> carries 60 bits
+// against a double's 53.  The operators used to evaluate in a double, which
+// quantized BOTH OPERANDS before the operation, and this suite is the evidence
+// that they no longer do (issue #1300).
+//
+// The sibling suites addition.cpp / multiplication.cpp / division.cpp check the
+// narrow configurations against a double, which is the correct reference THERE
+// and useless here: it is precisely the thing under test.
+//
+// So the reference is exact instead.  Every takum value is a dyadic rational
+// S * 2^e with S < 2^62, so a + b, a - b and a * b are exact integers and a / b is
+// an exact ratio of them.  Held in a 1024-bit integer<>, the reference is arrived
+// at with no floating-point arithmetic at all, and the check is the one that
+// matters: the produced encoding must be at least as close to the exact result as
+// either of its neighbours.  Both neighbours are consulted, since consecutive
+// encodings are consecutive in value (Prop. 4).
+//
+// Confirmed by mutation.  Reverting the operators to the double path fails this
+// at 64 bits for ~75% of addition pairs -- matching the 75.60% measured
+// independently against a 113-bit __float128 reference in #1300 -- and 0% at 16
+// and 32 bits, which is the whole shape of the defect.  Disabling the round-to-odd
+// step in the shared tail fails a further 834 cases, all of them at 64 bits.
+//
+// Exact ties are accepted either way: the check fails only on a strictly closer
+// neighbour, so it never reports a correct implementation for a tie-break
+// convention it was not told about.
+//
+// Saturated results -- zero, maxpos, maxneg -- are skipped.  Those are range
+// decisions the format makes on the caller's behalf, not rounding decisions, and
+// the nearest encoding to an out-of-range value is not what the type promises.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <cstdint>
+#include <universal/number/takum/takum.hpp>
+#include <universal/number/takum/math/fma.hpp>
+#include <universal/number/integer/integer.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// 1024 bits carries any comparison this suite forms at rbits = 3, where the
+// characteristic spans [-255, 254] and the widest span between two operands is
+// therefore about 630 bits.  Configurations whose span does not fit are skipped
+// rather than mis-verified; see fits() below.
+using BigInt = sw::universal::integer<1024, std::uint64_t>;
+constexpr int64_t SPAN_LIMIT = 820;
+
+enum class Op { add, sub, mul, div };
+
+// |value| = S * 2^e, with S = 2^p + M the significand and its implicit bit.
+struct fields {
+	std::uint64_t S;
+	std::int64_t  e;
+	bool          sign;
+	bool          zero;
+};
+
+template<typename T>
+fields decode(const T& x) {
+	if (x.iszero()) return fields{ 0ull, 0, x.sign(), true };
+	auto d = T::Codec::decode(x.magnitude_bits());
+	return fields{ (1ull << d.p) | d.M_bits,
+	               d.c - static_cast<std::int64_t>(d.p),
+	               x.sign(), false };
+}
+
+// S * 2^(e - base), signed.  Pre: e >= base, and the shift is within SPAN_LIMIT.
+BigInt scaled(std::uint64_t S, std::int64_t e, bool sign, std::int64_t base) {
+	BigInt v(S);
+	v <<= static_cast<int>(e - base);
+	return sign ? -v : v;
+}
+
+BigInt babs(const BigInt& a) { return (a < 0) ? -a : a; }
+
+// The signed integer the encoding denotes, sign extended to 64 bits.  Encodings
+// are ordered by value, so +/-1 on this is the neighbouring representable value.
+template<typename T>
+std::int64_t signed_bits(const T& x) {
+	std::uint64_t raw = x.raw_bits();
+	if constexpr (T::nbits < 64) {
+		if (raw & (1ull << (T::nbits - 1))) raw |= ~((1ull << T::nbits) - 1);
+	}
+	return static_cast<std::int64_t>(raw);
+}
+
+// The neighbour v steps away, or false when that would leave the finite range.
+// NaR is the most negative encoding and is excluded by construction.
+template<typename T>
+bool neighbour(std::int64_t v, T& out) {
+	constexpr std::int64_t hi = (T::nbits >= 64) ? INT64_MAX
+	                                            : ((std::int64_t(1) << (T::nbits - 1)) - 1);
+	if (v < -hi || v > hi) return false;
+	out.setbits(static_cast<std::uint64_t>(v) & T::Codec::nbits_mask());
+	return true;
+}
+
+template<typename T>
+bool saturated(const T& x) {
+	T maxpos(sw::universal::SpecificValue::maxpos), maxneg(sw::universal::SpecificValue::maxneg);
+	return x.iszero() || x.raw_bits() == maxpos.raw_bits() || x.raw_bits() == maxneg.raw_bits();
+}
+
+bool fits(std::int64_t e, std::int64_t base) { return (e - base) <= SPAN_LIMIT; }
+
+// Is `got` at least as close to num/den as both of its neighbours?  num and den
+// are exact, den > 0, and every value is scaled by the same 2^base, so comparing
+// |num - value(candidate) * den| across candidates decides it outright.
+template<typename T>
+bool nearest(const T& got, const BigInt& num, const BigInt& den, std::int64_t base, bool& skipped) {
+	auto distance = [&](const T& cand, bool& ok) -> BigInt {
+		fields f = decode(cand);
+		if (f.zero) { ok = true; return babs(num); }
+		if (!fits(f.e, base)) { ok = false; return BigInt(0); }
+		ok = true;
+		return babs(num - scaled(f.S, f.e, f.sign, base) * den);
+	};
+
+	bool ok = false;
+	const BigInt mine = distance(got, ok);
+	if (!ok) { skipped = true; return true; }
+
+	const std::int64_t g = signed_bits(got);
+	for (int k = -1; k <= 1; k += 2) {
+		T nb;
+		if (!neighbour<T>(g + k, nb)) continue;
+		const BigInt d = distance(nb, ok);
+		if (!ok) { skipped = true; return true; }
+		if (d < mine) return false;
+	}
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// a OP b, correctly rounded
+// ---------------------------------------------------------------------------
+template<unsigned nbits, unsigned rbits>
+int VerifyCorrectlyRounded(Op op, std::uint64_t stride, bool reportTestCases) {
+	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
+	int nrOfFailedTests = 0;
+	long exercised = 0;
+	// 1ull << nbits is undefined at nbits == 64, and 64 is the width this exists
+	// for, so the bound avoids it.  stride samples, since the sweep is over PAIRS.
+	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+
+	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+		T a; a.setbits(i);
+		if (a.isnar() || a.iszero()) continue;
+		const fields fa = decode(a);
+
+		for (std::uint64_t j = 0; j < NR && j + stride > j; j += stride) {
+			T b; b.setbits(j);
+			if (b.isnar() || b.iszero()) continue;
+			const fields fb = decode(b);
+
+			T got;
+			switch (op) {
+			case Op::add: got = a + b; break;
+			case Op::sub: got = a - b; break;
+			case Op::mul: got = a * b; break;
+			default:      got = a / b; break;
+			}
+			if (got.isnar() || saturated(got)) continue;
+
+			// Assemble the exact result as num/den, everything scaled by 2^base.
+			// den is 1 except for division, where the quotient is not dyadic and
+			// the comparison is cross-multiplied by the divisor's significand.
+			const fields fg = decode(got);
+			BigInt num(0), den(1);
+			std::int64_t base = 0;
+			bool skipped = false;
+
+			if (op == Op::add || op == Op::sub) {
+				base = std::min(std::min(fa.e, fb.e), fg.e) - 2;
+				if (!fits(fa.e, base) || !fits(fb.e, base)) continue;
+				const BigInt A = scaled(fa.S, fa.e, fa.sign, base);
+				const BigInt B = scaled(fb.S, fb.e, (op == Op::sub) ? !fb.sign : fb.sign, base);
+				num = A + B;
+			}
+			else if (op == Op::mul) {
+				const std::int64_t ep = fa.e + fb.e;
+				base = std::min(ep, fg.e) - 2;
+				if (!fits(ep, base)) continue;
+				BigInt P(fa.S);
+				P = P * BigInt(fb.S);
+				P <<= static_cast<int>(ep - base);
+				num = (fa.sign != fb.sign) ? -P : P;
+			}
+			else {
+				const std::int64_t eq = fa.e - fb.e;
+				base = std::min(eq, fg.e) - 2;
+				if (!fits(eq, base)) continue;
+				num = scaled(fa.S, eq, fa.sign != fb.sign, base);
+				den = BigInt(fb.S);
+			}
+
+			const bool ok = nearest(got, num, den, base, skipped);
+			if (skipped) continue;
+			++exercised;
+			if (!ok) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL not correctly rounded: op=" << int(op)
+					          << " a=" << to_binary(a) << " b=" << to_binary(b)
+					          << " got=" << to_binary(got) << '\n';
+				}
+			}
+		}
+	}
+	if (exercised == 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL correctly-rounded check compared nothing\n";
+	}
+	return nrOfFailedTests;
+}
+
+// ---------------------------------------------------------------------------
+// fma(a, b, c), correctly rounded
+//
+// The point of an fma is that the product is NOT rounded before the addend joins
+// it, which is exactly what a double intermediate destroyed here: it rounded both
+// factors first and then computed an exact product of the wrong numbers.
+// ---------------------------------------------------------------------------
+template<unsigned nbits, unsigned rbits>
+int VerifyFmaCorrectlyRounded(std::uint64_t stride, bool reportTestCases) {
+	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
+	int nrOfFailedTests = 0;
+	long exercised = 0;
+	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+	// a third operand from the same sweep, offset so it is not a repeat of a or b
+	const std::uint64_t skew = stride / 3ull + 1ull;
+
+	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+		T a; a.setbits(i);
+		if (a.isnar() || a.iszero()) continue;
+		const fields fa = decode(a);
+
+		for (std::uint64_t j = 0; j < NR && j + stride > j; j += stride) {
+			T b; b.setbits(j);
+			if (b.isnar() || b.iszero()) continue;
+			T c; c.setbits(i + j + skew);
+			if (c.isnar() || c.iszero()) continue;
+			const fields fb = decode(b);
+			const fields fc = decode(c);
+
+			T got = sw::universal::fma(a, b, c);
+			if (got.isnar() || saturated(got)) continue;
+
+			const fields fg = decode(got);
+			const std::int64_t ep = fa.e + fb.e;
+			const std::int64_t base = std::min(std::min(ep, fc.e), fg.e) - 2;
+			if (!fits(ep, base) || !fits(fc.e, base)) continue;
+
+			BigInt P(fa.S);
+			P = P * BigInt(fb.S);
+			P <<= static_cast<int>(ep - base);
+			if (fa.sign != fb.sign) P = -P;
+			const BigInt num = P + scaled(fc.S, fc.e, fc.sign, base);
+
+			bool skipped = false;
+			const bool ok = nearest(got, num, BigInt(1), base, skipped);
+			if (skipped) continue;
+			++exercised;
+			if (!ok) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL fma not correctly rounded: a=" << to_binary(a)
+					          << " b=" << to_binary(b) << " c=" << to_binary(c)
+					          << " got=" << to_binary(got) << '\n';
+				}
+			}
+		}
+	}
+	if (exercised == 0) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL fma correctly-rounded check compared nothing\n";
+	}
+	return nrOfFailedTests;
+}
+
+// ---------------------------------------------------------------------------
+// Exact identities
+//
+// These need no reference at all and they are what issue #1300 opened on: one
+// encoding step above 1.0, takum<64,3> lost its low bit to `x + 0` because the
+// operand was quantized on the way in.  Cheap enough to run at every width, and
+// they discriminate -- the double path fails a + 0 at 64 bits.
+// ---------------------------------------------------------------------------
+template<unsigned nbits, unsigned rbits>
+int VerifyExactIdentities(std::uint64_t stride, bool reportTestCases) {
+	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
+	int nrOfFailedTests = 0;
+	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+	T one(1.0), zero; zero.setzero();
+	T nar; nar.setnar();
+
+	auto fail = [&](const char* what, std::uint64_t bits) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL " << what << " at bits=" << bits << '\n';
+	};
+
+	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+		T a; a.setbits(i);
+		if (a.isnar()) continue;
+
+		if ((a + zero).raw_bits() != a.raw_bits()) fail("a + 0 != a", i);
+		if ((a - zero).raw_bits() != a.raw_bits()) fail("a - 0 != a", i);
+		if ((a * one).raw_bits() != a.raw_bits())  fail("a * 1 != a", i);
+		if (!(a * zero).iszero())                  fail("a * 0 != 0", i);
+		if (!(a - a).iszero())                     fail("a - a != 0", i);
+		if (!(a + nar).isnar())                    fail("a + NaR must be NaR", i);
+		if (!(a * nar).isnar())                    fail("a * NaR must be NaR", i);
+		if (!(a / zero).isnar())                   fail("a / 0 must be NaR", i);
+		if (!a.iszero()) {
+			if ((a / one).raw_bits() != a.raw_bits()) fail("a / 1 != a", i);
+			if ((a / a).raw_bits() != one.raw_bits()) fail("a / a != 1", i);
+			if (!(zero / a).iszero())                 fail("0 / a != 0", i);
+			if ((-a + a).raw_bits() != 0ull)          fail("-a + a != 0", i);
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// Addition and multiplication commute bit for bit.  Independent of any reference,
+// and it reaches the operand-ordering logic in the wide path's alignment step.
+template<unsigned nbits, unsigned rbits>
+int VerifyCommutative(std::uint64_t stride, bool reportTestCases) {
+	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
+	int nrOfFailedTests = 0;
+	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+
+	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+		T a; a.setbits(i);
+		if (a.isnar()) continue;
+		for (std::uint64_t j = 0; j < NR && j + stride > j; j += stride) {
+			T b; b.setbits(j);
+			if (b.isnar()) continue;
+			if ((a + b).raw_bits() != (b + a).raw_bits()) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cout << "FAIL addition not commutative at " << i << ',' << j << '\n';
+			}
+			if ((a * b).raw_bits() != (b * a).raw_bits()) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cout << "FAIL multiplication not commutative at " << i << ',' << j << '\n';
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// The reported symptom of #1300, verbatim: one encoding step above 1.0, then add
+// zero.  A named regression so the report stays legible in the suite output.
+int VerifyIssue1300Repro(bool reportTestCases) {
+	using namespace sw::universal;
+	using T64 = takum<64, 3, std::uint64_t>;
+	int nrOfFailedTests = 0;
+
+	T64 one(1.0), eps, zero;
+	zero.setzero();
+	eps.setbits(one.raw_bits() + 1ull);
+	if ((eps + zero).raw_bits() != eps.raw_bits()) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL takum<64,3>: eps + 0 lost the low bit\n";
+	}
+	if ((eps - zero).raw_bits() != eps.raw_bits()) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL takum<64,3>: eps - 0 lost the low bit\n";
+	}
+	if ((eps * one).raw_bits() != eps.raw_bits()) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL takum<64,3>: eps * 1 lost the low bit\n";
+	}
+	if ((eps / one).raw_bits() != eps.raw_bits()) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL takum<64,3>: eps / 1 lost the low bit\n";
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "takum wide-configuration arithmetic verification";
+	std::string test_tag    = "wide arithmetic";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// Strides are odd and coprime with the field structure so a sweep crosses
+	// every DR rather than revisiting one layout.  maybe_unused because which of
+	// them a build reaches depends on the regression level.
+	[[maybe_unused]] constexpr std::uint64_t stride64 = 0x0123456789ABCDEFull;   // ~225 samples
+	[[maybe_unused]] constexpr std::uint64_t stride32 = 0x01234567ull;           // ~225 samples
+	[[maybe_unused]] constexpr std::uint64_t stride16 = 211ull;                  // ~310 samples
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyIssue1300Repro(true), "takum<64,3>", "issue 1300 repro");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 3>(Op::add, stride64, true), "takum<64,3>", "correctly rounded add");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyIssue1300Repro(true), "takum<64,3>", "issue 1300 repro");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyExactIdentities<64, 3>(stride64, reportTestCases), "takum<64,3>", "exact identities");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 3>(Op::add, stride64, reportTestCases), "takum<64,3>", "correctly rounded add");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 3>(Op::mul, stride64, reportTestCases), "takum<64,3>", "correctly rounded mul");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 3>(Op::sub, stride64, reportTestCases), "takum<64,3>", "correctly rounded sub");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 3>(Op::div, stride64, reportTestCases), "takum<64,3>", "correctly rounded div");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCommutative<64, 3>(stride64, reportTestCases), "takum<64,3>", "commutativity");
+	// The narrow configurations keep the double path, where the operands are exact
+	// doubles and one rounding decides the result.  Verified against the SAME exact
+	// reference, so the boundary the gate draws is measured rather than asserted.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<32, 3>(Op::add, stride32, reportTestCases), "takum<32,3>", "correctly rounded add");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<32, 3>(Op::mul, stride32, reportTestCases), "takum<32,3>", "correctly rounded mul");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyFmaCorrectlyRounded<64, 3>(stride64, reportTestCases), "takum<64,3>", "correctly rounded fma");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<32, 3>(Op::sub, stride32, reportTestCases), "takum<32,3>", "correctly rounded sub");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<32, 3>(Op::div, stride32, reportTestCases), "takum<32,3>", "correctly rounded div");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<16, 3>(Op::add, stride16, reportTestCases), "takum<16,3>", "correctly rounded add");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<16, 3>(Op::div, stride16, reportTestCases), "takum<16,3>", "correctly rounded div");
+#endif
+
+#if REGRESSION_LEVEL_4
+	// takum<58,3> is the narrowest configuration on the wide path (nbits > 54 + rbits)
+	// and takum<64,1> the widest significand the format allows at 64 bits, p = 61,
+	// which is what fixes the round-to-odd width at 63.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyExactIdentities<58, 3>(stride64, reportTestCases), "takum<58,3>", "exact identities");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<58, 3>(Op::add, stride64, reportTestCases), "takum<58,3>", "correctly rounded add");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyExactIdentities<64, 1>(stride64, reportTestCases), "takum<64,1>", "exact identities");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 1>(Op::mul, stride64, reportTestCases), "takum<64,1>", "correctly rounded mul");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCorrectlyRounded<64, 1>(Op::div, stride64, reportTestCases), "takum<64,1>", "correctly rounded div");
+	// rbits = 5 pushes the characteristic past 2^31, an exponent range no binary
+	// floating-point type can hold.  The exact integer path carries the exponent
+	// as an int64_t outside the significand, so it is indifferent; the reference
+	// above is not, and skips the pairs whose span exceeds its width, which is why
+	// this configuration is covered structurally.
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyExactIdentities<64, 5>(stride64, reportTestCases), "takum<64,5>", "exact identities");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyCommutative<64, 5>(stride64, reportTestCases), "takum<64,5>", "commutativity");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/tapered/takum/arithmetic/wide_arithmetic.cpp
+++ b/static/tapered/takum/arithmetic/wide_arithmetic.cpp
@@ -56,6 +56,39 @@ constexpr int64_t SPAN_LIMIT = 820;
 
 enum class Op { add, sub, mul, div };
 
+// The largest encoding as a bit pattern, and the largest POSITIVE one as the
+// signed integer it denotes (NaR is the most negative encoding, so the negative
+// range stops one short of it).
+//
+// Both are right shifts on purpose.  The natural left-shift forms are 1ull << 64
+// and int64_t(1) << 63 at nbits == 64, which is the width this suite exists for;
+// guarding them behind a runtime ternary leaves the shift in the source even
+// though the branch never runs, and cppcheck is right to call it out.  A right
+// shift by 64 - nbits is total over the whole supported range.
+constexpr std::uint64_t last_encoding(unsigned nbits) noexcept {
+	return (~0ull) >> (64u - nbits);
+}
+constexpr std::int64_t max_positive_encoding(unsigned nbits) noexcept {
+	return static_cast<std::int64_t>((~0ull) >> (64u - nbits + 1u));
+}
+
+// The step that walks `samples` values across the encoding space, or 1 when the
+// space is small enough to enumerate.
+//
+// Derived from the width rather than passed in as a literal.  A fixed stride is
+// silently width-dependent: 0x0123456789ABCDEF samples a 64-bit space about 225
+// times, but it is a third of a 58-bit space, and takum<58,3> was getting NINE
+// comparisons out of a sweep that reported PASS.  A sweep that covers almost
+// nothing and a sweep that covers everything report identically, so the sample
+// count is the thing to fix in place, not the stride.
+//
+// Odd, so it is coprime with the power-of-two field boundaries and the walk
+// crosses every DR rather than revisiting one layout.
+constexpr std::uint64_t sample_stride(std::uint64_t last, unsigned samples) noexcept {
+	const std::uint64_t step = last / samples;
+	return (step < 2ull) ? 1ull : (step | 1ull);
+}
+
 // |value| = S * 2^e, with S = 2^p + M the significand and its implicit bit.
 struct fields {
 	std::uint64_t S;
@@ -97,8 +130,7 @@ std::int64_t signed_bits(const T& x) {
 // NaR is the most negative encoding and is excluded by construction.
 template<typename T>
 bool neighbour(std::int64_t v, T& out) {
-	constexpr std::int64_t hi = (T::nbits >= 64) ? INT64_MAX
-	                                            : ((std::int64_t(1) << (T::nbits - 1)) - 1);
+	constexpr std::int64_t hi = max_positive_encoding(T::nbits);
 	if (v < -hi || v > hi) return false;
 	out.setbits(static_cast<std::uint64_t>(v) & T::Codec::nbits_mask());
 	return true;
@@ -110,7 +142,28 @@ bool saturated(const T& x) {
 	return x.iszero() || x.raw_bits() == maxpos.raw_bits() || x.raw_bits() == maxneg.raw_bits();
 }
 
-bool fits(std::int64_t e, std::int64_t base) { return (e - base) <= SPAN_LIMIT; }
+// Two-sided on purpose.  The upper bound keeps the shift inside BigInt; the lower
+// bound is what stops scaled() from being handed a negative shift, which integer<>
+// silently turns into a right shift and would quietly truncate a candidate's value
+// rather than fail.  neighbour_margin() below is sized so this never trips, and
+// this check is what makes that reasoning falsifiable rather than load-bearing.
+bool fits(std::int64_t e, std::int64_t base) {
+	return e >= base && (e - base) <= SPAN_LIMIT;
+}
+
+// How far below the operands' exponents `base` has to sit so that the RESULT'S
+// NEIGHBOURS are also placeable.
+//
+// A neighbour is one encoding step from the result, so its characteristic c' is
+// within 1 of the result's c, but its trailing width p' is not within 1 of p --
+// crossing a DR boundary moves p by a lot.  With e = c - p and p' at most
+// maxCharBits,  e' >= (c - 1) - maxCharBits = e + p - 1 - maxCharBits, so a
+// neighbour's exponent can sit maxCharBits + 1 below the result's own.  Taking the
+// minimum over only the operands and the result, as an earlier draft did, left the
+// neighbours unaccounted for.
+constexpr std::int64_t neighbour_margin(unsigned maxCharBits) noexcept {
+	return static_cast<std::int64_t>(maxCharBits) + 2;
+}
 
 // Is `got` at least as close to num/den as both of its neighbours?  num and den
 // are exact, den > 0, and every value is scaled by the same 2^base, so comparing
@@ -144,20 +197,19 @@ bool nearest(const T& got, const BigInt& num, const BigInt& den, std::int64_t ba
 // a OP b, correctly rounded
 // ---------------------------------------------------------------------------
 template<unsigned nbits, unsigned rbits>
-int VerifyCorrectlyRounded(Op op, std::uint64_t stride, bool reportTestCases) {
+int VerifyCorrectlyRounded(Op op, unsigned samples, bool reportTestCases) {
 	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
 	int nrOfFailedTests = 0;
 	long exercised = 0;
-	// 1ull << nbits is undefined at nbits == 64, and 64 is the width this exists
-	// for, so the bound avoids it.  stride samples, since the sweep is over PAIRS.
-	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+	const std::uint64_t LAST   = last_encoding(nbits);
+	const std::uint64_t stride = sample_stride(LAST, samples);
 
-	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+	for (std::uint64_t i = 0; i <= LAST && i + stride > i; i += stride) {
 		T a; a.setbits(i);
 		if (a.isnar() || a.iszero()) continue;
 		const fields fa = decode(a);
 
-		for (std::uint64_t j = 0; j < NR && j + stride > j; j += stride) {
+		for (std::uint64_t j = 0; j <= LAST && j + stride > j; j += stride) {
 			T b; b.setbits(j);
 			if (b.isnar() || b.iszero()) continue;
 			const fields fb = decode(b);
@@ -180,7 +232,7 @@ int VerifyCorrectlyRounded(Op op, std::uint64_t stride, bool reportTestCases) {
 			bool skipped = false;
 
 			if (op == Op::add || op == Op::sub) {
-				base = std::min(std::min(fa.e, fb.e), fg.e) - 2;
+				base = std::min(std::min(fa.e, fb.e), fg.e) - neighbour_margin(T::maxCharBits);
 				if (!fits(fa.e, base) || !fits(fb.e, base)) continue;
 				const BigInt A = scaled(fa.S, fa.e, fa.sign, base);
 				const BigInt B = scaled(fb.S, fb.e, (op == Op::sub) ? !fb.sign : fb.sign, base);
@@ -188,7 +240,7 @@ int VerifyCorrectlyRounded(Op op, std::uint64_t stride, bool reportTestCases) {
 			}
 			else if (op == Op::mul) {
 				const std::int64_t ep = fa.e + fb.e;
-				base = std::min(ep, fg.e) - 2;
+				base = std::min(ep, fg.e) - neighbour_margin(T::maxCharBits);
 				if (!fits(ep, base)) continue;
 				BigInt P(fa.S);
 				P = P * BigInt(fb.S);
@@ -197,7 +249,7 @@ int VerifyCorrectlyRounded(Op op, std::uint64_t stride, bool reportTestCases) {
 			}
 			else {
 				const std::int64_t eq = fa.e - fb.e;
-				base = std::min(eq, fg.e) - 2;
+				base = std::min(eq, fg.e) - neighbour_margin(T::maxCharBits);
 				if (!fits(eq, base)) continue;
 				num = scaled(fa.S, eq, fa.sign != fb.sign, base);
 				den = BigInt(fb.S);
@@ -231,20 +283,21 @@ int VerifyCorrectlyRounded(Op op, std::uint64_t stride, bool reportTestCases) {
 // factors first and then computed an exact product of the wrong numbers.
 // ---------------------------------------------------------------------------
 template<unsigned nbits, unsigned rbits>
-int VerifyFmaCorrectlyRounded(std::uint64_t stride, bool reportTestCases) {
+int VerifyFmaCorrectlyRounded(unsigned samples, bool reportTestCases) {
 	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
 	int nrOfFailedTests = 0;
 	long exercised = 0;
-	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+	const std::uint64_t LAST   = last_encoding(nbits);
+	const std::uint64_t stride = sample_stride(LAST, samples);
 	// a third operand from the same sweep, offset so it is not a repeat of a or b
 	const std::uint64_t skew = stride / 3ull + 1ull;
 
-	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+	for (std::uint64_t i = 0; i <= LAST && i + stride > i; i += stride) {
 		T a; a.setbits(i);
 		if (a.isnar() || a.iszero()) continue;
 		const fields fa = decode(a);
 
-		for (std::uint64_t j = 0; j < NR && j + stride > j; j += stride) {
+		for (std::uint64_t j = 0; j <= LAST && j + stride > j; j += stride) {
 			T b; b.setbits(j);
 			if (b.isnar() || b.iszero()) continue;
 			T c; c.setbits(i + j + skew);
@@ -257,7 +310,7 @@ int VerifyFmaCorrectlyRounded(std::uint64_t stride, bool reportTestCases) {
 
 			const fields fg = decode(got);
 			const std::int64_t ep = fa.e + fb.e;
-			const std::int64_t base = std::min(std::min(ep, fc.e), fg.e) - 2;
+			const std::int64_t base = std::min(std::min(ep, fc.e), fg.e) - neighbour_margin(T::maxCharBits);
 			if (!fits(ep, base) || !fits(fc.e, base)) continue;
 
 			BigInt P(fa.S);
@@ -296,10 +349,11 @@ int VerifyFmaCorrectlyRounded(std::uint64_t stride, bool reportTestCases) {
 // they discriminate -- the double path fails a + 0 at 64 bits.
 // ---------------------------------------------------------------------------
 template<unsigned nbits, unsigned rbits>
-int VerifyExactIdentities(std::uint64_t stride, bool reportTestCases) {
+int VerifyExactIdentities(unsigned samples, bool reportTestCases) {
 	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
 	int nrOfFailedTests = 0;
-	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+	const std::uint64_t LAST   = last_encoding(nbits);
+	const std::uint64_t stride = sample_stride(LAST, samples);
 	T one(1.0), zero; zero.setzero();
 	T nar; nar.setnar();
 
@@ -308,7 +362,7 @@ int VerifyExactIdentities(std::uint64_t stride, bool reportTestCases) {
 		if (reportTestCases) std::cout << "FAIL " << what << " at bits=" << bits << '\n';
 	};
 
-	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+	for (std::uint64_t i = 0; i <= LAST && i + stride > i; i += stride) {
 		T a; a.setbits(i);
 		if (a.isnar()) continue;
 
@@ -333,15 +387,16 @@ int VerifyExactIdentities(std::uint64_t stride, bool reportTestCases) {
 // Addition and multiplication commute bit for bit.  Independent of any reference,
 // and it reaches the operand-ordering logic in the wide path's alignment step.
 template<unsigned nbits, unsigned rbits>
-int VerifyCommutative(std::uint64_t stride, bool reportTestCases) {
+int VerifyCommutative(unsigned samples, bool reportTestCases) {
 	using T = sw::universal::takum<nbits, rbits, std::uint64_t>;
 	int nrOfFailedTests = 0;
-	const std::uint64_t NR = (nbits >= 64) ? ~0ull : (1ull << nbits);
+	const std::uint64_t LAST   = last_encoding(nbits);
+	const std::uint64_t stride = sample_stride(LAST, samples);
 
-	for (std::uint64_t i = 0; i < NR && i + stride > i; i += stride) {
+	for (std::uint64_t i = 0; i <= LAST && i + stride > i; i += stride) {
 		T a; a.setbits(i);
 		if (a.isnar()) continue;
-		for (std::uint64_t j = 0; j < NR && j + stride > j; j += stride) {
+		for (std::uint64_t j = 0; j <= LAST && j + stride > j; j += stride) {
 			T b; b.setbits(j);
 			if (b.isnar()) continue;
 			if ((a + b).raw_bits() != (b + a).raw_bits()) {
@@ -413,18 +468,20 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// Strides are odd and coprime with the field structure so a sweep crosses
-	// every DR rather than revisiting one layout.  maybe_unused because which of
-	// them a build reaches depends on the regression level.
-	[[maybe_unused]] constexpr std::uint64_t stride64 = 0x0123456789ABCDEFull;   // ~225 samples
-	[[maybe_unused]] constexpr std::uint64_t stride32 = 0x01234567ull;           // ~225 samples
-	[[maybe_unused]] constexpr std::uint64_t stride16 = 211ull;                  // ~310 samples
+	// Sample counts, not strides -- sample_stride() derives the step from the width
+	// so every configuration gets the same coverage regardless of nbits.  The
+	// pairwise sweeps square: 225 samples is ~50k operand pairs, each of which
+	// builds an exact 1024-bit reference.  maybe_unused because which of them a
+	// build reaches depends on the regression level.
+	[[maybe_unused]] constexpr unsigned rounding_samples = 225;    // ~50k pairs
+	[[maybe_unused]] constexpr unsigned identity_samples = 4096;   // single ops, so cheap
+	[[maybe_unused]] constexpr unsigned commutative_samples = 300; // ~90k pairs, no reference
 
 #if MANUAL_TESTING
 
 	nrOfFailedTestCases += ReportTestResult(VerifyIssue1300Repro(true), "takum<64,3>", "issue 1300 repro");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<64, 3>(Op::add, stride64, true), "takum<64,3>", "correctly rounded add");
+		VerifyCorrectlyRounded<64, 3>(Op::add, rounding_samples, true), "takum<64,3>", "correctly rounded add");
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
@@ -434,40 +491,40 @@ try {
 	nrOfFailedTestCases += ReportTestResult(
 		VerifyIssue1300Repro(true), "takum<64,3>", "issue 1300 repro");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyExactIdentities<64, 3>(stride64, reportTestCases), "takum<64,3>", "exact identities");
+		VerifyExactIdentities<64, 3>(identity_samples, reportTestCases), "takum<64,3>", "exact identities");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<64, 3>(Op::add, stride64, reportTestCases), "takum<64,3>", "correctly rounded add");
+		VerifyCorrectlyRounded<64, 3>(Op::add, rounding_samples, reportTestCases), "takum<64,3>", "correctly rounded add");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<64, 3>(Op::mul, stride64, reportTestCases), "takum<64,3>", "correctly rounded mul");
+		VerifyCorrectlyRounded<64, 3>(Op::mul, rounding_samples, reportTestCases), "takum<64,3>", "correctly rounded mul");
 #endif
 
 #if REGRESSION_LEVEL_2
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<64, 3>(Op::sub, stride64, reportTestCases), "takum<64,3>", "correctly rounded sub");
+		VerifyCorrectlyRounded<64, 3>(Op::sub, rounding_samples, reportTestCases), "takum<64,3>", "correctly rounded sub");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<64, 3>(Op::div, stride64, reportTestCases), "takum<64,3>", "correctly rounded div");
+		VerifyCorrectlyRounded<64, 3>(Op::div, rounding_samples, reportTestCases), "takum<64,3>", "correctly rounded div");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCommutative<64, 3>(stride64, reportTestCases), "takum<64,3>", "commutativity");
+		VerifyCommutative<64, 3>(commutative_samples, reportTestCases), "takum<64,3>", "commutativity");
 	// The narrow configurations keep the double path, where the operands are exact
 	// doubles and one rounding decides the result.  Verified against the SAME exact
 	// reference, so the boundary the gate draws is measured rather than asserted.
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<32, 3>(Op::add, stride32, reportTestCases), "takum<32,3>", "correctly rounded add");
+		VerifyCorrectlyRounded<32, 3>(Op::add, rounding_samples, reportTestCases), "takum<32,3>", "correctly rounded add");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<32, 3>(Op::mul, stride32, reportTestCases), "takum<32,3>", "correctly rounded mul");
+		VerifyCorrectlyRounded<32, 3>(Op::mul, rounding_samples, reportTestCases), "takum<32,3>", "correctly rounded mul");
 #endif
 
 #if REGRESSION_LEVEL_3
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyFmaCorrectlyRounded<64, 3>(stride64, reportTestCases), "takum<64,3>", "correctly rounded fma");
+		VerifyFmaCorrectlyRounded<64, 3>(rounding_samples, reportTestCases), "takum<64,3>", "correctly rounded fma");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<32, 3>(Op::sub, stride32, reportTestCases), "takum<32,3>", "correctly rounded sub");
+		VerifyCorrectlyRounded<32, 3>(Op::sub, rounding_samples, reportTestCases), "takum<32,3>", "correctly rounded sub");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<32, 3>(Op::div, stride32, reportTestCases), "takum<32,3>", "correctly rounded div");
+		VerifyCorrectlyRounded<32, 3>(Op::div, rounding_samples, reportTestCases), "takum<32,3>", "correctly rounded div");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<16, 3>(Op::add, stride16, reportTestCases), "takum<16,3>", "correctly rounded add");
+		VerifyCorrectlyRounded<16, 3>(Op::add, rounding_samples, reportTestCases), "takum<16,3>", "correctly rounded add");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<16, 3>(Op::div, stride16, reportTestCases), "takum<16,3>", "correctly rounded div");
+		VerifyCorrectlyRounded<16, 3>(Op::div, rounding_samples, reportTestCases), "takum<16,3>", "correctly rounded div");
 #endif
 
 #if REGRESSION_LEVEL_4
@@ -475,24 +532,24 @@ try {
 	// and takum<64,1> the widest significand the format allows at 64 bits, p = 61,
 	// which is what fixes the round-to-odd width at 63.
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyExactIdentities<58, 3>(stride64, reportTestCases), "takum<58,3>", "exact identities");
+		VerifyExactIdentities<58, 3>(identity_samples, reportTestCases), "takum<58,3>", "exact identities");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<58, 3>(Op::add, stride64, reportTestCases), "takum<58,3>", "correctly rounded add");
+		VerifyCorrectlyRounded<58, 3>(Op::add, rounding_samples, reportTestCases), "takum<58,3>", "correctly rounded add");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyExactIdentities<64, 1>(stride64, reportTestCases), "takum<64,1>", "exact identities");
+		VerifyExactIdentities<64, 1>(identity_samples, reportTestCases), "takum<64,1>", "exact identities");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<64, 1>(Op::mul, stride64, reportTestCases), "takum<64,1>", "correctly rounded mul");
+		VerifyCorrectlyRounded<64, 1>(Op::mul, rounding_samples, reportTestCases), "takum<64,1>", "correctly rounded mul");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCorrectlyRounded<64, 1>(Op::div, stride64, reportTestCases), "takum<64,1>", "correctly rounded div");
+		VerifyCorrectlyRounded<64, 1>(Op::div, rounding_samples, reportTestCases), "takum<64,1>", "correctly rounded div");
 	// rbits = 5 pushes the characteristic past 2^31, an exponent range no binary
 	// floating-point type can hold.  The exact integer path carries the exponent
 	// as an int64_t outside the significand, so it is indifferent; the reference
 	// above is not, and skips the pairs whose span exceeds its width, which is why
 	// this configuration is covered structurally.
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyExactIdentities<64, 5>(stride64, reportTestCases), "takum<64,5>", "exact identities");
+		VerifyExactIdentities<64, 5>(identity_samples, reportTestCases), "takum<64,5>", "exact identities");
 	nrOfFailedTestCases += ReportTestResult(
-		VerifyCommutative<64, 5>(stride64, reportTestCases), "takum<64,5>", "commutativity");
+		VerifyCommutative<64, 5>(commutative_samples, reportTestCases), "takum<64,5>", "commutativity");
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);


### PR DESCRIPTION
Resolves the linear-takum half of #1300.

## What was wrong

`takum<>`'s four operators and `fma()` evaluated in a `double`. That is a single rounding only while the operands are exactly representable as doubles, and a takum significand is `1 + p` bits with `p` reaching `nbits - 2 - rbits`: `takum<64,3>` carries 60 bits against a double's 53, so **both operands were quantised before the operation**. The issue's repro -- one encoding step above 1.0, plus zero -- came back with its low bit gone.

## What it does now

Configurations with `nbits > 54 + rbits` evaluate exactly. Every takum value is a dyadic rational `S * 2^e` with `S < 2^62`, so the arithmetic is integer arithmetic:

| operation | exact path |
|---|---|
| `*` | the 124-bit integer product of the significands |
| `/` | 128 quotient bits by restoring division, plus a sticky remainder |
| `+` `-` | both terms aligned into a 128-bit window, sticky below it |
| `fma` | the product joins the addend unrounded, in the same window |

All of them share one tail: normalise, round to odd at 63 bits, hand to `takum_codec::encode_fraction()` for the one rounding the layout calls for. Round-to-odd is what keeps the two narrowings from disagreeing with a single rounding near a tie -- the same reason `takum_cross_conversion.hpp` adopted it in #1309.

## Why integers rather than the `dd_cascade` design in the issue

The recorded plan was a `dd_cascade` significand. That restores `+ - /`, but leaves a hole in `*`: the exact product of two 60-bit significands is 120 bits, and while an exact **tie** is safe in a double-double (a tie needs exactly `p+1` significant bits, which `dd` holds exactly) a **near-tie** is not -- the exact product can sit 2^-120 from a tie point, below `dd_cascade`'s own 2^-104 error. That is what motivated the `td_cascade` recommendation in the first comment.

Integers have no such hole, cost no extended-precision dependency in the core header (`takum_cross_conversion.hpp` treats the `dd_cascade` dependency as a deliberate opt-in), stay `constexpr`, and are faster. It is the same argument that made `takum_log`'s multiply and divide exact in #1312.

The exponent is carried as an `int64_t` outside the significand, so `rbits = 5` -- whose characteristic reaches 2^32, an exponent range no binary floating-point type can scale to, and the case comment 4 flagged as breaking the `dd_cascade` approach -- works the same as `rbits = 3`. No configuration is left on the inaccurate path.

## Narrow configurations

They keep the double path, where the operands **are** exact doubles. The new suite verifies them against the same exact reference, so the boundary the gate draws is measured rather than asserted: `takum<16,3>` and `takum<32,3>` are correctly rounded on the double path for all four operators.

## Verification

`static/tapered/takum/arithmetic/wide_arithmetic.cpp`. The reference is exact, not extended-precision: a 1024-bit `integer<>` holds the true result and the check is that the produced encoding is at least as close to it as either of its neighbours. No floating-point arithmetic is involved in reaching it.

Confirmed by mutation, since a first-cut check on this codebase has more often than not failed to discriminate:

| mutation | result |
|---|---|
| operators reverted to the double path | 37705/50172 (75.2%) of `takum<64,3>` addition pairs fail, 0% at 16 and 32 bits |
| round-to-odd disabled in the shared tail | a further 834 failures, all at 64 bits |

The 75.2% matches the **75.60%** measured independently against a 113-bit `__float128` reference in the issue -- two references, arrived at by different means, agreeing on the size of the defect.

Also covered: the issue's repro as a named regression, exact identities (`a+0`, `a*1`, `a/a`, `a-a`, NaR propagation), commutativity, and `takum<58,3>` / `takum<64,1>` / `takum<64,5>` at the edges of the gate.

## What is NOT in this PR

`takum_log`'s `+` and `-`, the remaining half of #1300. They have no logarithmic shortcut, so an exact path has to leave the logarithmic domain and come back at two transcendentals per operation, and comment 4 asks for that to be measured before it is committed to. Their comment now states the defect and its measured extent (99.22% of 64-bit sums incorrectly rounded) rather than leaving the reader to infer it.

`fma.hpp`'s comment has been narrowed to say which configurations the double intermediate suffices for, as the issue asked.

## Testing

- gcc and clang, Release: 20/20 takum + takum_log tests pass
- gcc Debug at `UNIVERSAL_BUILD_REGRESSION_STRESS=ON` (asserts live, so the path's preconditions are checked): 20/20 pass
- ASCII guard clean

Relates to #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved arithmetic accuracy for high-precision takum formats with exact wide-arithmetic calculations.
  * Enhanced handling of zero values, special values, rounding, underflow, and saturation.
  * Fused multiply-add now provides correctly rounded results for supported wide configurations.

* **Bug Fixes**
  * Reduced rounding errors in addition, subtraction, multiplication, division, and fused multiply-add operations.

* **Tests**
  * Added comprehensive validation across takum widths, including compile-time checks, exact-result comparisons, and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->