### PR TITLE
fix: classify IEEE NaN by exponent and mantissa, not by exact payload

### DIFF
--- a/include/sw/universal/internal/blocktriple/blocktriple.hpp
+++ b/include/sw/universal/internal/blocktriple/blocktriple.hpp
@@ -830,30 +830,12 @@ private:
 
 		// special case handling
 		if (rawExponent == ieee754_parameter<Real>::eallset) { // nan and inf
-			if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::snanmask) ||
-				rawFraction == (ieee754_parameter<Real>::fmask & (ieee754_parameter<Real>::qnanmask | ieee754_parameter<Real>::snanmask))) {
-				// 1.11111111.00000000.......00000001 signalling nan
-				// 0.11111111.00000000000000000000001 signalling nan
-				// MSVC
-				// 1.11111111.10000000.......00000001 signalling nan
-				// 0.11111111.10000000.......00000001 signalling nan
-				// NAN_TYPE_SIGNALLING;
-				_nan = true;
-				_inf = false; 
-				_sign = true; // this is the encoding of a signalling NaN
-				_scale = 0;
-				return *this;
-			}
-			if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask)) {
-				// 1.11111111.10000000.......00000000 quiet nan
-				// 0.11111111.10000000.......00000000 quiet nan
-				// NAN_TYPE_QUIET);
-				_nan = true;
-				_inf = false; 
-				_sign = false; // this is the encoding of a quiet NaN
-				_scale = 0;
-				return *this;
-			}
+			// IEEE-754: exponent all ones with a ZERO fraction is infinity, and with ANY
+			// non-zero fraction is a NaN, whatever the payload.  This used to compare the
+			// fraction for equality against three specific payloads, so every other one --
+			// including the canonical signalling 0x1 -- missed all three and fell through to
+			// the numeric path below, turning a NaN into a finite value.  Fourth instance of
+			// the same copy-pasted defect; issue #1303.
 			if (rawFraction == 0ull) {
 				// 1.11111111.0000000.......000000000 -inf
 				// 0.11111111.0000000.......000000000 +inf
@@ -863,6 +845,14 @@ private:
 				_scale = 10000;
 				return *this;
 			}
+			// the fraction's MSB is the quiet bit; a blocktriple carries the distinction in
+			// its sign, matching cfloat's convention of sign 1 for signalling
+			constexpr uint64_t quietbit = ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask;
+			_nan = true;
+			_inf = false;
+			_sign = ((rawFraction & quietbit) == 0ull);   // clear quiet bit == signalling
+			_scale = 0;
+			return *this;
 		}
 		if (rhs == 0.0f) { // IEEE rule: this is valid for + and - 0.0
 			_nan = false;

--- a/include/sw/universal/internal/blocktriple/blocktriple.hpp
+++ b/include/sw/universal/internal/blocktriple/blocktriple.hpp
@@ -841,6 +841,7 @@ private:
 				// 0.11111111.0000000.......000000000 +inf
 				_nan = false;
 				_inf = true;
+				_zero = false;   // clear() set it; a special is not a zero
 				_sign = s;  // + or - infinity
 				_scale = 10000;
 				return *this;
@@ -850,6 +851,7 @@ private:
 			constexpr uint64_t quietbit = ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask;
 			_nan = true;
 			_inf = false;
+			_zero = false;   // clear() set it; a special is not a zero
 			_sign = ((rawFraction & quietbit) == 0ull);   // clear quiet bit == signalling
 			_scale = 0;
 			return *this;

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -2587,6 +2587,43 @@ protected:
 	}
 
 public:
+	// Map an IEEE-754 special -- exponent all ones -- onto this cfloat's encoding.
+	// Returns true when rhs was a special and *this has been set, false when the
+	// caller should carry on with the numeric path.
+	//
+	// The classification is IEEE-754's: exponent all ones with a ZERO fraction is
+	// infinity, and with ANY non-zero fraction is a NaN, whatever the payload.  The
+	// code this replaced instead compared the fraction for equality against three
+	// specific payloads -- the platform's canonical quiet and signalling patterns
+	// and their union -- so every other NaN payload, including the canonical 0x1,
+	// fell through to the numeric path and was projected to infinity.  A NaN
+	// silently becoming +-inf is worse than a failed conversion: it is a plausible
+	// value that survives arithmetic and round-trips.  Issue #1303.
+	//
+	// Which of the two NaN kinds is decided by the fraction's MSB, the quiet bit.
+	// ieee754_parameter's qnanmask is the platform's own canonical quiet NaN, so
+	// masking it to the fraction field names that bit without hard-coding a width.
+	//
+	// The payload beyond the quiet bit is NOT carried across.  It cannot be in
+	// general -- a narrowing conversion has nowhere to put 52 bits of diagnostic in
+	// a 10-bit fraction -- and attempting it is what produced this defect, since a
+	// truncated payload can land on the neighbouring infinity encoding.  cfloat's
+	// inf encoding is not IEEE's either, so specials are remapped on every path,
+	// including the same-width ones where the finite values copy across verbatim.
+	template<typename Real>
+	CONSTEXPRESSION bool convert_ieee754_special(bool s, uint64_t rawExponent, uint64_t rawFraction) noexcept {
+		if (rawExponent != ieee754_parameter<Real>::eallset) return false;
+		if (rawFraction == 0ull) {          // +-inf
+			setinf(s);
+			return true;
+		}
+		constexpr uint64_t quietbit = ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask;
+		// a cfloat encodes a signalling NaN with sign = 1 and a quiet NaN with
+		// sign = 0, so the source sign is deliberately not propagated here
+		setnan((rawFraction & quietbit) != 0ull ? NAN_TYPE_QUIET : NAN_TYPE_SIGNALLING);
+		return true;
+	}
+
 	template<typename Real>
 	CONSTEXPRESSION cfloat& convert_ieee754(Real rhs) noexcept {
 		if constexpr (nbits == 32 && es == 8 && sizeof(Real) == 4) {
@@ -2600,32 +2637,8 @@ public:
 			uint64_t rawFraction{ 0 };
 			uint64_t bits{ 0 };
 			extractFields(rhs, s, rawExponent, rawFraction, bits);
-			if (rawExponent == ieee754_parameter<Real>::eallset) { // nan and inf need to be remapped
-				if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::snanmask) ||
-					rawFraction == (ieee754_parameter<Real>::fmask & (ieee754_parameter<Real>::qnanmask | ieee754_parameter<Real>::snanmask))) {
-					// 1.11111111.00000000.......00000001 signalling nan
-					// 0.11111111.00000000000000000000001 signalling nan
-					// MSVC
-					// 1.11111111.10000000.......00000001 signalling nan
-					// 0.11111111.10000000.......00000001 signalling nan
-					setnan(NAN_TYPE_SIGNALLING);
-					//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-					return *this;
-				}
-				if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask)) {
-					// 1.11111111.10000000.......00000000 quiet nan
-					// 0.11111111.10000000.......00000000 quiet nan
-					setnan(NAN_TYPE_QUIET);
-					//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-					return *this;
-				}
-				if (rawFraction == 0ull) {
-					// 1.11111111.0000000.......000000000 -inf
-					// 0.11111111.0000000.......000000000 +inf
-					setinf(s);
-					return *this;
-				}
-			}
+			// nan and inf need to be remapped; see convert_ieee754_special()
+			if (convert_ieee754_special<Real>(s, rawExponent, rawFraction)) return *this;
 			uint64_t raw{ s ? 1ull : 0ull };
 			raw <<= 31;
 			raw |= (rawExponent << fbits);
@@ -2640,32 +2653,8 @@ public:
 			uint64_t rawFraction{ 0 };
 			uint64_t bits{ 0 };
 			extractFields(rhs, s, rawExponent, rawFraction, bits);
