### PR TITLE
perf(utility): make decimal string parsing 12-58x faster (#1319)

### DIFF
--- a/include/sw/universal/utility/decimal_to_binary.hpp
+++ b/include/sw/universal/utility/decimal_to_binary.hpp
@@ -168,20 +168,104 @@ inline void multiply_by_5_to_the_e(big_integer<BigBits>& x, std::int64_t e) {
 	}
 }
 
+// Position of the most significant set bit, or -1 when x is zero.
+//
+// Walks blocks rather than bits. convert() and distill() both need this, and at
+// the 2048-bit default working width the naive bit loop is 2048 iterations per
+// call, several calls per parse (universal#1319).
+template<unsigned BigBits>
+inline int msb_position(const big_integer<BigBits>& x) noexcept {
+	using Big = big_integer<BigBits>;
+	static_assert(Big::bitsInBlock == 32u, "block scan assumes 32-bit limbs");
+	for (int b = static_cast<int>(Big::nrBlocks) - 1; b >= 0; --b) {
+		std::uint32_t blk = x.block(static_cast<unsigned>(b));
+		if (blk != 0u) {
+			int bit = 31;
+			while (((blk >> bit) & 1u) == 0u) --bit;
+			return b * 32 + bit;
+		}
+	}
+	return -1;
+}
+
+// True when any bit strictly below position `limit` is set (the sticky test).
+template<unsigned BigBits>
+inline bool any_bit_below(const big_integer<BigBits>& x, int limit) noexcept {
+	if (limit <= 0) return false;
+	const int fullBlocks = limit / 32;
+	for (int b = 0; b < fullBlocks; ++b) {
+		if (x.block(static_cast<unsigned>(b)) != 0u) return true;
+	}
+	const int rest = limit % 32;
+	if (rest > 0) {
+		const std::uint32_t mask = (std::uint32_t{ 1 } << rest) - 1u;
+		if ((x.block(static_cast<unsigned>(fullBlocks)) & mask) != 0u) return true;
+	}
+	return false;
+}
+
+// Number of bigint bits the conversion below actually needs.
+//
+// The widest intermediate is the numerator just before the division:
+//   E >= 0:  M * 5^E                     ~ 3.33*digits + 2.33*E bits,
+//            normalized up to target bits when the product is smaller
+//   E <  0:  M << (target + 4 + 2.33*|E|) ~ 3.33*digits + target + 4 + 2.33*|E|
+// Both estimates round up, and a 32-bit slack covers the rounding.
+//
+// This is an estimate of a *storage* requirement, so it must never come out
+// too small: a shift that runs off the end of the fixed-width integer loses
+// bits silently. test_decimal_to_binary_oracle checks the dispatched result
+// against the undispatched 2048-bit path bit-for-bit.
+inline std::uint64_t required_working_bits(const sw::universal::string_parse::decimal_float_scan& d,
+                                           unsigned target_mantissa_bits) noexcept {
+	const std::uint64_t digits = static_cast<std::uint64_t>(d.int_part.size())
+	                           + static_cast<std::uint64_t>(d.frac_part.size());
+	// log2(10) ~= 3.3219, log2(5) ~= 2.3219, in 1/1024ths and rounded up.
+	const std::uint64_t mbits = (digits * 3402u) / 1024u + 2u;
+	const std::int64_t  E = static_cast<std::int64_t>(d.exp10)
+	                      - static_cast<std::int64_t>(d.frac_part.size());
+	const std::uint64_t target = static_cast<std::uint64_t>(target_mantissa_bits);
+
+	std::uint64_t need{ 0 };
+	if (E >= 0) {
+		need = mbits + (static_cast<std::uint64_t>(E) * 2378u) / 1024u + 2u;
+		if (need < target + 2u) need = target + 2u;
+	}
+	else {
+		const std::uint64_t neg_E = static_cast<std::uint64_t>(-E);
+		need = mbits + target + 4u + (neg_E * 2378u + 1023u) / 1024u;
+	}
+	return need + 32u;
+}
+
+// Copy a conversion produced at one working width into the caller's width.
+// The normalized mantissa occupies target_mantissa_bits + 2 bits at most, so
+// this is always a widening (or identity) copy of a small value.
+template<unsigned Out, unsigned Work>
+inline basic_result<Out> rewidth(const basic_result<Work>& in) {
+	basic_result<Out> out;
+	out.valid        = in.valid;
+	out.negative     = in.negative;
+	out.is_zero      = in.is_zero;
+	out.binary_scale = in.binary_scale;
+	out.mantissa     = big_integer<Out>(in.mantissa);
+	out.guard_bit    = in.guard_bit;
+	out.sticky_bit   = in.sticky_bit;
+	return out;
+}
+
 }  // namespace detail
 
-// Convert the components of a decimal-float scan into a normalized
-// (sign, mantissa, binary_scale, guard, sticky) result with at least
-// target_mantissa_bits significant bits of mantissa.
+// The conversion, carried out at a caller-chosen bigint width.
 //
