### PR TITLE
fix(qd_cascade): replace the sorted multiply with the qd_mul schedule

### DIFF
--- a/benchmark/performance/arithmetic/highprecision/README.md
+++ b/benchmark/performance/arithmetic/highprecision/README.md
@@ -76,7 +76,8 @@ LCG in `[0.5, 2.0)`, so runs are reproducible and the multiplicative and additiv
 processor      : 12th Gen Intel(R) Core(TM) i7-12700K, pinned to core 0
 compiler       : gcc 13.3.0, -O3 -DNDEBUG, C++20, no ISA extensions beyond baseline
 measurement    : best of 3, 0.050 sec calibration window
-date           : 2026-08-15, re-measured after the universal#1317 fix
+date           : 2026-08-16, re-measured after universal#1317 and #1322
+  window         : 0.25 sec (the recorded run uses a longer window than the default)
 ```
 
 ### Scalar operators (nsec/op, lower is better)
@@ -84,20 +85,20 @@ date           : 2026-08-15, re-measured after the universal#1317 fix
 ```text
 operation                    double           dd   dd_cascade   td_cascade           qd   qd_cascade
 ----------------------------------------------------------------------------------------------------
-sink only (floor)              0.20         0.37         0.37         0.41         0.49         0.49
-construct                      0.20         0.29         0.27         0.37         0.41         0.41
-copy construct                 0.20         0.37         0.37         0.41         0.49         0.49
-assign                         0.20         0.37         0.37         0.41         0.49         0.51
-add                            0.41        23.86        16.06        35.46        62.44        70.36
-subtract                       0.41        23.86        15.53        32.54        61.51        66.16
-multiply                       0.82        22.26        24.50       215.81        73.01       581.26
-divide                         2.86       216.47        81.30       180.49       594.88       429.73
-compare (<)                    0.60         1.69         0.60         0.78         0.67         0.76
-compare (==)                   0.41         0.54         0.54         0.41         0.55         0.55
+sink only (floor)              0.21         0.37         0.37         0.41         0.49         0.49
+construct                      0.20         0.27         0.29         0.37         0.41         0.41
+copy construct                 0.21         0.37         0.37         0.41         0.49         0.49
+assign                         0.21         0.37         0.37         0.41         0.49         0.49
+add                            0.41        24.47        16.57        35.41        62.60        70.55
+subtract                       0.41        24.31        15.34        32.55        61.52        66.09
+multiply                       0.82        22.84        24.53       213.75        73.07        82.24
+divide                         2.86       216.56        78.90       181.06       591.99       442.80
+compare (<)                    0.59         1.69         0.77         0.58         0.66         0.57
+compare (==)                   0.41         0.54         0.55         0.41         0.54         0.55
 convert to double              0.41         0.41         0.41         0.41         0.41         0.41
-convert from double            0.20         0.27         0.29         0.41         0.41         0.41
-convert to string            510.09      2694.48      3804.09      4403.04      7722.31      7499.15
-convert from string          120.73    454849.97    453252.03    476934.70    486030.26    489235.67
+convert from double            0.20         0.27         0.29         0.37         0.41         0.41
+convert to string            510.35      2693.40      3658.46      4396.93      7714.33      8771.76
+convert from string          121.27    383642.58    383692.72    399603.22    415678.62    414774.32
 ```
 
 The construct/copy/assign/convert rows all sit at the sink floor: a copy is 2 to 4 `movsd`
@@ -109,12 +110,12 @@ because they distinguish the implementations.
 ```text
 operation                    double           dd   dd_cascade   td_cascade           qd   qd_cascade
 ----------------------------------------------------------------------------------------------------
-dot N=16                       0.10        39.37        49.95        77.57       137.13       157.74
-dot N=256                      0.29        29.49        46.51        83.99       141.93       165.08
-dot N=4096                     0.40        29.68        46.40        87.10       143.08       163.62
-axpy N=4096                    0.13        37.59        41.27        65.89       139.08       133.94
-matmul 32x32                   0.24        21.09        49.74        82.43       142.00       148.37
-horner deg 20                  0.32        47.49        59.42        75.35       150.29       153.61
+dot N=16                       0.10        39.41        48.58        91.34       136.72       144.74
+dot N=256                      0.31        28.65        42.46        96.99       138.17       152.41
+dot N=4096                     0.40        29.07        41.83        98.14       136.77       157.38
+axpy N=4096                    0.14        37.17        35.33        70.51       132.74       135.76
+matmul 32x32                   0.23        21.05        49.63        83.56       135.26       157.80
+horner deg 20                  0.32        47.53        58.25        75.46       143.40       169.28
 ```
 
 The `double` column is auto-vectorized and the multi-component columns are not, which is most of the
@@ -126,12 +127,12 @@ of these implementations.
 ```text
 operation                    double           dd   dd_cascade   td_cascade           qd   qd_cascade
 ----------------------------------------------------------------------------------------------------
-accumulate only                0.41        23.94        28.81        47.16        71.90        96.60
-sqrt                           1.23        42.74       313.70       771.98      1120.91      2879.21
-exp                            3.48       916.48      1230.00     13338.90      4169.76     26035.96
-log                            3.45      1960.27      2636.61     26134.51     13181.51     75320.89
-sin                            3.80       951.43      1446.23      9674.26      3531.18     24653.02
-cos                            3.63       960.57      1454.11      9832.77      3525.93     24816.82
+accumulate only                0.41        23.94        29.23        47.10        70.77        96.20
+sqrt                           1.23        42.80       302.30       774.61      1122.92      2228.46
+exp                            3.66       916.36      1178.58     13406.05      4164.54      6642.07
+log                            3.53      1958.61      2526.12     26224.25     13183.32     21813.91
+sin                            3.88       951.78      1368.23      9762.65      3529.60      6951.73
+cos                            3.80       959.65      1378.17      9871.94      3530.28      6919.18
 ```
 
 ### Normalized cost, cascade relative to classic (gcc)
@@ -141,20 +142,20 @@ Ratio of nsec/op. 1.00 is parity, above 1.00 means the cascade implementation is
 ```text
 operation                dd_cascade/dd   qd_cascade/qd   td_cascade/dd
 ----------------------------------------------------------------------