-			if (rawExponent == ieee754_parameter<Real>::eallset) { // nan and inf need to be remapped
-				if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::snanmask) ||
-					rawFraction == (ieee754_parameter<Real>::fmask & (ieee754_parameter<Real>::qnanmask | ieee754_parameter<Real>::snanmask))) {
-					// 1.11111111.00000000.......00000001 signalling nan
-					// 0.11111111.00000000000000000000001 signalling nan
-					// MSVC
-					// 1.11111111.10000000.......00000001 signalling nan
-					// 0.11111111.10000000.......00000001 signalling nan
-					setnan(NAN_TYPE_SIGNALLING);
-					//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-					return *this;
-				}
-				if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask)) {
-					// 1.11111111.10000000.......00000000 quiet nan
-					// 0.11111111.10000000.......00000000 quiet nan
-					setnan(NAN_TYPE_QUIET);
-					//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-					return *this;
-				}
-				if (rawFraction == 0ull) {
-					// 1.11111111.0000000.......000000000 -inf
-					// 0.11111111.0000000.......000000000 +inf
-					setinf(s);
-					return *this;
-				}
-			}
+			// nan and inf need to be remapped; see convert_ieee754_special()
+			if (convert_ieee754_special<Real>(s, rawExponent, rawFraction)) return *this;
 			// normal and subnormal handling
 			uint64_t raw{ s ? 1ull : 0ull };
 			raw <<= 63;
@@ -2683,32 +2672,8 @@ public:
 			uint64_t bits{ 0 };
 			extractFields(rhs, s, rawExponent, rawFraction, bits);
 			// special case handling
-			if (rawExponent == ieee754_parameter<Real>::eallset) { // nan and inf
-				if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::snanmask) ||
-					rawFraction == (ieee754_parameter<Real>::fmask & (ieee754_parameter<Real>::qnanmask | ieee754_parameter<Real>::snanmask))) {
-					// 1.11111111.00000000.......00000001 signalling nan
-					// 0.11111111.00000000000000000000001 signalling nan
-					// MSVC
-					// 1.11111111.10000000.......00000001 signalling nan
-					// 0.11111111.10000000.......00000001 signalling nan
-					setnan(NAN_TYPE_SIGNALLING);
-					//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-					return *this;
-				}
-				if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask)) {
-					// 1.11111111.10000000.......00000000 quiet nan
-					// 0.11111111.10000000.......00000000 quiet nan
-					setnan(NAN_TYPE_QUIET);
-					//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-					return *this;
-				}
-				if (rawFraction == 0ull) {
-					// 1.11111111.0000000.......000000000 -inf
-					// 0.11111111.0000000.......000000000 +inf
-					setinf(s);
-					return *this;
-				}
-			}
+			// nan and inf need to be remapped; see convert_ieee754_special()
+			if (convert_ieee754_special<Real>(s, rawExponent, rawFraction)) return *this;
 			if (rhs == 0.0) { // IEEE rule: this is valid for + and - 0.0
 				setbit(nbits - 1ull, s);
 				return *this;

--- a/include/sw/universal/number/dbns/dbns_impl.hpp
+++ b/include/sw/universal/number/dbns/dbns_impl.hpp
@@ -697,29 +697,20 @@ protected:
 		uint64_t bits{ 0 };
 		extractFields(v, s, unbiasedExponent, rawFraction, bits);
 		if (unbiasedExponent == ieee754_parameter<Real>::eallset) { // nan and inf need to be remapped
-			if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::snanmask) ||
-				rawFraction == (ieee754_parameter<Real>::fmask & (ieee754_parameter<Real>::qnanmask | ieee754_parameter<Real>::snanmask))) {
-				// 1.11111111.00000000.......00000001 signalling nan
-				// 0.11111111.00000000000000000000001 signalling nan
-				// MSVC
-				// 1.11111111.10000000.......00000001 signalling nan
-				// 0.11111111.10000000.......00000001 signalling nan
-				setnan();
-				return *this;
-			}
-			if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask)) {
-				// 1.11111111.10000000.......00000000 quiet nan
-				// 0.11111111.10000000.......00000000 quiet nan
-				setnan();
-				//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-				return *this;
-			}
+			// IEEE-754: exponent all ones with a ZERO fraction is infinity, and with ANY
+			// non-zero fraction is a NaN, whatever the payload.  This used to compare the
+			// fraction for equality against three specific payloads, so every other one --
+			// including the canonical signalling 0x1 -- missed all three and fell through to
+			// the numeric path below, which turned a NaN into a finite value or an infinity.
+			// Same defect as cfloat's, same origin; issue #1303.
 			if (rawFraction == 0ull) {
-				// 1.11111111.0000000.......000000000 -inf
-				// 0.11111111.0000000.......000000000 +inf
 				setinf(s);
 				return *this;
 			}
+			// dbns has a single NaN encoding, so the quiet / signalling distinction the
+			// source carries in its fraction MSB has nowhere to go and is not preserved.
+			setnan();
+			return *this;
 		}
 		if (v == 0.0) {
 			setzero();

--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -597,29 +597,20 @@ protected:
 		uint64_t bits{ 0 };
 		extractFields(v, s, unbiasedExponent, rawFraction, bits);
 		if (unbiasedExponent == ieee754_parameter<Real>::eallset) { // nan and inf need to be remapped
-			if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::snanmask) ||
-				rawFraction == (ieee754_parameter<Real>::fmask & (ieee754_parameter<Real>::qnanmask | ieee754_parameter<Real>::snanmask))) {
-				// 1.11111111.00000000.......00000001 signalling nan
-				// 0.11111111.00000000000000000000001 signalling nan
-				// MSVC
-				// 1.11111111.10000000.......00000001 signalling nan
-				// 0.11111111.10000000.......00000001 signalling nan
-				setnan();
-				return *this;
-			}
-			if (rawFraction == (ieee754_parameter<Real>::fmask & ieee754_parameter<Real>::qnanmask)) {
-				// 1.11111111.10000000.......00000000 quiet nan
-				// 0.11111111.10000000.......00000000 quiet nan
-				setnan();
-				//setsign(s);  a cfloat encodes a signalling nan with sign = 1, and a quiet nan with sign = 0
-				return *this;
-			}
+			// IEEE-754: exponent all ones with a ZERO fraction is infinity, and with ANY
+			// non-zero fraction is a NaN, whatever the payload.  This used to compare the
+			// fraction for equality against three specific payloads, so every other one --
+			// including the canonical signalling 0x1 -- missed all three and fell through to
+			// the numeric path below, which turned a NaN into a finite value or an infinity.
+			// Same defect as cfloat's, same origin; issue #1303.
 			if (rawFraction == 0ull) {
-				// 1.11111111.0000000.......000000000 -inf
-				// 0.11111111.0000000.......000000000 +inf
 				setinf(s);
 				return *this;
 			}