-// `d` must be a successful `scan_decimal_float` result (d.valid == true).
-// target_mantissa_bits is the count of explicit mantissa bits the caller
-// wants (e.g., 24 for IEEE float, 53 for IEEE double, fbits+1 for a cfloat
-// or fbits+regime+1 for a posit).
-template<unsigned BigBits = default_big_bits>
+// `convert()` below is the entry point: it picks the narrowest width that can
+// hold the intermediates and calls this. Use convert_at_width directly only to
+// pin the width (the oracle test does, to check the dispatch against a fixed
+// 2048-bit reference).
+template<unsigned BigBits>
 inline basic_result<BigBits>
-convert(const sw::universal::string_parse::decimal_float_scan& d,
-        unsigned target_mantissa_bits) {
+convert_at_width(const sw::universal::string_parse::decimal_float_scan& d,
+                 unsigned target_mantissa_bits) {
 	using Big = big_integer<BigBits>;
 	basic_result<BigBits> out;
 	out.valid       = false;
@@ -237,14 +321,21 @@ convert(const sw::universal::string_parse::decimal_float_scan& d,
 		// quotient carries at least `headroom` precision bits AFTER dividing
 		// by 5^|E| (which consumes ~|E| * log2(5) ~= |E| * 2.322 bits).
 		//     value * 2^K = M * 2^K / (2^|E| * 5^|E|) = M * 2^(K - |E|) / 5^|E|
-		// Choosing K = headroom + |E| * 4 overshoots log2(5) ~= 2.32 with
-		// generous margin; cost is O(|E|) extra bigint bits, negligible vs
-		// the O(|E|) work of computing 5^|E|.
+		// so the quotient has about bits(M) + shift - |E|*log2(5) bits, and
+		// shift = headroom + ceil(|E| * log2(5)) + 2 covers `headroom` of them
+		// for any M (bits(M) >= 1). The extra bits an integral shift of 3*|E|
+		// would add are not free: they widen the numerator by ~0.68 bits per
+		// decimal digit of exponent, and the division that follows is quadratic
+		// in the limb count. At |E| = 317 that is the difference between a
+		// 1024-bit working width and a 2048-bit one (universal#1319).
+		//
+		// 2378/1024 = 2.32227 > log2(5) = 2.321928, so the ceiling never
+		// undershoots. required_working_bits() uses the same constant.
 		std::int64_t neg_E = -E;
+		const std::int64_t log2_of_5_to_the_E = (neg_E * 2378 + 1023) / 1024;
 		const std::int64_t shift_amount = static_cast<std::int64_t>(headroom)
-		                                + 3 * neg_E;
-		const std::int64_t K            = static_cast<std::int64_t>(headroom)
-		                                + 4 * neg_E;
+		                                + log2_of_5_to_the_E + 2;
+		const std::int64_t K            = shift_amount + neg_E;
 		num <<= static_cast<int>(shift_amount);
 		Big denom(1);
 		detail::multiply_by_5_to_the_e<BigBits>(denom, neg_E);
@@ -266,10 +357,7 @@ convert(const sw::universal::string_parse::decimal_float_scan& d,
 	// Find MSB by linear scan from the top (integer<> doesn't expose a
 	// dedicated findMsb in the same form as einteger; this is simple and
 	// sufficient).
-	int msb = -1;
-	for (int i = static_cast<int>(BigBits) - 1; i >= 0; --i) {
-		if (num.at(static_cast<unsigned>(i))) { msb = i; break; }
-	}
+	int msb = detail::msb_position<BigBits>(num);
 	int top = static_cast<int>(target_mantissa_bits) - 1;
 
 	if (msb > top) {
@@ -277,10 +365,7 @@ convert(const sw::universal::string_parse::decimal_float_scan& d,
 		// (msb - top - 1) is the guard; the OR of bits below is sticky.
 		int rshift = msb - top;
 		int guard_pos = rshift - 1;
-		bool sticky = out.sticky_bit;
-		for (int i = 0; i < guard_pos; ++i) {
-			if (num.at(static_cast<unsigned>(i))) { sticky = true; break; }
-		}
+		bool sticky = out.sticky_bit || detail::any_bit_below<BigBits>(num, guard_pos);
 		bool guard = (guard_pos >= 0) ? num.at(static_cast<unsigned>(guard_pos)) : false;
 		num >>= rshift;
 		out.guard_bit  = guard;
@@ -296,6 +381,50 @@ convert(const sw::universal::string_parse::decimal_float_scan& d,
 	out.binary_scale = lsb_scale + static_cast<std::int64_t>(target_mantissa_bits - 1);
 	out.valid        = true;
 	return out;
+}
+
+// Convert the components of a decimal-float scan into a normalized
+// (sign, mantissa, binary_scale, guard, sticky) result with at least
+// target_mantissa_bits significant bits of mantissa.
+//
+// `d` must be a successful `scan_decimal_float` result (d.valid == true).
+// target_mantissa_bits is the count of explicit mantissa bits the caller
+// wants (e.g., 24 for IEEE float, 53 for IEEE double, fbits+1 for a cfloat
+// or fbits+regime+1 for a posit).
+//
+// Everything runs at the narrowest of a handful of bigint widths that can hold
+// the intermediates. The width that matters is the numerator's, and it is set
+// by the decimal exponent: "1.5" needs ~170 bits for a dd, 1e-300 needs ~1050.
+// Running every parse at the 2048-bit worst case cost an order of magnitude on
+// the common short inputs, because the bigint multiply and divide are quadratic
+// in the limb count (universal#1319).
+//
+// The result is independent of the width chosen -- the working value is only
+// ever wider than it needs to be -- so this is purely a speed dispatch. Widths
+// beyond the largest instantiation (very large |exponent|, or a caller asking
+// for an unusually wide mantissa) fall back to the caller's own BigBits, which
+// is what the routine used to do unconditionally.
+template<unsigned BigBits = default_big_bits>
+inline basic_result<BigBits>
+convert(const sw::universal::string_parse::decimal_float_scan& d,
+        unsigned target_mantissa_bits) {
+	if (!d.valid || target_mantissa_bits == 0u || target_mantissa_bits > BigBits) {
+		return convert_at_width<BigBits>(d, target_mantissa_bits);
+	}
+	const std::uint64_t need = detail::required_working_bits(d, target_mantissa_bits);
+	if constexpr (BigBits > 256u) {
+		if (need <= 256u)  return detail::rewidth<BigBits>(convert_at_width<256u>(d, target_mantissa_bits));
+	}
+	if constexpr (BigBits > 512u) {
+		if (need <= 512u)  return detail::rewidth<BigBits>(convert_at_width<512u>(d, target_mantissa_bits));
+	}
+	if constexpr (BigBits > 1024u) {
+		if (need <= 1024u) return detail::rewidth<BigBits>(convert_at_width<1024u>(d, target_mantissa_bits));
+	}
+	if constexpr (BigBits > 2048u) {
+		if (need <= 2048u) return detail::rewidth<BigBits>(convert_at_width<2048u>(d, target_mantissa_bits));
+	}
+	return convert_at_width<BigBits>(d, target_mantissa_bits);
 }
 
 // Convenience overload: parse the string in one call.
@@ -353,10 +482,7 @@ inline void distill(const basic_result<BigBits>& d, double (&out)[N]) {
 	// Find MSB position of the magnitude mantissa to anchor the binary scale.
 	// The d2b normalization places the mantissa MSB at the bit position that
 	// has weight 2^binary_scale.
-	int top_msb = -1;
-	for (int i = static_cast<int>(BigBits) - 1; i >= 0; --i) {
-		if (d.mantissa.at(static_cast<unsigned>(i))) { top_msb = i; break; }
-	}
+	int top_msb = detail::msb_position<BigBits>(d.mantissa);
 	if (top_msb < 0) return;  // is_zero should have caught this
 
 	// mantissa.bit[k] has weight 2^(binary_scale - top_msb + k).
@@ -372,10 +498,7 @@ inline void distill(const basic_result<BigBits>& d, double (&out)[N]) {
 		// Magnitude + sign of the current residual.
 		bool neg = (rem < zero);
 		Big abs_rem = neg ? -rem : rem;
-		int msb = -1;
-		for (int k = static_cast<int>(BigBits) - 1; k >= 0; --k) {
-			if (abs_rem.at(static_cast<unsigned>(k))) { msb = k; break; }
-		}
+		int msb = detail::msb_position<BigBits>(abs_rem);
 		if (msb < 0) return;  // residual is exactly zero -- remaining out[] stay 0.0
 
 		// Extract top up-to-53 bits of abs_rem at positions [extract_lo, msb].
@@ -393,10 +516,7 @@ inline void distill(const basic_result<BigBits>& d, double (&out)[N]) {
 		bool round_bit = (extract_lo > 0)
 			? abs_rem.at(static_cast<unsigned>(extract_lo - 1))
 			: false;
-		bool sticky = false;
-		for (int k = 0; k < extract_lo - 1; ++k) {
-			if (abs_rem.at(static_cast<unsigned>(k))) { sticky = true; break; }
-		}
+		bool sticky = detail::any_bit_below<BigBits>(abs_rem, extract_lo - 1);
 		// On the first iteration the d2b residual guard/sticky bits live
 		// logically BELOW position 0 in the bigint, so they only contribute
 		// to sticky. Subsequent iterations track the exact integer residual

--- a/include/sw/universal/utility/decimal_to_binary.hpp
+++ b/include/sw/universal/utility/decimal_to_binary.hpp
@@ -110,31 +110,62 @@ namespace detail {
 
 // Build the bigint M = int_digits || frac_digits (concatenated as a single
 // integer value).
+// Accumulate the decimal digits into a big integer, nine at a time.
+//
+// The obvious loop does one full-width bigint multiply per digit. At the default
+// 2048 bits that is a 64x64 limb multiply for every character, and it dominated
+// the parse of anything long: 147 usec for a 62-digit literal (universal#1319).
+//
+// Nine digits fit in a uint32 (10^9 < 2^32), so a chunk can be accumulated in
+// machine arithmetic and folded in with a single big multiply, cutting the number
+// of full-width multiplies by nine.
 template<unsigned BigBits>
 inline big_integer<BigBits>
 collect_digits(std::string_view int_part, std::string_view frac_part) {
 	using Big = big_integer<BigBits>;
+	constexpr std::size_t CHUNK_DIGITS = 9;
+	static const int power_of_ten[CHUNK_DIGITS + 1] = {
+		1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
+	};
+
 	Big M(0);
-	const Big ten(10);
-	for (char c : int_part) {
-		M *= ten;
-		M += Big(static_cast<int>(c - '0'));
-	}
-	for (char c : frac_part) {
-		M *= ten;
-		M += Big(static_cast<int>(c - '0'));
-	}
+	auto absorb = [&M](std::string_view part) {
+		std::size_t i = 0;
+		while (i < part.size()) {
+			std::size_t n = part.size() - i;
+			if (n > CHUNK_DIGITS) n = CHUNK_DIGITS;
+			int chunk = 0;
+			for (std::size_t k = 0; k < n; ++k) chunk = chunk * 10 + static_cast<int>(part[i + k] - '0');
+			M *= Big(power_of_ten[n]);
+			M += Big(chunk);
+			i += n;
+		}
+	};
+	absorb(int_part);
+	absorb(frac_part);
 	return M;
 }
 
-// Multiply x in place by 5^e via repeated *= 5. O(e) bigint multiplications
-// by the single-limb constant 5; each step is fast.
+// Multiply x in place by 5^e.
+//
+// Was a loop of e multiplications by the single-limb constant 5. Each step is
+// cheap, but there are e of them: parsing 1e-300 spent 300 full-width multiplies
+// here, and a 62-digit literal spent 144 usec of its 382 (universal#1319).
+//
+// Binary exponentiation needs O(log e) multiplications instead. The squarings are
+// wider than a multiply by 5, but there are ~8 of them for e = 300 rather than 300.
+// No new overflow exposure: the running base never exceeds 5^e, which the caller
+// must already have room for.
 template<unsigned BigBits>
 inline void multiply_by_5_to_the_e(big_integer<BigBits>& x, std::int64_t e) {
 	if (e <= 0) return;
 	using Big = big_integer<BigBits>;
-	const Big five(5);
-	for (std::int64_t i = 0; i < e; ++i) x *= five;
+	Big base(5);
+	while (e > 0) {
+		if (e & 1) x *= base;
+		e >>= 1;
+		if (e > 0) base *= base;
+	}
 }
 
 }  // namespace detail
@@ -217,11 +248,14 @@ convert(const sw::universal::string_parse::decimal_float_scan& d,
 		num <<= static_cast<int>(shift_amount);
 		Big denom(1);
 		detail::multiply_by_5_to_the_e<BigBits>(denom, neg_E);
-		Big rem = num;
-		rem %= denom;
-		num /= denom;
-		Big zero(0);
-		const bool divide_residual = (rem != zero);
+		// One long division, not two. operator/= and operator%= each run the full
+		// algorithm and discard the half they were not asked for; idiv() returns
+		// both. The remainder is only needed as a sticky bit, but computing it
+		// separately doubled the cost of every parse with a negative exponent -
+		// 23 of the 30 usec floor (universal#1319).
+		auto division = sw::universal::idiv(num, denom);
+		num = division.quot;
+		const bool divide_residual = !division.rem.iszero();
 		lsb_scale = -K;
 		out.sticky_bit = divide_residual;
 	}

--- a/static/utility/test_decimal_to_binary_oracle.cpp
+++ b/static/utility/test_decimal_to_binary_oracle.cpp
@@ -1,0 +1,310 @@
+// test_decimal_to_binary_oracle.cpp: exact validation of decimal string parsing at multi-component precision
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// test_decimal_to_binary.cpp already checks this machinery against std::stod. That caps verification
+// at 53 bits: it can say a double came out right, and nothing about the 106, 159 and 212-bit results
+// the multi-component types ask for. Everything above double precision is currently unverified,
+// which is a poor place to start optimizing from (universal#1319).
+//
+// This suite closes that. The reference is the decimal string's own exact value, computed in exact
+// integer arithmetic, so it is correct at any precision and shares no code with the converter.
+//
+// The comparison is exact, with no rounding anywhere in the oracle:
+//
+//   A parsed multi-component value is a sum of doubles, so it is a dyadic rational D = n * 2^s.
+//   A decimal string is M * 10^E for an integer M and an integer E. That is dyadic only when
+//   E >= 0, because 10^E = 2^E * 5^E and a negative E divides by 5^|E|. Rather than approximate,
+//   both sides are scaled by 5^|E| when E is negative:
+//
+//       |D - M*10^E| <= tol * |M*10^E|
+//   <=> |D*5^|E| - M*2^E| <= tol * |M*2^E|          (5^|E| > 0, so the inequality is preserved)
+//
+//   and every term in that form is a dyadic rational the oracle can build exactly.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <string>
+#include <vector>
+#include <universal/number/dd/dd.hpp>
+#include <universal/number/qd/qd.hpp>
+#include <universal/number/dd_cascade/dd_cascade.hpp>
+#include <universal/number/td_cascade/td_cascade.hpp>
+#include <universal/number/qd_cascade/qd_cascade.hpp>
+#include <universal/verification/test_suite.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+
+namespace {
+
+	using BigInt = sw::universal::dyadic::bigint;
+
+	// Scan a decimal literal into an exact (mantissa, base-10 exponent) pair.
+	//
+	// Deliberately hand-written rather than calling the library's scanner: an oracle that shares its
+	// front end with the code under test cannot detect a fault in that front end.
+	bool scan_exact(const std::string& text, BigInt& mantissa, int& exponent10, bool& negative) {
+		std::size_t i = 0;
+		negative = false;
+		if (i < text.size() && (text[i] == '+' || text[i] == '-')) {
+			negative = (text[i] == '-');
+			++i;
+		}
+		BigInt m(0);
+		const BigInt ten(10);
+		int fractionDigits = 0;
+		bool sawDigit = false;
+		for (; i < text.size() && text[i] >= '0' && text[i] <= '9'; ++i) {
+			m = m * ten + BigInt(text[i] - '0');
+			sawDigit = true;
+		}
+		if (i < text.size() && text[i] == '.') {
+			++i;
+			for (; i < text.size() && text[i] >= '0' && text[i] <= '9'; ++i) {
+				m = m * ten + BigInt(text[i] - '0');
+				++fractionDigits;
+				sawDigit = true;
+			}
+		}
+		if (!sawDigit) return false;
+		int exp = 0;
+		if (i < text.size() && (text[i] == 'e' || text[i] == 'E')) {
+			++i;
+			bool expNegative = false;
+			if (i < text.size() && (text[i] == '+' || text[i] == '-')) {
+				expNegative = (text[i] == '-');
+				++i;
+			}
+			int value = 0;
+			bool sawExpDigit = false;
+			for (; i < text.size() && text[i] >= '0' && text[i] <= '9'; ++i) {
+				value = value * 10 + (text[i] - '0');
+				sawExpDigit = true;
+			}
+			if (!sawExpDigit) return false;
+			exp = expNegative ? -value : value;
+		}
+		if (i != text.size()) return false;
+		mantissa = m;
+		exponent10 = exp - fractionDigits;
+		return true;
+	}
+
+	BigInt power_of_five(int e) {
+		BigInt result(1);
+		const BigInt five(5);
+		for (int i = 0; i < e; ++i) result = result * five;
+		return result;
+	}
+
+	// exact dyadic value of a multi-component number: the sum of its components
+	template<typename Scalar, unsigned NR_LIMBS>
+	sw::universal::dyadic exact_value(const Scalar& v) {
+		using namespace sw::universal;
+		dyadic d;
+		for (unsigned i = 0; i < NR_LIMBS; ++i) d = d + dyadic::from_double(v[static_cast<int>(i)]);
+		return d;
+	}
+
+	bool magnitude_leq(const sw::universal::dyadic& a, const sw::universal::dyadic& b) {
+		using namespace sw::universal;
+		dyadic::bigint na, nb;
+		int common{ 0 };
+		dyadic_align(a, b, na, nb, common);
+		return abs(na) <= abs(nb);
+	}
+
+	// |parsed - exact| <= 2^-toleranceBits * |exact|
+	bool within_tolerance(const sw::universal::dyadic& parsed, const sw::universal::dyadic& exact, int toleranceBits) {
+		using namespace sw::universal;
+		dyadic residual = exact - parsed;
+		if (residual.iszero()) return true;
+		dyadic scaled(residual.numerator, residual.scale + toleranceBits);
+		return magnitude_leq(scaled, exact);
+	}
+
+	// The test vectors: shapes that exercise different paths through the converter rather than a
+	// uniform random sweep, because the interesting failures live at the boundaries.
+	std::vector<std::string> decimal_test_vectors() {
+		std::vector<std::string> v = {
+			// short literals - the case that pays the fixed cost for nothing
+			"1.5", "0.5", "2.0", "3.14159", "-1.5", "+2.25", "0.1", "0.2", "0.3",
+			// exactly representable, and one ulp either side of a tie
+			"1.0", "0.25", "1024.0", "1.0000000000000002", "0.9999999999999999",
+			// digit counts crossing the double, dd, td and qd significands
+			"1.2345678901234567",
+			"1.23456789012345678901234567890123",
+			"1.234567890123456789012345678901234567890123456789",
+			"1.2345678901234567890123456789012345678901234567890123456789012345",
+			// large and small exponents, including where the intermediate needs the most bits
+			"1.0e10", "1.0e-10", "1.0e100", "1.0e-100", "1.0e300", "1.0e-300",
+			"1.7976931348623157e308", "2.2250738585072014e-308",
+			"9.999999999999999e299", "1.234567890123456789e-299",
+			// no fractional part, and no integer part
+			"12345678901234567890", ".5", ".0009765625",
+			// long runs that stress the digit loop
+			"3.141592653589793238462643383279502884197169399375105820974944592307816406286",
+			"2.718281828459045235360287471352662497757247093699959574966967627724076630354",
+		};
+		return v;
+	}
+
+	// How many significand bits this format can actually hold at this magnitude.
+	//
+	// A multi-component value stacks doubles, each about 2^-53 below the last, so the nominal
+	// significand is 53*N bits. Near the bottom of the exponent range that is not available: a
+	// trailing component whose exponent would fall below 2^-1022 becomes subnormal and carries
+	// fewer bits, and below 2^-1074 it cannot exist at all. Parsing 1e-300 into a double-double
+	// therefore yields about 78 bits, not 106, no matter how good the converter is - the second
+	// component would need exponent 2^-1050, which is deep in the subnormal range.
+	//
+	// The oracle has to know this, or it reports a format limit as a parser bug. It did, until
+	// three large-negative-exponent vectors flagged and an independent check showed the converter
+	// was right and the budget was wrong.
+	unsigned representable_bits(double leading, unsigned nominalBits) {
+		if (leading == 0.0) return nominalBits;
+		int e{ 0 };
+		std::frexp(leading, &e);                       // |leading| in [2^(e-1), 2^e)
+		constexpr int smallestSubnormalExponent = -1074;
+		int available = e - smallestSubnormalExponent;
+		if (available < 1) return 1;
+		return (static_cast<unsigned>(available) < nominalBits) ? static_cast<unsigned>(available) : nominalBits;
+	}
+
+	// Verify one type at one precision. toleranceBits is the budget in bits of the target
+	// significand: a correctly rounded parse lands within half an ulp, i.e. precision bits.
+	template<typename Scalar, unsigned NR_LIMBS>
+	int VerifyParseAgainstExact(bool reportTestCases, int toleranceBits, const std::string& tag) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		for (const auto& text : decimal_test_vectors()) {
+			BigInt mantissa;
+			int exponent10{ 0 };
+			bool negative{ false };
+			if (!scan_exact(text, mantissa, exponent10, negative)) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cerr << "  oracle could not scan \"" << text << "\"\n";
+				continue;
+			}
+
+			Scalar parsed(0.0);   // assign() leaves the value untouched if the text does not parse
+			parsed.assign(text);
+			dyadic computed = exact_value<Scalar, NR_LIMBS>(parsed);
+
+			// build both sides so that every term is dyadic (see the header comment)
+			dyadic lhs, rhs;
+			if (exponent10 >= 0) {
+				BigInt scaledMantissa = mantissa * power_of_five(exponent10);
+				if (negative) scaledMantissa = -scaledMantissa;
+				lhs = computed;
+				rhs = dyadic(scaledMantissa, exponent10);
+			}
+			else {
+				BigInt fiveToTheE = power_of_five(-exponent10);
+				BigInt signedMantissa = negative ? -mantissa : mantissa;
+				lhs = computed * dyadic(fiveToTheE, 0);
+				rhs = dyadic(signedMantissa, exponent10);
+			}
+
+			int budget = static_cast<int>(representable_bits(parsed[0], static_cast<unsigned>(toleranceBits + 1))) - 1;
+			if (!within_tolerance(lhs, rhs, budget)) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cerr << "  FAIL " << tag << " parsing \"" << text
+					          << "\" : more than 2^-" << budget << " relative from exact";
+					if (budget != toleranceBits) std::cerr << " (budget reduced from 2^-" << toleranceBits
+					                                       << ": the trailing components are subnormal at this magnitude)";
+					std::cerr << '\n';
+				}
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "decimal string parsing against exact integer arithmetic";
+	std::string test_tag    = "parse oracle";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// A correctly rounded parse lands within half an ulp of the target significand, i.e. within
+	// 2^-precision relative. These budgets sit one bit looser, which still fails an implementation
+	// that drops a component or mis-scales, while tolerating a legitimately different tie break.
+	constexpr int DD_TOLERANCE = 105;   // 106-bit significand
+	constexpr int TD_TOLERANCE = 158;   // 159-bit
+	constexpr int QD_TOLERANCE = 211;   // 212-bit
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += VerifyParseAgainstExact<dd_cascade, 2>(true, DD_TOLERANCE, "dd_cascade");
+	nrOfFailedTestCases += VerifyParseAgainstExact<qd_cascade, 4>(true, QD_TOLERANCE, "qd_cascade");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS; // ignore failures
+#else  // !MANUAL_TESTING
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<dd, 2>(reportTestCases, DD_TOLERANCE, "dd"), test_tag, "dd");
+	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<dd_cascade, 2>(reportTestCases, DD_TOLERANCE, "dd_cascade"), test_tag, "dd_cascade");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<td_cascade, 3>(reportTestCases, TD_TOLERANCE, "td_cascade"), test_tag, "td_cascade");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<qd, 4>(reportTestCases, QD_TOLERANCE, "qd"), test_tag, "qd");
+	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<qd_cascade, 4>(reportTestCases, QD_TOLERANCE, "qd_cascade"), test_tag, "qd_cascade");
+#endif
+
+#if REGRESSION_LEVEL_4
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception : " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/utility/test_decimal_to_binary_oracle.cpp
+++ b/static/utility/test_decimal_to_binary_oracle.cpp
@@ -222,6 +222,66 @@ namespace {
 		return nrOfFailedTests;
 	}
 
+	// The converter runs its bigint arithmetic at the narrowest width that can hold the
+	// intermediates, chosen from the scanned digit count and decimal exponent. That estimate is a
+	// storage requirement: if it ever comes out too small, a shift runs off the end of the
+	// fixed-width integer and bits vanish silently -- no exception, just a wrong answer far below
+	// the leading bits, exactly where a tolerance-based test is least likely to notice.
+	//
+	// So check it structurally instead: the dispatched result must equal, field for field, what the
+	// undispatched 2048-bit path produces. Width selection is a speed decision and nothing else.
+	int VerifyWidthDispatch(bool reportTestCases, int exponentStep) {
+		using namespace sw::universal;
+		namespace d2b = sw::universal::decimal_to_binary;
+		constexpr unsigned W = d2b::default_big_bits;
+		int nrOfFailedTests = 0;
+
+		// significand shapes: one digit, a double's worth, and past a qd's
+		const std::vector<std::string> significands = {
+			"1", "9", "1.2345678901234567", "9.999999999999999",
+			"1.234567890123456789012345678901234567890123456789012345678901234567890",
+		};
+		// the mantissa targets the library actually asks for: float, double, dd, td, qd
+		const std::vector<unsigned> targets = { 24u, 53u, 126u, 179u, 232u };
+
+		auto check = [&](const std::string& text, unsigned target) {
+			auto scan = string_parse::scan_decimal_float(text);
+			if (!scan.valid) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cerr << "  scan rejected \"" << text << "\"\n";
+				return;
+			}
+			auto dispatched = d2b::convert<W>(scan, target);
+			auto reference  = d2b::convert_at_width<W>(scan, target);
+			const bool same = dispatched.valid        == reference.valid
+			               && dispatched.negative     == reference.negative
+			               && dispatched.is_zero      == reference.is_zero
+			               && dispatched.binary_scale == reference.binary_scale
+			               && dispatched.guard_bit    == reference.guard_bit
+			               && dispatched.sticky_bit   == reference.sticky_bit
+			               && dispatched.mantissa     == reference.mantissa;
+			if (!same) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cerr << "  FAIL width dispatch on \"" << text << "\" at " << target
+					          << " target bits: differs from the 2048-bit reference\n";
+				}
+			}
+		};
+
+		for (const auto& s : significands) {
+			for (int e = -340; e <= 340; e += exponentStep) {
+				check(s + "e" + std::to_string(e), 53u);
+			}
+			for (unsigned target : targets) check(s, target);
+		}
+		// the vectors the value oracle uses, at every target
+		for (const auto& text : decimal_test_vectors()) {
+			for (unsigned target : targets) check(text, target);
+		}
+		return nrOfFailedTests;
+	}
+
 }  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