-add                               0.67            1.13            1.49
-subtract                          0.65            1.08            1.36
-multiply                          1.10            7.96            9.69
-divide                            0.38            0.72            0.83
-dot N=256                         1.58            1.16            2.85
-dot N=4096                        1.56            1.14            2.93
-axpy N=4096                       1.10            0.96            1.75
-matmul 32x32                      2.36            1.04            3.91
-horner deg 20                     1.25            1.02            1.59
-sqrt                              7.34            2.57           18.06
-exp                               1.34            6.24           14.55
-log                               1.35            5.71           13.33
-sin                               1.52            6.98           10.17
-cos                               1.51            7.04           10.24
+add                            0.68            1.13            1.45
+subtract                       0.63            1.07            1.34
+multiply                       1.07            1.13            9.36
+divide                         0.36            0.75            0.84
+dot N=256                      1.48            1.10            3.38
+dot N=4096                     1.44            1.15            3.38
+axpy N=4096                    0.95            1.02            1.90
+matmul 32x32                   2.36            1.17            3.97
+horner deg 20                  1.23            1.18            1.59
+sqrt                           7.06            1.98           18.10
+exp                            1.29            1.59           14.63
+log                            1.29            1.65           13.39
+sin                            1.44            1.97           10.26
+cos                            1.44            1.96           10.29
 ```
 
 ## Code generation sensitivity
@@ -228,7 +229,7 @@ dd                           10.83             1.479                 10.88
 dd_cascade                   2.867             1.479                 2.389
 td_cascade                   7.198            0.8534             4.277e+15
 qd                           1.046             0.215             1.494e+23
-qd_cascade                      15            0.2215             3.852e+31
+qd_cascade                   8.572            0.2392             3.852e+31
 ```
 
 Reading the large residuals as correct decimal digits:
@@ -236,10 +237,11 @@ Reading the large residuals as correct decimal digits:
 - `qd_cascade` `sqrt`, `exp` and `log` were the original finding of this benchmark: 48 to 50 correct
   digits where `qd` delivers 63. That was **fixed** in universal#1317 - the cause was not in those
   functions but in addition, which returned an exact-valued but overlapping expansion whose fourth
-  component the renormalization then dropped. The rows above are post-fix; `exp` and `log` now agree
-  with `qd` to the last bit against an exact oracle, and `sqrt` sits at 15 ulps of 212 bits (63.2 of
-  63.6 digits). The cost is on the other axis: quad-double addition is now 46% more expensive, which
-  is what turned `qd_cascade`'s dot product from 0.83x `qd` into 1.15x.
+  component the renormalization then dropped. universal#1322 then replaced the multiplication with
+  the classic qd_mul schedule, which took `sqrt` from 15 ulps to 8.6 and made multiplication agree
+  with `qd` bit for bit against an exact oracle. `exp` and `log` also match `qd` exactly. The cost
+  of the first fix is on the other axis: quad-double addition is 46% more expensive, which is what
+  turned `qd_cascade`'s dot product from 0.83x `qd` into 1.10x.
 - `sin`/`cos` above double-double precision lose digits on every type tested, over the sampled
   domain `[0.5, 2.0)`: `qd` holds about 41 digits, `qd_cascade` and `td_cascade` about 32, which is
   `dd` precision. The extra limbs are not carrying information through the trigonometric evaluation.
@@ -263,31 +265,38 @@ benchmark results.
 
 ## What the numbers say
 
-1. **What does the generic `floatcascade<N>` renormalization cost?** For division, nothing: the
-   cascade implementations beat the classic ones (0.38x and 0.72x). For addition it is free at N=2
-   (0.67x) but costs 13% at N=4, which is the price of the universal#1317 correctness fix - the
-   expansion has to be compressed before it can be renormalized without dropping a component. For
-   multiplication it is expensive and grows with N: 1.1x at N=2 under gcc, 8.0x at N=4.
-   `qd_cascade` multiply at 581 nsec/op against `qd`'s 73 is the single worst row in the suite.
+1. **What does the generic `floatcascade<N>` renormalization cost?** Much less than it did. For
+   division, nothing: the cascade implementations beat the classic ones (0.36x and 0.75x). For
+   addition it is free at N=2 (0.68x) and costs 13% at N=4, the price of the universal#1317
+   correctness fix. Multiplication used to be the suite's worst row at 8.0x `qd`; universal#1322
+   replaced the sort-based accumulation with a transliteration of the classic qd_mul schedule and
+   it is now 1.13x. What remains is the generic machinery's floor: a cascade operation carries its
+   components through a renormalization that the hand-specialized code folds into the arithmetic.
 2. **Does the `volatile` hardening cost throughput?** Not measurably at the level this benchmark can
    isolate. The add/subtract rows, where the hardened error-free transformations dominate, are the
    rows where the cascade types *win*.