+			// lns has a single NaN encoding, so the quiet / signalling distinction the
+			// source carries in its fraction MSB has nowhere to go and is not preserved.
+			setnan();
+			return *this;
 		}
 		if (v == 0.0) {
 			setzero();

--- a/include/sw/universal/utility/architecture.hpp
+++ b/include/sw/universal/utility/architecture.hpp
@@ -55,10 +55,30 @@
 // ARM    : similar to RISC-V; the default-NaN mode in FPCR quiets
 //          sNaN on most operations (and many toolchains enable it).
 //
+// The hardware is not the only thing that can quiet an sNaN: the standard
+// library can too, and on one toolchain it does so by construction.
+//
+// MSVC : std::numeric_limits<T>::signaling_NaN() has the QUIET BIT SET.
+//        Measured on the CI runner, its float value is
+//            0b0.11111111.10000000000000000000001   (0x7FC00001)
+//        which IEEE-754 classifies as a QUIET NaN regardless of the name.
+//        cfloat::to_ieee754() hands a signalling cfloat out through that
+//        constant, so the value leaving the type is already quiet and no
+//        conforming classification can recover "signalling" on the way back.
+//        This is independent of the x86-64 register behaviour above -- the
+//        payload never carried the signal in the first place.
+//
+//        The previous conversion appeared to round-trip only because it
+//        matched that exact payload as a special case, which is the same
+//        exact-payload matching that turned every other NaN into infinity
+//        (issue #1303).  Reinstating it to keep this one round-trip working
+//        would reinstate the defect.
+//
 // Define this macro only on platforms where sNaN can survive a
-// round-trip through native float/double without being quieted.
+// round-trip through native float/double without being quieted -- by the
+// architecture OR by the standard library.
 #undef UNIVERSAL_SNAN_ROUND_TRIPS_NATIVE_FP
 
-#if defined(UNIVERSAL_ARCH_X86_64)
+#if defined(UNIVERSAL_ARCH_X86_64) && !defined(_MSC_VER)
 #define UNIVERSAL_SNAN_ROUND_TRIPS_NATIVE_FP 1
 #endif

--- a/internal/blocktriple/conversion/nan_conversion.cpp
+++ b/internal/blocktriple/conversion/nan_conversion.cpp
@@ -64,6 +64,8 @@ int VerifyDoubleNaNPayloads(bool reportTestCases) {
 		0xFFF0000000000001ull,   // negative signalling
 		0xFFF8000000000000ull,   // negative quiet
 	};
+	// double's quiet bit is the fraction MSB, bit 51
+	constexpr uint64_t QUIETBIT = 0x0008000000000000ull;
 	for (uint64_t bits : payloads) {
 		BlockTriple t;
 		t = sw::bit_cast<double>(bits);
@@ -73,17 +75,42 @@ int VerifyDoubleNaNPayloads(bool reportTestCases) {
 				std::cout << "FAIL double NaN 0x" << std::hex << bits << std::dec
 				          << " -> isnan=" << t.isnan() << " isinf=" << t.isinf() << '\n';
 			}
+			continue;
+		}
+		// A special is not a zero.  clear() sets _zero at the top of the conversion
+		// and the special branches have to clear it again; when they did not, a NaN
+		// reported isnan() and iszero() at the same time, and iszero() is what the
+		// arithmetic paths consult for their shortcuts.
+		if (t.iszero()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL double NaN 0x" << std::hex << bits << std::dec
+				          << " reports iszero() as well\n";
+			}
+		}
+		// blocktriple carries the quiet / signalling distinction in its sign:
+		// sign set means signalling, matching cfloat's convention.  Asserting only
+		// "is a NaN" would pass a conversion that dropped or reversed that bit.
+		const bool srcQuiet = (bits & QUIETBIT) != 0ull;
+		if (t.sign() == srcQuiet) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL double NaN 0x" << std::hex << bits << std::dec
+				          << " is a " << (srcQuiet ? "quiet" : "signalling")
+				          << " NaN but blocktriple sign says otherwise\n";
+			}
 		}
 	}
 	// and the infinities must stay infinities, distinct from the NaN class
 	for (uint64_t bits : { 0x7FF0000000000000ull, 0xFFF0000000000000ull }) {
 		BlockTriple t;
 		t = sw::bit_cast<double>(bits);
-		if (t.isnan() || !t.isinf()) {
+		if (t.isnan() || !t.isinf() || t.iszero()) {
 			++nrOfFailedTests;
 			if (reportTestCases) {
 				std::cout << "FAIL double inf 0x" << std::hex << bits << std::dec
-				          << " -> isnan=" << t.isnan() << " isinf=" << t.isinf() << '\n';
+				          << " -> isnan=" << t.isnan() << " isinf=" << t.isinf()
+				          << " iszero=" << t.iszero() << '\n';
 			}
 		}
 	}
@@ -146,17 +173,22 @@ try {
 
 #if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyDoubleNaNPayloads<bt23>(true), "blocktriple<23>", "double NaN payloads");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<bt23>(reportTestCases), "blocktriple<23>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<bt23>(reportTestCases), "blocktriple<23>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyDoubleNaNPayloads<bt52>(reportTestCases), "blocktriple<52>", "double NaN payloads");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<bt52>(reportTestCases), "blocktriple<52>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyDoubleNaNPayloads<bt52>(reportTestCases), "blocktriple<52>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<bt52>(reportTestCases), "blocktriple<52>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyDoubleNaNPayloads<bt10>(reportTestCases), "blocktriple<10>", "double NaN payloads");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<bt10>(reportTestCases), "blocktriple<10>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyDoubleNaNPayloads<bt10>(reportTestCases), "blocktriple<10>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<bt10>(reportTestCases), "blocktriple<10>", "binary16 NaN space");
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/internal/blocktriple/conversion/nan_conversion.cpp
+++ b/internal/blocktriple/conversion/nan_conversion.cpp
@@ -1,0 +1,176 @@
+// nan_conversion.cpp: verify that every IEEE-754 NaN encoding converts to a blocktriple NaN
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// blocktriple carried the same NaN classification defect cfloat did (issue
+// #1303), and it is the most consequential of the four places that defect was
+// copy-pasted to: blocktriple is what the arithmetic paths run on, so a NaN
+// operand entering an add or a multiply was not merely mis-encoded, it stopped
+// being a NaN at all.  Unmatched payloads fell through to the numeric path and
+// came out as FINITE values -- not even the infinity the conversion path
+// produced -- so a NaN silently stopped propagating.
+//
+// The classification compared the source fraction for equality against three
+// specific payloads, so every other payload, including the canonical signalling
+// 0x1, missed all three.  std::nan("") is one of the three, which is why nothing
+// noticed.
+//
+// The sources here are built as BIT PATTERNS through sw::bit_cast, never with
+// std::nan or a computed double: building a signaling NaN in a double and passing
+// it reproduces on Linux and macOS but NOT on Windows, where the payload is
+// quieted first and the obvious test passes while the bug remains.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <cstdint>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/internal/blocktriple/blocktriple.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+using namespace sw::universal;
+
+// binary16 pattern -> float pattern, by moving bits: the exponent stays all ones
+// and the 10-bit fraction shifts up 13 places, so the quiet bit stays the quiet
+// bit and a non-zero payload stays non-zero.
+constexpr uint32_t half_bits_to_float_bits(uint16_t h) noexcept {
+	const uint32_t sign = static_cast<uint32_t>(h >> 15) << 31;
+	const uint32_t exp  = static_cast<uint32_t>((h >> 10) & 0x1Fu);
+	const uint32_t frac = static_cast<uint32_t>(h & 0x3FFu);
+	if (exp == 0x1Fu) return sign | 0x7F800000u | (frac << 13);
+	if (exp == 0u) {
+		if (frac == 0u) return sign;
+		uint32_t f = frac, e = 0;
+		while ((f & 0x400u) == 0u) { f <<= 1; ++e; }
+		f &= 0x3FFu;
+		return sign | ((127u - 15u - e) << 23) | (f << 13);
+	}
+	return sign | ((exp + 127u - 15u) << 23) | (frac << 13);
+}
+
+template<typename BlockTriple>
+int VerifyDoubleNaNPayloads(bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	const uint64_t payloads[] = {
+		0x7FF0000000000001ull,   // signalling, canonical payload 1
+		0x7FF0004000000000ull,   // signalling, other payload
+		0x7FF4000000000000ull,   // the platform's signalling pattern
+		0x7FF8000000000000ull,   // the platform's quiet pattern
+		0x7FFFFFFFFFFFFFFFull,   // all payload bits set
+		0xFFF0000000000001ull,   // negative signalling
+		0xFFF8000000000000ull,   // negative quiet
+	};
+	for (uint64_t bits : payloads) {
+		BlockTriple t;
+		t = sw::bit_cast<double>(bits);
+		if (!t.isnan() || t.isinf()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL double NaN 0x" << std::hex << bits << std::dec
+				          << " -> isnan=" << t.isnan() << " isinf=" << t.isinf() << '\n';
+			}
+		}
+	}
+	// and the infinities must stay infinities, distinct from the NaN class
+	for (uint64_t bits : { 0x7FF0000000000000ull, 0xFFF0000000000000ull }) {
+		BlockTriple t;
+		t = sw::bit_cast<double>(bits);
+		if (t.isnan() || !t.isinf()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL double inf 0x" << std::hex << bits << std::dec
+				          << " -> isnan=" << t.isnan() << " isinf=" << t.isinf() << '\n';
+			}
+		}
+	}
+	return nrOfFailedTests;
+}
+
+template<typename BlockTriple>
+int VerifyBinary16NaNSpace(bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	long nans = 0;
+	for (uint32_t i = 0; i < 0x10000u; ++i) {
+		const uint16_t h = static_cast<uint16_t>(i);
+		if (((h & 0x7C00u) != 0x7C00u) || ((h & 0x03FFu) == 0u)) continue;   // NaNs only
+		++nans;
+		BlockTriple t;
+		t = sw::bit_cast<float>(half_bits_to_float_bits(h));
+		if (!t.isnan()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL binary16 NaN 0x" << std::hex << h << std::dec
+				          << " did not convert to a NaN\n";
+			}
+		}
+	}
+	if (nans != 2046) {
+		++nrOfFailedTests;
+		std::cout << "FAIL binary16 sweep covered " << nans << " NaNs, expected 2046\n";
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "blocktriple NaN conversion validation";
+	std::string test_tag    = "nan conversion";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	using bt23 [[maybe_unused]] = blocktriple<23, BlockTripleOperator::REP, uint32_t>;
+	using bt52 [[maybe_unused]] = blocktriple<52, BlockTripleOperator::REP, uint32_t>;
+	using bt10 [[maybe_unused]] = blocktriple<10, BlockTripleOperator::REP, uint16_t>;
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleNaNPayloads<bt23>(true), "blocktriple<23>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<bt23>(reportTestCases), "blocktriple<23>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleNaNPayloads<bt52>(reportTestCases), "blocktriple<52>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<bt52>(reportTestCases), "blocktriple<52>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyDoubleNaNPayloads<bt10>(reportTestCases), "blocktriple<10>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<bt10>(reportTestCases), "blocktriple<10>", "binary16 NaN space");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/float/cfloat/conversion/nan_conversion.cpp
+++ b/static/float/cfloat/conversion/nan_conversion.cpp
@@ -157,6 +157,23 @@ int VerifyBinary16NaNSpace(bool reportTestCases) {
 					          << (c.isinf() ? "infinity" : "a finite value") << '\n';
 				}
 			}