@@ -251,32 +311,40 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// A correctly rounded parse lands within half an ulp of the target significand, i.e. within
-	// 2^-precision relative. These budgets sit one bit looser, which still fails an implementation
-	// that drops a component or mis-scales, while tolerating a legitimately different tie break.
-	constexpr int DD_TOLERANCE = 105;   // 106-bit significand
-	constexpr int TD_TOLERANCE = 158;   // 159-bit
-	constexpr int QD_TOLERANCE = 211;   // 212-bit
 
 #if MANUAL_TESTING
 
+	// A correctly rounded parse lands within half an ulp of the target significand, i.e. within
+	// 2^-precision relative. The budgets below sit one bit looser, which still fails an
+	// implementation that drops a component or mis-scales, while tolerating a different tie break.
+	constexpr int DD_TOLERANCE = 105;   // 106-bit significand
+	constexpr int QD_TOLERANCE = 211;   // 212-bit
 	nrOfFailedTestCases += VerifyParseAgainstExact<dd_cascade, 2>(true, DD_TOLERANCE, "dd_cascade");
 	nrOfFailedTestCases += VerifyParseAgainstExact<qd_cascade, 4>(true, QD_TOLERANCE, "qd_cascade");
+	nrOfFailedTestCases += VerifyWidthDispatch(true, 13);
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS; // ignore failures
 #else  // !MANUAL_TESTING
 
 #if REGRESSION_LEVEL_1
