### PR TITLE
fix(qd): bound the sqrt intermediates across the dynamic range (#1332)

### DIFF
--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -204,8 +204,11 @@ and the speed is opt-in. What the change actually delivers is three things:
   counterpart's accuracy - `KARP` *is* `dd`'s algorithm, `NEWTON_RECIPROCAL` at N=4 *is* `qd`'s.
 - Every formulation now scales the argument into `[0.5, 2)` by an exact power of two first. Each
   squares a value of magnitude ~sqrt(a) or ~1/sqrt(a), which leaves the representable range at the
-  extremes: **`sqrt(maxpos)` returns inf or NaN today in `dd`, `dd_cascade` and `qd`**. All three
-  cascade types now handle the full range; `dd` and `qd` still do not (universal#1332).
+  extremes: `sqrt(maxpos)` used to return inf or NaN in `dd`, `dd_cascade` and `qd`. `dd` and `qd`
+  received the same prologue in universal#1332, which turned out to fix more than the overflow --
+  scored end to end over the exponent range, `dd`'s worst case went from 52 to 105 bits of its 106
+  and `qd`'s from 60 to 214 of its 212, and `qd`'s 28 non-finite results went to none. `qd::sqrt(0)`
+  also returned NaN, having never guarded zero at all.
 
 A third reciprocal iteration was measured at N=2 and rejected: 3.3 ulps for 532 nsec/op, dominated
 by the division iteration at 1.4 ulps for 607. What limits that path is the rounding inside the

--- a/include/sw/universal/number/dd/math/functions/sqrt.hpp
+++ b/include/sw/universal/number/dd/math/functions/sqrt.hpp
@@ -36,9 +36,23 @@ namespace sw { namespace universal {
         if (a.isneg()) std::cerr << "double-double argument to sqrt is negative: " << a << std::endl;
 #endif
 
-        double x = 1.0 / std::sqrt(a.high());
-        double ax = a.high() * x;
-        return add(ax, (a - sqr(dd(ax))).high() * (x * 0.5));
+        if (a.isnan() || a.isinf()) return a;
+
+        // Scale into [0.5, 2) first. The scaling is by a power of two, so it is exact and
+        // costs no accuracy, and it bounds every intermediate wherever the argument sits.
+        // Karp's trick forms (a*x)^2, a value of the argument's own magnitude: within a
+        // rounding of maxpos that square overflows and the result comes back inf or NaN,
+        // and at the bottom of the range the residual a - (a*x)^2 lands in the subnormals
+        // and takes the correction term's accuracy with it -- sqrt(1e-300) held 80 bits of
+        // its 106 (universal#1332).
+        int e{ 0 };
+        std::frexp(a.high(), &e);
+        int k = e >> 1;                  // floor(e/2), correct for negative e
+        dd b = ldexp(a, -2 * k);         // b in [0.5, 2), exact
+
+        double x  = 1.0 / std::sqrt(b.high());
+        double bx = b.high() * x;
+        return ldexp(add(bx, (b - sqr(dd(bx))).high() * (x * 0.5)), k);
     }
 
 #else

--- a/include/sw/universal/number/qd/math/functions/sqrt.hpp
+++ b/include/sw/universal/number/qd/math/functions/sqrt.hpp
@@ -45,15 +45,31 @@ namespace sw { namespace universal {
         }
 #endif
 
-        qd r = (1.0 / std::sqrt(a[0]));
-        qd h = mul_pwr2(a, 0.5);
+        // sqrt(0) is 0. Without this the seed below is 1/sqrt(0) = inf and the iteration
+        // returns NaN; dd has always guarded it, qd never did (universal#1332).
+        if (a.iszero()) return qd(0.0);
+        if (a.isnan() || a.isinf()) return a;
+
+        // Scale into [0.5, 2) first. The scaling is by a power of two, so it is exact and
+        // costs no accuracy, and it bounds every intermediate wherever the argument sits.
+        // The iteration converges to 1/sqrt(a) and then multiplies by a, so it holds values
+        // of magnitude 1/sqrt(a) and sqrt(a) and squares them: near maxpos that overflows,
+        // and near the bottom of the range the trailing limbs of those squares go subnormal
+        // -- sqrt(1e300) held 81 bits of its 212 (universal#1332).
+        int e{ 0 };
+        std::frexp(a[0], &e);
+        int k = e >> 1;                  // floor(e/2), correct for negative e
+        qd b = ldexp(a, -2 * k);         // b in [0.5, 2), exact
+
+        qd r = (1.0 / std::sqrt(b[0]));
+        qd h = mul_pwr2(b, 0.5);
 
         r += ((0.5 - h * sqr(r)) * r);
         r += ((0.5 - h * sqr(r)) * r);
         r += ((0.5 - h * sqr(r)) * r);
 
-        r *= a;
-        return r;
+        r *= b;
+        return ldexp(r, k);
 }
 
 #else

--- a/static/highprecision/qd_cascade/math/sqrt_range_oracle.cpp
+++ b/static/highprecision/qd_cascade/math/sqrt_range_oracle.cpp
@@ -1,0 +1,203 @@
+// sqrt_range_oracle.cpp: multi-component sqrt across the whole dynamic range
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The sqrt suites in the tree chain the function from 2.0 and 0.5 and check the result against
+// std::sqrt. Neither end of the range is ever visited, which is how sqrt(maxpos) came to return inf
+// or NaN in dd and qd, and sqrt(0) NaN in qd, while every suite stayed green (universal#1332).
+//
+// This one walks the exponent range end to end. It covers all five multi-component types, not just
+// the two that were broken: the cascade types were fixed in universal#1331 and this is what keeps
+// them fixed. It lives with the widest type for the same reason the trigonometry oracle does.
+//
+// The check is a residual rather than a comparison against a reference value. sqrt is irrational,
+// so there is no exact reference to compare to -- but squaring the result is exact: a and r are
+// sums of doubles, so both are dyadic rationals, and dyadic rationals are closed under
+// multiplication. |r*r - a| <= 2^-budget * a is therefore decided in exact integer arithmetic, with
+// no floating-point between the implementation and its verdict. Since r = sqrt(a)(1+e) gives
+// r*r = a(1 + 2e + e^2), the residual reads one bit larger than the error in r itself.
+//
+// Measured worst residual over ~2,800 arguments per type, which is where the budgets come from:
+//
+//     dd          2^-104     dd_cascade  2^-106     td_cascade  2^-159
+//     qd          2^-213     qd_cascade  2^-214
+//
+// The budgets sit four bits below each format's significand. A correct implementation clears them
+// with room to spare; the implementation this test was written against delivered 52 bits in dd and
+// 60 in qd, and returned 28 non-finite results.
+#include <universal/utility/directives.hpp>
+#include <string>
+#include <universal/number/dd/dd.hpp>
+#include <universal/number/qd/qd.hpp>
+#include <universal/number/dd_cascade/dd_cascade.hpp>
+#include <universal/number/td_cascade/td_cascade.hpp>
+#include <universal/number/qd_cascade/qd_cascade.hpp>
+#include <universal/verification/test_suite.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+
+namespace {
+
+	// exact dyadic value of a multi-component number: the sum of its components
+	template<typename Scalar, unsigned NR_LIMBS>
+	sw::universal::dyadic exact_value(const Scalar& v) {
+		using namespace sw::universal;
+		dyadic d;
+		for (unsigned i = 0; i < NR_LIMBS; ++i) d = d + dyadic::from_double(v[static_cast<int>(i)]);
+		return d;
+	}
+
+	bool magnitude_leq(const sw::universal::dyadic& a, const sw::universal::dyadic& b) {
+		using namespace sw::universal;
+		dyadic::bigint na, nb;
+		int common{ 0 };
+		dyadic_align(a, b, na, nb, common);
+		return abs(na) <= abs(nb);
+	}
+
+	// |r*r - a| <= 2^-budgetBits * a, exactly
+	bool residual_within(const sw::universal::dyadic& r, const sw::universal::dyadic& a, int budgetBits) {
+		using namespace sw::universal;
+		dyadic residual = r * r - a;
+		if (residual.iszero()) return true;
+		dyadic scaled(residual.numerator, residual.scale + budgetBits);
+		return magnitude_leq(scaled, a);
+	}
+
+	// significandBits is what the format carries; the budget sits four bits below it
+	template<typename Scalar, unsigned NR_LIMBS>
+	int VerifySqrtRange(bool reportTestCases, int significandBits, int exponentStep, const std::string& tag) {
+		using namespace sw::universal;
+		using std::sqrt;
+		const int budget = significandBits - 4;
+		int nrOfFailedTests = 0;
+
+		auto check = [&](const Scalar& a, const std::string& what) {
+			Scalar r = sqrt(a);
+			if (r.isnan() || r.isinf()) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cerr << "  FAIL " << tag << " sqrt(" << what
+				                               << ") is not finite\n";
+				return;
+			}
+			if (a.iszero()) {
+				if (!r.iszero()) {
+					++nrOfFailedTests;
+					if (reportTestCases) std::cerr << "  FAIL " << tag << " sqrt(0) is not zero\n";
+				}
+				return;
+			}
+			if (!residual_within(exact_value<Scalar, NR_LIMBS>(r), exact_value<Scalar, NR_LIMBS>(a), budget)) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cerr << "  FAIL " << tag << " sqrt(" << what
+				                               << ") : |r*r - a| exceeds 2^-" << budget << " * a\n";
+			}
+		};
+
+		// the special values the range tests never reached
+		check(Scalar(0.0), "zero");
+		check(Scalar(SpecificValue::minpos), "minpos");
+		check(Scalar(SpecificValue::maxpos), "maxpos");
+		check(Scalar(1.7976931348623157e308), "the largest double");
+		check(Scalar(1.0), "1.0");
+
+		// and the range end to end
+		for (int e = -1070; e <= 1020; e += exponentStep) {
+			for (double m : { 1.0, 1.3, 1.7, 1.9999999 }) {
+				Scalar a = ldexp(Scalar(m), e);
+				if (a.iszero() || a.isinf()) continue;
+				check(a, "2^" + std::to_string(e));
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "multi-component sqrt across the dynamic range";
+	std::string test_tag    = "sqrt range";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	constexpr int QD_SIGNIFICAND = 212;
+	nrOfFailedTestCases += VerifySqrtRange<qd, 4>(true, QD_SIGNIFICAND, 31, "qd");
+	nrOfFailedTestCases += VerifySqrtRange<qd_cascade, 4>(true, QD_SIGNIFICAND, 31, "qd_cascade");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS; // ignore failures
+#else  // !MANUAL_TESTING
+
+#if REGRESSION_LEVEL_1
+	constexpr int DD_SIGNIFICAND = 106;   // a double-double's significand
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<dd, 2>(reportTestCases, DD_SIGNIFICAND, 31, "dd"), test_tag, "dd");
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<dd_cascade, 2>(reportTestCases, DD_SIGNIFICAND, 31, "dd_cascade"), test_tag, "dd_cascade");
+#endif
+
+#if REGRESSION_LEVEL_2
+	constexpr int TD_SIGNIFICAND = 159;   // a triple-double's significand
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<td_cascade, 3>(reportTestCases, TD_SIGNIFICAND, 31, "td_cascade"), test_tag, "td_cascade");
+#endif
+
+#if REGRESSION_LEVEL_3
+	constexpr int QD_SIGNIFICAND = 212;   // a quad-double's significand
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<qd, 4>(reportTestCases, QD_SIGNIFICAND, 31, "qd"), test_tag, "qd");
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<qd_cascade, 4>(reportTestCases, QD_SIGNIFICAND, 31, "qd_cascade"), test_tag, "qd_cascade");
+#endif
+
+#if REGRESSION_LEVEL_4
+	// every seventh exponent rather than every thirty-first
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<dd, 2>(reportTestCases, 106, 7, "dd"), test_tag, "dd, dense");
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<td_cascade, 3>(reportTestCases, 159, 7, "td_cascade"), test_tag, "td_cascade, dense");
+	nrOfFailedTestCases += ReportTestResult(VerifySqrtRange<qd, 4>(reportTestCases, 212, 7, "qd"), test_tag, "qd, dense");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
Closes #1332.