+			else {
+				// and it must be the RIGHT KIND of NaN.  Asserting only "is a NaN"
+				// would pass a conversion that discarded the source's quiet bit, or
+				// reversed it -- which is the very field this fix reads.  binary16's
+				// quiet bit is bit 9 of the fraction.
+				const bool srcQuiet = (h & 0x0200u) != 0u;
+				const bool gotQuiet = c.isnan(sw::universal::NAN_TYPE_QUIET);
+				if (gotQuiet != srcQuiet) {
+					++nrOfFailedTests;
+					if (reportTestCases) {
+						std::cout << "FAIL binary16 0x" << std::hex << h << std::dec
+						          << " is a " << (srcQuiet ? "quiet" : "signalling")
+						          << " NaN but converted to a "
+						          << (gotQuiet ? "quiet" : "signalling") << " one\n";
+					}
+				}
+			}
 		}
 		else {
 			++infs;
@@ -194,11 +211,17 @@ int VerifyIssue1303Repro(bool reportTestCases) {
 	const F16 fs(snan), fq(qnan);
 	if (!fs.isnan()) {
 		++nrOfFailedTests;
-		if (reportTestCases) std::cout << "FAIL sNaN double converted to " << (fs.isinf() ? "infinity\n" : "a finite value\n");
+		if (reportTestCases) {
+			std::cout << "FAIL sNaN double converted to "
+			          << (fs.isinf() ? "infinity\n" : "a finite value\n");
+		}
 	}
 	if (!fq.isnan()) {
 		++nrOfFailedTests;
-		if (reportTestCases) std::cout << "FAIL qNaN double converted to " << (fq.isinf() ? "infinity\n" : "a finite value\n");
+		if (reportTestCases) {
+			std::cout << "FAIL qNaN double converted to "
+			          << (fq.isinf() ? "infinity\n" : "a finite value\n");
+		}
 	}
 	return nrOfFailedTests;
 }
@@ -240,39 +263,53 @@ try {
 
 #if MANUAL_TESTING
 	nrOfFailedTestCases += ReportTestResult(VerifyIssue1303Repro(true), "cfloat<16,5>", "issue 1303 repro");
-	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_sub, double>(true)), "cfloat<16,5>", "classification");
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyClassification<f16_sub, double>(true)), "cfloat<16,5>", "classification");
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return EXIT_SUCCESS;
 #else
 
 #if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyIssue1303Repro(true), "cfloat<16,5>", "issue 1303 repro");
