### PR TITLE
docs(dx): point the assessment at the clang follow-up (#1342)

### DIFF
--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -304,9 +304,11 @@ compression into that step rather than running it in the addition was measured t
 both slower and less accurate. So the 46% was never the compression's to give back - the redundant
 work was the sort.
 
-The clang direction is the same compiler flip #1315 recorded for these benchmarks generally. Three
-formulations of the merge - branchy, branchless, register-resident - landed within 1 nsec of each
-other there, so nothing in the merge itself explains it.
+The clang direction is the same compiler flip #1315 recorded for these benchmarks generally, and it
+is tracked as universal#1342. Four formulations of the merge - branchy, branchless,
+register-resident, and with both operands ordered unconditionally - landed within a couple of nsec of
+each other there, so the merge's shape is not the variable; clang's codegen for the bubble sort it
+replaces is simply good.
 
 ### 3. The generic templates are still the old design - CLOSED
 


### PR DESCRIPTION
One paragraph in the multi-component assessment. It records the clang regression from #1340 without saying where it is tracked, and says three formulations of the merge were measured when it was four -- the fourth ordered both operands unconditionally and was the worst of them under clang (94.3 nsec/op).

Cross-references #1342 so a reader of the published page can find the follow-up.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the explanation of performance improvements for the N=4 addition optimization.
  * Documented compiler-specific performance comparisons between merge-based and bubble-sort implementations.
  * Added tracking information for the related optimization work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->