`sqrt(maxpos)` returned inf or NaN in `dd` and `qd`. Both algorithms square a value of the argument's own magnitude -- `dd`'s Karp trick forms `(a*x)^2`, `qd`'s iteration forms `r^2` with `r ~ 1/sqrt(a)` and closes with `r*a` -- so within a rounding of maxpos the square leaves the representable range.

Both now scale the argument into `[0.5, 2)` before iterating and scale the result back by half the exponent, which is what the three cascade types have done since #1331. The scaling is by a power of two: exact, no accuracy cost, and it bounds every intermediate wherever the argument sits.

## The defect was wider than the overflow

Scoring `sqrt` end to end over the exponent range against an exact oracle, rather than only at maxpos: the same squares that overflow at the top go **subnormal** at the bottom, and the trailing limbs of the result go with them.

| | worst over the range | non-finite results |
|---|---|---|
| `dd` | 52 -> **105** bits of 106 | 0 -> 0 |
| `qd` | 60 -> **214** bits of 212 | 28 -> **0** |

`sqrt(1e-300)` in a `dd` held 80 bits of its 106 before this; `sqrt(1e300)` in a `qd` held 81 of its 212.

And one the issue did not mention: **`qd::sqrt(0)` returned NaN**. The seed is `1/sqrt(a[0])`, which is inf at zero, and `qd` never guarded the case -- `dd` always had. Both now guard zero, NaN and infinity.