-	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_sub, double>(reportTestCases)), "cfloat<16,5> from double", "classification");
-	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_sub, float>(reportTestCases)),  "cfloat<16,5> from float",  "classification");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_sub>(reportTestCases), "cfloat<16,5>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyClassification<f16_sub, double>(reportTestCases)), "cfloat<16,5> from double", "classification");
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyClassification<f16_sub, float>(reportTestCases)),  "cfloat<16,5> from float",  "classification");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<f16_sub>(reportTestCases), "cfloat<16,5>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_2
 	// the flag combinations from the issue's table: subnormals, supernormals and
 	// saturation are all irrelevant to the defect, and the suite says so
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_super>(reportTestCases), "cfloat<16,5> supernormals", "binary16 NaN space");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_nosub>(reportTestCases), "cfloat<16,5> no subnormals", "binary16 NaN space");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_sat>(reportTestCases),   "cfloat<16,5> saturating",    "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<f16_super>(reportTestCases), "cfloat<16,5> supernormals", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<f16_nosub>(reportTestCases), "cfloat<16,5> no subnormals", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<f16_sat>(reportTestCases),   "cfloat<16,5> saturating",    "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_3
 	// narrower and wider targets: e5m2 is narrower than the source fraction,
 	// cfloat<32,8> and cfloat<64,11> take the same-width fast paths
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f8_e5m2>(reportTestCases),    "cfloat<8,5>",   "binary16 NaN space");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f32_single>(reportTestCases), "cfloat<32,8>",  "binary16 NaN space");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f64_double>(reportTestCases), "cfloat<64,11>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<f8_e5m2>(reportTestCases),    "cfloat<8,5>",   "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<f32_single>(reportTestCases), "cfloat<32,8>",  "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<f64_double>(reportTestCases), "cfloat<64,11>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f8_e5m2, float>(reportTestCases)),    "cfloat<8,5>",   "classification");
-	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f32_single, double>(reportTestCases)), "cfloat<32,8>",  "classification");
-	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f64_double, double>(reportTestCases)), "cfloat<64,11>", "classification");
-	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_super, double>(reportTestCases)),  "cfloat<16,5> supernormals", "classification");
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyClassification<f8_e5m2, float>(reportTestCases)),    "cfloat<8,5>",   "classification");
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyClassification<f32_single, double>(reportTestCases)), "cfloat<32,8>",  "classification");
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyClassification<f64_double, double>(reportTestCases)), "cfloat<64,11>", "classification");
+	nrOfFailedTestCases += ReportTestResult(
+		(VerifyClassification<f16_super, double>(reportTestCases)),  "cfloat<16,5> supernormals", "classification");
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/static/float/cfloat/conversion/nan_conversion.cpp
+++ b/static/float/cfloat/conversion/nan_conversion.cpp
@@ -1,0 +1,293 @@
+// nan_conversion.cpp: verify that every IEEE-754 NaN encoding converts to a cfloat NaN
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Converting a signaling NaN into a narrower cfloat produced INFINITY (issue
+// #1303).  The classification compared the source fraction for equality against
+// three specific payloads -- the platform's canonical quiet and signalling
+// patterns and their union -- so every other payload, including the canonical
+// 0x1, missed all three, fell through to the numeric path, and was projected to
+// infinity by the out-of-range logic.  std::nan("") happens to be one of the
+// three, which is why the existing coverage never saw it.
+//
+// A NaN silently becoming +-inf is worse than a failed conversion: it turns a
+// value that would have propagated and been detectable into a plausible one that
+// survives arithmetic and round-trips.  Downstream, 2040 of binary16's 2046 NaN
+// encodings decoded to the wrong CLASS of value.
+//
+// HOW THIS SUITE IS BUILT, which matters more than usual here
+//
+// Do NOT reach for std::nan variants or a memcpy-constructed double.  Building a
+// signaling NaN in a double and passing it in reproduces on Linux and macOS but
+// NOT on Windows, where the sNaN is quieted before it reaches the conversion --
+// the obvious test passes on MSVC while the bug remains.  Reported on the issue
+// after it cost a red CI run.
+//
+// So the source values here are built as BIT PATTERNS and handed over through
+// sw::bit_cast, with no arithmetic in between that could quiet a payload, and the
+// classification itself is additionally exercised through integer arguments that
+// never touch a floating-point register at all.  The two layers fail
+// independently: the integer one pins the logic on every platform, the bit-cast
+// one pins the whole conversion path on platforms that deliver the payload.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <cstdint>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/number/cfloat/cfloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Layer 1: the classification, on integer fields only
+//
+// convert_ieee754_special() takes the decoded sign / exponent / fraction, so this
+// walks the payload space without ever putting a NaN in a register.  Nothing a
+// platform does to signaling NaNs can make this vacuous.
+// ---------------------------------------------------------------------------
+template<typename Cfloat, typename Real>
+int VerifyClassification(bool reportTestCases) {
+	using namespace sw::universal;
+	int nrOfFailedTests = 0;
+
+	constexpr uint64_t eallset  = ieee754_parameter<Real>::eallset;
+	constexpr uint64_t fmask    = ieee754_parameter<Real>::fmask;
+	constexpr uint64_t quietbit = fmask & ieee754_parameter<Real>::qnanmask;
+
+	auto expect = [&](const char* what, bool sign, uint64_t e, uint64_t f,
+	                  bool wantSpecial, bool wantNaN, bool wantInf) {
+		Cfloat c{};
+		const bool handled = c.template convert_ieee754_special<Real>(sign, e, f);
+		if (handled != wantSpecial || (wantSpecial && (c.isnan() != wantNaN || c.isinf() != wantInf))) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL " << what << " e=0x" << std::hex << e << " f=0x" << f << std::dec
+				          << ": handled=" << handled << " isnan=" << c.isnan() << " isinf=" << c.isinf()
+				          << " (wanted handled=" << wantSpecial << " isnan=" << wantNaN
+				          << " isinf=" << wantInf << ")\n";
+			}
+		}
+	};
+
+	// infinity: exponent all ones, fraction zero
+	expect("+inf", false, eallset, 0ull, true, false, true);
+	expect("-inf", true,  eallset, 0ull, true, false, true);
+
+	// a finite exponent is not a special at all, whatever the fraction
+	expect("finite", false, 1ull, 0ull, false, false, false);
+	expect("finite", false, eallset - 1ull, quietbit, false, false, false);
+
+	// EVERY non-zero fraction is a NaN.  The walk covers each single-bit payload,
+	// which is where the old code failed: only three exact values were recognised.
+	for (unsigned b = 0; b < 64u; ++b) {
+		const uint64_t f = (1ull << b) & fmask;
+		if (f == 0ull) continue;
+		expect("single-bit payload", false, eallset, f, true, true, false);
+		expect("single-bit payload", true,  eallset, f, true, true, false);
+	}
+
+	// and the quiet bit decides WHICH NaN: set is quiet, clear is signalling.
+	// cfloat encodes a quiet NaN with sign 0 and a signalling NaN with sign 1.
+	{
+		Cfloat q{}, sn{};
+		q.template convert_ieee754_special<Real>(false, eallset, quietbit);
+		sn.template convert_ieee754_special<Real>(false, eallset, 1ull);
+		if (!q.isnan(NAN_TYPE_QUIET)) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL quiet bit set did not yield a quiet NaN\n";
+		}
+		if (!sn.isnan(NAN_TYPE_SIGNALLING)) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL quiet bit clear did not yield a signalling NaN\n";
+		}
+	}
+	return nrOfFailedTests;
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: the whole conversion, driven from binary16 encodings
+//
+// This is the downstream repro in C++: walk all 65536 binary16 patterns, widen
+// each to a float by MOVING BITS -- exponent all ones stays all ones and the
+// 10-bit fraction shifts up 13 places, so the quiet bit stays the quiet bit and a
+// non-zero payload stays non-zero -- and convert.  No arithmetic touches the
+// value, so a signaling payload arrives intact.
+// ---------------------------------------------------------------------------
+constexpr uint32_t half_bits_to_float_bits(uint16_t h) noexcept {
+	const uint32_t sign = static_cast<uint32_t>(h >> 15) << 31;
+	const uint32_t exp  = static_cast<uint32_t>((h >> 10) & 0x1Fu);
+	const uint32_t frac = static_cast<uint32_t>(h & 0x3FFu);
+	if (exp == 0x1Fu) return sign | 0x7F800000u | (frac << 13);   // inf / NaN
+	if (exp == 0u) {
+		if (frac == 0u) return sign;                              // +-0
+		// subnormal: normalize into float's wider exponent range
+		uint32_t f = frac, e = 0;
+		while ((f & 0x400u) == 0u) { f <<= 1; ++e; }
+		f &= 0x3FFu;
+		return sign | ((127u - 15u - e) << 23) | (f << 13);
+	}
+	return sign | ((exp + 127u - 15u) << 23) | (frac << 13);
+}
+
+template<typename Cfloat>
+int VerifyBinary16NaNSpace(bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	long nans = 0, infs = 0;
+
+	for (uint32_t i = 0; i < 0x10000u; ++i) {
+		const uint16_t h = static_cast<uint16_t>(i);
+		const bool srcIsNaN = ((h & 0x7C00u) == 0x7C00u) && ((h & 0x03FFu) != 0u);
+		const bool srcIsInf = ((h & 0x7C00u) == 0x7C00u) && ((h & 0x03FFu) == 0u);
+		if (!srcIsNaN && !srcIsInf) continue;
+
+		const float f = sw::bit_cast<float>(half_bits_to_float_bits(h));
+		const Cfloat c(f);
+
+		if (srcIsNaN) {
+			++nans;
+			if (!c.isnan()) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL binary16 0x" << std::hex << h << std::dec
+					          << " is a NaN but converted to "
+					          << (c.isinf() ? "infinity" : "a finite value") << '\n';
+				}
+			}
+		}
+		else {
+			++infs;
+			if (!c.isinf()) {
+				++nrOfFailedTests;
+				if (reportTestCases) {
+					std::cout << "FAIL binary16 0x" << std::hex << h << std::dec
+					          << " is an infinity but did not convert to one\n";
+				}
+			}
+		}
+	}
+	// binary16 has 2046 NaN encodings and 2 infinities; if the sweep saw a
+	// different number it is not testing what it claims to.
+	if (nans != 2046 || infs != 2) {
+		++nrOfFailedTests;
+		std::cout << "FAIL binary16 sweep covered " << nans << " NaNs and " << infs
+		          << " infinities, expected 2046 and 2\n";
+	}
+	return nrOfFailedTests;
+}
+
+// The issue's own repro, kept as a named regression.  Only meaningful on
+// platforms that deliver a signaling payload through a double; where the
+// platform quiets it first this degrades to a second quiet-NaN check rather than
+// a false pass, because the assertion is "is a NaN", not "is a signalling NaN".
+int VerifyIssue1303Repro(bool reportTestCases) {
+	using namespace sw::universal;
+	int nrOfFailedTests = 0;
+
+	const double snan = sw::bit_cast<double>(0x7FF0000000000001ull);
+	const double qnan = sw::bit_cast<double>(0x7FF8000000000000ull);
+
+	using F16 = cfloat<16, 5, uint16_t, true, false, false>;
+	const F16 fs(snan), fq(qnan);
+	if (!fs.isnan()) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL sNaN double converted to " << (fs.isinf() ? "infinity\n" : "a finite value\n");
+	}
+	if (!fq.isnan()) {
+		++nrOfFailedTests;
+		if (reportTestCases) std::cout << "FAIL qNaN double converted to " << (fq.isinf() ? "infinity\n" : "a finite value\n");
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "cfloat NaN conversion validation";
+	std::string test_tag    = "nan conversion";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+	// The shapes named in issue #1303.  maybe_unused because which of them a build
+	// reaches depends on the regression level.
+	using f16_sub    [[maybe_unused]] = cfloat<16, 5, uint16_t, true,  false, false>;
+	using f16_super  [[maybe_unused]] = cfloat<16, 5, uint16_t, true,  true,  false>;
+	using f16_nosub  [[maybe_unused]] = cfloat<16, 5, uint16_t, false, false, false>;
+	using f16_sat    [[maybe_unused]] = cfloat<16, 5, uint16_t, true,  false, true>;
+	using f8_e5m2    [[maybe_unused]] = cfloat<8,  5, uint8_t,  true,  false, false>;
+	using f32_single [[maybe_unused]] = cfloat<32, 8, uint32_t, true,  false, false>;
+	using f64_double [[maybe_unused]] = cfloat<64, 11, uint64_t, true, false, false>;
+
+#if MANUAL_TESTING
+	nrOfFailedTestCases += ReportTestResult(VerifyIssue1303Repro(true), "cfloat<16,5>", "issue 1303 repro");
+	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_sub, double>(true)), "cfloat<16,5>", "classification");
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS;
+#else
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyIssue1303Repro(true), "cfloat<16,5>", "issue 1303 repro");
+	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_sub, double>(reportTestCases)), "cfloat<16,5> from double", "classification");
+	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_sub, float>(reportTestCases)),  "cfloat<16,5> from float",  "classification");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_sub>(reportTestCases), "cfloat<16,5>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_2
+	// the flag combinations from the issue's table: subnormals, supernormals and
+	// saturation are all irrelevant to the defect, and the suite says so
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_super>(reportTestCases), "cfloat<16,5> supernormals", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_nosub>(reportTestCases), "cfloat<16,5> no subnormals", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f16_sat>(reportTestCases),   "cfloat<16,5> saturating",    "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_3
+	// narrower and wider targets: e5m2 is narrower than the source fraction,
+	// cfloat<32,8> and cfloat<64,11> take the same-width fast paths
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f8_e5m2>(reportTestCases),    "cfloat<8,5>",   "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f32_single>(reportTestCases), "cfloat<32,8>",  "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<f64_double>(reportTestCases), "cfloat<64,11>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f8_e5m2, float>(reportTestCases)),    "cfloat<8,5>",   "classification");
+	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f32_single, double>(reportTestCases)), "cfloat<32,8>",  "classification");
+	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f64_double, double>(reportTestCases)), "cfloat<64,11>", "classification");
+	nrOfFailedTestCases += ReportTestResult((VerifyClassification<f16_super, double>(reportTestCases)),  "cfloat<16,5> supernormals", "classification");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/logarithmic/dbns/conversion/nan_conversion.cpp
+++ b/static/logarithmic/dbns/conversion/nan_conversion.cpp
@@ -83,6 +83,10 @@ int VerifyDoublePayloads(bool reportTestCases) {
 		0xFFF0000000000001ull,   // negative signalling
 		0xFFF8000000000000ull,   // negative quiet
 	};