-3. **Is `td_cascade` a useful middle point?** Not on speed. Against `dd` it ranges from 0.83x
-   (divide) to 9.7x (multiply), with add/subtract at 1.4x and the kernels at 1.8x to 3.8x, and its
+3. **Is `td_cascade` a useful middle point?** Not on speed, and it is now the odd one out: it is
+   the only width still on the generic multiply, at 9.4x `dd`. Against `dd` it ranges from 0.84x
+   (divide) to 9.4x (multiply), with add/subtract at 1.4x and the kernels at 1.9x to 4.0x, and its
    trigonometry is no more accurate than `dd`'s. Its value has to come from the 159-bit significand
    in code paths that need it (universal#1300 wants it for takum64), not from filling a performance
-   gap.
-4. **Is there a crossover length where the cascade dot product wins?** No, at either width, and
-   this is the one conclusion universal#1317 reversed. `dd_cascade` is 1.3x to 1.6x `dd` at every
-   length from 16 to 4096 under both compilers, unchanged. `qd_cascade` used to be *faster* than
-   `qd` at every length (0.83x), but that margin came from an addition that was dropping a
-   component; with the correct addition it is 1.14x to 1.16x, i.e. slightly slower. The earlier
-   win was not real.
-5. **Can we retire classic `dd` and `qd`?** Closer than before, but not yet. `dd_cascade` is a
-   defensible replacement for `dd` once the multiply is addressed. `qd_cascade`'s accuracy blocker
-   is gone (universal#1317), so what remains is purely a speed question: its multiply is 8x `qd`'s,
-   and its addition is now 13% more expensive. Both are in the generic expansion code rather than
-   in the number system, which is where a follow-up should look.
+   gap. Porting the qd_mul schedule to N=3 is the obvious follow-up.
+4. **Is there a crossover length where the cascade dot product wins?** No, at either width.
+   `dd_cascade` is 1.4x to 1.5x `dd` at every length from 16 to 4096 under both compilers.
+   `qd_cascade` measured *faster* than `qd` (0.83x) before universal#1317, but that margin came
+   from an addition that was dropping a component; with the correct addition it is 1.10x to 1.15x.
+   The earlier win was not real.
+5. **Can we retire classic `dd` and `qd`?** For `qd`, this is now a real option. universal#1317
+   removed the accuracy blocker and universal#1322 removed the speed one: against an exact oracle
+   `qd_cascade` matches `qd` bit for bit on multiplication and to a rounding on sqrt/exp/log, and
+   the cost is 1.1x to 2.0x rather than 6x to 8x - with division actually faster (0.75x). Whether
+   1.1x on add/multiply is an acceptable price for one implementation instead of two is a
+   judgement call, not a measurement. `dd_cascade` is the better bargain: faster than `dd` on
+   add/subtract/divide, 1.07x on multiply, and its `sqrt` is more accurate.
+
+   The remaining outlier at both widths is `sqrt`, 7.1x `dd` and 2.0x `qd`, because the cascade
+   types reach it through Newton iteration on division while classic `qd` uses a multiplication-only
+   reciprocal iteration.
 
 ## Caveats
 

--- a/benchmark/performance/arithmetic/highprecision/README.md
+++ b/benchmark/performance/arithmetic/highprecision/README.md
@@ -188,9 +188,11 @@ depends on those two rows should be re-measured on the exact build in question, 
 made from a single compiler.
 
 Everything else is stable in direction across compilers: the kernel and mathlib ratios agree to
-within about 20% between gcc and clang, and `qd_cascade` multiply is 6x to 8x `qd` in both. The
-post-universal#1317 `qd_cascade` addition is 1.13x `qd` under gcc and 1.25x under clang - same
-direction, and slower than `qd` under both.
+within about 20% between gcc and clang. After universal#1322, `qd_cascade` multiply is 1.13x `qd`
+under gcc and 0.89x under clang - the only remaining row where the two compilers disagree about
+which implementation is ahead, and by a margin small enough that neither answer is interesting.
+The post-universal#1317 `qd_cascade` addition is 1.13x `qd` under gcc and 1.33x under clang: same
+direction, slower than `qd` under both.
 
 ### AVX2
 
@@ -235,13 +237,21 @@ qd_cascade                   8.572            0.2392             3.852e+31
 Reading the large residuals as correct decimal digits:
 
 - `qd_cascade` `sqrt`, `exp` and `log` were the original finding of this benchmark: 48 to 50 correct
-  digits where `qd` delivers 63. That was **fixed** in universal#1317 - the cause was not in those
-  functions but in addition, which returned an exact-valued but overlapping expansion whose fourth
-  component the renormalization then dropped. universal#1322 then replaced the multiplication with
-  the classic qd_mul schedule, which took `sqrt` from 15 ulps to 8.6 and made multiplication agree
-  with `qd` bit for bit against an exact oracle. `exp` and `log` also match `qd` exactly. The cost
-  of the first fix is on the other axis: quad-double addition is 46% more expensive, which is what
-  turned `qd_cascade`'s dot product from 0.83x `qd` into 1.10x.
+  digits where `qd` delivers 63. That was **fixed** in universal#1317 (an overlapping expansion
+  returned by addition, whose fourth component the renormalization then dropped) and improved again
+  in universal#1322 (multiplication rewritten to the classic qd_mul schedule).
+
+  What the numbers above show, and what they do not: the residuals are *self-consistency* checks,
+  so they bound the error from below and cannot certify a result as correctly rounded. On that
+  evidence `qd_cascade` went from 2.1e+15 ulps to 8.6 on `sqrt` and from 4.7e+13 to 0.24 on
+  `exp(log(x))`, against 1.0 and 0.22 for `qd` - the same order of magnitude, no longer 13 to 15
+  digits apart. The stronger claim, that `qd_cascade` multiplication is now bit-for-bit identical
+  to `qd`, rests on an external exact oracle rather than on this program; the in-repo artifact for
+  it is `static/highprecision/qd_cascade/arithmetic/addition_oracle.cpp`, which pins addition and
+  multiplication to within 2^-205 and 2^-210 of exact dyadic arithmetic.
+
+  The cost of the first fix is on the other axis: quad-double addition is 46% more expensive, which
+  is what turned `qd_cascade`'s dot product from 0.83x `qd` into 1.10x.
 - `sin`/`cos` above double-double precision lose digits on every type tested, over the sampled
   domain `[0.5, 2.0)`: `qd` holds about 41 digits, `qd_cascade` and `td_cascade` about 32, which is
   `dd` precision. The extra limbs are not carrying information through the trigonometric evaluation.
@@ -273,8 +283,10 @@ benchmark results.
    it is now 1.13x. What remains is the generic machinery's floor: a cascade operation carries its
    components through a renormalization that the hand-specialized code folds into the arithmetic.
 2. **Does the `volatile` hardening cost throughput?** Not measurably at the level this benchmark can
-   isolate. The add/subtract rows, where the hardened error-free transformations dominate, are the
-   rows where the cascade types *win*.
+   isolate. On the add/subtract rows, where the hardened error-free transformations dominate,
+   `dd_cascade` is the faster implementation (0.68x and 0.63x `dd`). `qd_cascade` is slightly
+   slower there (1.13x and 1.07x `qd`), but that is the compression universal#1317 added, not the
+   hardening: the same hardening is in both widths and only the wider one pays.
 3. **Is `td_cascade` a useful middle point?** Not on speed, and it is now the odd one out: it is
    the only width still on the generic multiply, at 9.4x `dd`. Against `dd` it ranges from 0.84x
    (divide) to 9.4x (multiply), with add/subtract at 1.4x and the kernels at 1.9x to 4.0x, and its
@@ -287,9 +299,11 @@ benchmark results.
    from an addition that was dropping a component; with the correct addition it is 1.10x to 1.15x.
    The earlier win was not real.
 5. **Can we retire classic `dd` and `qd`?** For `qd`, this is now a real option. universal#1317
-   removed the accuracy blocker and universal#1322 removed the speed one: against an exact oracle
-   `qd_cascade` matches `qd` bit for bit on multiplication and to a rounding on sqrt/exp/log, and
-   the cost is 1.1x to 2.0x rather than 6x to 8x - with division actually faster (0.75x). Whether
+   removed the accuracy blocker and universal#1322 removed the speed one: `qd_cascade` multiplication
+   is exact to within 2^-210 of dyadic arithmetic (the in-repo oracle test) and identical to `qd`
+   against an external decimal oracle, the mathlib residuals are within an order of magnitude of
+   `qd`'s, and the cost is 1.1x to 2.0x rather than 6x to 8x - with division actually faster
+   (0.75x). Whether
    1.1x on add/multiply is an acceptable price for one implementation instead of two is a
    judgement call, not a measurement. `dd_cascade` is the better bargain: faster than `dd` on
    add/subtract/divide, 1.07x on multiply, and its `sqrt` is more accurate.

--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -1549,7 +1549,6 @@ namespace expansion_ops {
         double p0 = tprod(a[0], b, q0);
         double p1 = tprod(a[1], b, q1);
         double p2 = tprod(a[2], b, q2);
-        double p3 = a[3] * b;
 
         double s0 = p0;
         double s2{};
@@ -1559,6 +1558,9 @@ namespace expansion_ops {
 
         // three_sum2: keep the sum and one residual, drop what falls below eps^4
         {
+            // the fourth partial product contributes only here, and only at
+            // eps^3, so it does not need its error term
+            double p3 = a[3] * b;
             double u{}, v{}, w{};
             u = tsum(q1, q2, v);
             q1 = tsum(p3, u, w);

--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -1443,64 +1443,242 @@ namespace expansion_ops {
         return compress_expansion(result);
     }
 
-    // Multiply two floatcascade<4> -> floatcascade<4>.  Computes 16 partial
-    // products with two_prod, sorts the 32-term expansion (16 products + 16
-    // errors) by magnitude in a fixed-size array (no std::sort), then
-    // accumulates with two_sum chains into a 4-component result and
-    // renormalizes.
-    constexpr inline floatcascade<4> multiply_cascades(const floatcascade<4>& a, const floatcascade<4>& b) {
-        // Compute all 16 partial products with their error terms.
-        double prod[16] = {};
-        double err[16]  = {};
-        for (int i = 0; i < 4; ++i) {
-            for (int j = 0; j < 4; ++j) {
-                two_prod(a[i], b[j], prod[i * 4 + j], err[i * 4 + j]);
+    // Five-term renormalization (Hida/Li/Bailey QD renorm), written against the
+    // hardened fast_two_sum above.  It is the companion to the multiplication
+    // below: that accumulation delivers five terms in decreasing magnitude, each
+    // within an ulp of the one before, which is the precondition a fast_two_sum
+    // chain needs (see compress_expansion for what happens when it is missing).
+    constexpr inline void renorm5(double& a0, double& a1, double& a2, double& a3, double& a4) {
+        if (std::is_constant_evaluated()) {
+            if (sw::universal::is_inf_cx(a0)) return;
+        }
+        else {
+            if (std::isinf(a0)) return;
+        }
+
+        double s0{}, s1{}, s2{ 0.0 }, s3{ 0.0 };
+
+        // Phase 1: bottom-up accumulation, carrying each remainder up one place.
+        fast_two_sum(a3, a4, s0, a4);
+        fast_two_sum(a2, s0, s0, a3);
+        fast_two_sum(a1, s0, s0, a2);
+        fast_two_sum(a0, s0, a0, a1);
+
+        // Phase 2: extract four non-overlapping components, shifting the
+        // remaining precision down whenever a component cancels to zero.
+        fast_two_sum(a0, a1, s0, s1);
+        if (s1 != 0.0) {
+            fast_two_sum(s1, a2, s1, s2);
+            if (s2 != 0.0) {
+                fast_two_sum(s2, a3, s2, s3);
+                if (s3 != 0.0) s3 += a4; else s2 += a4;
+            }
+            else {
+                fast_two_sum(s1, a3, s1, s2);
+                if (s2 != 0.0) fast_two_sum(s2, a4, s2, s3);
+                else           fast_two_sum(s1, a4, s1, s2);
+            }
+        }
+        else {
+            fast_two_sum(s0, a2, s0, s1);
+            if (s1 != 0.0) {
+                fast_two_sum(s1, a3, s1, s2);
+                if (s2 != 0.0) fast_two_sum(s2, a4, s2, s3);
+                else           fast_two_sum(s1, a4, s1, s2);
+            }
+            else {
+                fast_two_sum(s0, a3, s0, s1);
+                if (s1 != 0.0) fast_two_sum(s1, a4, s1, s2);
+                else           fast_two_sum(s0, a4, s0, s1);
             }
         }
 
-        // Build expansion: up to 32 terms.
-        double expansion[32] = {};
-        int n_expansion = 0;
-        for (int k = 0; k < 16; ++k) {
-            if (prod[k] != 0.0) expansion[n_expansion++] = prod[k];
-            if (err[k]  != 0.0) expansion[n_expansion++] = err[k];
-        }
+        a0 = s0;
+        a1 = s1;
+        a2 = s2;
+        a3 = s3;
+    }
 
-        auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
+    // Non-finite operands need to be taken out before the error-free transformations
+    // run.  two_prod(inf, x) computes fma(inf, x, -inf), which is NaN, and every
+    // sum downstream smears that NaN across the expansion: the old sort-based
+    // multiply turned inf * 3 into a NaN, and a transliteration of qd_mul returns
+    // the right leading value with -nan trailing components (qd itself does this).
+    // IEEE already defines the answer, and the trailing components of an infinity
+    // or a NaN carry no information, so they are cleared.
+    constexpr inline bool is_finite_product(double a, double b) {
+        double p = a * b;
+        if (std::is_constant_evaluated()) return sw::universal::is_finite_cx(p);
+        return std::isfinite(p);
+    }
 
-        // Sort expansion by descending magnitude (bubble sort over up to 32 elements).
-        for (int pass = 0; pass < n_expansion - 1; ++pass) {
-            for (int j = 0; j < n_expansion - 1 - pass; ++j) {
-                if (absv(expansion[j]) < absv(expansion[j + 1])) {
-                    double t = expansion[j]; expansion[j] = expansion[j + 1]; expansion[j + 1] = t;
-                }
-            }
-        }
-
-        // Accumulate sorted expansion into a 4-component result with carry
-        // propagation through two_sum chains.
+    constexpr inline floatcascade<4> nonfinite_product(double a, double b) {
         floatcascade<4> result;
-        if (n_expansion > 0) {
-            result[0] = expansion[0];
-            for (int i = 1; i < n_expansion; ++i) {
-                double carry = expansion[i];
-                for (int j = 0; j < 4 && carry != 0.0; ++j) {
-                    double s = 0.0, e = 0.0;
-                    two_sum(result[j], carry, s, e);
-                    result[j] = s;
-                    carry = e;
-                }
-                // Sub-ULP carry below the last component is precision loss
-                // beyond what 4 doubles can represent; absorb into result[3].
-                if (carry != 0.0) {
-                    double s = 0.0, e = 0.0;
-                    two_sum(result[3], carry, s, e);
-                    result[3] = s;
-                }
-            }
-        }
+        result[0] = a * b;
+        result[1] = 0.0;
+        result[2] = 0.0;
+        result[3] = 0.0;
+        return result;
+    }
 
-        return renormalize(result);
+    // Multiply a floatcascade<4> by a single double.  Classic qd gets this from a
+    // separate operator*=(double); the cascade framework needs it as a named
+    // function because the general multiply is reached through one entry point.
+    //
+    // It is worth having: scaling by a double is common on its own, and it is
+    // also the shape division produces internally, where the initial quotient
+    // estimate is a one-component cascade. Running that through the full
+    // 4x4 schedule wastes ten of the sixteen partial products.
+    constexpr inline floatcascade<4> multiply_cascade_by_double(const floatcascade<4>& a, double b) {
+        if (!is_finite_product(a[0], b)) return nonfinite_product(a[0], b);
+
+        auto tsum = [](double x, double y, double& err) constexpr -> double {
+            double s{}, e{};
+            two_sum(x, y, s, e);
+            err = e;
+            return s;
+        };
+        auto tprod = [](double x, double y, double& err) constexpr -> double {
+            double p{}, e{};
+            two_prod(x, y, p, e);
+            err = e;
+            return p;
+        };
+
+        double q0{}, q1{}, q2{};
+        double p0 = tprod(a[0], b, q0);
+        double p1 = tprod(a[1], b, q1);
+        double p2 = tprod(a[2], b, q2);
+        double p3 = a[3] * b;
+
+        double s0 = p0;
+        double s2{};
+        double s1 = tsum(q0, p1, s2);
+
+        three_sum(s2, q1, p2);
+
+        // three_sum2: keep the sum and one residual, drop what falls below eps^4
+        {
+            double u{}, v{}, w{};
+            u = tsum(q1, q2, v);
+            q1 = tsum(p3, u, w);
+            q2 = v + w;
+        }
+        double s3 = q1;
+        double s4 = q2 + p2;
+
+        renorm5(s0, s1, s2, s3, s4);
+
+        floatcascade<4> result;
+        result[0] = s0;
+        result[1] = s1;
+        result[2] = s2;
+        result[3] = s3;
+        return result;
+    }
+
+    // Multiply two floatcascade<4> -> floatcascade<4>.
+    //
+    // This is a transliteration of the classic qd_mul (Hida/Li/Bailey accurate
+    // multiplication, as implemented by qd::accurate_multiplication), expressed
+    // with the volatile-hardened error-free transformations above.
+    //
+    // The previous implementation computed the same 16 partial products but then
+    // bubble sorted the resulting 32-term expansion - up to 496 compare-and-swap
+    // steps - and folded it into 4 components with a carry loop that discarded
+    // the error term of every sub-ulp carry.  That cost about two decimal digits
+    // against qd (1.7e-63 vs 1.6e-65 worst case on full-width operands) and ran
+    // 8x slower (universal#1322).
+    //
+    // The reference algorithm needs no sorting at all: the products are generated
+    // in order of decreasing significance by construction, grouped by the total
+    // order of their operands (a[i]*b[j] contributes at order eps^(i+j)), and the
+    // groups are accumulated with three_sum / two_sum chains that keep every
+    // error term.  Terms below eps^4 cannot affect a 4-component result and are
+    // summed in plain arithmetic, exactly as the reference does.
+    constexpr inline floatcascade<4> multiply_cascades(const floatcascade<4>& a, const floatcascade<4>& b) {
+        if (!is_finite_product(a[0], b[0])) return nonfinite_product(a[0], b[0]);
+
+        // A one-component operand is common enough to be worth three comparisons:
+        // scaling by a double lands here, and so does every division, whose
+        // initial quotient estimate is a single double. The general schedule
+        // would spend ten of its sixteen partial products multiplying by zero.
+        if (b[1] == 0.0 && b[2] == 0.0 && b[3] == 0.0) return multiply_cascade_by_double(a, b[0]);
+        if (a[1] == 0.0 && a[2] == 0.0 && a[3] == 0.0) return multiply_cascade_by_double(b, a[0]);
+
+        // return-style wrappers so the body reads like the published algorithm
+        auto tsum = [](double x, double y, double& err) constexpr -> double {
+            double s{}, e{};
+            two_sum(x, y, s, e);
+            err = e;
+            return s;
+        };
+        auto tprod = [](double x, double y, double& err) constexpr -> double {
+            double p{}, e{};
+            two_prod(x, y, p, e);
+            err = e;
+            return p;
+        };
+
+        // order eps^0 and eps^1
+        double q0{}, q1{}, q2{}, q3{}, q4{}, q5{};
+        double p0 = tprod(a[0], b[0], q0);
+
+        double p1 = tprod(a[0], b[1], q1);
+        double p2 = tprod(a[1], b[0], q2);
+
+        // order eps^2
+        double p3 = tprod(a[0], b[2], q3);
+        double p4 = tprod(a[1], b[1], q4);
+        double p5 = tprod(a[2], b[0], q5);
+
+        // start accumulation
+        three_sum(p1, p2, q0);
+
+        // six-three sum of p2, q1, q2, p3, p4, p5
+        three_sum(p2, q1, q2);
+        three_sum(p3, p4, p5);
+        double t0{}, t1{};
+        double s0 = tsum(p2, p3, t0);
+        double s1 = tsum(q1, p4, t1);
+        double s2 = q2 + p5;
+        s1 = tsum(s1, t0, t0);
+        s2 += (t0 + t1);
+
+        // order eps^3
+        double q6{}, q7{}, q8{}, q9{};
+        double p6 = tprod(a[0], b[3], q6);
+        double p7 = tprod(a[1], b[2], q7);
+        double p8 = tprod(a[2], b[1], q8);
+        double p9 = tprod(a[3], b[0], q9);
+
+        // nine-two sum of q0, s1, q3, q4, q5, p6, p7, p8, p9
+        q0 = tsum(q0, q3, q3);
+        q4 = tsum(q4, q5, q5);
+        p6 = tsum(p6, p7, p7);
+        p8 = tsum(p8, p9, p9);
+        t0 = tsum(q0, q4, t1);
+        t1 += (q3 + q5);
+        double r1{};
+        double r0 = tsum(p6, p8, r1);
+        r1 += (p7 + p9);
+        q3 = tsum(t0, r0, q4);
+        q4 += (t1 + r1);
+        t0 = tsum(q3, s1, t1);
+        t1 += q4;
+
+        // order eps^4 and below: too small to move a 4-component result, so a
+        // plain sum is all the reference algorithm spends here
+        t1 += a[1] * b[3] + a[2] * b[2] + a[3] * b[1] + q6 + q7 + q8 + q9 + s2;
+
+        renorm5(p0, p1, s0, t0, t1);
+
+        floatcascade<4> result;
+        result[0] = p0;
+        result[1] = p1;
+        result[2] = s0;
+        result[3] = t0;
+        return result;
     }
 
 } // namespace expansion_ops

--- a/include/sw/universal/number/qd_cascade/compress_8_4_bug.md
+++ b/include/sw/universal/number/qd_cascade/compress_8_4_bug.md
@@ -122,3 +122,46 @@ the overlap never reaches a surviving component. Compressing them anyway would h
 cost of `dd_cascade` addition for no accuracy gain, so the two overloads carry a comment saying
 so, and `static/highprecision/td_cascade/arithmetic/addition_oracle.cpp` pins the triple-double
 case in case that ever stops being true.
+
+
+## Follow-up (universal#1322, 2026-08-16): multiplication
+
+With the addition fixed, multiplication became the remaining gap: about two decimal digits behind
+`qd` (1.7e-63 vs 1.6e-65 worst case on full-width operands) and 8x slower.
+
+The old implementation computed the 16 partial products with `two_prod`, built a 32-term expansion,
+**bubble sorted it** - up to 496 compare-and-swap steps - and folded it into 4 components with a
+carry loop that discarded the error term of every sub-ulp carry. Both problems came from the same
+place: sorting throws away the structure that makes the reference algorithm work.
+
+`multiply_cascades(floatcascade<4>, floatcascade<4>)` is now a transliteration of the classic
+qd_mul (`qd::accurate_multiplication`), written against the volatile-hardened error-free
+transformations. It needs no sorting at all: `a[i]*b[j]` contributes at order eps^(i+j), so the
+products are generated in order of decreasing significance by construction, and the groups are
+accumulated with `three_sum`/`two_sum` chains that keep every error term. Terms below eps^4 cannot
+move a 4-component result and are summed in plain arithmetic, exactly as the reference does. The
+five-term accumulation is closed by `renorm5()`, the QD renormalization companion to that schedule.
+
+Two smaller pieces came with it:
+
+- `multiply_cascade_by_double()`, the equivalent of qd's separate `operator*=(double)`. A
+  one-component operand is common - scaling by a double, and the initial quotient estimate inside
+  every division - and running it through the full 4x4 schedule wastes ten of the sixteen partial
+  products. `multiply_cascades` dispatches to it on three comparisons.
+- A non-finite guard. `two_prod(inf, x)` computes `fma(inf, x, -inf)`, which is NaN, and the sums
+  downstream smear it across the expansion. The old sort-based multiply turned `inf * 3` into a
+  **NaN**; a faithful qd_mul returns `inf` with `-nan` in the trailing components, which is what
+  classic `qd` does to this day. Both are now short-circuited to the IEEE result with cleared
+  trailing components.
+
+| measurement | before | after | classic `qd` |
+|---|---|---|---|
+| multiply, worst rel err (full-width operands) | 1.7e-63 | **1.6e-65** | 1.6e-65 |
+| multiply, nsec/op | 581 | **82** | 73 |
+| exp, nsec/op | 26036 | **6642** | 4165 |
+| log, nsec/op | 75321 | **21814** | 13183 |
+| sqrt residual, ulps of 2^-212 | 15 | **8.6** | 1.0 |
+| `inf * 3` | NaN | inf | inf |
+
+`floatcascade<3>` (td_cascade) still uses the generic sorted multiply and is 9.4x `dd` on that
+operation; porting the same schedule to N=3 is the natural next step.

--- a/static/highprecision/qd_cascade/arithmetic/addition_oracle.cpp
+++ b/static/highprecision/qd_cascade/arithmetic/addition_oracle.cpp
@@ -83,6 +83,13 @@ namespace {
 	// dropped component through.
 	constexpr int TOLERANCE_BITS = 205;
 
+	// Multiplication is held to a tighter budget, because the defect it guards against is a
+	// quality gap rather than a dropped component: before universal#1322 the worst case was
+	// 1.7e-63 (2^-209), against 1.6e-65 (2^-215) for both qd and the current implementation.
+	// 210 bits sits between the two - it fails the discarded-carry implementation while leaving
+	// the correct one a factor of 45 of headroom for platform-dependent rounding.
+	constexpr int MULTIPLICATION_TOLERANCE_BITS = 210;
+
 	int VerifyAdditionAgainstOracle(bool reportTestCases, unsigned nrOfTestCases, std::uint64_t seed) {
 		using namespace sw::universal;
 		int nrOfFailedTests = 0;
@@ -102,6 +109,35 @@ namespace {
 					std::cerr << "  a   = " << to_quad(a) << '\n';
 					std::cerr << "  b   = " << to_quad(b) << '\n';
 					std::cerr << "  a+b = " << to_quad(sum) << '\n';
+				}
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+	// universal#1322: multiplication had no accuracy defect of #1317's size, but it was about two
+	// decimal digits behind qd because it discarded the error term of every sub-ulp carry while
+	// folding a sorted 32-term expansion into 4 components. Dyadic multiplication is exact, so the
+	// reference here is the true product, not an approximation of it.
+	int VerifyMultiplicationAgainstOracle(bool reportTestCases, unsigned nrOfTestCases, std::uint64_t seed) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		Generator gen(seed);
+		for (unsigned i = 0; i < nrOfTestCases; ++i) {
+			qd_cascade a = gen.nextQuadDouble();
+			qd_cascade b = gen.nextQuadDouble();
+			qd_cascade product = a * b;
+
+			dyadic exact = exact_value<qd_cascade, 4>(a) * exact_value<qd_cascade, 4>(b);
+			dyadic computed = exact_value<qd_cascade, 4>(product);
+
+			if (!within_tolerance(computed, exact, MULTIPLICATION_TOLERANCE_BITS)) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cerr << "FAIL: qd_cascade multiplication is more than 2^-" << MULTIPLICATION_TOLERANCE_BITS << " relative from exact\n";
+					std::cerr << "  a   = " << to_quad(a) << '\n';
+					std::cerr << "  b   = " << to_quad(b) << '\n';
+					std::cerr << "  a*b = " << to_quad(product) << '\n';
 				}
 			}
 		}
@@ -160,7 +196,7 @@ int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite         = "quad-double cascade addition against an exact dyadic oracle";
+	std::string test_suite         = "quad-double cascade addition and multiplication against an exact dyadic oracle";
 	std::string test_tag           = "qd_cascade addition oracle";
 	bool reportTestCases           = false;
 	int nrOfFailedTestCases        = 0;
@@ -170,6 +206,7 @@ try {
 #if MANUAL_TESTING
 
 	nrOfFailedTestCases += VerifyAdditionAgainstOracle(true, 32, 0xC0FFEEull);
+	nrOfFailedTestCases += VerifyMultiplicationAgainstOracle(true, 32, 0xF00Dull);
 	nrOfFailedTestCases += VerifySqrtResidual(true, 32, 0xBEEFull);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
@@ -178,11 +215,13 @@ try {
 
 #if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyAdditionAgainstOracle(reportTestCases, 64, 0xC0FFEEull), test_tag, "addition vs exact dyadic");
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplicationAgainstOracle(reportTestCases, 64, 0xF00Dull), test_tag, "multiplication vs exact dyadic");
 	nrOfFailedTestCases += ReportTestResult(VerifySqrtResidual(reportTestCases, 32, 0xBEEFull), test_tag, "sqrt residual vs exact dyadic");
 #endif
 
 #if REGRESSION_LEVEL_2
 	nrOfFailedTestCases += ReportTestResult(VerifyAdditionAgainstOracle(reportTestCases, 256, 0x1234ull), test_tag, "addition vs exact dyadic (level 2)");
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplicationAgainstOracle(reportTestCases, 256, 0x2345ull), test_tag, "multiplication vs exact dyadic (level 2)");
 #endif
 
 #if REGRESSION_LEVEL_3
@@ -191,6 +230,7 @@ try {
 
 #if REGRESSION_LEVEL_4
 	nrOfFailedTestCases += ReportTestResult(VerifyAdditionAgainstOracle(reportTestCases, 4096, 0x9ABCull), test_tag, "addition vs exact dyadic (level 4)");
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplicationAgainstOracle(reportTestCases, 4096, 0xBCDEull), test_tag, "multiplication vs exact dyadic (level 4)");
 	nrOfFailedTestCases += ReportTestResult(VerifySqrtResidual(reportTestCases, 512, 0xDEF0ull), test_tag, "sqrt residual vs exact dyadic (level 4)");
 #endif
 


### PR DESCRIPTION
Closes #1322.

`qd_cascade` multiplication was ~2 decimal digits behind `qd` on full-width operands (1.7e-63 vs
1.6e-65 worst case) and 8x slower. Both came from the same decision.

### Root cause

The old implementation computed the 16 partial products with `two_prod`, built a 32-term expansion,
**bubble sorted it** — up to 496 compare-and-swap steps — and folded it into 4 components with a
carry loop that discarded the error term of every sub-ulp carry:

```cpp
// Sub-ULP carry below the last component is precision loss
// beyond what 4 doubles can represent; absorb into result[3].
if (carry != 0.0) {
    double s = 0.0, e = 0.0;
    two_sum(result[3], carry, s, e);
    result[3] = s;                      // e is discarded
}
```

Sorting throws away the structure the reference algorithm relies on, and the fold then throws away
the terms that structure would have placed.

### Fix

`multiply_cascades(floatcascade<4>, floatcascade<4>)` is now a transliteration of the classic
qd_mul (`qd::accurate_multiplication`), written against the volatile-hardened EFTs. It needs no
sorting at all: `a[i]*b[j]` contributes at order `eps^(i+j)`, so products are generated in
decreasing significance **by construction**, and the groups are accumulated with `three_sum` /
`two_sum` chains that keep every error term. `renorm5()` closes the five-term accumulation.

Two smaller pieces came with it:

- **`multiply_cascade_by_double()`** — the equivalent of qd's separate `operator*=(double)`. Without
  it, fixing multiplication would have made **division 23% slower**: division's initial quotient
  estimate is a one-component cascade, and where the old sorted multiply skipped the zero products,
  a fixed schedule spends ten of its sixteen partial products multiplying by zero.
- **A non-finite guard.** `two_prod(inf, x)` is `fma(inf, x, -inf)` = NaN, which the downstream sums
  smear across the expansion. The old multiply turned `inf * 3` into a **NaN**; a faithful qd_mul
  returns `inf` with `-nan` trailing components, which is what classic `qd` still does. Both are now
  short-circuited to the IEEE result with cleared trailing components — tidier than either.

### Verification

Exact oracle (Python `decimal` at 160 digits, no shared code), 200 random pairs where **both**
operands carry all four components — operands built from a single `double` do not show the defect,
since their product is exactly representable and every implementation returns it bit-for-bit:

| operation | before | after | classic `qd` |
|---|---|---|---|
| multiply | 1.7e-63 | **1.6e-65** | 1.6e-65 |
| divide | 2.6e-64 | 2.8e-64 | 2.1e-65 |

Multiplication now matches `qd` bit for bit, worst *and* median.

### Measured (i7-12700K, gcc 13.3, -O3, pinned, 0.25 s window), nsec/op

| operation | before | after | classic `qd` |
|---|---|---|---|
| multiply | 581 | **82** | 73 |
| exp | 26036 | **6642** | 4165 |
| log | 75321 | **21814** | 13183 |
| sin | 24653 | **6952** | 3530 |
| sqrt | 2879 | **2228** | 1123 |
| divide | 430 | 443 | 592 |

`qd_cascade`'s `sqrt` self-consistency residual also improves from 15 ulps to 8.6 — a knock-on from
the more accurate multiply feeding its Newton iteration.

### Tests

The multiplication verifier added to the qd_cascade oracle suite holds a tighter budget than the
addition one (2^-210 vs 2^-205), because the defect here is a quality gap rather than a dropped
component: the threshold has to sit between the old 2^-209 and the correct 2^-215. It fails **235 of
4096** cases at `REGRESSION_LEVEL_4` on the old implementation and passes on the new.

113 dd/qd/cascade regression tests pass under gcc 13.3.0 and clang 18.1.3. The benchmark README is
re-measured; with #1317 and this change, `qd_cascade` is 1.1x–2.0x `qd` rather than 6x–8x, and the
"can we retire classic qd" answer changes from "no" to a judgement call.

`floatcascade<3>` still uses the generic sorted multiply and is 9.4x `dd` on that operation;
porting this schedule to N=3 is the natural next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved quad-double multiplication accuracy and performance.
  - Updated benchmark results and analysis, including revised performance ratios.
  - Confirmed that retiring the classic quad-double implementation is now viable.

- **Reliability**
  - Improved handling of non-finite multiplication results.
  - Added stronger multiplication validation against exact reference results.

- **Documentation**
  - Documented multiplication behavior, accuracy, performance, and remaining implementation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->