### PR TITLE
feat(takum): generate encoding tables for the logarithmic takum

### DIFF
--- a/education/tables/takum_logs.cpp
+++ b/education/tables/takum_logs.cpp
@@ -1,0 +1,116 @@
+// takum_logs.cpp: generates encoding tables of logarithmic takum configurations
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The companion to takums.cpp.  The two variants share the (S, D, R, C, M) bit
+// layout exactly, so reading the two tables side by side is the clearest way to
+// see what the value map alone changes: identical encodings, identical sign,
+// direction, regime and characteristic columns, and completely different values.
+//
+// The last column differs by design.  A linear takum's value is (1 + f) * 2^c, so
+// its base-2 scale is the natural companion; a logarithmic takum's value is
+// sqrt(e)^l, and l -- the quantity the encoding actually carries -- is printed
+// instead.  takum_log::scale() exists and is base 2 for library-wide consistency,
+// but it is a converted quantity and would be the less honest column here.
+#include <universal/utility/directives.hpp>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+
+// Configure the takum template environment
+#include <universal/number/takum/takum.hpp>
+#include <universal/number/takum/table.hpp>
+
+#define MANUAL_TESTING 0
+
+int main(int argc, char** argv)
+try {
+	using namespace sw::universal;
+
+	// Usage: edu_tables_takum_logs [-csv]
+	bool csv = false;
+	if (argc == 2) {
+		std::string arg(argv[1]);
+		if (arg == "-csv") {
+			csv = true;
+		}
+		else {
+			std::cerr << "Usage: " << argv[0] << " [-csv]\n";
+			return EXIT_FAILURE;
+		}
+	}
+	else if (argc > 2) {
+		std::cerr << "Usage: " << argv[0] << " [-csv]\n";
+		return EXIT_FAILURE;
+	}
+	std::cout << "Generate value tables for logarithmic takum number system configurations\n";
+
+#if MANUAL_TESTING
+
+	GenerateTakumLogTable<6, 3>(std::cout, csv);
+	GenerateTakumLogTable<8, 3>(std::cout, csv);
+
+#else // !MANUAL_TESTING
+
+	std::ofstream ostr;
+	std::string filename, extension;
+	extension = (csv ? ".csv" : ".txt");
+	filename = std::string("takum_logs") + extension;
+	ostr.open(filename);
+	if (!ostr) {
+		std::cerr << "Error: could not open " << filename << " for writing\n";
+		return EXIT_FAILURE;
+	}
+
+	// The same configurations takums.cpp emits, so the two files line up row for row.
+
+	// Standard takum configurations (rbits = 3, the paper's default)
+	// Small configurations: 6, 7, 8 bits
+	GenerateTakumLogTable<6, 3>(ostr, csv);
+	GenerateTakumLogTable<7, 3>(ostr, csv);
+	GenerateTakumLogTable<8, 3>(ostr, csv);
+
+	// Medium configurations: 10, 12 bits
+	GenerateTakumLogTable<10, 3>(ostr, csv);
+	GenerateTakumLogTable<12, 3>(ostr, csv);
+
+	// Exploration: varying regime widths at 8 bits
+	// rbits=2: narrower range, more mantissa bits
+	GenerateTakumLogTable<8, 2>(ostr, csv);
+	// rbits=4: wider range, fewer mantissa bits
+	GenerateTakumLogTable<8, 4>(ostr, csv);
+
+	ostr.close();
+	std::cout << "Created value tables for takum_log<nbits, rbits> in " << filename << '\n';
+
+#endif
+
+	return EXIT_SUCCESS;
+}
+catch (char const* msg) {
+	std::cerr << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Uncaught universal arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Uncaught universal internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Uncaught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::exception& err) {
+	std::cerr << "Uncaught exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/takum/table.hpp
+++ b/include/sw/universal/number/takum/table.hpp
@@ -8,15 +8,36 @@
 
 namespace sw { namespace universal {
 
-// generate a full binary representation table for a given takum configuration
-template<unsigned nbits, unsigned rbits = 3, typename BlockType = std::uint8_t>
-void GenerateTakumTable(std::ostream& ostr, bool csvFormat = false) {
+// Generate a full binary representation table for a takum or takum_log
+// configuration.
+//
+// The two variants share the (S, D, R, C, M) layout down to the bit, so the
+// table shares every column but the last.  A linear takum's value is
+// (1 + f) * 2^c, and its base-2 scale is the natural companion column.  A
+// logarithmic takum's value is sqrt(e)^l, where l is what the encoding actually
+// carries; its scale() is a converted quantity and would be the less honest
+// column of the two, so the logarithmic value is printed instead.
+template<typename TakumType>
+void GenerateTakumVariantTable(std::ostream& ostr, bool csvFormat = false) {
+	constexpr bool logarithmic = is_takum_log<TakumType>;
+	constexpr unsigned nbits = TakumType::nbits;
+	constexpr unsigned rbits = TakumType::rbits;
+	const char* typeName = (logarithmic ? "takum_log<" : "takum<");
+	const char* lastLabel = (logarithmic ? "l" : "scale");
+
+	// if constexpr, not a ternary: both arms of a ternary are compiled, and only
+	// one of the two variants has each accessor.
+	auto lastColumn = [](const TakumType& x) -> double {
+		if constexpr (logarithmic) return x.logarithmic_value();
+		else return static_cast<double>(x.scale());
+	};
+
 	const unsigned size = (1u << nbits);
-	sw::universal::takum<nbits, rbits, BlockType> v;
+	TakumType v;
 
 	if (csvFormat) {
-		ostr << "\"Generate Value table for a takum<" << nbits << "," << rbits << "> in CSV format\"" << '\n';
-		ostr << "#, Binary, sign, direction, regime, characteristic, scale, value\n";
+		ostr << "\"Generate Value table for a " << typeName << nbits << "," << rbits << "> in CSV format\"" << '\n';
+		ostr << "#, Binary, sign, direction, regime, characteristic, " << lastLabel << ", value\n";
 		for (unsigned i = 0; i < size; i++) {
 			v.setbits(i);
 			if (v.isnar()) {
@@ -34,7 +55,7 @@ void GenerateTakumTable(std::ostream& ostr, bool csvFormat = false) {
 					<< v.direct() << ","
 					<< v.regime() << ","
 					<< v.characteristic() << ","
-					<< v.scale() << ","
+					<< lastColumn(v) << ","
 					<< v
 					<< '\n';
 			}
@@ -42,7 +63,7 @@ void GenerateTakumTable(std::ostream& ostr, bool csvFormat = false) {
 		ostr << '\n';
 	}
 	else {
-		ostr << "Generate Value table for a takum<" << nbits << "," << rbits << "> in TXT format" << '\n';
+		ostr << "Generate Value table for a " << typeName << nbits << "," << rbits << "> in TXT format" << '\n';
 
 		const unsigned index_column = 5;
 		const unsigned bin_column = nbits + 8;  // accommodate dots in to_binary
@@ -59,7 +80,7 @@ void GenerateTakumTable(std::ostream& ostr, bool csvFormat = false) {
 			<< std::setw(dir_column) << "dir"
 			<< std::setw(regime_column) << "regime"
 			<< std::setw(char_column) << "char"
-			<< std::setw(scale_column) << "scale"
+			<< std::setw(scale_column) << lastLabel
 			<< std::setw(value_column) << "value"
 			<< '\n';
 		for (unsigned i = 0; i < size; i++) {
@@ -82,12 +103,24 @@ void GenerateTakumTable(std::ostream& ostr, bool csvFormat = false) {
 					<< std::setw(dir_column) << v.direct()
 					<< std::setw(regime_column) << v.regime()
 					<< std::setw(char_column) << v.characteristic()
-					<< std::setw(scale_column) << v.scale()
+					<< std::setw(scale_column) << lastColumn(v)
 					<< std::setw(value_column) << v
 					<< '\n';
 			}
 		}
 	}
+}
+
+// The original entry point, unchanged for every existing caller.
+template<unsigned nbits, unsigned rbits = 3, typename BlockType = std::uint8_t>
+void GenerateTakumTable(std::ostream& ostr, bool csvFormat = false) {
+	GenerateTakumVariantTable< takum<nbits, rbits, BlockType> >(ostr, csvFormat);
+}
+
+// ... and its logarithmic counterpart.
+template<unsigned nbits, unsigned rbits = 3, typename BlockType = std::uint8_t>
+void GenerateTakumLogTable(std::ostream& ostr, bool csvFormat = false) {
+	GenerateTakumVariantTable< takum_log<nbits, rbits, BlockType> >(ostr, csvFormat);
 }
 
 }} // namespace sw::universal


### PR DESCRIPTION
The last unchecked task on #1297.

Everything else on that epic has landed — shared codec (#1299), the type itself (#1304), numeric_limits, traits, manipulators, mathlib (#1305), constant tables (#1306), cross-conversion (#1309), the five regression suites, and ucalc registration (#1310). I audited the checklist against the tree rather than against commit messages; the table generator was the one genuine gap, with no `takum_log` anywhere under `education/`.

## Change

`table.hpp`'s generator is now templated on the takum type. `GenerateTakumTable` is kept as a thin wrapper with its original signature, so every existing caller is untouched, and `GenerateTakumLogTable` is added alongside it.

`education/tables/takum_logs.cpp` emits the same seven configurations `takums.cpp` does, so the two files line up row for row:

```
takum<6,3>      #1  0b0.0.000.1.  char -191  scale -191   3.18618e-58
takum_log<6,3>  #1  0b0.0.000.1.  char -191      l -191   3.34871e-42
```

Identical encoding, identical sign / direction / regime / characteristic — entirely different value. Read side by side, the two tables are the clearest statement of what #1297 argued for in drawing the type boundary.

## Two deliberate choices

**The last column differs.** A linear takum's value is `(1 + f) * 2^c`, so its base-2 `scale` is the natural companion column. A logarithmic takum's value is `sqrt(e)^l`, and `l` — what the encoding actually carries — is printed instead. `takum_log::scale()` does exist and is base 2 for library-wide consistency, but it is a *converted* quantity and would be the less honest column here.

**`if constexpr`, not a ternary.** Both arms of a ternary are compiled and only one variant has each accessor, so the ternary form broke the linear generator. Caught at build time, noted in the code.

## Testing

- gcc and clang: both generators build clean, zero warnings
- CMake picks up the new target automatically (glob-wired); `edu_tables_takums` and `edu_tables_takum_logs` both build
- Regression unaffected: cfloat/lns/dbns/internals 232/232, takum + takum_log 21/21
- ASCII guard clean
- Output spot-checked against the value maps: `2^-191 = 3.19e-58` and `sqrt(e)^-191 = e^-95.5 = 3.35e-42`

Closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)