+	// No quiet / signalling assertion here, unlike cfloat's and blocktriple's
+	// suites: dbns has a SINGLE NaN encoding and isnan() takes no kind, so the
+	// source's quiet bit has nowhere to land and there is nothing to check.  Saying
+	// so beats adding an assertion that could only ever be vacuous.
 	for (uint64_t bits : payloads) {
 		const Number v(sw::bit_cast<double>(bits));
 		if (!v.isnan()) {
@@ -142,21 +146,27 @@ try {
 
 #if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<dbns<16, 5>>(true), "dbns<16,5>", "double NaN payloads");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<16, 5>>(reportTestCases), "dbns<16,5>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<dbns<16, 5>>(reportTestCases), "dbns<16,5>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<8, 3>>(reportTestCases), "dbns<8,3>", "binary16 NaN space");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<10, 4>>(reportTestCases), "dbns<10,4>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<dbns<8, 3>>(reportTestCases), "dbns<8,3>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<dbns<10, 4>>(reportTestCases), "dbns<10,4>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<dbns<8, 3>>(reportTestCases), "dbns<8,3>", "double NaN payloads");
-	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<dbns<10, 4>>(reportTestCases), "dbns<10,4>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyDoublePayloads<dbns<8, 3>>(reportTestCases), "dbns<8,3>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyDoublePayloads<dbns<10, 4>>(reportTestCases), "dbns<10,4>", "double NaN payloads");
 #endif
 
 #if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<10, 3>>(reportTestCases), "dbns<10,3>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<dbns<10, 3>>(reportTestCases), "dbns<10,3>", "binary16 NaN space");
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/static/logarithmic/dbns/conversion/nan_conversion.cpp
+++ b/static/logarithmic/dbns/conversion/nan_conversion.cpp
@@ -1,0 +1,176 @@
+// nan_conversion.cpp: verify that every IEEE-754 NaN encoding converts to an dbns NaN
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// dbns carried the same NaN classification defect cfloat did (issue #1303): the
+// conversion compared the source fraction for equality against three specific
+// payloads, so every other payload -- including the canonical signalling 0x1 --
+// missed all three and fell through to the numeric path, where a NaN silently
+// became a finite value or an infinity.
+//
+// The source values here are built as BIT PATTERNS and handed over through
+// sw::bit_cast, never through std::nan or a computed double.  Building a
+// signaling NaN in a double and passing it in reproduces on Linux and macOS but
+// NOT on Windows, where the payload is quieted before it reaches the conversion
+// and the obvious test passes while the bug remains.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <cstdint>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/number/dbns/dbns.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// binary16 pattern -> float pattern, by moving bits: exponent all ones stays all
+// ones and the 10-bit fraction shifts up 13 places, so the quiet bit stays the
+// quiet bit and a non-zero payload stays non-zero.
+constexpr uint32_t half_bits_to_float_bits(uint16_t h) noexcept {
+	const uint32_t sign = static_cast<uint32_t>(h >> 15) << 31;
+	const uint32_t exp  = static_cast<uint32_t>((h >> 10) & 0x1Fu);
+	const uint32_t frac = static_cast<uint32_t>(h & 0x3FFu);
+	if (exp == 0x1Fu) return sign | 0x7F800000u | (frac << 13);
+	if (exp == 0u) {
+		if (frac == 0u) return sign;
+		uint32_t f = frac, e = 0;
+		while ((f & 0x400u) == 0u) { f <<= 1; ++e; }
+		f &= 0x3FFu;
+		return sign | ((127u - 15u - e) << 23) | (f << 13);
+	}
+	return sign | ((exp + 127u - 15u) << 23) | (frac << 13);
+}
+
+template<typename Number>
+int VerifyBinary16NaNSpace(bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	long nans = 0;
+
+	for (uint32_t i = 0; i < 0x10000u; ++i) {
+		const uint16_t h = static_cast<uint16_t>(i);
+		if (((h & 0x7C00u) != 0x7C00u) || ((h & 0x03FFu) == 0u)) continue;   // NaNs only
+		++nans;
+		const Number v(sw::bit_cast<float>(half_bits_to_float_bits(h)));
+		if (!v.isnan()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL binary16 NaN 0x" << std::hex << h << std::dec
+				          << " did not convert to a NaN\n";
+			}
+		}
+	}
+	if (nans != 2046) {
+		++nrOfFailedTests;
+		std::cout << "FAIL binary16 sweep covered " << nans << " NaNs, expected 2046\n";
+	}
+	return nrOfFailedTests;
+}
+
+// A handful of double-sourced payloads, including the two the old code happened
+// to recognise, so the contrast is on the record.
+template<typename Number>
+int VerifyDoublePayloads(bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	const uint64_t payloads[] = {
+		0x7FF0000000000001ull,   // signalling, canonical payload 1
+		0x7FF0004000000000ull,   // signalling, other payload
+		0x7FF4000000000000ull,   // the platform's signalling pattern
+		0x7FF8000000000000ull,   // the platform's quiet pattern
+		0x7FFFFFFFFFFFFFFFull,   // all payload bits set
+		0xFFF0000000000001ull,   // negative signalling
+		0xFFF8000000000000ull,   // negative quiet
+	};
+	for (uint64_t bits : payloads) {
+		const Number v(sw::bit_cast<double>(bits));
+		if (!v.isnan()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL double NaN 0x" << std::hex << bits << std::dec
+				          << " did not convert to a NaN\n";
+			}
+		}
+	}
+	// The infinities must stay OUT of the NaN class.  This type has no infinity
+	// encoding -- setinf() saturates to maxpos / maxneg by design, and isinf() is
+	// therefore always false -- so the invariant worth asserting is that an
+	// infinite input saturates rather than being swept into a NaN, which is what a
+	// classification that mixed the two would do.
+	{
+		const Number pos(sw::bit_cast<double>(0x7FF0000000000000ull));
+		const Number neg(sw::bit_cast<double>(0xFFF0000000000000ull));
+		const Number maxpos(sw::universal::SpecificValue::maxpos);
+		const Number maxneg(sw::universal::SpecificValue::maxneg);
+		if (pos.isnan() || neg.isnan()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL an infinity converted into the NaN class\n";
+		}
+		if (pos != maxpos || neg != maxneg) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL an infinity did not saturate to maxpos / maxneg\n";
+		}
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "dbns NaN conversion validation";
+	std::string test_tag    = "nan conversion";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<dbns<16, 5>>(true), "dbns<16,5>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<16, 5>>(reportTestCases), "dbns<16,5>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<8, 3>>(reportTestCases), "dbns<8,3>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<10, 4>>(reportTestCases), "dbns<10,4>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<dbns<8, 3>>(reportTestCases), "dbns<8,3>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<dbns<10, 4>>(reportTestCases), "dbns<10,4>", "double NaN payloads");
+#endif
+
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<dbns<10, 3>>(reportTestCases), "dbns<10,3>", "binary16 NaN space");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/logarithmic/lns/conversion/nan_conversion.cpp
+++ b/static/logarithmic/lns/conversion/nan_conversion.cpp
@@ -83,6 +83,10 @@ int VerifyDoublePayloads(bool reportTestCases) {
 		0xFFF0000000000001ull,   // negative signalling
 		0xFFF8000000000000ull,   // negative quiet
 	};