## Verification

The suites that existed chain `sqrt` from 2.0 and 0.5 and compare against `std::sqrt`. Neither end of the range is ever visited, which is how this stayed green.

The new suite walks the exponent range end to end for all five multi-component types -- the cascades included, since #1331 is what keeps them correct. It checks the **residual** rather than a reference value: `sqrt` is irrational and has no exact reference, but squaring the result is exact, because `a` and `r` are sums of doubles and dyadic rationals are closed under multiplication. So `|r*r - a| <= 2^-budget * a` is decided in exact integer arithmetic, with no floating-point between the implementation and its verdict.

Budgets sit four bits under each significand, calibrated from the measured worst residual over ~2,800 arguments per type (`dd` 2^-104, `dd_cascade` 2^-106, `td_cascade` 2^-159, `qd` 2^-213, `qd_cascade` 2^-214). Against the implementation before this change the suite fails 14 cases in `dd` and 29 in `qd` at the default level, 49 and 107 at level 4; the cascades pass in both, as they should.

## Cost

The prologue is one `frexp` and two `ldexp`: `dd` sqrt goes 32.1 -> 40.3 nsec, `qd` 1007 -> 1043.

The obvious way to trim the `dd` figure -- form the scale factor once and multiply instead of calling `ldexp` per limb -- does not work here: at the bottom of the range the factor is `2^1074`, which is not a double. A banded fast path would recover it, but a fast path that is correct only in the middle of the range is precisely what produced this bug, so it does not belong in the fix for it. Worth doing separately if `dd` sqrt throughput matters.

132/132 tests pass under gcc 13.3 and clang 18.1, warning-clean at every regression level. ASCII guard clean. The assessment page records the closed item.

Draft while CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
