### PR TITLE
docs(dx): give the clang outlier its measured number (#1342)

### DIFF
--- a/docs/assessments/multi-component-cascade-vs-direct.md
+++ b/docs/assessments/multi-component-cascade-vs-direct.md
@@ -305,10 +305,10 @@ both slower and less accurate. So the 46% was never the compression's to give ba
 work was the sort.
 
 The clang direction is the same compiler flip #1315 recorded for these benchmarks generally, and it
-is tracked as universal#1342. Four formulations of the merge - branchy, branchless,
-register-resident, and with both operands ordered unconditionally - landed within a couple of nsec of
-each other there, so the merge's shape is not the variable; clang's codegen for the bubble sort it
-replaces is simply good.
+is tracked as universal#1342. Four formulations of the merge were measured there: branchy, branchless
+and register-resident land within 2.6 nsec of each other (83.0, 83.6 and 85.6 nsec/op), and ordering
+both operands unconditionally is the outlier at 94.3. So no shape of the merge recovers what clang
+gets from the bubble sort it replaces.
 
 ### 3. The generic templates are still the old design - CLOSED
 


### PR DESCRIPTION
Follow-up to #1343, which said four formulations of the merge landed "within a couple of nsec of each other." Three did -- 83.0, 83.6 and 85.6 nsec/op. The fourth, ordering both operands unconditionally, measured **94.3**, so the sentence hid the outlier in a paragraph whose whole purpose was recording the comparison accurately.

Caught by CodeRabbit on #1343, after it had merged.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)