+	// No quiet / signalling assertion here, unlike cfloat's and blocktriple's
+	// suites: lns has a SINGLE NaN encoding and isnan() takes no kind, so the
+	// source's quiet bit has nowhere to land and there is nothing to check.  Saying
+	// so beats adding an assertion that could only ever be vacuous.
 	for (uint64_t bits : payloads) {
 		const Number v(sw::bit_cast<double>(bits));
 		if (!v.isnan()) {
@@ -142,21 +146,27 @@ try {
 
 #if REGRESSION_LEVEL_1
 	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<lns<16, 5>>(true), "lns<16,5>", "double NaN payloads");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<16, 5>>(reportTestCases), "lns<16,5>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<lns<16, 5>>(reportTestCases), "lns<16,5>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<8, 3>>(reportTestCases), "lns<8,3>", "binary16 NaN space");
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<32, 8>>(reportTestCases), "lns<32,8>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<lns<8, 3>>(reportTestCases), "lns<8,3>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<lns<32, 8>>(reportTestCases), "lns<32,8>", "binary16 NaN space");
 #endif
 
 #if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<lns<32, 8>>(reportTestCases), "lns<32,8>", "double NaN payloads");
-	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<lns<64, 11>>(reportTestCases), "lns<64,11>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyDoublePayloads<lns<32, 8>>(reportTestCases), "lns<32,8>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyDoublePayloads<lns<64, 11>>(reportTestCases), "lns<64,11>", "double NaN payloads");
 #endif
 
 #if REGRESSION_LEVEL_4
-	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<64, 11>>(reportTestCases), "lns<64,11>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(
+		VerifyBinary16NaNSpace<lns<64, 11>>(reportTestCases), "lns<64,11>", "binary16 NaN space");
 #endif
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);