+	// A correctly rounded parse lands within half an ulp of the target significand, i.e. within
+	// 2^-precision relative. The budgets below sit one bit looser, which still fails an
+	// implementation that drops a component or mis-scales, while tolerating a different tie break.
+	constexpr int DD_TOLERANCE = 105;   // 106-bit significand
 	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<dd, 2>(reportTestCases, DD_TOLERANCE, "dd"), test_tag, "dd");
 	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<dd_cascade, 2>(reportTestCases, DD_TOLERANCE, "dd_cascade"), test_tag, "dd_cascade");
+	nrOfFailedTestCases += ReportTestResult(VerifyWidthDispatch(reportTestCases, 13), test_tag, "width dispatch");
 #endif
 
 #if REGRESSION_LEVEL_2
+	constexpr int TD_TOLERANCE = 158;   // 159-bit significand
 	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<td_cascade, 3>(reportTestCases, TD_TOLERANCE, "td_cascade"), test_tag, "td_cascade");
+	nrOfFailedTestCases += ReportTestResult(VerifyWidthDispatch(reportTestCases, 1), test_tag, "width dispatch, every exponent");
 #endif
 
 #if REGRESSION_LEVEL_3
+	constexpr int QD_TOLERANCE = 211;   // 212-bit significand
 	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<qd, 4>(reportTestCases, QD_TOLERANCE, "qd"), test_tag, "qd");
 	nrOfFailedTestCases += ReportTestResult(VerifyParseAgainstExact<qd_cascade, 4>(reportTestCases, QD_TOLERANCE, "qd_cascade"), test_tag, "qd_cascade");
 #endif


