### PR TITLE
fix(internal): refuse to compile floatcascade arithmetic at unsupported widths

### DIFF
--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -250,16 +250,23 @@ Porting that formulation to `add_cascades<4>` would plausibly recover most of th
 exactness, since it is the algorithm the compression is emulating. Same move as #1322 and #1324 made
 for multiplication.
 
-### 3. The generic templates are still the old design
+### 3. The generic templates are still the old design - CLOSED
 
-`add_cascades<N>` and `multiply_cascades<N>` - reached for any N outside {2, 3, 4} - still use
-`std::sort`/`std::vector` and the uncompressed, sorted-expansion formulation that #1317 and #1322
-replaced, and they know nothing of the quotient-digit fix. Nothing instantiates them today, so this
-is not a live defect, but the first person to instantiate `floatcascade<5>` inherits every bug this
-effort fixed, silently.
+`add_cascades<N>` and `multiply_cascades<N>` - reached for any N outside {2, 3, 4} - still carry
+`std::sort`/`std::vector` and the uncompressed, sorted-expansion formulation that #1317, #1322 and
+#1324 replaced, and they know nothing of the quotient-digit fix. Nothing instantiated them, so this
+was never a live defect, but the first person to write `floatcascade<5>` would have inherited every
+bug this effort fixed, silently and with no indication anything was wrong.
 
-Either specialize them the same way, or make the primary template `static_assert` that N is one of
-the supported widths.
+Both templates now `static_assert` that N is 2, 3 or 4. Instantiating another width is a compile
+error naming this document rather than an arithmetic result that is quietly 15 digits short.
+
+Specializing them properly was considered and rejected: there is no generic form of the corrected
+algorithms to fall back on. The multiplication schedule is derived from the eps^(i+j) ordering of the
+partial products for one specific N; the division needs N+1 quotient digits closed by an N+1-term
+renormalization; and whether the addition needs compression is a measured property, not a derived one
+(N=2 and N=3 do not need it, N=4 does). A new width needs a new derivation, and the error message
+says so.
 
 ### 4. Shared weaknesses that cap both families
 
@@ -289,7 +296,7 @@ trigonometric code.
    than assuming it. Removes the worst ratio in the suite.
 2. **Port `accurate_addition` to `add_cascades<4>`** (item 2). Highest confidence: the algorithm is
    known-good, sitting next door, and the pattern is proven three times over.
-3. **Close the generic templates** (item 3). Cheap, prevents silent regression.
+3. ~~Close the generic templates~~ - done; they refuse to compile for unsupported widths.
 4. **Then the shared items** (item 4), which are number-system work rather than framework work, and
    which now hold the largest remaining errors in either family.
 

--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -473,6 +473,23 @@ namespace expansion_ops {
     // Add two cascades of same size, result in double-size cascade
     template<size_t N>
     floatcascade<2 * N> add_cascades(const floatcascade<N>& a, const floatcascade<N>& b) {
+        // Widths 2, 3 and 4 never reach this template - they have non-template
+        // overloads below, which is where the corrected algorithms live. Anything
+        // else lands here, and this code is the superseded formulation: the
+        // uncompressed expansion universal#1317 fixed, and the sorted
+        // accumulation universal#1322 and #1324 replaced. Rather than hand a new
+        // width silently wrong arithmetic, refuse to compile it.
+        //
+        // Supporting another width is real work, not a generic fallback: the
+        // multiplication schedule is derived from the eps^(i+j) ordering of the
+        // partial products for that specific N, the division needs N+1 quotient
+        // digits closed by an N+1-term renormalization, and whether the addition
+        // needs compression has to be measured (N=2 and N=3 do not, N=4 does).
+        static_assert(N == 2 || N == 3 || N == 4,
+            "floatcascade arithmetic is derived per width; only 2, 3 and 4 components are "
+            "implemented. See docs/assessments/multi-component-cascade-vs-direct.md before "
+            "adding another.");
+
         // Merge the two N-component cascades
         std::array<double, 2 * N> merged;
         std::array<double, 2 * N> magnitudes;
@@ -998,6 +1015,23 @@ namespace expansion_ops {
     // accurate_multiplication() algorithm (qd_impl.hpp lines 619-675).
     template<size_t N>
     floatcascade<N> multiply_cascades(const floatcascade<N>& a, const floatcascade<N>& b) {
+        // Widths 2, 3 and 4 never reach this template - they have non-template
+        // overloads below, which is where the corrected algorithms live. Anything
+        // else lands here, and this code is the superseded formulation: the
+        // uncompressed expansion universal#1317 fixed, and the sorted
+        // accumulation universal#1322 and #1324 replaced. Rather than hand a new
+        // width silently wrong arithmetic, refuse to compile it.
+        //
+        // Supporting another width is real work, not a generic fallback: the
+        // multiplication schedule is derived from the eps^(i+j) ordering of the
+        // partial products for that specific N, the division needs N+1 quotient
+        // digits closed by an N+1-term renormalization, and whether the addition
+        // needs compression has to be measured (N=2 and N=3 do not, N=4 does).
+        static_assert(N == 2 || N == 3 || N == 4,
+            "floatcascade arithmetic is derived per width; only 2, 3 and 4 components are "
+            "implemented. See docs/assessments/multi-component-cascade-vs-direct.md before "
+            "adding another.");
+
         // Generate N*N products (partial products matrix)
         std::array<double, N * N> products;
         std::array<double, N * N> errors;


### PR DESCRIPTION
Item 3 of the [multi-component design assessment](https://stillwater-sc.github.io/universal/assessments/multi-component/).

The generic `add_cascades<N>` and `multiply_cascades<N>` templates — reached for any N outside {2, 3, 4} — still carry the superseded formulation: the uncompressed expansion #1317 fixed, the sorted accumulation #1322 and #1324 replaced, and no knowledge of the quotient digit #1326 added.

Nothing instantiates them, so this was never a live defect. But the first person to write `floatcascade<5>` would have inherited **every bug this effort fixed**, silently — a result quietly 15 digits short with no indication anything was wrong.

Both templates now `static_assert` that N is 2, 3 or 4:

```
error: static assertion failed: floatcascade arithmetic is derived per width; only 2, 3
and 4 components are implemented. See docs/assessments/multi-component-cascade-vs-direct.md
before adding another.
```

### Why not specialize them properly

There is no generic form of the corrected algorithms to fall back on:

- the **multiplication** schedule is derived from the `eps^(i+j)` ordering of the partial products for one specific N;
- the **division** needs N+1 quotient digits closed by an N+1-term renormalization;
- whether the **addition** needs compression is a *measured* property, not a derived one — N=2 and N=3 do not need it, N=4 does.

A new width needs a new derivation, and the error message says so rather than pretending a fallback exists.

### Verification

`floatcascade<5>` arithmetic now fails at compile time with that message. The 113 dd/qd/cascade regression tests and all four benchmark targets build and pass unchanged under gcc 13.3.0 and clang 18.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added compile-time validation for cascade operations, preventing unsupported component widths from being used.
  * Supported two-, three-, and four-component configurations continue to work as expected.

* **Documentation**
  * Updated assessment and sequencing documentation to reflect completion of the generic-template issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->