--- a/static/logarithmic/lns/conversion/nan_conversion.cpp
+++ b/static/logarithmic/lns/conversion/nan_conversion.cpp
@@ -1,0 +1,176 @@
+// nan_conversion.cpp: verify that every IEEE-754 NaN encoding converts to an lns NaN
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// lns carried the same NaN classification defect cfloat did (issue #1303): the
+// conversion compared the source fraction for equality against three specific
+// payloads, so every other payload -- including the canonical signalling 0x1 --
+// missed all three and fell through to the numeric path, where a NaN silently
+// became a finite value or an infinity.
+//
+// The source values here are built as BIT PATTERNS and handed over through
+// sw::bit_cast, never through std::nan or a computed double.  Building a
+// signaling NaN in a double and passing it in reproduces on Linux and macOS but
+// NOT on Windows, where the payload is quieted before it reaches the conversion
+// and the obvious test passes while the bug remains.
+#include <universal/utility/directives.hpp>
+
+#include <iostream>
+#include <cstdint>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/number/lns/lns.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+// binary16 pattern -> float pattern, by moving bits: exponent all ones stays all
+// ones and the 10-bit fraction shifts up 13 places, so the quiet bit stays the
+// quiet bit and a non-zero payload stays non-zero.
+constexpr uint32_t half_bits_to_float_bits(uint16_t h) noexcept {
+	const uint32_t sign = static_cast<uint32_t>(h >> 15) << 31;
+	const uint32_t exp  = static_cast<uint32_t>((h >> 10) & 0x1Fu);
+	const uint32_t frac = static_cast<uint32_t>(h & 0x3FFu);
+	if (exp == 0x1Fu) return sign | 0x7F800000u | (frac << 13);
+	if (exp == 0u) {
+		if (frac == 0u) return sign;
+		uint32_t f = frac, e = 0;
+		while ((f & 0x400u) == 0u) { f <<= 1; ++e; }
+		f &= 0x3FFu;
+		return sign | ((127u - 15u - e) << 23) | (f << 13);
+	}
+	return sign | ((exp + 127u - 15u) << 23) | (frac << 13);
+}
+
+template<typename Number>
+int VerifyBinary16NaNSpace(bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	long nans = 0;
+
+	for (uint32_t i = 0; i < 0x10000u; ++i) {
+		const uint16_t h = static_cast<uint16_t>(i);
+		if (((h & 0x7C00u) != 0x7C00u) || ((h & 0x03FFu) == 0u)) continue;   // NaNs only
+		++nans;
+		const Number v(sw::bit_cast<float>(half_bits_to_float_bits(h)));
+		if (!v.isnan()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL binary16 NaN 0x" << std::hex << h << std::dec
+				          << " did not convert to a NaN\n";
+			}
+		}
+	}
+	if (nans != 2046) {
+		++nrOfFailedTests;
+		std::cout << "FAIL binary16 sweep covered " << nans << " NaNs, expected 2046\n";
+	}
+	return nrOfFailedTests;
+}
+
+// A handful of double-sourced payloads, including the two the old code happened
+// to recognise, so the contrast is on the record.
+template<typename Number>
+int VerifyDoublePayloads(bool reportTestCases) {
+	int nrOfFailedTests = 0;
+	const uint64_t payloads[] = {
+		0x7FF0000000000001ull,   // signalling, canonical payload 1
+		0x7FF0004000000000ull,   // signalling, other payload
+		0x7FF4000000000000ull,   // the platform's signalling pattern
+		0x7FF8000000000000ull,   // the platform's quiet pattern
+		0x7FFFFFFFFFFFFFFFull,   // all payload bits set
+		0xFFF0000000000001ull,   // negative signalling
+		0xFFF8000000000000ull,   // negative quiet
+	};
+	for (uint64_t bits : payloads) {
+		const Number v(sw::bit_cast<double>(bits));
+		if (!v.isnan()) {
+			++nrOfFailedTests;
+			if (reportTestCases) {
+				std::cout << "FAIL double NaN 0x" << std::hex << bits << std::dec
+				          << " did not convert to a NaN\n";
+			}
+		}
+	}
+	// The infinities must stay OUT of the NaN class.  This type has no infinity
+	// encoding -- setinf() saturates to maxpos / maxneg by design, and isinf() is
+	// therefore always false -- so the invariant worth asserting is that an
+	// infinite input saturates rather than being swept into a NaN, which is what a
+	// classification that mixed the two would do.
+	{
+		const Number pos(sw::bit_cast<double>(0x7FF0000000000000ull));
+		const Number neg(sw::bit_cast<double>(0xFFF0000000000000ull));
+		const Number maxpos(sw::universal::SpecificValue::maxpos);
+		const Number maxneg(sw::universal::SpecificValue::maxneg);
+		if (pos.isnan() || neg.isnan()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL an infinity converted into the NaN class\n";
+		}
+		if (pos != maxpos || neg != maxneg) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cout << "FAIL an infinity did not saturate to maxpos / maxneg\n";
+		}
+	}
+	return nrOfFailedTests;
+}
+
+} // anonymous namespace
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "lns NaN conversion validation";
+	std::string test_tag    = "nan conversion";
+	bool reportTestCases    = false;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<lns<16, 5>>(true), "lns<16,5>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<16, 5>>(reportTestCases), "lns<16,5>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<8, 3>>(reportTestCases), "lns<8,3>", "binary16 NaN space");
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<32, 8>>(reportTestCases), "lns<32,8>", "binary16 NaN space");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<lns<32, 8>>(reportTestCases), "lns<32,8>", "double NaN payloads");
+	nrOfFailedTestCases += ReportTestResult(VerifyDoublePayloads<lns<64, 11>>(reportTestCases), "lns<64,11>", "double NaN payloads");
+#endif
+
+#if REGRESSION_LEVEL_4
+	nrOfFailedTestCases += ReportTestResult(VerifyBinary16NaNSpace<lns<64, 11>>(reportTestCases), "lns<64,11>", "binary16 NaN space");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
Resolves #1303.

## What was wrong

Converting a signaling NaN into a narrower `cfloat` produced **infinity**. The classification compared the source fraction for **equality** against three specific payloads — the platform's canonical quiet and signalling patterns and their union — so every other payload, including the canonical signalling `0x1`, missed all three, fell through to the numeric path, and was projected to infinity by the out-of-range logic.

`std::nan("")` happens to be one of the three. That is why the existing coverage never saw it.

So the discriminator was not the quiet bit, as the issue reasonably inferred from its samples — it was exact equality against three magic values.

## Scope: four types, six copies

The same block had been copy-pasted six times. All six now use IEEE-754's rule: exponent all ones with a **zero** fraction is infinity, with **any** non-zero fraction is a NaN, and the fraction's MSB — the quiet bit, named by the platform's own `qnanmask` — decides which kind.

| type | symptom before | note |
|---|---|---|
| `cfloat` | sNaN -> **+inf** | three copies, now one `convert_ieee754_special()` helper |
| `lns` | sNaN -> finite value | |
| `dbns` | sNaN -> finite value | |
| `blocktriple` | sNaN -> finite value | **the consequential one** — see below |

`blocktriple` is what the arithmetic paths run on, so a NaN operand entering an `add` or a `multiply` was not merely mis-encoded, it **stopped being a NaN at all** and stopped propagating. Nothing in the cfloat arithmetic suites covered a NaN operand, so there was no guard on it whatever.

Two of these extensions were approved after I confirmed the symptom; `blocktriple` I found afterwards by grepping for the pattern and verified before touching.

## A correction to the issue's table

`cfloat<64,11>` is listed as healthy. It is — **from a `double`**, because the same-width path copies the bits verbatim and the result happens to satisfy `isnan()`. From a `float` source it takes the general path and is affected like the rest. The mutation run below shows the same accident for `cfloat<32,8>`, which still passes with the old logic restored.

## Payload is not preserved, deliberately

Only the quiet bit crosses. It cannot be otherwise in general — a narrowing conversion has nowhere to put 52 bits of diagnostic in a 10-bit fraction — and attempting it is what produced this defect, since a truncated payload can land on the neighbouring infinity encoding. `cfloat`'s inf encoding is not IEEE's either, so specials are remapped on every path, including the same-width ones where finite values copy across verbatim.

## Tests, and the platform trap they are built to survive

Per the note on the issue: a signaling NaN constructed in a `double` is quieted before it reaches the conversion on Windows, so the obvious test **passes on MSVC while the bug remains**. Sources here are bit patterns handed through `sw::bit_cast`, and cfloat's suite additionally drives the classification through integer fields that never enter a floating-point register — that layer cannot be made vacuous by any platform's sNaN handling.

Each suite walks all 2046 binary16 NaN encodings, the C++ equivalent of the downstream numpy repro.

Confirmed by mutation — restoring the old matching:

| suite | failures |
|---|---|
| cfloat, binary16 NaN space | **2042** (matching the 2040 measured downstream) |
| blocktriple, binary16 NaN space | **2044**, with the telling `isnan=0 isinf=0` |
| cfloat, integer classification | 101 |

## Not fixed here, flagged for a decision

`lns` and `dbns` have **no infinity encoding**: `setinf()` saturates to maxpos and `isinf()` is always false, so `lns<16,5>(+inf)` is indistinguishable from a finite overflow. Verified against the pristine tree, so it predates this change. It reads as deliberate for a logarithmic format, and the suites assert it as the invariant rather than treating it as a defect — but it is the same shape as #1303 and may deserve its own issue.

## Testing

- gcc and clang, Release, cfloat + lns + dbns + internals: **232/232**, zero warnings
- ASCII guard clean
- rebased onto current `main` and re-verified on the new base

Resolves #1303

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IEEE-754 conversion to correctly recognize all infinity and NaN encodings.
  - Previously unrecognized NaN payloads are now consistently classified as NaN across supported numeric formats.
  - Cfloat and block-based conversions now determine signaling versus quiet NaNs from the IEEE-754 quiet bit.
  - Infinity conversions remain distinct from NaN conversions across logarithmic and block-based formats.
  - Corrected signaling-NaN handling on supported Microsoft compiler environments.

- **Tests**
  - Added comprehensive regression coverage for binary16 and double-precision NaN and infinity patterns across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->