### PR TITLE
perf(floatcascade): merge the operands of add_cascades<4> instead of sorting them (#1340)

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -74,6 +74,7 @@ jobs:
             blockdecimal
             blocksignificand
             blocktriple
+            floatcascade
             microfloat
             e8m0
             mxblock

--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -274,16 +274,33 @@ away, each option landing on its direct counterpart's accuracy. `td_cascade` is 
 improved outright. `sqrt(maxpos)`, broken in `dd`, `dd_cascade` and `qd`, is fixed at all three
 cascade widths by the argument scaling every formulation now shares. See the fix section above.
 
-### 2. The 46% that compression costs N=4 addition
+### 2. The 46% that compression costs N=4 addition - CLOSED, and the diagnosis was wrong
 
-Unchanged from the original list. The compression added by universal#1317 is applied *after* the
-fact, to repair an expansion built without the non-overlapping invariant. The direct implementation
-never needs it, because `accurate_addition` maintains a two-term running carry and emits components
-already settled.
+The hypothesis here was that compression is applied *after the fact* to repair an expansion built
+without the non-overlapping invariant, and that a formulation which emits settled components would
+not need it. Measurement (universal#1340) says otherwise, and it is worth recording which half was
+wrong.
 
-Porting that formulation to `add_cascades<4>` would plausibly recover most of the 46% *and* keep the
-exactness, since it is the algorithm the compression is emulating. Same move as #1322 and #1324 made
-for multiplication.
+`add_cascades<4>` now merges its two operands instead of bubble-sorting them -- they arrive sorted,
+so the 28 comparisons were pure waste -- and runs one `two_sum` chain over the merged sequence,
+which is Shewchuk's `fast_expansion_sum`. Results are **bit-identical** to the previous formulation
+over 40,000 random full-width additions and subtractions. Addition cost, i7-12700K -O3:
+
+| | gcc 13.3 | clang 18.1 |
+|---|---|---|
+| before | 69.6 nsec/op | 80.1 nsec/op |
+| after | **50.1** | 83.0 |
+
+**But the compression pass had to stay.** It is not repairing sloppiness: the 2N -> N step needs a
+*nonadjacent* expansion, not merely a non-overlapping one, and feeding it the raw chain output costs
+a factor of three on the composite identities (`sqrt(x)^2 - x` goes 0.42 -> 1.61 ulps). Folding the
+compression into that step rather than running it in the addition was measured too, and came out
+both slower and less accurate. So the 46% was never the compression's to give back - the redundant
+work was the sort.
+
+The clang direction is the same compiler flip #1315 recorded for these benchmarks generally. Three
+formulations of the merge - branchy, branchless, register-resident - landed within 1 nsec of each
+other there, so nothing in the merge itself explains it.
 
 ### 3. The generic templates are still the old design - CLOSED
 
@@ -341,9 +358,9 @@ Fixing these benefits both families at once. The first two are now the ceiling o
 
 1. ~~Reformulate `sqrt`~~ - done (universal#1331); the accuracy cost was measured, not assumed, and
    it differed by width.
-2. **Port `accurate_addition` to `add_cascades<4>`** (item 2), now the only open framework item.
-   Highest confidence: the algorithm is known-good, sitting next door, and the pattern is proven
-   four times over.
+2. ~~Port `accurate_addition` to `add_cascades<4>`~~ - done (universal#1340), though not as
+   predicted: the merge was the win, the compression pass had to stay, and the result is
+   bit-identical to what it replaced. No framework items remain open.
 3. ~~Close the generic templates~~ - done; they refuse to compile for unsupported widths.
 4. **Then the shared items** (item 4), which are number-system work rather than framework work, and
    which now hold the largest remaining errors in either family - `square` at 4 ulps and `log` at 15

--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -289,7 +289,13 @@ over 40,000 random full-width additions and subtractions. Addition cost, i7-1270
 | | gcc 13.3 | clang 18.1 |
 |---|---|---|
 | before | 69.6 nsec/op | 80.1 nsec/op |
-| after | **50.1** | 83.0 |
+| after | **51.0** | 85.6 |
+
+Operands that are not in magnitude order -- which nothing in the library produces, but which a
+caller can build through the raw-limb constructor or the mutable component accessor -- are put in
+order first, by a five-comparator network per operand behind a six-comparison test. Without that
+guard the merge returns zero where the exact answer is 2^-100, and `qd_cascade` would have been the
+one multi-component type that got such an operand wrong.
 
 **But the compression pass had to stay.** It is not repairing sloppiness: the 2N -> N step needs a
 *nonadjacent* expansion, not merely a non-overlapping one, and feeding it the raw chain output costs

--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -1560,28 +1560,43 @@ namespace expansion_ops {
     // and the digit subtraction in to_decimal_string both depend on it.
     //
     // Results are bit-identical to the formulation this replaces, over 40,000 random full-width
-    // additions and subtractions. Cost of an addition, i7-12700K -O3: gcc 13.3 69.6 -> 50.1
-    // nsec/op, clang 18.1 80.1 -> 83.0. The clang direction is the same flip #1315 recorded for
-    // the cascade benchmarks generally; nothing in the merge explains it, and three formulations
-    // of it (branchy, branchless, register-resident) measured within 1 nsec of each other there
-    // (universal#1340).
-    //
-    // PRECONDITION, new with this formulation: both operands must be canonical cascades, in
-    // decreasing magnitude. The sort this replaces would tolerate an unsorted operand; the merge
-    // will not. Every caller builds its operands from cascade arithmetic or by negating one
-    // componentwise, both of which preserve the ordering.
+    // additions and subtractions, so this is a speed change and nothing else. Cost of an
+    // addition, i7-12700K -O3: gcc 13.3 69.6 -> 51.0 nsec/op, clang 18.1 80.1 -> 85.6. The clang
+    // direction is the same compiler flip #1315 recorded for these benchmarks generally, and it
+    // survives every formulation of the merge that was tried -- branchy, branchless,
+    // register-resident, and with the operands ordered unconditionally -- all within a couple of
+    // nsec of each other there (universal#1340).
     constexpr inline floatcascade<8> add_cascades(const floatcascade<4>& a, const floatcascade<4>& b) {
         // std::abs(double) is not constexpr in C++20; use a ternary helper.
         auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
 
+        double a0 = a[0], a1 = a[1], a2 = a[2], a3 = a[3];
+        double b0 = b[0], b1 = b[1], b2 = b[2], b3 = b[3];
+
+        // Six comparisons establish the merge's precondition. Operands that fail it are put in
+        // order by a five-comparator network -- nothing in the library produces one, but
+        // floatcascade exposes mutable component storage and the number types take raw limbs, so
+        // a caller can build one, and it should sum correctly rather than silently give zero.
+        auto ordered = [&absv](double x0, double x1, double x2, double x3) constexpr -> bool {
+            return absv(x0) >= absv(x1) && absv(x1) >= absv(x2) && absv(x2) >= absv(x3);
+        };
+        auto ce = [&absv](double& p, double& q) constexpr {
+            if (absv(p) < absv(q)) { double t = p; p = q; q = t; }
+        };
+        if (!ordered(a0, a1, a2, a3)) { ce(a0, a1); ce(a2, a3); ce(a0, a2); ce(a1, a3); ce(a1, a2); }
+        if (!ordered(b0, b1, b2, b3)) { ce(b0, b1); ce(b2, b3); ce(b0, b2); ce(b1, b3); ce(b1, b2); }
+
         // Merge into increasing magnitude order, which is the direction the chain runs.
+        const double av[4] = { a3, a2, a1, a0 };
+        const double bv[4] = { b3, b2, b1, b0 };
         double g[8]{};
-        int i = 3, j = 3, n = 0;
-        while (i >= 0 && j >= 0) {
-            if (absv(a[i]) < absv(b[j])) g[n++] = a[i--]; else g[n++] = b[j--];
+        int i = 0, j = 0;
+        for (int n = 0; n < 8; ++n) {
+            bool takeA = (j >= 4) || (i < 4 && absv(av[i]) < absv(bv[j]));
+            g[n] = takeA ? av[i] : bv[j];
+            i += takeA ? 1 : 0;
+            j += takeA ? 0 : 1;
         }
-        while (i >= 0) g[n++] = a[i--];
-        while (j >= 0) g[n++] = b[j--];
 
         // One two_sum chain, smallest to largest. The first step can be a fast_two_sum because
         // the merge guarantees |g[1]| >= |g[0]|.

--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -1538,46 +1538,67 @@ namespace expansion_ops {
 
     // Add two floatcascade<4> -> floatcascade<8>.  Magnitude-sorted merge
     // of the eight limbs, then accumulates smallest-to-largest with two_sum.
+    // Shewchuk's fast_expansion_sum (Geometric Predicates, Fig. 7).
+    //
+    // Both inputs are non-overlapping expansions already in decreasing magnitude, which is what
+    // makes this cheap: merging two sorted sequences is linear, and a single two_sum chain over
+    // the merged sequence produces a result that is exact and non-overlapping.
+    //
+    // What this replaces sorted the eight components with a bubble sort -- 28 comparisons on two
+    // sequences that arrive sorted -- then accumulated them smallest-first and emitted the two_sum
+    // errors in the order they fell out.
+    //
+    // The COMPRESS pass below stays, and it is worth being precise about why, because the
+    // assessment that motivated this change guessed otherwise. Compression is not repairing
+    // sloppiness that a better addition formulation avoids: the 2N -> N step needs a NONADJACENT
+    // expansion, not merely a non-overlapping one, and feeding it the raw chain output costs a
+    // factor of three on the composite identities (sqrt(x)^2 - x goes from 0.42 to 1.61 ulps).
+    // Folding the compression into that step instead of running it here was measured too, and
+    // came out both slower and less accurate. The redundant work was the sort, not the pass.
+    //
+    // The 2N result must stay exact, not merely accurate to N components: the division residual
+    // and the digit subtraction in to_decimal_string both depend on it.
+    //
+    // Results are bit-identical to the formulation this replaces, over 40,000 random full-width
+    // additions and subtractions. Cost of an addition, i7-12700K -O3: gcc 13.3 69.6 -> 50.1
+    // nsec/op, clang 18.1 80.1 -> 83.0. The clang direction is the same flip #1315 recorded for
+    // the cascade benchmarks generally; nothing in the merge explains it, and three formulations
+    // of it (branchy, branchless, register-resident) measured within 1 nsec of each other there
+    // (universal#1340).
+    //
+    // PRECONDITION, new with this formulation: both operands must be canonical cascades, in
+    // decreasing magnitude. The sort this replaces would tolerate an unsorted operand; the merge
+    // will not. Every caller builds its operands from cascade arithmetic or by negating one
+    // componentwise, both of which preserve the ordering.
     constexpr inline floatcascade<8> add_cascades(const floatcascade<4>& a, const floatcascade<4>& b) {
-        double m[8] = { a[0], a[1], a[2], a[3], b[0], b[1], b[2], b[3] };
-
+        // std::abs(double) is not constexpr in C++20; use a ternary helper.
         auto absv = [](double x) constexpr -> double { return x < 0.0 ? -x : x; };
 
-        // Bubble sort 8 elements by descending magnitude (7 passes).
-        for (int pass = 0; pass < 7; ++pass) {
-            for (int j = 0; j < 7 - pass; ++j) {
-                if (absv(m[j]) < absv(m[j + 1])) {
-                    double t = m[j]; m[j] = m[j + 1]; m[j + 1] = t;
-                }
-            }
+        // Merge into increasing magnitude order, which is the direction the chain runs.
+        double g[8]{};
+        int i = 3, j = 3, n = 0;
+        while (i >= 0 && j >= 0) {
+            if (absv(a[i]) < absv(b[j])) g[n++] = a[i--]; else g[n++] = b[j--];
         }
+        while (i >= 0) g[n++] = a[i--];
+        while (j >= 0) g[n++] = b[j--];
 
-        // Accumulate from smallest (m[7]) to largest (m[0]) with two_sum.
-        double sum = 0.0;
-        double corrections[7] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
-        int nc = 0;
-
-        double new_sum = 0.0, error = 0.0;
-        for (int i = 7; i >= 0; --i) {
-            two_sum(sum, m[i], new_sum, error);
-            if (error != 0.0 && nc < 7) corrections[nc++] = error;
-            sum = new_sum;
+        // One two_sum chain, smallest to largest. The first step can be a fast_two_sum because
+        // the merge guarantees |g[1]| >= |g[0]|.
+        double h[8]{};
+        double Q{ 0.0 }, q{ 0.0 };
+        fast_two_sum(g[1], g[0], Q, h[0]);
+        for (int k = 2; k < 8; ++k) {
+            two_sum(Q, g[k], Q, q);
+            h[k - 1] = q;
         }
+        h[7] = Q;
 
+        // Store in decreasing magnitude. Zeros wherever the chain was exact are left in place:
+        // compress_expansion eliminates them itself, and filtering them here measured slower
+        // under both compilers.
         floatcascade<8> result;
-        result[0] = sum;
-        // Store corrections in decreasing order of significance.
-        for (int i = 0; i < nc; ++i) {
-            result[i + 1] = corrections[nc - 1 - i];
-        }
-        // result[nc+1..7] already zero (default-constructed).
-
-        // The sum above is exact but its components overlap; compression makes
-        // them non-overlapping so compress_8to4 can keep the tail.  Measured:
-        // without it, 25 in 200 random full-precision quad-double additions lose
-        // the fourth component entirely (relative error 2e-49 where the format
-        // carries 2^-212), which is what made qd_cascade sqrt/exp/log 13-15
-        // decimal digits worse than qd (universal#1317).
+        for (int k = 0; k < 8; ++k) result[k] = h[7 - k];
         return compress_expansion(result);
     }
 


### PR DESCRIPTION
Closes #1340. Last open framework item from the multi-component assessment.

The two operands of a cascade addition are non-overlapping expansions **already in decreasing magnitude**. `add_cascades<4>` bubble-sorted all eight components anyway -- 28 comparisons on data that arrives sorted -- then accumulated them smallest-first and emitted the `two_sum` errors as they fell out.

Merging the two sequences is linear, and a single `two_sum` chain over the merged sequence is Shewchuk's `fast_expansion_sum` (Geometric Predicates, Fig. 7).

## Results are bit-identical

Over 40,000 random full-width additions and subtractions, every limb matches the previous formulation exactly. This is a speed change and nothing else -- no accuracy claim to argue about, and the dyadic oracles, identity residuals and 132 tests all agree.

| addition, i7-12700K -O3 | before | after | |
|---|---|---|---|
| gcc 13.3 | 69.6 nsec/op | **50.1** | -28% |
| clang 18.1 | 80.1 nsec/op | 83.0 | +3.6% |

The clang direction is the same compiler flip #1315 recorded for these benchmarks generally. I tried three formulations of the merge -- branchy, branchless, and register-resident with no arrays -- and they landed within 1 nsec of each other under clang, so nothing in the merge itself explains it. Reporting it rather than tuning it away; worth a follow-up if clang throughput matters.

## The issue's diagnosis was wrong, and that is the more useful finding

#1340 (and the assessment behind it) said the compression added by #1317 is applied *after the fact* to repair an expansion built without the invariant, and that a formulation emitting settled components would not need it -- so removing it should recover the 46%.

The first half is right: the sort was waste. The second half is not. **The compression pass had to stay.** The `2N -> N` step needs a *nonadjacent* expansion, not merely a non-overlapping one. Feeding it the raw chain output costs a factor of three on the composite identities:

| | with COMPRESS | without |
|---|---|---|
| `sqrt(x)^2 - x` | 0.4185 ulps | 1.611 |
| `exp(log(x)) - x` | 0.215 | 0.8274 |
| `sin^2 + cos^2 - 1` | 0.3555 | 0.9297 |

Folding the compression into the `2N -> N` step instead of running it in the addition was measured too (including a variant that folds the dropped tail back into the fourth component, which recovers about half the accuracy): both slower and less accurate than keeping it where it is. So the 46% was never the compression's to give back.

## One new precondition

The sort used to absorb an unsorted operand; the merge will not. Every caller builds its operands from cascade arithmetic or by negating one componentwise, both of which preserve the ordering, and the requirement is documented at the function.

132/132 tests pass under gcc 13.3 and clang 18.1, warning-clean at every regression level. The dyadic addition oracles for `qd_cascade` and `td_cascade` pass at every level. ASCII guard clean. The assessment page records the closed item and the corrected diagnosis.

Draft while CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved four-component cascade addition performance, particularly when compiled with GCC, by using a more efficient merge and accumulation process.

* **Accuracy and Reliability**
  * Preserved bit-identical results for sorted cascade operands.
  * Continued compression of nonadjacent expansions to maintain numerical accuracy.

* **Documentation**
  * Updated assessment documentation to reflect completed accurate-addition work and remaining arithmetic improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->