### PR TITLE
fix(td_cascade): port the qd_mul schedule to the 3-component width

### DIFF
--- a/benchmark/performance/arithmetic/highprecision/README.md
+++ b/benchmark/performance/arithmetic/highprecision/README.md
@@ -284,8 +284,8 @@ benchmark results.
    components through a renormalization that the hand-specialized code folds into the arithmetic.
 2. **Does the `volatile` hardening cost throughput?** Not measurably at the level this benchmark can
    isolate. On the add/subtract rows, where the hardened error-free transformations dominate,
-   `dd_cascade` is the faster implementation (0.68x and 0.63x `dd`). `qd_cascade` is slightly
-   slower there (1.13x and 1.07x `qd`), but that is the compression universal#1317 added, not the
+   `dd_cascade` is the faster implementation (0.67x and 0.64x `dd`). `qd_cascade` is slightly
+   slower there (1.12x and 1.08x `qd`), but that is the compression universal#1317 added, not the
    hardening: the same hardening is in both widths and only the wider one pays.
 3. **Is `td_cascade` a useful middle point?** On speed it is now what its width suggests: against
    `dd` it ranges from 0.96x (divide) to 2.8x (multiply), with add/subtract at 1.4x, the kernels at

--- a/benchmark/performance/arithmetic/highprecision/README.md
+++ b/benchmark/performance/arithmetic/highprecision/README.md
@@ -76,7 +76,7 @@ LCG in `[0.5, 2.0)`, so runs are reproducible and the multiplicative and additiv
 processor      : 12th Gen Intel(R) Core(TM) i7-12700K, pinned to core 0
 compiler       : gcc 13.3.0, -O3 -DNDEBUG, C++20, no ISA extensions beyond baseline
 measurement    : best of 3, 0.050 sec calibration window
-date           : 2026-08-16, re-measured after universal#1317 and #1322
+date           : 2026-08-16, re-measured after universal#1317 and #1322 (both widths)
   window         : 0.25 sec (the recorded run uses a longer window than the default)
 ```
 
@@ -85,20 +85,20 @@ date           : 2026-08-16, re-measured after universal#1317 and #1322
 ```text
 operation                    double           dd   dd_cascade   td_cascade           qd   qd_cascade
 ----------------------------------------------------------------------------------------------------
-sink only (floor)              0.21         0.37         0.37         0.41         0.49         0.49
-construct                      0.20         0.27         0.29         0.37         0.41         0.41
+sink only (floor)              0.20         0.37         0.37         0.41         0.50         0.49
+construct                      0.20         0.29         0.27         0.37         0.41         0.41
 copy construct                 0.21         0.37         0.37         0.41         0.49         0.49
-assign                         0.21         0.37         0.37         0.41         0.49         0.49
-add                            0.41        24.47        16.57        35.41        62.60        70.55
-subtract                       0.41        24.31        15.34        32.55        61.52        66.09
-multiply                       0.82        22.84        24.53       213.75        73.07        82.24
-divide                         2.86       216.56        78.90       181.06       591.99       442.80
-compare (<)                    0.59         1.69         0.77         0.58         0.66         0.57
-compare (==)                   0.41         0.54         0.55         0.41         0.54         0.55
+assign                         0.20         0.37         0.37         0.41         0.49         0.49
+add                            0.41        23.88        16.05        35.09        62.51        70.27
+subtract                       0.41        23.89        15.31        32.61        61.52        66.40
+multiply                       0.82        22.30        24.55        62.98        73.09        83.13
+divide                         2.86       216.87        78.15       209.24       587.77       442.61
+compare (<)                    0.62         1.69         0.61         0.75         0.65         0.74
+compare (==)                   0.41         0.55         0.55         0.41         0.55         0.55
 convert to double              0.41         0.41         0.41         0.41         0.41         0.41
-convert from double            0.20         0.27         0.29         0.37         0.41         0.41
-convert to string            510.35      2693.40      3658.46      4396.93      7714.33      8771.76
-convert from string          121.27    383642.58    383692.72    399603.22    415678.62    414774.32
+convert from double            0.21         0.27         0.29         0.41         0.41         0.41
+convert to string            513.61      2708.69      3582.20      5973.99      7708.84      8783.55
+convert from string          120.75    387242.40    386866.48    404230.50    418011.99    417810.97
 ```
 
 The construct/copy/assign/convert rows all sit at the sink floor: a copy is 2 to 4 `movsd`
@@ -110,12 +110,12 @@ because they distinguish the implementations.
 ```text
 operation                    double           dd   dd_cascade   td_cascade           qd   qd_cascade
 ----------------------------------------------------------------------------------------------------
-dot N=16                       0.10        39.41        48.58        91.34       136.72       144.74
-dot N=256                      0.31        28.65        42.46        96.99       138.17       152.41
-dot N=4096                     0.40        29.07        41.83        98.14       136.77       157.38
-axpy N=4096                    0.14        37.17        35.33        70.51       132.74       135.76
-matmul 32x32                   0.23        21.05        49.63        83.56       135.26       157.80
-horner deg 20                  0.32        47.53        58.25        75.46       143.40       169.28
+dot N=16                       0.10        40.56        52.91        80.46       145.44       150.11
+dot N=256                      0.29        33.44        46.64        86.25       146.91       158.19
+dot N=4096                     0.40        33.52        46.70        90.45       145.80       163.54
+axpy N=4096                    0.17        39.02        42.02        77.49       143.15       144.15
+matmul 32x32                   0.24        24.34        51.06        85.29       145.11       164.03
+horner deg 20                  0.33        47.72        58.79       104.52       154.35       171.88
 ```
 
 The `double` column is auto-vectorized and the multi-component columns are not, which is most of the
@@ -127,12 +127,12 @@ of these implementations.
 ```text
 operation                    double           dd   dd_cascade   td_cascade           qd   qd_cascade
 ----------------------------------------------------------------------------------------------------
-accumulate only                0.41        23.94        29.23        47.10        70.77        96.20
-sqrt                           1.23        42.80       302.30       774.61      1122.92      2228.46
-exp                            3.66       916.36      1178.58     13406.05      4164.54      6642.07
-log                            3.53      1958.61      2526.12     26224.25     13183.32     21813.91
-sin                            3.88       951.78      1368.23      9762.65      3529.60      6951.73
-cos                            3.80       959.65      1378.17      9871.94      3530.28      6919.18
+accumulate only                0.42        23.96        29.25        47.28        71.86        95.95
+sqrt                           1.25        42.77       299.04       726.04      1123.38      2221.94
+exp                            3.56       918.07      1174.77      3280.47      4166.86      6761.49
+log                            3.45      1963.75      2507.83      7009.07     13186.61     22049.89
+sin                            3.83       952.96      1280.67      2846.36      3530.69      7106.00
+cos                            3.66       960.09      1284.42      2867.30      3538.01      7058.37
 ```
 
 ### Normalized cost, cascade relative to classic (gcc)
@@ -142,20 +142,20 @@ Ratio of nsec/op. 1.00 is parity, above 1.00 means the cascade implementation is
 ```text
 operation                dd_cascade/dd   qd_cascade/qd   td_cascade/dd
 ----------------------------------------------------------------------