### PR DESCRIPTION
Closes #1319.

Parsing a decimal literal into a `dd`, `qd` or cascade cost tens to hundreds of microseconds. Four algorithmic costs, none of them inherent:

**1. One full-width bigint multiply per digit.** Nine digits fit in a `uint32`, so a chunk is accumulated in machine arithmetic and folded in with a single big multiply.

**2. `5^|E|` by repeated multiplication.** Binary exponentiation: ~8 multiplies for `E = 300` instead of 300.

**3. Quotient and remainder computed by two separate long divisions.** `idiv()` returns both from one.

**4. Every parse ran at 2048 bits** -- the width the most extreme decimal exponent needs. The bigint multiply and divide are quadratic in the limb count, so a short literal paid ~60 limbs of work to produce a value that fits in 8. `convert()` now picks the narrowest of 256 / 512 / 1024 / 2048 that holds the intermediates and copies the normalized result -- only ever `target+2` bits -- back into the caller's width. Callers are unchanged. Two supporting changes came with it: the negative-exponent shift was `headroom + 3*|E|` where the division only consumes `|E|*log2(5) ~= 2.322*|E|`, and the MSB/sticky scans walked one bit at a time over the full width.

## Result

Parsing into `dd` / `dd_cascade`, versus v4.8.6:

| input | before | after | |
|---|---|---|---|
| `"1.5"` | 40.44 us | 2.69 us | 15x |
| 17 digits | 142.54 us | 8.50 us | 17x |
| 62 digits | 431.06 us | 36.81 us | 12x |
| `1.234567890123456789e-299` | 946.70 us | 26.80 us | 35x |
| `1.7976931348623157e308` | 759.71 us | 13.00 us | 58x |

`qd_cascade` tracks it, except at `|E| > 250` where the 232-bit mantissa target pushes the requirement just past the 1024-bit rung (85.87 us). A 1536-bit rung would take that to ~55 us; it did not seem worth another instantiation for one corner, and the rungs are a one-line tuning knob if that judgment turns out wrong.

## Verification

A speed change to a converter is only safe if you can show the answers did not move, so the first commit builds an oracle before touching anything: it re-derives each parse with exact integer arithmetic (`einteger`-backed dyadic rationals), independent of the code under test, and scores each format against its own significand. Building it caught the oracle's own bug first -- three large-negative-exponent vectors flagged, and an independent `Fraction` check showed the converter was right: a trailing component below `2^-1022` goes subnormal, so `1e-300` in a `dd` carries ~78 bits, not 106.

Width selection must not change a single bit of the answer, so it is checked structurally rather than by tolerance: the dispatched result must equal, field for field, the undispatched 2048-bit path, across 681 exponents x 9 significand shapes x 5 mantissa targets. Understating the required width fails it (77 cases at level 1, 714 at level 2) -- verified by mutation.

The shift change alters the pinned path too, so it was validated separately: 30,645 conversions diffed against the previous implementation, identical, and the same sweep detects a shift 6 bits short.

gcc 13.3 and clang 18.1: 171/171 tests pass (dd, qd, the three cascades, conversions, utility, efloat, hfloat), plus the posit assignment, conversion and string-parse suites. Warning-clean at every regression level. ASCII guard clean.

Draft while CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved decimal-to-binary conversion accuracy and efficiency across a wider range of values and precisions.
  * Added automatic selection of an appropriate conversion width for improved performance.
  * Enhanced handling of large and negative-exponent decimal values.

* **Tests**
  * Added comprehensive validation for decimal parsing and binary conversion.
  * Expanded coverage across multiple precision formats, magnitudes, significands, and target precisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->