-add                            0.68            1.13            1.45
-subtract                       0.63            1.07            1.34
-multiply                       1.07            1.13            9.36
-divide                         0.36            0.75            0.84
-dot N=256                      1.48            1.10            3.38
-dot N=4096                     1.44            1.15            3.38
-axpy N=4096                    0.95            1.02            1.90
-matmul 32x32                   2.36            1.17            3.97
-horner deg 20                  1.23            1.18            1.59
-sqrt                           7.06            1.98           18.10
-exp                            1.29            1.59           14.63
-log                            1.29            1.65           13.39
-sin                            1.44            1.97           10.26
-cos                            1.44            1.96           10.29
+add                            0.67            1.12            1.47
+subtract                       0.64            1.08            1.37
+multiply                       1.10            1.14            2.82
+divide                         0.36            0.75            0.96
+dot N=256                      1.39            1.08            2.58
+dot N=4096                     1.39            1.12            2.70
+axpy N=4096                    1.08            1.01            1.99
+matmul 32x32                   2.10            1.13            3.50
+horner deg 20                  1.23            1.11            2.19
+sqrt                           6.99            1.98           16.97
+exp                            1.28            1.62            3.57
+log                            1.28            1.67            3.57
+sin                            1.34            2.01            2.99
+cos                            1.34            2.00            2.99
 ```
 
 ## Code generation sensitivity
@@ -279,20 +279,21 @@ benchmark results.
    division, nothing: the cascade implementations beat the classic ones (0.36x and 0.75x). For
    addition it is free at N=2 (0.68x) and costs 13% at N=4, the price of the universal#1317
    correctness fix. Multiplication used to be the suite's worst row at 8.0x `qd`; universal#1322
-   replaced the sort-based accumulation with a transliteration of the classic qd_mul schedule and
-   it is now 1.13x. What remains is the generic machinery's floor: a cascade operation carries its
+   replaced the sort-based accumulation with a transliteration of the classic qd_mul schedule, at
+   both the 3- and 4-component widths, and it is now 1.14x at N=4 and 2.8x `dd` at N=3. What remains is the generic machinery's floor: a cascade operation carries its
    components through a renormalization that the hand-specialized code folds into the arithmetic.
 2. **Does the `volatile` hardening cost throughput?** Not measurably at the level this benchmark can
    isolate. On the add/subtract rows, where the hardened error-free transformations dominate,
    `dd_cascade` is the faster implementation (0.68x and 0.63x `dd`). `qd_cascade` is slightly
    slower there (1.13x and 1.07x `qd`), but that is the compression universal#1317 added, not the
    hardening: the same hardening is in both widths and only the wider one pays.
-3. **Is `td_cascade` a useful middle point?** Not on speed, and it is now the odd one out: it is
-   the only width still on the generic multiply, at 9.4x `dd`. Against `dd` it ranges from 0.84x
-   (divide) to 9.4x (multiply), with add/subtract at 1.4x and the kernels at 1.9x to 4.0x, and its
-   trigonometry is no more accurate than `dd`'s. Its value has to come from the 159-bit significand
-   in code paths that need it (universal#1300 wants it for takum64), not from filling a performance
-   gap. Porting the qd_mul schedule to N=3 is the obvious follow-up.
+3. **Is `td_cascade` a useful middle point?** On speed it is now what its width suggests: against
+   `dd` it ranges from 0.96x (divide) to 2.8x (multiply), with add/subtract at 1.4x, the kernels at
+   2.0x to 3.5x, and the mathlib at 3.0x to 3.6x - roughly the cost of carrying a third component,
+   where before the schedule port it paid 9.4x on multiply and 13x to 15x on exp/log. It also sits
+   between `dd` and `qd` on the mathlib in absolute terms, which is the point of a middle width.
+   The remaining caveat is accuracy, not speed: its trigonometry is no more accurate than `dd`'s
+   (universal#1318), so the 159-bit significand only pays off outside `sin`/`cos`.
 4. **Is there a crossover length where the cascade dot product wins?** No, at either width.
    `dd_cascade` is 1.4x to 1.5x `dd` at every length from 16 to 4096 under both compilers.
    `qd_cascade` measured *faster* than `qd` (0.83x) before universal#1317, but that margin came
@@ -308,9 +309,11 @@ benchmark results.
    judgement call, not a measurement. `dd_cascade` is the better bargain: faster than `dd` on
    add/subtract/divide, 1.07x on multiply, and its `sqrt` is more accurate.
 
-   The remaining outlier at both widths is `sqrt`, 7.1x `dd` and 2.0x `qd`, because the cascade
+   The remaining outlier at every width is `sqrt`, 7.0x `dd` and 2.0x `qd`, because the cascade
    types reach it through Newton iteration on division while classic `qd` uses a multiplication-only
-   reciprocal iteration.
+   reciprocal iteration. `td_cascade` division is also the one operation the schedule port left
+   behind: it is still 3.2 ulps of the 159-bit format worst case against an exact oracle, where its
+   multiplication is now 0.23.
 
 ## Caveats
 

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -147,6 +147,10 @@ export default defineConfig({
           items: [{ autogenerate: { directory: 'design' } }],
         },
         {
+          label: 'Assessments',
+          items: [{ autogenerate: { directory: 'assessments' } }],
+        },
+        {
           label: 'Build & Install',
           items: [{ autogenerate: { directory: 'build' } }],
         },

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -103,6 +103,9 @@ const FILE_MAP = {
   'ereal_limb_limit_derivation.md': 'design/ereal_limb_limit.md',
 
   // -- Assessments -------------------------------------------------
+  'assessments/elreal-phase4-status.md': 'assessments/elreal-phase4-status.md',
+  'assessments/ereal-retrospective.md': 'assessments/ereal-retrospective.md',
+  'assessments/millions-of-digits.md': 'assessments/millions-of-digits.md',
   'assessments/multi-component-cascade-vs-direct.md': 'assessments/multi-component.md',
 
   // -- Build & Install --------------------------------------------

--- a/docs-site/sync-content.mjs
+++ b/docs-site/sync-content.mjs
@@ -102,6 +102,9 @@ const FILE_MAP = {
   'decimal_conversion.md': 'design/decimal-conversion.md',
   'ereal_limb_limit_derivation.md': 'design/ereal_limb_limit.md',
 
+  // -- Assessments -------------------------------------------------
+  'assessments/multi-component-cascade-vs-direct.md': 'assessments/multi-component.md',
+
   // -- Build & Install --------------------------------------------
   'cross-compilation.md': 'build/cross-compilation.md',
   'code-formatting.md': 'build/code-formatting.md',

--- a/docs/assessments/ereal-retrospective.md
+++ b/docs/assessments/ereal-retrospective.md
@@ -1,4 +1,6 @@
-# ereal Retrospective: Development, Testing, Bugs, and Architecture Mishaps
+# ereal Retrospective
+
+**Development, testing, bugs, and architecture mishaps.**
 
 **Type under review:** `ereal<maxlimbs>` — adaptive multi-component (Priest/Shewchuk
 expansion) floating-point over `std::vector<double>`.

--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -1,0 +1,283 @@
+# Multi-component arithmetic: cascade vs direct
+
+Universal carries two implementations of multi-component floating-point. The **direct** types, `dd`
+and `qd`, are hand-specialized transliterations of the Hida/Li/Bailey QD library: one algorithm per
+operation per width, written out in full. The **cascade** types, `dd_cascade`, `td_cascade` and
+`qd_cascade`, are built on `floatcascade<N>`, a generic N-component expansion framework with
+volatile-hardened error-free transformations, and the stated intent is that they replace the direct
+ones.
+
+This document records what the two families actually cost against each other, what was fixed in
+August 2026 (universal#1317, #1322, #1324), and what is left for a second optimization pass. It is
+written to be the starting point for that pass.
+
+## Method, and why it matters here
+
+Every accuracy number below comes from an oracle that shares no code with the implementations under
+test:
+
+- an external reference (Python `decimal` at 140-200 digits) for transcendentals and for scoring
+  worst/median error over random operand sweeps;
+- the in-repo exact dyadic oracle (`verification/dyadic_exact.hpp`, backed by `einteger`) for `+`,
+  `-` and `*`, where the true result is a dyadic rational and the comparison is exact.
+
+This is not a formality. The defect that started this effort (#1317) survived every existing test
+because those tests are **self-consistent**: they check that a result is normalized, that it
+round-trips, and that the two implementations agree with each other. A result that is well-formed
+and wrong passes all three. Two further traps are worth stating outright, because both hid real
+defects:
+
+1. **Operands built from a single `double` prove nothing.** Their sum and product are exactly
+   representable, so every implementation returns them bit-for-bit. Defects only appear with
+   *full-width* operands - each component ~2^-53 below the previous - which is what Taylor series,
+   Newton iterations and Horner evaluations actually produce internally.
+2. **Score each width against its own ulp.** 2^-106 for `dd`, 2^-159 for `td`, 2^-212 for `qd`.
+   Applying a `qd`-calibrated threshold to a triple-double once led this effort to "find" a defect
+   in `td_cascade` that did not exist.
+
+Self-consistency residuals (`sqrt(x)^2 - x`, `sin^2 + cos^2 - 1`) still have a place - they are
+cheap and they *attribute* a disagreement to one side - but they bound error from below and cannot
+certify correct rounding. They are used below only where labelled.
+
+Measurements: i7-12700K pinned to one P-core, gcc 13.3.0 and clang 18.1.3, `-O3 -DNDEBUG`, via
+`benchmark/performance/arithmetic/highprecision/`. Accuracy sweeps are 400 random operand pairs in
+`[0.5, 2.0)` unless noted.
+
+## Where the two designs differ by construction
+
+| Operation | Direct (`dd`/`qd`) | Cascade (`floatcascade<N>`) |
+|---|---|---|
+| Addition | magnitude-ordered merge with a **two-term running carry** (`quick_three_accumulation`), emitting a component only once it is settled | merge, accumulate with a **single running sum**, collect the errors, then renormalize the collected expansion |
+| Multiplication | fixed schedule ordered by `eps^(i+j)`, no sorting | *was* a sorted 18/32-term expansion; **now the same fixed schedule** at N=3 and N=4 |
+| Division | long division with exact residuals | Newton refinement, residual via `add_cascades` + compress |
+| `sqrt` | Newton on the **reciprocal** square root - multiplication only | Newton on `(x + a/x)/2` - **one division per iteration** |
+| Special values | `renorm` bails out on infinity | explicit non-finite guard on the leading product |
+| Widths | 2 and 4, written out | 2, 3, 4 specialized; a generic template for any other N |
+
+The first row is the structural heart of the matter. Keeping a two-term carry is what makes the
+direct addition emit a *non-overlapping* expansion; collecting errors into a flat array does not,
+and that is what #1317 had to repair after the fact.
+
+## What was fixed
+
+### universal#1317 - compress the expansion before renormalizing (N=4 addition)
+
+`add_cascades` returned a sum whose *value* was exact and whose *components overlapped* -
+consecutive terms within a factor of two of each other rather than 2^53. `compress_8to4` is QD's
+`renorm`, built entirely from `fast_two_sum` chains, and `fast_two_sum(a, b)` is error-free only
+when `|a| >= |b|`. Handed an overlapping expansion it ran out of places for the tail and returned a
+fourth component of **exactly zero**, on roughly one addition in eight.
+
+The fix is Shewchuk's COMPRESS (*Geometric Predicates*, Fig. 22), applied to the `floatcascade<4>`
+overload. It is value-preserving: it changes only the shape of the expansion.
+
+| | before | after | `qd` |
+|---|---|---|---|
+| addition, worst rel err | 1.7e-49 | **exact** | 6.2e-65 |
+| `sqrt` | 1.3e-49 | 6.1e-64 | 5.5e-65 |
+| `exp` | 4.8e-51 | 4.0e-65 | 4.0e-65 |
+| `log` | 1.3e-50 | 2.3e-63 | 2.3e-63 |
+| qd_cascade addition | 48.4 ns | 70.4 ns | 62.5 ns |
+
+**Cost: +46% on quad-double addition**, and it reversed a benchmark conclusion - `qd_cascade`'s dot
+product had measured 0.83x `qd` only because the addition was dropping a component.
+
+Deliberately **not** applied at N=2 and N=3: both stay within 0.49 ulp of their own format with and
+without it, measured over 5000 random full-width additions. Fewer merged terms compressed into
+fewer output components leaves enough slack that the overlap never reaches a surviving component.
+
+### universal#1322 - the qd_mul schedule at N=4
+
+The old multiplication computed 16 partial products, **bubble sorted** the 32-term expansion (up to
+496 compare-and-swap steps), and folded it into 4 components with a carry loop that discarded the
+error term of every sub-ulp carry. Sorting throws away the structure the reference algorithm relies
+on; the fold then throws away the terms that structure would have placed.
+
+Replaced by a transliteration of `qd::accurate_multiplication`, which needs no sorting at all:
+`a[i]*b[j]` contributes at order `eps^(i+j)`, so the products emerge in decreasing significance by
+construction.
+
+| | before | after | `qd` |
+|---|---|---|---|
+| multiply, worst rel err | 1.7e-63 | **1.6e-65** | 1.6e-65 |
+| multiply | 581 ns | **82 ns** | 73 ns |
+| `exp` | 26036 ns | **6642 ns** | 4165 ns |
+| `log` | 75321 ns | **21814 ns** | 13183 ns |
+| `inf * 3` | **NaN** | inf | inf |
+
+Two pieces came with it and are worth remembering as a pattern:
+
+- `multiply_cascade_by_double`, the equivalent of qd's separate `operator*=(double)`. Without it,
+  fixing multiplication would have made **division 23% slower**: division's initial quotient
+  estimate is a one-component cascade, and where the sorted multiply skipped zero products, a fixed
+  schedule spends ten of its sixteen partial products multiplying by zero.
+- A non-finite guard. `two_prod(inf, x)` is `fma(inf, x, -inf)` = NaN, which the downstream sums
+  smear across the expansion. The old multiply turned `inf * 3` into a NaN - a real bug no test
+  caught. A faithful qd_mul returns `inf` with `-nan` trailing components, which is what classic
+  `qd` still does; the cascade now clears them.
+
+### universal#1324 - the same schedule at N=3
+
+| | before | after |
+|---|---|---|
+| multiply, worst | 5.53 ulps of 2^-159 | **0.23 ulps** |
+| multiply, past 1 ulp | 102 / 400 | **0 / 400** |
+| square, worst | 9.72 ulps | **0.22 ulps** |
+| multiply | 214 ns | **63 ns** |
+| `exp` | 13406 ns | **3280 ns** |
+| `log` | 26224 ns | **7009 ns** |
+| `sin` | 9763 ns | **2846 ns** |
+
+Multiplication is now correctly rounded at this width, and `td_cascade` costs roughly what carrying
+a third component should rather than 9x-15x `dd`.
+
+## Where the two families stand today
+
+### Accuracy, worst case in ulps of each format's own significand
+
+Lower is better; a correctly rounded operation is at or below 0.5. The `add`/`multiply`/`square`/
+`divide` rows are 400 random **full-width** operand pairs against the exact oracle - every component
+populated, the shape that arises inside iterative kernels. The `sqrt`/`exp`/`log` rows are 200
+single-argument evaluations, where the operand shape is not the variable of interest.
+
+| | `dd` | `dd_cascade` | `td_cascade` | `qd` | `qd_cascade` |
+|---|---|---|---|---|---|
+| add | 0.46 | 0.46 | 0.48 | 0.41 | **0.00** |
+| multiply | 0.46 | 0.46 | 0.23 | 0.11 | 0.11 |
+| square | 4.23 | 4.23 | 0.22 | 4.01 | 4.01 |
+| divide | 0.47 | **2.21** | **3.16** | 0.14 | **1.84** |
+| `sqrt` | 10.8 (*) | 2.9 (*) | 7.2 (*) | 0.37 | 4.03 |
+| `exp` | - | - | - | 0.26 | 0.26 |
+| `log` | - | - | - | 15.3 | 15.3 |
+
+(*) self-consistency residual, a lower bound, not an oracle comparison.
+
+Read across the rows: **add and multiply are settled** - the cascade matches or beats the direct
+implementation at every width. **Divide is the outlier at all three widths**, 4x to 13x the direct
+error. **Square and `log` are weak in both families equally**, which makes them upstream problems
+rather than cascade problems.
+
+### Performance, nsec/op (gcc 13.3, -O3, pinned)
+
+| | `dd` | `dd_cascade` | ratio | `td_cascade` | `qd` | `qd_cascade` | ratio |
+|---|---|---|---|---|---|---|---|
+| add | 23.9 | 16.1 | **0.67** | 35.1 | 62.5 | 70.3 | 1.12 |
+| subtract | 23.9 | 15.3 | **0.64** | 32.6 | 61.5 | 66.4 | 1.08 |
+| multiply | 22.3 | 24.6 | 1.10 | 63.0 | 73.1 | 83.1 | 1.14 |
+| divide | 216.9 | 78.2 | **0.36** | 209.2 | 587.8 | 442.6 | **0.75** |
+| `sqrt` | 42.8 | 299.0 | **6.99** | 726.0 | 1123.4 | 2221.9 | **1.98** |
+| `exp` | 918 | 1175 | 1.28 | 3280 | 4167 | 6761 | 1.62 |
+| `log` | 1964 | 2508 | 1.28 | 7009 | 13187 | 22050 | 1.67 |
+| `sin` | 953 | 1281 | 1.34 | 2846 | 3531 | 7106 | 2.01 |
+
+The generic framework now costs 1.1x-1.7x on most operations, wins on division and on
+double-double add/subtract, and loses badly on exactly one: `sqrt`.
+
+## Remaining discrepancies, in the order a second pass should take them
+
+### 1. Division accuracy - all three widths (highest value)
+
+The only operation where the cascade is *consistently* behind the direct implementation, and the
+gap is structural rather than incidental.
+
+```text
+                worst      >1 ulp     direct counterpart
+dd_cascade      2.21 ulps   30/400    dd 0.47
+td_cascade      3.16 ulps   24/400    (none)
+qd_cascade      1.84 ulps    -        qd 0.14
+```
+
+The cascade divides by Newton refinement: estimate `q0 = a[0]/b[0]`, form the residual
+`a - q0*b` through `add_cascades` + compress, then refine. Two suspects, in order: the residual is
+formed through the compression path added by #1317 (which is exact but may not be the tightest
+formulation available), and the refinement takes a fixed number of steps rather than iterating to
+the format's precision. Classic `qd` uses long division with exact residuals instead.
+
+Note that cascade division is simultaneously *faster* than direct (0.36x at N=2, 0.75x at N=4), so
+there is budget to spend. This is the one place where a more accurate algorithm can plausibly be
+adopted without going backwards on speed.
+
+### 2. `sqrt` algorithm choice - all widths
+
+`qd_cascade` is 2.0x `qd` and `dd_cascade` is 7.0x `dd`, the worst ratios in the suite, and
+`qd_cascade`'s result is 4.0 ulps against `qd`'s 0.37.
+
+The cause is a design choice, not an implementation flaw: the cascade iterates `x = (x + a/x)/2`,
+one **division** per step, while classic `qd` iterates on the reciprocal square root using
+**multiplication only**, then multiplies through once at the end. Now that cascade multiplication
+is at parity (1.10x-1.14x) and division is the expensive operation (443 ns at N=4 against 83 ns for
+a multiply), the reciprocal formulation is clearly the right one and was not when the cascade
+`sqrt` was written.
+
+Interesting counter-example worth preserving: `dd_cascade`'s `sqrt` is *more accurate* than `dd`'s
+(2.9 vs 10.8 ulps residual). The direct family could take something from the cascade here.
+
+### 3. The cost of #1317's compression at N=4
+
+Quad-double addition pays 46% for correctness, and that is the single largest performance
+regression this effort introduced. The compression is applied *after* the fact, to repair an
+expansion that was built without the non-overlapping invariant. The direct implementation never
+needs it because `accurate_addition` maintains a two-term running carry and emits components
+already settled.
+
+Porting that formulation to `add_cascades<4>` would plausibly recover most of the 46% *and* keep
+the exactness, since it is the algorithm the compression is emulating. This is the same move that
+#1322 made for multiplication, and it is the obvious next application of the pattern.
+
+### 4. The generic templates are still the old design (latent)
+
+`add_cascades<N>` and `multiply_cascades<N>` - the templates reached for any N outside {2, 3, 4} -
+still use `std::sort`/`std::vector` and the uncompressed, sorted-expansion formulation that #1317
+and #1322 replaced. Nothing instantiates them today, so this is not a live defect, but it is a trap:
+the first person to instantiate `floatcascade<5>` inherits every bug this effort fixed, silently.
+
+Either specialize them the same way, or make the primary template `static_assert` that N is one of
+the supported widths.
+
+### 5. Shared weaknesses - not cascade problems, but they cap both families
+
+- **Square is 4.0-4.2 ulps in both `dd` and `qd`** (and in their cascade counterparts, identically),
+  where multiplication is 0.11-0.46. `sqr(a)` is not simply `a*a` in these implementations, and
+  whatever it does is worse. `exp` squares 16 times.
+- **`log` is 15.3 ulps in both `qd` and `qd_cascade`**, an order of magnitude worse than `exp` at
+  0.26.
+- **`sin`/`cos` never reach format precision above `dd`** - universal#1318. `qd` holds ~41 digits of
+  63, `qd_cascade` and `td_cascade` ~32, i.e. the third and fourth components carry nothing through
+  the trigonometric evaluation.
+- **Decimal string parsing costs 45-460 usec per value** across every multi-component type -
+  universal#1319 - which puts it in shared conversion machinery, not in any one number system.
+
+Fixing these benefits both families at once, and #1318 in particular means the extra components of
+`td_cascade` and `qd_cascade` are currently wasted in trigonometric code.
+
+## Suggested sequencing
+
+1. **Port `accurate_addition` to `add_cascades<4>`** (item 3). Highest confidence: the algorithm is
+   known-good, sitting next door, and the pattern is proven twice over. Recovers most of a 46%
+   regression.
+2. **Reformulate `sqrt` on the reciprocal iteration** (item 2). Removes the worst performance ratio
+   in the suite and should improve accuracy at the same time.
+3. **Attack division accuracy** (item 1). Highest value, least certain shape; there is speed budget
+   to trade.
+4. **Close the generic templates** (item 4). Cheap, prevents silent regression.
+5. **Then the shared items** (item 5), which are number-system work rather than framework work.
+
+Items 1-3 are all the same move: where the cascade improvises, adopt the direct family's proven
+schedule and express it with the framework's hardened primitives. That move has now paid off three
+times.
+
+## Reproducing any of this
+
+```bash
+cmake -DUNIVERSAL_BUILD_BENCHMARK_PERFORMANCE=ON -DUNIVERSAL_BUILD_NUMBER_STATICS=ON ..
+make -j4 benchmark_hp_scalar benchmark_hp_mathlib benchmark_hp_kernels benchmark_hp_equivalence
+taskset -c 0 ./benchmark/performance/arithmetic/benchmark_hp_scalar 0.25
+```
+
+- `benchmark/performance/arithmetic/highprecision/` - the performance and equivalence suite, with
+  its own README carrying the full recorded tables and the gcc/clang/AVX2 sensitivity analysis.
+- `static/highprecision/{qd,td}_cascade/arithmetic/addition_oracle.cpp` - exact dyadic validation of
+  addition and multiplication. These fail loudly on the pre-fix implementations (825/4096 and
+  235/4096 at `REGRESSION_LEVEL_4`), which is the property that makes them worth keeping.
+- `include/sw/universal/number/qd_cascade/compress_8_4_bug.md` - the mechanism-level write-up of
+  #1317 and #1322, including the expansion shapes that break `fast_two_sum`.

--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -1,4 +1,7 @@
-# Multi-component arithmetic: cascade vs direct
+# Multi-component Systems
+
+**A design assessment of the cascade and direct implementations: what they cost against each other,
+what the August 2026 optimizations bought, and where a second pass should start.**
 
 Universal carries two implementations of multi-component floating-point. The **direct** types, `dd`
 and `qd`, are hand-specialized transliterations of the Hida/Li/Bailey QD library: one algorithm per

--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -588,6 +588,27 @@ namespace expansion_ops {
         two_sum(t2, t3, y, z);
     }
 
+    // Non-finite operands have to be taken out before the error-free transformations
+    // run.  two_prod(inf, x) computes fma(inf, x, -inf), which is NaN, and every sum
+    // downstream smears that NaN across the expansion: the old sort-based multiply
+    // turned inf * 3 into a NaN, and a faithful transliteration of qd_mul returns the
+    // right leading value with -nan trailing components (classic qd does this to this
+    // day).  IEEE already defines the answer, and the trailing components of an
+    // infinity or a NaN carry no information, so they are cleared.
+    constexpr inline bool is_finite_product(double a, double b) {
+        double p = a * b;
+        if (std::is_constant_evaluated()) return sw::universal::is_finite_cx(p);
+        return std::isfinite(p);
+    }
+
+    template<size_t M>
+    constexpr inline floatcascade<M> nonfinite_product(double a, double b) {
+        floatcascade<M> result;
+        result[0] = a * b;
+        for (size_t i = 1; i < M; ++i) result[i] = 0.0;
+        return result;
+    }
+
     // Renormalize N components to maintain non-overlapping property
     // Improved two-phase algorithm based on Hida-Li-Bailey QD library
     // Volatiles are handled inside quick_two_sum, so locals don't need to be volatile
@@ -1331,72 +1352,152 @@ namespace expansion_ops {
     }
 
     // Multiply two floatcascade<3> -> floatcascade<3>.  Adapted from the
-    // generic multiply_cascades algorithm: compute the 9 partial products
-    // (with two_prod for exact errors), accumulate diagonals, take the top
-    // 3 components.  Avoids std::sort/std::vector (use fixed-size arrays
-    // and a small bubble sort over the resulting expansion).
-    constexpr inline floatcascade<3> multiply_cascades(const floatcascade<3>& a, const floatcascade<3>& b) {
-        // Compute all 9 partial products with their error terms (18 doubles total).
-        double prod[9] = {};
-        double err[9]  = {};
-        for (int i = 0; i < 3; ++i) {
-            for (int j = 0; j < 3; ++j) {
-                two_prod(a[i], b[j], prod[i * 3 + j], err[i * 3 + j]);
-            }
+    // Four-term renormalization into three components: the N=3 companion to
+    // renorm5, same two-phase shape (bottom-up accumulation, then extraction
+    // that shifts precision down whenever a component cancels to zero).
+    constexpr inline void renorm4(double& a0, double& a1, double& a2, double& a3) {
+        if (std::is_constant_evaluated()) {
+            if (sw::universal::is_inf_cx(a0)) return;
+        }
+        else {
+            if (std::isinf(a0)) return;
         }
 
-        // Build expansion: all 18 terms.
-        double expansion[18] = {};
-        int n_expansion = 0;
-        for (int k = 0; k < 9; ++k) {
-            if (prod[k] != 0.0) expansion[n_expansion++] = prod[k];
-            if (err[k]  != 0.0) expansion[n_expansion++] = err[k];
+        double s0{}, s1{}, s2{ 0.0 };
+
+        fast_two_sum(a2, a3, s0, a3);
+        fast_two_sum(a1, s0, s0, a2);
+        fast_two_sum(a0, s0, a0, a1);
+
+        fast_two_sum(a0, a1, s0, s1);
+        if (s1 != 0.0) {
+            fast_two_sum(s1, a2, s1, s2);
+            if (s2 != 0.0) s2 += a3;
+            else           fast_two_sum(s1, a3, s1, s2);
+        }
+        else {
+            fast_two_sum(s0, a2, s0, s1);
+            if (s1 != 0.0) fast_two_sum(s1, a3, s1, s2);
+            else           fast_two_sum(s0, a3, s0, s1);
         }
 
-        auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
-
-        // Sort expansion by descending magnitude (bubble sort over up to 18 elements).
-        for (int pass = 0; pass < n_expansion - 1; ++pass) {
-            for (int j = 0; j < n_expansion - 1 - pass; ++j) {
-                if (absv(expansion[j]) < absv(expansion[j + 1])) {
-                    double t = expansion[j]; expansion[j] = expansion[j + 1]; expansion[j + 1] = t;
-                }
-            }
-        }
-
-        // Accumulate sorted expansion into a 3-component result with carry
-        // propagation through two_sum chains.
-        floatcascade<3> result;
-        if (n_expansion > 0) {
-            result[0] = expansion[0];
-            for (int i = 1; i < n_expansion; ++i) {
-                double carry = expansion[i];
-                for (int j = 0; j < 3 && carry != 0.0; ++j) {
-                    double s = 0.0, e = 0.0;
-                    two_sum(result[j], carry, s, e);
-                    result[j] = s;
-                    carry = e;
-                }
-                // Sub-ULP carry below the last component is precision loss
-                // beyond what 3 doubles can represent; absorb into result[2].
-                if (carry != 0.0) {
-                    double s = 0.0, e = 0.0;
-                    two_sum(result[2], carry, s, e);
-                    result[2] = s;
-                }
-            }
-        }
-
-        return renormalize(result);
+        a0 = s0;
+        a1 = s1;
+        a2 = s2;
     }
 
-    // ---------------------------------------------------------------------
-    // Constexpr-friendly overloads for floatcascade<4> (used by qd_cascade)
-    // ---------------------------------------------------------------------
+    // Multiply a floatcascade<3> by a single double: the N=3 form of
+    // multiply_cascade_by_double, and the shape division's initial quotient
+    // estimate produces.
+    constexpr inline floatcascade<3> multiply_cascade_by_double(const floatcascade<3>& a, double b) {
+        if (!is_finite_product(a[0], b)) return nonfinite_product<3>(a[0], b);
+
+        auto tsum = [](double x, double y, double& err) constexpr -> double {
+            double s{}, e{};
+            two_sum(x, y, s, e);
+            err = e;
+            return s;
+        };
+        auto tprod = [](double x, double y, double& err) constexpr -> double {
+            double p{}, e{};
+            two_prod(x, y, p, e);
+            err = e;
+            return p;
+        };
+
+        double q0{}, q1{};
+        double p0 = tprod(a[0], b, q0);
+        double p1 = tprod(a[1], b, q1);
+
+        double s0 = p0;
+        double s2{};
+        double s1 = tsum(q0, p1, s2);
+
+        // order eps^2: the carry out of the eps^1 sum, the error of a[1]*b, and
+        // the last product; whatever spills goes to eps^3 in plain arithmetic
+        double p2 = a[2] * b;
+        three_sum(s2, q1, p2);
+        double s3 = q1 + p2;
+
+        renorm4(s0, s1, s2, s3);
+
+        floatcascade<3> result;
+        result[0] = s0;
+        result[1] = s1;
+        result[2] = s2;
+        return result;
+    }
+
+    // Multiply two floatcascade<3> -> floatcascade<3>.
     //
-    // Same rationale as the floatcascade<2> and floatcascade<3> overloads:
-    // the generic templates use std::sort and std::vector and aren't
-    // constexpr in C++20.
+    // The same schedule as the floatcascade<4> multiply one order shorter (see
+    // universal#1322 for the reasoning): a[i]*b[j] contributes at order
+    // eps^(i+j), so the products come out in decreasing significance by
+    // construction and no sorting is needed.  Terms at eps^3 and below cannot
+    // move a 3-component result by more than a rounding of its last component,
+    // so they are summed in plain arithmetic.
+    //
+    // The previous implementation sorted an 18-term expansion and folded it with
+    // a carry loop that dropped each sub-ulp error term, which cost accuracy the
+    // format was paying for: 5.5 ulps worst case over 400 random full-width
+    // operand pairs, with a quarter of them past 1 ulp.
+    constexpr inline floatcascade<3> multiply_cascades(const floatcascade<3>& a, const floatcascade<3>& b) {
+        if (!is_finite_product(a[0], b[0])) return nonfinite_product<3>(a[0], b[0]);
+
+        if (b[1] == 0.0 && b[2] == 0.0) return multiply_cascade_by_double(a, b[0]);
+        if (a[1] == 0.0 && a[2] == 0.0) return multiply_cascade_by_double(b, a[0]);
+
+        auto tsum = [](double x, double y, double& err) constexpr -> double {
+            double s{}, e{};
+            two_sum(x, y, s, e);
+            err = e;
+            return s;
+        };
+        auto tprod = [](double x, double y, double& err) constexpr -> double {
+            double p{}, e{};
+            two_prod(x, y, p, e);
+            err = e;
+            return p;
+        };
+
+        // order eps^0
+        double q0{};
+        double p0 = tprod(a[0], b[0], q0);
+
+        // order eps^1
+        double q1{}, q2{};
+        double p1 = tprod(a[0], b[1], q1);
+        double p2 = tprod(a[1], b[0], q2);
+
+        // order eps^2
+        double q3{}, q4{}, q5{};
+        double p3 = tprod(a[0], b[2], q3);
+        double p4 = tprod(a[1], b[1], q4);
+        double p5 = tprod(a[2], b[0], q5);
+
+        // settle eps^1: p1 becomes the component, p2 and q0 spill into eps^2
+        three_sum(p1, p2, q0);
+
+        // settle eps^2: seven terms (p2, q0, q1, q2, p3, p4, p5) reduced with
+        // three_sum pairs, then combined
+        three_sum(p2, q0, q1);
+        three_sum(q2, p3, p4);
+        double t0{}, t1{};
+        double s2 = tsum(p2, q2, t0);
+        s2 = tsum(s2, p5, t1);
+
+        // eps^3 and below
+        double s3 = q0 + q1 + p3 + p4 + t0 + t1 + q3 + q4 + q5
+                  + a[1] * b[2] + a[2] * b[1] + a[2] * b[2];
+
+        renorm4(p0, p1, s2, s3);
+
+        floatcascade<3> result;
+        result[0] = p0;
+        result[1] = p1;
+        result[2] = s2;
+        return result;
+    }
 
     // Add two floatcascade<4> -> floatcascade<8>.  Magnitude-sorted merge
     // of the eight limbs, then accumulates smallest-to-largest with two_sum.
@@ -1499,28 +1600,6 @@ namespace expansion_ops {
         a3 = s3;
     }
 
-    // Non-finite operands need to be taken out before the error-free transformations
-    // run.  two_prod(inf, x) computes fma(inf, x, -inf), which is NaN, and every
-    // sum downstream smears that NaN across the expansion: the old sort-based
-    // multiply turned inf * 3 into a NaN, and a transliteration of qd_mul returns
-    // the right leading value with -nan trailing components (qd itself does this).
-    // IEEE already defines the answer, and the trailing components of an infinity
-    // or a NaN carry no information, so they are cleared.
-    constexpr inline bool is_finite_product(double a, double b) {
-        double p = a * b;
-        if (std::is_constant_evaluated()) return sw::universal::is_finite_cx(p);
-        return std::isfinite(p);
-    }
-
-    constexpr inline floatcascade<4> nonfinite_product(double a, double b) {
-        floatcascade<4> result;
-        result[0] = a * b;
-        result[1] = 0.0;
-        result[2] = 0.0;
-        result[3] = 0.0;
-        return result;
-    }
-
     // Multiply a floatcascade<4> by a single double.  Classic qd gets this from a
     // separate operator*=(double); the cascade framework needs it as a named
     // function because the general multiply is reached through one entry point.
@@ -1530,7 +1609,7 @@ namespace expansion_ops {
     // estimate is a one-component cascade. Running that through the full
     // 4x4 schedule wastes ten of the sixteen partial products.
     constexpr inline floatcascade<4> multiply_cascade_by_double(const floatcascade<4>& a, double b) {
-        if (!is_finite_product(a[0], b)) return nonfinite_product(a[0], b);
+        if (!is_finite_product(a[0], b)) return nonfinite_product<4>(a[0], b);
 
         auto tsum = [](double x, double y, double& err) constexpr -> double {
             double s{}, e{};
@@ -1599,7 +1678,7 @@ namespace expansion_ops {
     // error term.  Terms below eps^4 cannot affect a 4-component result and are
     // summed in plain arithmetic, exactly as the reference does.
     constexpr inline floatcascade<4> multiply_cascades(const floatcascade<4>& a, const floatcascade<4>& b) {
-        if (!is_finite_product(a[0], b[0])) return nonfinite_product(a[0], b[0]);
+        if (!is_finite_product(a[0], b[0])) return nonfinite_product<4>(a[0], b[0]);
 
         // A one-component operand is common enough to be worth three comparisons:
         // scaling by a double lands here, and so does every division, whose

--- a/include/sw/universal/number/qd_cascade/compress_8_4_bug.md
+++ b/include/sw/universal/number/qd_cascade/compress_8_4_bug.md
@@ -163,5 +163,25 @@ Two smaller pieces came with it:
 | sqrt residual, ulps of 2^-212 | 15 | **8.6** | 1.0 |
 | `inf * 3` | NaN | inf | inf |
 
-`floatcascade<3>` (td_cascade) still uses the generic sorted multiply and is 9.4x `dd` on that
-operation; porting the same schedule to N=3 is the natural next step.
+### N=3
+
+The same schedule was then ported to `floatcascade<3>`, one order shorter: products through eps^2
+are accumulated exactly with `three_sum`/`two_sum` chains, everything at eps^3 and below is summed
+in plain arithmetic, and `renorm4()` closes four terms into three components. `multiply_cascade_by_double`
+has an N=3 form for the same reason it has an N=4 one.
+
+Measured over 400 random full-width triple-double products against the exact dyadic oracle, and on
+the benchmark suite:
+
+| measurement | sorted accumulation | qd_mul schedule |
+|---|---|---|
+| multiply, worst error | 5.53 ulps of 2^-159 | **0.23 ulps** |
+| multiply, products past 1 ulp | 102 of 400 | **0 of 400** |
+| square, worst error | 9.72 ulps | **0.22 ulps** |
+| multiply, nsec/op | 214 | **63** |
+| exp, nsec/op | 13406 | **3280** |
+| log, nsec/op | 26224 | **7009** |
+| sin, nsec/op | 9763 | **2846** |
+
+Division is untouched by this and remains the weakest `td_cascade` operation at 3.2 ulps worst
+case; it uses a Newton refinement whose residual path has its own rounding behaviour.

--- a/static/highprecision/td_cascade/arithmetic/addition_oracle.cpp
+++ b/static/highprecision/td_cascade/arithmetic/addition_oracle.cpp
@@ -85,6 +85,11 @@ namespace {
 	// ever dropped, which would cost roughly 2^53 times this budget.
 	constexpr int TOLERANCE_BITS = 152;
 
+	// Multiplication is held to a tighter budget: it is correctly rounded, measuring 0.23 ulp of
+	// the 159-bit format worst case over 400 random full-width products, where the sorted
+	// accumulation it replaced measured 5.5. 157 bits sits between the two.
+	constexpr int MULTIPLICATION_TOLERANCE_BITS = 157;
+
 	int VerifyAdditionAgainstOracle(bool reportTestCases, unsigned nrOfTestCases, std::uint64_t seed) {
 		using namespace sw::universal;
 		int nrOfFailedTests = 0;
@@ -104,6 +109,35 @@ namespace {
 					std::cerr << "  a   = " << to_triple(a) << '\n';
 					std::cerr << "  b   = " << to_triple(b) << '\n';
 					std::cerr << "  a+b = " << to_triple(sum) << '\n';
+				}
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+	// universal#1322 ported the classic qd_mul schedule to this width too. Before it, the sorted
+	// accumulation dropped the error term of every sub-ulp carry and was accurate to 5.5 ulps worst
+	// case, with a quarter of random full-width products past 1 ulp. Dyadic multiplication is
+	// exact, so the reference here is the true product.
+	int VerifyMultiplicationAgainstOracle(bool reportTestCases, unsigned nrOfTestCases, std::uint64_t seed) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		Generator gen(seed);
+		for (unsigned i = 0; i < nrOfTestCases; ++i) {
+			td_cascade a = gen.nextTripleDouble();
+			td_cascade b = gen.nextTripleDouble();
+			td_cascade product = a * b;
+
+			dyadic exact = exact_value<td_cascade, 3>(a) * exact_value<td_cascade, 3>(b);
+			dyadic computed = exact_value<td_cascade, 3>(product);
+
+			if (!within_tolerance(computed, exact, MULTIPLICATION_TOLERANCE_BITS)) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cerr << "FAIL: td_cascade multiplication is more than 2^-" << MULTIPLICATION_TOLERANCE_BITS << " relative from exact\n";
+					std::cerr << "  a   = " << to_triple(a) << '\n';
+					std::cerr << "  b   = " << to_triple(b) << '\n';
+					std::cerr << "  a*b = " << to_triple(product) << '\n';
 				}
 			}
 		}
@@ -162,7 +196,7 @@ int main()
 try {
 	using namespace sw::universal;
 
-	std::string test_suite         = "triple-double cascade addition against an exact dyadic oracle";
+	std::string test_suite         = "triple-double cascade addition and multiplication against an exact dyadic oracle";
 	std::string test_tag           = "td_cascade addition oracle";
 	bool reportTestCases           = false;
 	int nrOfFailedTestCases        = 0;
@@ -180,6 +214,7 @@ try {
 
 #if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyAdditionAgainstOracle(reportTestCases, 64, 0xC0FFEEull), test_tag, "addition vs exact dyadic");
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplicationAgainstOracle(reportTestCases, 64, 0xF00Dull), test_tag, "multiplication vs exact dyadic");
 	nrOfFailedTestCases += ReportTestResult(VerifySqrtResidual(reportTestCases, 32, 0xBEEFull), test_tag, "sqrt residual vs exact dyadic");
 #endif
 
@@ -193,6 +228,7 @@ try {
 
 #if REGRESSION_LEVEL_4
 	nrOfFailedTestCases += ReportTestResult(VerifyAdditionAgainstOracle(reportTestCases, 4096, 0x9ABCull), test_tag, "addition vs exact dyadic (level 4)");
+	nrOfFailedTestCases += ReportTestResult(VerifyMultiplicationAgainstOracle(reportTestCases, 4096, 0xBCDEull), test_tag, "multiplication vs exact dyadic (level 4)");
 	nrOfFailedTestCases += ReportTestResult(VerifySqrtResidual(reportTestCases, 512, 0xDEF0ull), test_tag, "sqrt residual vs exact dyadic (level 4)");
 #endif
 


### PR DESCRIPTION
Closes #1324. Follow-up to #1322, which fixed the same defect at the 4-component width.

`td_cascade` was the last width still on the generic sorted accumulation: 9 partial products, an
18-term expansion sorted by magnitude, then a fold into 3 components that discarded the error term
of every sub-ulp carry.

### The port

The #1322 schedule, one order shorter. `a[i]*b[j]` contributes at order `eps^(i+j)`, so the products
come out in decreasing significance **by construction** and no sorting is needed: accumulate through
`eps^2` with `three_sum`/`two_sum` chains that keep every error term, sum `eps^3` and below in plain
arithmetic, and close with `renorm4()` — the four-terms-into-three companion to `renorm5()`.

`multiply_cascade_by_double()` gains an N=3 form for the same reason it has an N=4 one: division's
initial quotient estimate is a one-component cascade, and without it the fixed schedule would spend
six of its nine partial products multiplying by zero.

### Accuracy, against exact dyadic arithmetic (400 random full-width products)

| | sorted | schedule |
|---|---|---|
| multiply, worst | 5.53 ulps of 2^-159 | **0.23 ulps** |
| multiply, past 1 ulp | 102 / 400 | **0 / 400** |
| square, worst | 9.72 ulps | **0.22 ulps** |
| square, past 1 ulp | 162 / 400 | **0 / 400** |

Multiplication is now correctly rounded at this width. Squaring matters disproportionately: `exp`
does 16 of them.

### Speed (i7-12700K, gcc 13.3, -O3, pinned), nsec/op

| operation | before | after | ratio to `dd` |
|---|---|---|---|
| multiply | 214 | **63** | 2.8x (was 9.6x) |
| exp | 13406 | **3280** | 3.6x (was 14.6x) |
| log | 26224 | **7009** | 3.6x (was 13.4x) |
| sin | 9763 | **2846** | 3.0x (was 10.3x) |

`td_cascade` now costs roughly what carrying a third component should, and sits between `dd` and
`qd` on the mathlib in absolute terms — which is the point of a middle width. The benchmark README's
"`td_cascade` is the odd one out" conclusion is updated accordingly.

### Details worth noting

- **Special values** are handled as at N=4: `two_prod(inf, x)` is NaN, so non-finite products
  short-circuit to the IEEE result with cleared trailing components. `inf * 3` is `inf`, `nan * 3`
  is `(nan, 0, 0)`.
- **The superseded implementation is deleted**, not kept behind a name. Git history has it, and an
  unused second multiply invites drift.
- **Division is untouched** and is now the weakest `td_cascade` operation at 3.2 ulps worst case. It
  has its own Newton residual path; worth its own issue rather than being folded in here.

### Tests

The `td_cascade` oracle suite gains a multiplication verifier held to `2^-157` — between the sorted
implementation's 5.5 ulps and the schedule's 0.23. It fails **68 of 4096** cases at
`REGRESSION_LEVEL_4` on the old code and passes on the new.

113 dd/qd/cascade regression tests pass under gcc 13.3.0 and clang 18.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved high-precision cascade multiplication speed, including optimized 3- and 4-component operations.
  - Reduced computational costs across multiplication and transcendental benchmarks.

- **Accuracy & Reliability**
  - Improved multiplication and square accuracy, eliminating results exceeding 1 ulp.
  - Added robust handling for non-finite multiplication results.
  - Expanded regression coverage for high-precision multiplication.

- **Documentation**
  - Updated benchmark results, accuracy observations, and implementation notes.
  - Documented that division remains the least optimized high-precision operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->