### PR TITLE
fix(microfloat): make e4m3 conversion bit-correct for OCP OFP8

### DIFF
--- a/docs/number-systems/microfloat.md
+++ b/docs/number-systems/microfloat.md
@@ -25,8 +25,33 @@ But not all 4-bit and 8-bit formats are the same. The OCP (Open Compute Project)
 | `e2m1` | `microfloat<4,2,false,false,true>` | [0.5, 6.0] | 1 fraction bit | Minimal storage, maximum compression |
 | `e2m3` | `microfloat<6,2,false,false,true>` | [0.0625, 7.5] | 3 fraction bits | More fraction bits |
 | `e3m2` | `microfloat<6,3,false,false,true>` | [0.03125, 28] | 2 fraction bits | More exponent range |
-| `e4m3` | `microfloat<8,4,false,true,true>` | [~0.002, 240] | 3 fraction bits | Balanced; NVIDIA FP8 |
-| `e5m2` | `microfloat<8,5,true,true,false>` | [~0.001, 57344] | 2 fraction bits | Wide range; non-saturating |
+| `e4m3` (= `e4m3fn`) | `microfloat<8,4,false,true,false>` | [~0.002, 448] | 3 fraction bits | Balanced; the OCP OFP8 FP8 format |
+| `e4m3_saturating` | `microfloat<8,4,false,true,true>` | [~0.002, 448] | 3 fraction bits | Same encoding, clamps on overflow; used by MX and NVFP4 blocks |
+| `e5m2` | `microfloat<8,5,true,true,false>` | [~0.001, 57344] | 2 fraction bits | Wide range; IEEE-like, has infinity |
+
+### The two e4m3 conversion policies
+
+`e4m3` and `e4m3_saturating` are the same encoding -- no infinity, NaN at
+`S.1111.111`, maxpos 448 at `0x7E` -- and all 256 patterns decode identically.
+They differ only in what a conversion from a wider type does with a value past
+maxpos:
+
+| source | `e4m3` (OCP) | `e4m3_saturating` |
+|--------|--------------|-------------------|
+| 464.0 (the round-to-even tie) | `0x7E` (448) | `0x7E` (448) |
+| 500.0 | `0x7F` (NaN) | `0x7E` (448) |
+| `-inf` | `0xFF` (-NaN) | `0xFE` (-448) |
+| `-NaN` | `0xFF` | `0xFF` |
+
+`e4m3` follows the [OCP 8-bit Floating Point
+Specification](https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-12-01-pdf-1),
+which is what `ml_dtypes.float8_e4m3fn`, JAX and PyTorch implement: the format
+has no infinity, so overflow has to signal as NaN, and the sign is preserved.
+
+`e4m3_saturating` is what block quantization needs. MX and NVFP4 both scale the
+block maximum into a range whose top sits above 448, so the largest element of a
+block routinely lands past maxpos; clipping it is right, and poisoning the block
+with a NaN is not. `mxfp8` and the NVFP4 block scale use this policy.
 
 ### Key Properties
 
@@ -45,7 +70,7 @@ A microfloat follows the standard sign-exponent-fraction layout:
 ```
 
 The key differences from standard IEEE-754 are:
-1. **Saturation**: when `isSaturating=true`, overflow clamps to maxpos instead of producing infinity
+1. **Overflow policy**: a value that rounds past maxpos becomes maxpos when `isSaturating=true`, infinity when the format has one, and NaN when it has a NaN but no infinity (the OCP rule). A format with none of the three has only maxpos to offer.
 2. **No infinity/NaN**: when `hasInf=false` and `hasNaN=false`, all bit patterns encode valid numbers
 3. **Block scaling**: microfloats are typically not used alone -- they are elements in an `mxblock` or `nvblock`, where a shared scale factor extends their dynamic range
 
@@ -107,11 +132,11 @@ for (float w : fp32_weights) {
 #include <universal/number/mxfloat/mxfloat.hpp>
 
 // MX block: 32 e4m3 elements sharing one e8m0 scale
-mxblock<e4m3, 32> block;
+mxblock<e4m3_saturating, 32> block;   // == mxfp8
 
 // NVIDIA block: 16 e2m1 elements sharing one e4m3 scale
 #include <universal/number/nvblock/nvblock.hpp>
-nvblock<e2m1, 16, e4m3> nv_block;
+nvblock<e2m1, 16, e4m3_saturating> nv_block;   // == nvfp4
 ```
 
 ## Problems It Solves

--- a/include/sw/universal/number/microfloat/manipulators.hpp
+++ b/include/sw/universal/number/microfloat/manipulators.hpp
@@ -19,7 +19,8 @@ namespace sw { namespace universal {
 		if constexpr (nbits == 4 && es == 2 && !hasInf && !hasNaN && isSaturating) return "e2m1";
 		if constexpr (nbits == 6 && es == 2 && !hasInf && !hasNaN && isSaturating) return "e2m3";
 		if constexpr (nbits == 6 && es == 3 && !hasInf && !hasNaN && isSaturating) return "e3m2";
-		if constexpr (nbits == 8 && es == 4 && !hasInf && hasNaN && isSaturating) return "e4m3";
+		if constexpr (nbits == 8 && es == 4 && !hasInf && hasNaN && !isSaturating) return "e4m3";
+		if constexpr (nbits == 8 && es == 4 && !hasInf && hasNaN && isSaturating) return "e4m3_saturating";
 		if constexpr (nbits == 8 && es == 5 && hasInf && hasNaN && !isSaturating) return "e5m2";
 		// Generic fallback
 		std::stringstream s;

--- a/include/sw/universal/number/microfloat/microfloat_fwd.hpp
+++ b/include/sw/universal/number/microfloat/microfloat_fwd.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <type_traits>
 
 namespace sw { namespace universal {
 
@@ -16,7 +17,32 @@ class microfloat;
 using e2m1 = microfloat<4, 2, false, false, true>;
 using e2m3 = microfloat<6, 2, false, false, true>;
 using e3m2 = microfloat<6, 3, false, false, true>;
-using e4m3 = microfloat<8, 4, false, true,  true>;
+
+// e4m3 comes in two conversion policies over the same encoding.  The encoding
+// is the OCP OFP8 E4M3 one either way -- no infinity, NaN at S.1111.111,
+// maxpos 448 at 0x7E -- and all 256 patterns decode identically.  They differ
+// only in what a conversion from a wider type does with a value beyond maxpos:
+//
+//   e4m3fn          NaN, with the sign preserved.  This is the OCP 8-bit
+//                   Floating Point Specification, and what ml_dtypes, JAX and
+//                   PyTorch call float8_e4m3fn ("fn" = finite: no infinities,
+//                   NaN signals overflow).  e4m3 names this one, because that
+//                   is what the ecosystem reads e4m3 to mean.
+//   e4m3_saturating clamp to maxpos/maxneg.  This is what block quantization
+//                   wants: MX and NVFP4 both scale amax to just under 2^9
+//                   against a maxpos of 448, so the largest element of a block
+//                   routinely lands past the top of the range and must clip
+//                   rather than poison the block with a NaN.
+using e4m3fn          = microfloat<8, 4, false, true,  false>;
+using e4m3_saturating = microfloat<8, 4, false, true,  true>;
+using e4m3            = e4m3fn;
+
 using e5m2 = microfloat<8, 5, true,  true,  false>;
+
+// true for either e4m3 conversion policy: both carry the OCP E4M3 encoding,
+// so anything that keys off the encoding rather than the overflow behavior
+// (a name, a max element exponent, a bit layout) wants both.
+template<typename T>
+constexpr bool is_e4m3_encoding = std::is_same_v<T, e4m3fn> || std::is_same_v<T, e4m3_saturating>;
 
 }}  // namespace sw::universal

--- a/include/sw/universal/number/microfloat/microfloat_impl.hpp
+++ b/include/sw/universal/number/microfloat/microfloat_impl.hpp
@@ -38,6 +38,15 @@ class microfloat {
 	static_assert(_es >= 1, "need at least 1 exponent bit");
 
 	// HELPER methods
+
+	// the IEEE-like infinity encoding: all-ones exponent, zero fraction.
+	// Only meaningful when hasInf; setinf() and setoverflow() both reach it.
+	constexpr void set_infinite_encoding(bool sign) noexcept {
+		_bits = exponent_mask;
+		if (sign) _bits |= sign_mask;
+		_bits &= bitmask;
+	}
+
 	template<typename SignedInt,
 		typename = typename std::enable_if< std::is_integral<SignedInt>::value, SignedInt >::type>
 	constexpr microfloat& convert_signed(SignedInt v) noexcept {
@@ -276,19 +285,53 @@ public:
 		_bits &= bitmask;
 	}
 
-	constexpr void setinf(bool sign = false) noexcept {
-		if constexpr (hasInf) {
-			// e5m2 (IEEE-like): all-ones exponent, zero fraction
-			_bits = exponent_mask;
-			if (sign) _bits |= sign_mask;
-			_bits &= bitmask;
+	// set the NaN encoding, carrying the sign of the source.  Both e4m3 and
+	// e5m2 have signed NaN encodings, and OCP OFP8 requires a NaN produced by
+	// conversion to keep its sign: -NaN must land on 0xFF, not 0x7F.
+	constexpr void setnan(int NaNType, bool sign) noexcept {
+		setnan(NaNType);
+		if constexpr (hasNaN) {
+			if (sign) _bits = static_cast<uint8_t>((_bits | sign_mask) & bitmask);
 		}
-		else if constexpr (isSaturating) {
-			// saturate to maxpos/maxneg
+	}
+
+	// The overflow policy, in one place.  The same decision is needed for a
+	// finite value that rounds past maxpos and for an infinite source in a
+	// format that has no infinity, and the three copies it used to be written
+	// in did not agree (universal#1302):
+	//
+	//   isSaturating  -> maxpos / maxneg
+	//   hasInf        -> +-inf
+	//   hasNaN        -> NaN with the sign preserved.  This is the OCP OFP8
+	//                    E4M3 rule ("fn" = finite, NaN signals overflow), and
+	//                    it is what e4m3fn / JAX / PyTorch / ml_dtypes do.
+	//   neither       -> maxpos / maxneg, the only thing the format can say.
+	//
+	// The last case used to be zero, which turned an overflow into the most
+	// benign value in the format.
+	constexpr void setoverflow(bool sign) noexcept {
+		if constexpr (isSaturating) {
 			if (sign) maxneg(); else maxpos();
 		}
+		else if constexpr (hasInf) {
+			set_infinite_encoding(sign);
+		}
+		else if constexpr (hasNaN) {
+			setnan(NAN_TYPE_QUIET, sign);
+		}
 		else {
-			_bits = 0;
+			if (sign) maxneg(); else maxpos();
+		}
+	}
+
+	constexpr void setinf(bool sign = false) noexcept {
+		if constexpr (hasInf) {
+			set_infinite_encoding(sign);
+		}
+		else {
+			// no infinity in this format: say whatever it can say about a
+			// value beyond maxpos
+			setoverflow(sign);
 		}
 	}
 
@@ -506,38 +549,43 @@ public:
 	//                     plus cx_ldexp for the subnormal divisor
 	// Both paths converge on the same RNE-rounded encoding.
 	constexpr void from_float(float v) noexcept {
-		if (v != v) { // NaN check
+		// The sign is extracted before the NaN test: a NaN source carries a
+		// sign too, and OCP OFP8 requires the converted NaN to keep it.
+		bool s;
+		bool is_nan;
+		bool is_inf;
+		if (std::is_constant_evaluated()) {
+			float_fields ff = extract_float_fields(v);
+			s = ff.sign;
+			is_nan = (ff.rawExp == 0xFF) && (ff.rawFrac != 0u);
+			is_inf = (ff.rawExp == 0xFF) && (ff.rawFrac == 0u);
+		}
+		else {
+			s = std::signbit(v);
+			is_nan = (v != v);
+			is_inf = std::isinf(v);
+		}
+
+		if (is_nan) {
 			if constexpr (hasNaN) {
-				setnan(NAN_TYPE_QUIET);
+				setnan(NAN_TYPE_QUIET, s);
 			}
 			else {
 				setzero();
 			}
 			return;
 		}
-
-		bool s;
-		bool is_inf;
-		if (std::is_constant_evaluated()) {
-			float_fields ff = extract_float_fields(v);
-			s = ff.sign;
-			is_inf = (ff.rawExp == 0xFF) && (ff.rawFrac == 0u);
-		}
-		else {
-			s = std::signbit(v);
-			is_inf = std::isinf(v);
-		}
 		if (s) v = -v;
 
 		if (is_inf) {
+			// An infinite source is not an arithmetic overflow, but where the
+			// format has no infinity the answer is the same question: what can
+			// it say about a value beyond maxpos.
 			if constexpr (hasInf) {
 				setinf(s);
 			}
-			else if constexpr (isSaturating) {
-				if (s) maxneg(); else maxpos();
-			}
 			else {
-				setzero();
+				setoverflow(s);
 			}
 			return;
 		}
@@ -552,31 +600,14 @@ public:
 			return;
 		}
 
-		// Compute the maxpos value for clamping
-		microfloat mp;
-		mp.maxpos();
-		float maxval = mp.to_float();
-
-		if (v >= maxval) {
-			// Check if we need to round to maxpos or to inf
-			if constexpr (hasInf) {
-				// Compute the tie-point between maxpos and inf
-				// For IEEE-like types, values > maxval round to inf or stay at maxval
-				// The tie point is maxval + 0.5 ULP above maxval
-				// For simplicity with these small types: if v > maxval, go to inf
-				if (v > maxval) {
-					setinf(s);
-					return;
-				}
-			}
-			if constexpr (isSaturating) {
-				if (s) maxneg(); else maxpos();
-				return;
-			}
-			// non-saturating without inf: clamp to max
-			if (s) maxneg(); else maxpos();
-			return;
-		}
+		// There is deliberately no pre-clamp against maxpos here.  The rounding
+		// below already decides the top of the range correctly -- it rounds to
+		// nearest-even against the format's exponent range and reports overflow
+		// through biased_exp -- and a pre-clamp can only get that wrong.  The
+		// one that used to sit here answered maxpos for every value above
+		// maxpos, so e4m3 saturated where OCP requires NaN, and answered inf
+		// for every value above maxpos in e5m2, where 57344 < v <= 61440 must
+		// round back down to maxpos (universal#1302).
 
 		// Extract exponent and fraction from the float value.
 		// frexp returns frac in [0.5, 1.0), exp such that v = frac * 2^exp.
@@ -672,31 +703,28 @@ public:
 				f_int = 0;
 				biased_exp += 1;
 			}
-			// Check for overflow after rounding
+			// Check for overflow after rounding.  What overflow *is* depends on
+			// which encodings the format reserves; what to do about it is the
+			// single policy in setoverflow().
+			bool overflow;
 			if constexpr (hasNaN && hasInf) {
-				// e5m2: max biased exp for normal = max_exp_code - 1
-				if (static_cast<unsigned>(biased_exp) >= max_exp_code) {
-					setinf(s);
-					return;
-				}
+				// e5m2: the all-ones exponent is Inf/NaN, so the last normal
+				// biased exponent is max_exp_code - 1
+				overflow = (static_cast<unsigned>(biased_exp) >= max_exp_code);
 			}
 			else if constexpr (hasNaN && !hasInf) {
-				// e4m3: max biased exp = max_exp_code, but all-ones exp + all-ones frac = NaN
-				if (static_cast<unsigned>(biased_exp) > max_exp_code) {
-					if (s) maxneg(); else maxpos();
-					return;
-				}
-				if (static_cast<unsigned>(biased_exp) == max_exp_code && f_int >= fraction_mask) {
-					if (s) maxneg(); else maxpos();
-					return;
-				}
+				// e4m3: the all-ones exponent is normal except for the
+				// all-ones fraction, which is NaN
+				overflow = (static_cast<unsigned>(biased_exp) > max_exp_code)
+					|| (static_cast<unsigned>(biased_exp) == max_exp_code && f_int >= fraction_mask);
 			}
 			else {
-				// No NaN, no Inf: all encodings valid
-				if (static_cast<unsigned>(biased_exp) > max_exp_code) {
-					if (s) maxneg(); else maxpos();
-					return;
-				}
+				// no NaN, no Inf: every encoding is a number
+				overflow = (static_cast<unsigned>(biased_exp) > max_exp_code);
+			}
+			if (overflow) {
+				setoverflow(s);
+				return;
 			}
 			_bits = static_cast<uint8_t>((static_cast<unsigned>(biased_exp) << fbits) | f_int);
 		}

--- a/include/sw/universal/number/microfloat/microfloat_impl.hpp
+++ b/include/sw/universal/number/microfloat/microfloat_impl.hpp
@@ -606,8 +606,10 @@ public:
 		// through biased_exp -- and a pre-clamp can only get that wrong.  The
 		// one that used to sit here answered maxpos for every value above
 		// maxpos, so e4m3 saturated where OCP requires NaN, and answered inf
-		// for every value above maxpos in e5m2, where 57344 < v <= 61440 must
-		// round back down to maxpos (universal#1302).
+		// for every value above maxpos in e5m2, where 57344 < v < 61440 must
+		// round back down to maxpos.  61440 itself is the tie, and it rounds
+		// the other way: the even candidate is 2^16, which e5m2 cannot
+		// represent, so that one really is infinity (universal#1302).
 
 		// Extract exponent and fraction from the float value.
 		// frexp returns frac in [0.5, 1.0), exp such that v = frac * 2^exp.

--- a/include/sw/universal/number/microfloat/numeric_limits.hpp
+++ b/include/sw/universal/number/microfloat/numeric_limits.hpp
@@ -41,7 +41,12 @@ public:
 		return Microfloat(sw::universal::SpecificValue::minpos);
 	}
 	static constexpr Microfloat infinity() {
-		return Microfloat(sw::universal::SpecificValue::infpos);
+		// has_infinity == false requires infinity() to return T(): the format
+		// has no infinity to hand back, and setinf() answers with whatever the
+		// overflow policy says (maxpos, or NaN for the OCP "fn" policy), which
+		// is not what this query means.
+		if constexpr (hasInf) return Microfloat(sw::universal::SpecificValue::infpos);
+		else return Microfloat(sw::universal::SpecificValue::zero);
 	}
 	static constexpr Microfloat quiet_NaN() {
 		return Microfloat(sw::universal::SpecificValue::qnan);

--- a/include/sw/universal/number/mxfloat/manipulators.hpp
+++ b/include/sw/universal/number/mxfloat/manipulators.hpp
@@ -23,8 +23,10 @@ namespace sw { namespace universal {
 			elemName = "e2m3";
 		} else if constexpr (std::is_same_v<ElementType, e3m2>) {
 			elemName = "e3m2";
-		} else if constexpr (std::is_same_v<ElementType, e4m3>) {
+		} else if constexpr (std::is_same_v<ElementType, e4m3fn>) {
 			elemName = "e4m3";
+		} else if constexpr (std::is_same_v<ElementType, e4m3_saturating>) {
+			elemName = "e4m3_saturating";
 		} else if constexpr (std::is_same_v<ElementType, e5m2>) {
 			elemName = "e5m2";
 		} else if constexpr (std::is_same_v<ElementType, int8_t>) {
@@ -38,7 +40,7 @@ namespace sw { namespace universal {
 			if constexpr (std::is_same_v<ElementType, e2m1>) return "mxfp4";
 			if constexpr (std::is_same_v<ElementType, e3m2>) return "mxfp6";
 			if constexpr (std::is_same_v<ElementType, e2m3>) return "mxfp6e2m3";
-			if constexpr (std::is_same_v<ElementType, e4m3>) return "mxfp8";
+			if constexpr (std::is_same_v<ElementType, e4m3_saturating>) return "mxfp8";
 			if constexpr (std::is_same_v<ElementType, e5m2>) return "mxfp8e5m2";
 			if constexpr (std::is_same_v<ElementType, int8_t>) return "mxint8";
 		}

--- a/include/sw/universal/number/mxfloat/mxfloat_fwd.hpp
+++ b/include/sw/universal/number/mxfloat/mxfloat_fwd.hpp
@@ -30,7 +30,10 @@ template<>
 constexpr int max_elem_exponent<e3m2> = 4;
 
 template<>
-constexpr int max_elem_exponent<e4m3> = 8;
+constexpr int max_elem_exponent<e4m3fn> = 8;
+
+template<>
+constexpr int max_elem_exponent<e4m3_saturating> = 8;
 
 template<>
 constexpr int max_elem_exponent<e5m2> = 15;
@@ -42,7 +45,12 @@ constexpr int max_elem_exponent<int8_t> = 7;
 using mxfp4     = mxblock<e2m1>;
 using mxfp6     = mxblock<e3m2>;
 using mxfp6e2m3 = mxblock<e2m3>;
-using mxfp8     = mxblock<e4m3>;
+// MX FP8 quantization scales amax into [2^8, 2^9) against an e4m3 maxpos of
+// 448, so the largest element of a block lands past the top of the range
+// whenever amax/2^shared_exp exceeds 1.8125.  That has to clip, not turn into
+// a NaN, which is why the element type here is the saturating policy and not
+// the OCP conversion policy that plain e4m3 (= e4m3fn) carries.
+using mxfp8     = mxblock<e4m3_saturating>;
 using mxfp8e5m2 = mxblock<e5m2>;
 using mxint8    = mxblock<int8_t>;
 

--- a/include/sw/universal/number/nvblock/manipulators.hpp
+++ b/include/sw/universal/number/nvblock/manipulators.hpp
@@ -20,7 +20,7 @@ namespace sw { namespace universal {
 		// Return NVIDIA alias for the canonical configuration
 		if constexpr (std::is_same_v<ElementType, e2m1> &&
 			BlockSize == 16 &&
-			std::is_same_v<ScaleType, e4m3>) {
+			std::is_same_v<ScaleType, e4m3_saturating>) {
 			return "nvfp4";
 		}
 
@@ -32,8 +32,10 @@ namespace sw { namespace universal {
 			elemName = "e2m3";
 		} else if constexpr (std::is_same_v<ElementType, e3m2>) {
 			elemName = "e3m2";
-		} else if constexpr (std::is_same_v<ElementType, e4m3>) {
+		} else if constexpr (std::is_same_v<ElementType, e4m3fn>) {
 			elemName = "e4m3";
+		} else if constexpr (std::is_same_v<ElementType, e4m3_saturating>) {
+			elemName = "e4m3_saturating";
 		} else if constexpr (std::is_same_v<ElementType, e5m2>) {
 			elemName = "e5m2";
 		} else {
@@ -41,8 +43,10 @@ namespace sw { namespace universal {
 		}
 
 		std::string scaleName;
-		if constexpr (std::is_same_v<ScaleType, e4m3>) {
+		if constexpr (std::is_same_v<ScaleType, e4m3fn>) {
 			scaleName = "e4m3";
+		} else if constexpr (std::is_same_v<ScaleType, e4m3_saturating>) {
+			scaleName = "e4m3_saturating";
 		} else if constexpr (std::is_same_v<ScaleType, e5m2>) {
 			scaleName = "e5m2";
 		} else {

--- a/include/sw/universal/number/nvblock/nvblock_fwd.hpp
+++ b/include/sw/universal/number/nvblock/nvblock_fwd.hpp
@@ -18,10 +18,13 @@ namespace sw { namespace universal {
 //   ElementType - microfloat element (default: e2m1 for NVFP4)
 //   BlockSize   - elements per block (default: 16 per NVIDIA spec)
 //   ScaleType   - block scale type (default: e4m3, fractional unlike MX's e8m0)
-template<typename ElementType = e2m1, size_t BlockSize = 16, typename ScaleType = e4m3>
+template<typename ElementType = e2m1, size_t BlockSize = 16, typename ScaleType = e4m3_saturating>
 class nvblock;
 
 // type alias for the canonical NVFP4 configuration
-using nvfp4 = nvblock<e2m1, 16, e4m3>;
+// the block scale saturates rather than becoming NaN: raw_scale = amax/elem_max
+// can exceed the e4m3 range for large-magnitude inputs, and a NaN scale poisons
+// the whole block.  Same encoding as e4m3, different conversion policy.
+using nvfp4 = nvblock<e2m1, 16, e4m3_saturating>;
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/nvblock/nvblock_fwd.hpp
+++ b/include/sw/universal/number/nvblock/nvblock_fwd.hpp
@@ -17,7 +17,7 @@ namespace sw { namespace universal {
 // Template parameters:
 //   ElementType - microfloat element (default: e2m1 for NVFP4)
 //   BlockSize   - elements per block (default: 16 per NVIDIA spec)
-//   ScaleType   - block scale type (default: e4m3, fractional unlike MX's e8m0)
+//   ScaleType   - block scale type (default: e4m3_saturating, fractional unlike MX's e8m0)
 template<typename ElementType = e2m1, size_t BlockSize = 16, typename ScaleType = e4m3_saturating>
 class nvblock;
 

--- a/include/sw/universal/number/nvblock/nvblock_impl.hpp
+++ b/include/sw/universal/number/nvblock/nvblock_impl.hpp
@@ -33,7 +33,7 @@ namespace sw { namespace universal {
 // Template parameters:
 //   ElementType - microfloat element type (e.g. e2m1 for NVFP4)
 //   BlockSize   - number of elements per block (16 for NVFP4)
-//   ScaleType   - block-level scale type (e4m3 for NVFP4, fractional precision)
+//   ScaleType   - block-level scale type (e4m3_saturating for NVFP4, fractional precision)
 template<typename ElementType, size_t BlockSize, typename ScaleType>
 class nvblock {
 public:

--- a/static/block/microfloat/api/constexpr.cpp
+++ b/static/block/microfloat/api/constexpr.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <limits>
 #include <universal/number/microfloat/microfloat.hpp>
 #include <universal/verification/test_suite.hpp>
 
@@ -24,10 +25,10 @@ try {
 
 	ReportTestSuiteHeader(test_suite, reportTestCases);
 
-	// e4m3: 8 bits, 4 exponent bits, no infinity, has NaN, saturating.
+	// e4m3: 8 bits, 4 exponent bits, no infinity, has NaN, NaN on overflow (OCP).
 	// e5m2: 8 bits, 5 exponent bits, has infinity, has NaN, IEEE-like.
-	using e4m3 = microfloat<8, 4, false, true, true>;
-	using e5m2 = microfloat<8, 5, true,  true, false>;
+	// Both come from the library rather than being re-declared here, so these
+	// tests exercise the aliases downstream code actually uses.
 
 	// ----------------------------------------------------------------------------
 	// SpecificValue construction (smoke)
@@ -165,6 +166,44 @@ try {
 		// should produce a microfloat infinity, not maxpos.
 		constexpr e5m2 inf_pos(std::numeric_limits<float>::infinity());
 		static_assert(inf_pos.isinf(),        "constexpr e5m2(+inf) isinf");
+	}
+
+	// ----------------------------------------------------------------------------
+	// Overflow policy at compile time (universal#1302).  The constexpr path
+	// extracts the IEEE 754 fields by hand instead of calling frexp/signbit,
+	// so it has to reach the same verdict as the runtime path independently.
+	// ----------------------------------------------------------------------------
+	{
+		constexpr float finf = std::numeric_limits<float>::infinity();
+
+		// e4m3 is the OCP format: overflow and infinity both become NaN, and
+		// the sign survives
+		constexpr e4m3 tie(464.0f);       // the round-to-even tie, still maxpos
+		constexpr e4m3 over(465.0f);
+		constexpr e4m3 huge(-1e30f);
+		constexpr e4m3 infinite(finf);
+		constexpr e4m3 neg_infinite(-finf);
+		static_assert(tie == e4m3(SpecificValue::maxpos), "constexpr e4m3(464) is maxpos");
+		static_assert(over.isnan(),                       "constexpr e4m3(465) is NaN");
+		static_assert(huge.isnan() && huge.isneg(),       "constexpr e4m3(-1e30) is -NaN");
+		static_assert(infinite.isnan() && !infinite.isneg(),      "constexpr e4m3(+inf) is +NaN");
+		static_assert(neg_infinite.isnan() && neg_infinite.isneg(), "constexpr e4m3(-inf) is -NaN");
+
+		// the saturating policy over the same encoding still clamps
+		constexpr e4m3_saturating sat(1e30f);
+		constexpr e4m3_saturating sat_neg(-finf);
+		static_assert(sat == e4m3_saturating(SpecificValue::maxpos),     "constexpr saturating clamps");
+		static_assert(sat_neg == e4m3_saturating(SpecificValue::maxneg), "constexpr saturating clamps -inf");
+
+		// e5m2 rounds to nearest against infinity rather than clamping at maxpos
+		constexpr e5m2 below(58000.0f);
+		constexpr e5m2 at_tie(61440.0f);
+		static_assert(below == e5m2(SpecificValue::maxpos), "constexpr e5m2(58000) rounds to maxpos");
+		static_assert(at_tie.isinf(),                       "constexpr e5m2(61440) rounds to inf");
+
+		// and a format with neither infinity nor NaN has only one answer
+		constexpr e2m1 saturated(1e30f);
+		static_assert(saturated == e2m1(SpecificValue::maxpos), "constexpr e2m1(1e30) is maxpos");
 	}
 
 	// ----------------------------------------------------------------------------

--- a/static/block/microfloat/conversion/ocp_e4m3_conformance.cpp
+++ b/static/block/microfloat/conversion/ocp_e4m3_conformance.cpp
@@ -172,7 +172,8 @@ namespace {
 		return nrOfFailedTests;
 	}
 
-	[[maybe_unused]] int check(bool reportTestCases, const std::string& tag, float input, unsigned encoding, unsigned expected) {
+	[[maybe_unused]] int check(bool reportTestCases, const std::string& tag,
+	                           float input, unsigned encoding, unsigned expected) {
 		if (encoding == expected) return 0;
 		if (reportTestCases) std::cerr << "  FAIL " << tag << " (" << input << ") -> 0x" << std::hex
 		                               << encoding << " expected 0x" << expected << std::dec << '\n';
@@ -300,6 +301,25 @@ namespace {
 		return nrOfFailedTests;
 	}
 
+	// every alias, plus the two configurations that have no alias, in one place
+	[[maybe_unused]] int VerifyInfiniteSourceAcrossFormats(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<e2m1>(reportTestCases, "e2m1");
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<e2m3>(reportTestCases, "e2m3");
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<e3m2>(reportTestCases, "e3m2");
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<e4m3>(reportTestCases, "e4m3");
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<e4m3_saturating>(reportTestCases, "e4m3_saturating");
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<e5m2>(reportTestCases, "e5m2");
+		// no infinity and no NaN to fall back on: maxpos is the only answer
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<microfloat<8, 4, false, false, false>>(
+			reportTestCases, "microfloat<8,4,-,-,->");
+		// no infinity, but a NaN to signal with
+		nrOfFailedTests += VerifyInfiniteSourceIsNeverZero<microfloat<6, 3, false, true, false>>(
+			reportTestCases, "microfloat<6,3,-,nan,->");
+		return nrOfFailedTests;
+	}
+
 }  // anonymous namespace
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
@@ -339,26 +359,24 @@ try {
 #else  // !MANUAL_TESTING
 
 #if REGRESSION_LEVEL_1
-	nrOfFailedTestCases += ReportTestResult(VerifyDecodeTable<e4m3>(reportTestCases, "e4m3"), test_tag, "e4m3 decode, all 256");
-	nrOfFailedTestCases += ReportTestResult(VerifyOcpDivergences(reportTestCases), test_tag, "e4m3 conversion, OCP cases");
-	nrOfFailedTestCases += ReportTestResult(VerifyConversionAgainstOracle(reportTestCases), test_tag, "e4m3 conversion, vs oracle");
+	nrOfFailedTestCases += ReportTestResult(VerifyDecodeTable<e4m3>(reportTestCases, "e4m3"),
+		test_tag, "e4m3 decode, all 256");
+	nrOfFailedTestCases += ReportTestResult(VerifyOcpDivergences(reportTestCases),
+		test_tag, "e4m3 conversion, OCP cases");
+	nrOfFailedTestCases += ReportTestResult(VerifyConversionAgainstOracle(reportTestCases),
+		test_tag, "e4m3 conversion, vs oracle");
 #endif
 
 #if REGRESSION_LEVEL_2
-	nrOfFailedTestCases += ReportTestResult(VerifySaturatingPolicy(reportTestCases), test_tag, "e4m3_saturating policy");
-	nrOfFailedTestCases += ReportTestResult(VerifyE5m2Boundary(reportTestCases), test_tag, "e5m2 overflow boundary");
+	nrOfFailedTestCases += ReportTestResult(VerifySaturatingPolicy(reportTestCases),
+		test_tag, "e4m3_saturating policy");
+	nrOfFailedTestCases += ReportTestResult(VerifyE5m2Boundary(reportTestCases),
+		test_tag, "e5m2 overflow boundary");
 #endif
 
 #if REGRESSION_LEVEL_3
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e2m1>(reportTestCases, "e2m1"), test_tag, "e2m1 infinite source");
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e2m3>(reportTestCases, "e2m3"), test_tag, "e2m3 infinite source");
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e3m2>(reportTestCases, "e3m2"), test_tag, "e3m2 infinite source");
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e4m3>(reportTestCases, "e4m3"), test_tag, "e4m3 infinite source");
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e4m3_saturating>(reportTestCases, "e4m3_saturating"), test_tag, "e4m3_saturating infinite source");
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e5m2>(reportTestCases, "e5m2"), test_tag, "e5m2 infinite source");
-	// the configurations without an alias: no infinity and no NaN to fall back on
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<microfloat<8, 4, false, false, false>>(reportTestCases, "microfloat<8,4,-,-,->"), test_tag, "no inf, no nan, no saturation");
-	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<microfloat<6, 3, false, true, false>>(reportTestCases, "microfloat<6,3,-,nan,->"), test_tag, "no inf, nan, no saturation");
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceAcrossFormats(reportTestCases),
+		test_tag, "infinite source is never zero");
 #endif
 
 #if REGRESSION_LEVEL_4

--- a/static/block/microfloat/conversion/ocp_e4m3_conformance.cpp
+++ b/static/block/microfloat/conversion/ocp_e4m3_conformance.cpp
@@ -1,0 +1,401 @@
+// ocp_e4m3_conformance.cpp: OCP 8-bit floating point (OFP8) E4M3 conformance
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// microfloat's E4M3 *encoding* was already exact -- all 256 patterns decode to
+// the right value -- but conversion from a wider type diverged from the OCP
+// specification in four places, and every existing suite stayed green because
+// none of them looked above maxpos (universal#1302):
+//
+//     input          was          OCP OFP8 E4M3
+//     500.0          0x7e (448)   0x7f (NaN)
+//     +inf / -inf    0x7e / 0xfe  0x7f / 0xff
+//     -NaN           0x7f         0xff
+//     e5m2 58000.0   0x7c (inf)   0x7b (57344)
+//
+// This suite pins both halves.  The decode reference is a 256-entry table
+// generated straight from the specification's field layout -- sign, 4-bit
+// exponent biased by 7, 3-bit mantissa, subnormals at exponent code 0, NaN at
+// S.1111.111, no infinity -- and the conversion reference is a brute-force
+// search over that same table for the nearest representable value with
+// ties-to-even.  Neither consults microfloat to decide what the answer is.
+//
+// The two conversion policies are both tested, because both are wanted:
+// e4m3 (= e4m3fn) is the OCP format that ml_dtypes, JAX and PyTorch implement,
+// and e4m3_saturating is what MX and NVFP4 block quantization needs, since
+// those scale amax into a range whose top lies past e4m3's maxpos of 448.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <universal/number/microfloat/microfloat.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	// The OCP OFP8 E4M3 value of every one of the 256 encodings, decoded from
+	// the specification rather than from microfloat:
+	//     e == 0            (-1)^s * 2^-6 * (m/8)          subnormal
+	//     e == 15 && m == 7 NaN                            the only non-finite
+	//     otherwise         (-1)^s * 2^(e-7) * (1 + m/8)   normal
+	// The two NaN slots hold 0.0f as a placeholder; is_nan_encoding() decides
+	// which entries those are.
+	constexpr float e4m3_reference[256] = {
+		0.0f,                  0.001953125f,          0.00390625f,           0.005859375f,
+		0.0078125f,            0.009765625f,          0.01171875f,           0.013671875f,
+		0.015625f,             0.017578125f,          0.01953125f,           0.021484375f,
+		0.0234375f,            0.025390625f,          0.02734375f,           0.029296875f,
+		0.03125f,              0.03515625f,           0.0390625f,            0.04296875f,
+		0.046875f,             0.05078125f,           0.0546875f,            0.05859375f,
+		0.0625f,               0.0703125f,            0.078125f,             0.0859375f,
+		0.09375f,              0.1015625f,            0.109375f,             0.1171875f,
+		0.125f,                0.140625f,             0.15625f,              0.171875f,
+		0.1875f,               0.203125f,             0.21875f,              0.234375f,
+		0.25f,                 0.28125f,              0.3125f,               0.34375f,
+		0.375f,                0.40625f,              0.4375f,               0.46875f,
+		0.5f,                  0.5625f,               0.625f,                0.6875f,
+		0.75f,                 0.8125f,               0.875f,                0.9375f,
+		1.0f,                  1.125f,                1.25f,                 1.375f,
+		1.5f,                  1.625f,                1.75f,                 1.875f,
+		2.0f,                  2.25f,                 2.5f,                  2.75f,
+		3.0f,                  3.25f,                 3.5f,                  3.75f,
+		4.0f,                  4.5f,                  5.0f,                  5.5f,
+		6.0f,                  6.5f,                  7.0f,                  7.5f,
+		8.0f,                  9.0f,                  10.0f,                 11.0f,
+		12.0f,                 13.0f,                 14.0f,                 15.0f,
+		16.0f,                 18.0f,                 20.0f,                 22.0f,
+		24.0f,                 26.0f,                 28.0f,                 30.0f,
+		32.0f,                 36.0f,                 40.0f,                 44.0f,
+		48.0f,                 52.0f,                 56.0f,                 60.0f,
+		64.0f,                 72.0f,                 80.0f,                 88.0f,
+		96.0f,                 104.0f,                112.0f,                120.0f,
+		128.0f,                144.0f,                160.0f,                176.0f,
+		192.0f,                208.0f,                224.0f,                240.0f,
+		256.0f,                288.0f,                320.0f,                352.0f,
+		384.0f,                416.0f,                448.0f,                0.0f,
+		-0.0f,                 -0.001953125f,         -0.00390625f,          -0.005859375f,
+		-0.0078125f,           -0.009765625f,         -0.01171875f,          -0.013671875f,
+		-0.015625f,            -0.017578125f,         -0.01953125f,          -0.021484375f,
+		-0.0234375f,           -0.025390625f,         -0.02734375f,          -0.029296875f,
+		-0.03125f,             -0.03515625f,          -0.0390625f,           -0.04296875f,
+		-0.046875f,            -0.05078125f,          -0.0546875f,           -0.05859375f,
+		-0.0625f,              -0.0703125f,           -0.078125f,            -0.0859375f,
+		-0.09375f,             -0.1015625f,           -0.109375f,            -0.1171875f,
+		-0.125f,               -0.140625f,            -0.15625f,             -0.171875f,
+		-0.1875f,              -0.203125f,            -0.21875f,             -0.234375f,
+		-0.25f,                -0.28125f,             -0.3125f,              -0.34375f,
+		-0.375f,               -0.40625f,             -0.4375f,              -0.46875f,
+		-0.5f,                 -0.5625f,              -0.625f,               -0.6875f,
+		-0.75f,                -0.8125f,              -0.875f,               -0.9375f,
+		-1.0f,                 -1.125f,               -1.25f,                -1.375f,
+		-1.5f,                 -1.625f,               -1.75f,                -1.875f,
+		-2.0f,                 -2.25f,                -2.5f,                 -2.75f,
+		-3.0f,                 -3.25f,                -3.5f,                 -3.75f,
+		-4.0f,                 -4.5f,                 -5.0f,                 -5.5f,
+		-6.0f,                 -6.5f,                 -7.0f,                 -7.5f,
+		-8.0f,                 -9.0f,                 -10.0f,                -11.0f,
+		-12.0f,                -13.0f,                -14.0f,                -15.0f,
+		-16.0f,                -18.0f,                -20.0f,                -22.0f,
+		-24.0f,                -26.0f,                -28.0f,                -30.0f,
+		-32.0f,                -36.0f,                -40.0f,                -44.0f,
+		-48.0f,                -52.0f,                -56.0f,                -60.0f,
+		-64.0f,                -72.0f,                -80.0f,                -88.0f,
+		-96.0f,                -104.0f,               -112.0f,               -120.0f,
+		-128.0f,               -144.0f,               -160.0f,               -176.0f,
+		-192.0f,               -208.0f,               -224.0f,               -240.0f,
+		-256.0f,               -288.0f,               -320.0f,               -352.0f,
+		-384.0f,               -416.0f,               -448.0f,               0.0f,
+	};
+
+	// NaN is S.1111.111: encodings 0x7F and 0xFF
+	constexpr bool is_nan_encoding(unsigned code) noexcept { return (code & 0x7Fu) == 0x7Fu; }
+
+	// the value one step above maxpos, had the top encoding not been NaN, and
+	// the round-to-nearest boundary halfway to it.  464.0 itself is a tie
+	// between 448 (mantissa 110, even) and 480 (mantissa 111, odd), so it
+	// rounds down to 448; anything strictly above it overflows.
+	constexpr float e4m3_step_above = 480.0f;          // 448 + one ulp of 32
+	constexpr float e4m3_overflow_boundary = 464.0f;   // (448 + 480) / 2
+
+	// Brute-force OCP conversion oracle: the nearest table entry to x, ties to
+	// even, NaN once x is past the boundary.  O(256) per call and completely
+	// independent of the implementation under test.
+	[[maybe_unused]] unsigned ocp_encode(float x) {
+		unsigned sign = std::signbit(x) ? 0x80u : 0x00u;
+		if (x != x) return sign | 0x7Fu;                       // NaN keeps its sign
+		if (std::isinf(x)) return sign | 0x7Fu;                // no infinity: NaN
+		float a = std::fabs(x);
+		if (a > e4m3_overflow_boundary) return sign | 0x7Fu;   // overflow: NaN
+		unsigned best = 0u;
+		float bestDistance = std::numeric_limits<float>::infinity();
+		for (unsigned code = 0u; code < 128u; ++code) {        // the positive half
+			if (is_nan_encoding(code)) continue;
+			float candidate = e4m3_reference[code];
+			float distance = std::fabs(candidate - a);
+			if (distance < bestDistance) {
+				bestDistance = distance;
+				best = code;
+			}
+			else if (distance == bestDistance && (code & 1u) == 0u) {
+				best = code;                                   // tie: take the even one
+			}
+		}
+		return sign | best;
+	}
+
+	// every encoding decodes to the specification's value
+	template<typename Microfloat>
+	int VerifyDecodeTable(bool reportTestCases, const std::string& tag) {
+		int nrOfFailedTests = 0;
+		for (unsigned code = 0u; code < 256u; ++code) {
+			Microfloat a{};
+			a.setbits(code);
+			if (is_nan_encoding(code)) {
+				if (!a.isnan()) {
+					++nrOfFailedTests;
+					if (reportTestCases) std::cerr << "  FAIL " << tag << " 0x" << std::hex << code
+					                               << std::dec << " should decode to NaN\n";
+				}
+				continue;
+			}
+			float decoded = float(a);
+			if (decoded != e4m3_reference[code] || std::signbit(decoded) != std::signbit(e4m3_reference[code])) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cerr << "  FAIL " << tag << " 0x" << std::hex << code << std::dec
+				                               << " decoded " << decoded << " expected "
+				                               << e4m3_reference[code] << '\n';
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+	[[maybe_unused]] int check(bool reportTestCases, const std::string& tag, float input, unsigned encoding, unsigned expected) {
+		if (encoding == expected) return 0;
+		if (reportTestCases) std::cerr << "  FAIL " << tag << " (" << input << ") -> 0x" << std::hex
+		                               << encoding << " expected 0x" << expected << std::dec << '\n';
+		return 1;
+	}
+
+	// the four divergences of universal#1302, stated as the issue states them
+	[[maybe_unused]] int VerifyOcpDivergences(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		float inf = std::numeric_limits<float>::infinity();
+		struct { float input; unsigned expected; } cases[] = {
+			{ 448.0f,        0x7Eu },   // maxpos, unchanged
+			{ 464.0f,        0x7Eu },   // the tie, rounds down to even
+			{ 465.0f,        0x7Fu },   // first value past the boundary
+			{ 480.0f,        0x7Fu },   // the encoding the NaN slot took
+			{ 500.0f,        0x7Fu },
+			{ 1e30f,         0x7Fu },
+			{ -1e30f,        0xFFu },
+			{ inf,           0x7Fu },
+			{ -inf,          0xFFu },
+			{ std::numeric_limits<float>::quiet_NaN(),  0x7Fu },
+			{ -std::numeric_limits<float>::quiet_NaN(), 0xFFu },
+		};
+		for (auto& c : cases) {
+			e4m3 a(c.input);
+			nrOfFailedTests += check(reportTestCases, "e4m3", c.input, a.bits(), c.expected);
+		}
+		return nrOfFailedTests;
+	}
+
+	// conversion against the brute-force oracle, over the values that decide it:
+	// every representable value, every midpoint between neighbours, and a step
+	// either side of every midpoint
+	[[maybe_unused]] int VerifyConversionAgainstOracle(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		auto probe = [&](float x) {
+			e4m3 a(x);
+			nrOfFailedTests += check(reportTestCases, "e4m3 oracle", x, a.bits(), ocp_encode(x));
+		};
+		for (unsigned code = 0u; code < 128u; ++code) {
+			if (is_nan_encoding(code)) continue;
+			float v = e4m3_reference[code];
+			float next = (code == 0x7Eu) ? e4m3_step_above : e4m3_reference[code + 1u];
+			if (is_nan_encoding(code + 1u)) next = e4m3_step_above;
+			float mid = 0.5f * (v + next);
+			for (float x : { v, mid, std::nextafter(mid, 0.0f), std::nextafter(mid, 1e30f) }) {
+				probe(x);
+				probe(-x);
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+	// the saturating policy stays reachable and keeps clamping: MX and NVFP4
+	// quantization depend on it
+	[[maybe_unused]] int VerifySaturatingPolicy(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		float inf = std::numeric_limits<float>::infinity();
+		struct { float input; unsigned expected; } cases[] = {
+			{ 464.0f, 0x7Eu }, { 500.0f, 0x7Eu }, { 1e30f, 0x7Eu },
+			{ -1e30f, 0xFEu }, { inf, 0x7Eu }, { -inf, 0xFEu },
+		};
+		for (auto& c : cases) {
+			e4m3_saturating a(c.input);
+			nrOfFailedTests += check(reportTestCases, "e4m3_saturating", c.input, a.bits(), c.expected);
+		}
+		// the encoding is the same format: it must decode identically
+		nrOfFailedTests += VerifyDecodeTable<e4m3_saturating>(reportTestCases, "e4m3_saturating");
+		return nrOfFailedTests;
+	}
+
+	// e5m2 is IEEE-like, so the top of its range rounds to nearest against
+	// infinity: 57344 is maxpos, 61440 is the tie and rounds up to inf because
+	// the significand of 2^16 is the even one.  The pre-clamp used to send
+	// every value above maxpos to infinity.
+	[[maybe_unused]] int VerifyE5m2Boundary(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		float inf = std::numeric_limits<float>::infinity();
+		struct { float input; unsigned expected; } cases[] = {
+			{ 57344.0f, 0x7Bu },   // maxpos
+			{ 58000.0f, 0x7Bu },   // rounds back down to maxpos
+			{ 61439.0f, 0x7Bu },   // still below the tie
+			{ 61440.0f, 0x7Cu },   // the tie, rounds up to infinity
+			{ 61441.0f, 0x7Cu },
+			{ 1e30f,    0x7Cu },
+			{ -1e30f,   0xFCu },
+			{ inf,      0x7Cu },
+			{ -inf,     0xFCu },
+		};
+		for (auto& c : cases) {
+			e5m2 a(c.input);
+			nrOfFailedTests += check(reportTestCases, "e5m2", c.input, a.bits(), c.expected);
+		}
+		// a negative NaN stays a negative quiet NaN
+		e5m2 n(-std::numeric_limits<float>::quiet_NaN());
+		if (!n.isnan() || !n.isneg()) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cerr << "  FAIL e5m2 (-NaN) lost its sign\n";
+		}
+		return nrOfFailedTests;
+	}
+
+	// an infinite source must never convert to zero.  It did for every
+	// non-saturating configuration without infinity, which turned an overflow
+	// into the most benign value in the format.
+	template<typename Microfloat>
+	int VerifyInfiniteSourceIsNeverZero(bool reportTestCases, const std::string& tag) {
+		int nrOfFailedTests = 0;
+		float inf = std::numeric_limits<float>::infinity();
+		for (float x : { inf, -inf }) {
+			Microfloat a(x);
+			if (a.iszero()) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cerr << "  FAIL " << tag << " (" << x << ") converted to zero\n";
+			}
+			if (a.isneg() != std::signbit(x)) {
+				++nrOfFailedTests;
+				if (reportTestCases) std::cerr << "  FAIL " << tag << " (" << x << ") lost its sign\n";
+			}
+		}
+		return nrOfFailedTests;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "OCP OFP8 E4M3 conformance";
+	std::string test_tag    = "conformance";
+	bool reportTestCases    = true;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyOcpDivergences(true), test_tag, "e4m3 divergences");
+	nrOfFailedTestCases += ReportTestResult(VerifyConversionAgainstOracle(true), test_tag, "e4m3 vs oracle");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS; // ignore failures
+#else  // !MANUAL_TESTING
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyDecodeTable<e4m3>(reportTestCases, "e4m3"), test_tag, "e4m3 decode, all 256");
+	nrOfFailedTestCases += ReportTestResult(VerifyOcpDivergences(reportTestCases), test_tag, "e4m3 conversion, OCP cases");
+	nrOfFailedTestCases += ReportTestResult(VerifyConversionAgainstOracle(reportTestCases), test_tag, "e4m3 conversion, vs oracle");
+#endif
+
+#if REGRESSION_LEVEL_2
+	nrOfFailedTestCases += ReportTestResult(VerifySaturatingPolicy(reportTestCases), test_tag, "e4m3_saturating policy");
+	nrOfFailedTestCases += ReportTestResult(VerifyE5m2Boundary(reportTestCases), test_tag, "e5m2 overflow boundary");
+#endif
+
+#if REGRESSION_LEVEL_3
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e2m1>(reportTestCases, "e2m1"), test_tag, "e2m1 infinite source");
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e2m3>(reportTestCases, "e2m3"), test_tag, "e2m3 infinite source");
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e3m2>(reportTestCases, "e3m2"), test_tag, "e3m2 infinite source");
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e4m3>(reportTestCases, "e4m3"), test_tag, "e4m3 infinite source");
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e4m3_saturating>(reportTestCases, "e4m3_saturating"), test_tag, "e4m3_saturating infinite source");
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<e5m2>(reportTestCases, "e5m2"), test_tag, "e5m2 infinite source");
+	// the configurations without an alias: no infinity and no NaN to fall back on
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<microfloat<8, 4, false, false, false>>(reportTestCases, "microfloat<8,4,-,-,->"), test_tag, "no inf, no nan, no saturation");
+	nrOfFailedTestCases += ReportTestResult(VerifyInfiniteSourceIsNeverZero<microfloat<6, 3, false, true, false>>(reportTestCases, "microfloat<6,3,-,nan,->"), test_tag, "no inf, nan, no saturation");
+#endif
+
+#if REGRESSION_LEVEL_4
+	// a dense sweep of the whole finite range against the oracle, at a step
+	// well below the smallest subnormal
+	{
+		int nrOfFailedTests = 0;
+		for (float x = 0.0f; x <= 520.0f; x += 0.000244140625f) {   // 2^-12
+			e4m3 a(x), b(-x);
+			nrOfFailedTests += check(reportTestCases, "e4m3 sweep", x, a.bits(), ocp_encode(x));
+			nrOfFailedTests += check(reportTestCases, "e4m3 sweep", -x, b.bits(), ocp_encode(-x));
+		}
+		nrOfFailedTestCases += ReportTestResult(nrOfFailedTests, test_tag, "e4m3 dense sweep");
+	}
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_internal_exception& err) {
+	std::cerr << "Caught unexpected universal internal exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}

--- a/static/block/mxfloat/api/api.cpp
+++ b/static/block/mxfloat/api/api.cpp
@@ -167,7 +167,7 @@ try {
 		std::cout << mxblock_range<e2m1, 32>() << '\n';
 		std::cout << mxblock_range<e3m2, 32>() << '\n';
 		std::cout << mxblock_range<e2m3, 32>() << '\n';
-		std::cout << mxblock_range<e4m3, 32>() << '\n';
+		std::cout << mxblock_range<e4m3_saturating, 32>() << '\n';
 		std::cout << mxblock_range<e5m2, 32>() << '\n';
 		std::cout << mxblock_range<int8_t, 32>() << '\n';
 	}

--- a/static/block/nvblock/api/api.cpp
+++ b/static/block/nvblock/api/api.cpp
@@ -163,7 +163,7 @@ try {
 	// dynamic range
 	std::cout << "+---------    dynamic range   --------+\n";
 	{
-		std::cout << nvblock_range<e2m1, 16, e4m3>() << '\n';
+		std::cout << nvblock_range<e2m1, 16, e4m3_saturating>() << '\n';
 	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);


### PR DESCRIPTION
## Summary

`microfloat`'s E4M3 *encoding* was already exact -- all 256 patterns decode to the specification's value -- but conversion from a wider type diverged from the [OCP 8-bit Floating Point Specification](https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-12-01-pdf-1) in the three places #1302 lists. A fourth turned up in `e5m2` while fixing them.

| input | was | OCP / IEEE |
|-------|-----|------------|
| `500.0` | `0x7e` (448) | `0x7f` (NaN) |
| `+inf` / `-inf` | `0x7e` / `0xfe` | `0x7f` / `0xff` |
| `-NaN` | `0x7f` | `0xff` |
| `e5m2` `58000.0` | `0x7c` (inf) | `0x7b` (57344) |
| `<8,4,false,true,false>` `+-inf` | `0x00` (+0) | -- plain bug |

## Root cause

All of them come from one block. `from_float()` pre-clamped against maxpos *before* rounding, short-circuiting the post-rounding overflow check underneath it. That check was already correct -- it rounds to nearest-even against the format's exponent range, so `464.0` (the tie between 448 and the 480 the NaN slot took) rounds down to maxpos and `465.0` overflows, exactly as the spec requires. The fix is to delete the pre-clamp and let it decide.

What to *do* about an overflow was spelled out three times and the copies did not agree. It is now one `setoverflow()` policy:

| | |
|---|---|
| `isSaturating` | maxpos / maxneg |
| `hasInf` | `+-inf` |
| `hasNaN`, no inf | NaN, sign preserved -- the OCP `fn` rule |
| none of the three | maxpos / maxneg, the only thing the format can say |

The last case used to be zero, which is why every non-saturating configuration without infinity turned `+-inf` into `+0`.

## The two e4m3 policies

Identical encoding, different conversion:

- **`e4m3` (= `e4m3fn`)** -- NaN on overflow, per OCP. What `ml_dtypes.float8_e4m3fn`, JAX and PyTorch implement, and what [universal_dtypes](https://github.com/stillwater-sc/universal_dtypes) needs in order to ship an `e4m3` NumPy dtype.
- **`e4m3_saturating`** -- clamps. MX and NVFP4 scale the block maximum into a range whose top lies above 448, so the largest element of a block routinely lands past maxpos and has to clip rather than poison the block with a NaN.

`mxfp8` and the NVFP4 block scale are pinned to `e4m3_saturating` and are **unchanged bit-for-bit**; the bare `e4m3` name now means the standard format, as #1302 recommends.

## Changes

- `microfloat_impl.hpp` -- `setoverflow()` policy; sign extracted before the NaN branch; `setnan(type, sign)`; pre-clamp deleted; the three overflow arms and `setinf`-without-infinity routed through the policy
- `microfloat_fwd.hpp` -- `e4m3fn`, `e4m3_saturating`, `e4m3 = e4m3fn`, `is_e4m3_encoding`
- `numeric_limits.hpp` -- `infinity()` returns `T()` when `has_infinity` is false, per the std convention, now that `setinf()` answers with the overflow policy rather than zero
- `mxfloat_fwd.hpp` / `nvblock_fwd.hpp` / both `manipulators.hpp` -- `mxfp8` and the NVFP4 scale pinned to the saturating policy; type tags know both
- `static/block/microfloat/conversion/ocp_e4m3_conformance.cpp` (new) -- all 256 decodings against a table generated from the specification's field layout, plus conversion against a brute-force nearest-with-ties-to-even search over that table. Neither oracle consults `microfloat` to decide what the answer is.
- `static/block/microfloat/api/constexpr.cpp` -- the overflow policy at compile time (the constexpr path extracts IEEE 754 fields by hand instead of calling `frexp`/`signbit`, so it has to reach the same verdict independently); the local aliases that shadowed the library's are gone
- `docs/number-systems/microfloat.md` -- the two policies, and the e4m3 range corrected from 240 to 448

## Oracle mutation test

Run against the pre-fix implementation, the new suite reports the decode half green and every divergence red -- which is the claim #1302 makes:

```
e4m3 decode, all 256                PASS
e4m3 conversion, OCP cases          FAIL 8 failed test cases
e4m3 conversion, vs oracle          FAIL 2 failed test cases
e4m3_saturating policy              PASS
e5m2 overflow boundary              FAIL 3 failed test cases
e4m3 infinite source                FAIL 3 failed test cases
no inf, no nan, no saturation       FAIL 3 failed test cases
e4m3 dense sweep                    FAIL 458752 failed test cases
```

## Test Results

All 23 microfloat + mxfloat + nvblock tests, both compilers, plus the new suite at all four regression levels standalone (the dense sweep at level 4 walks the whole finite range at 2^-12 against the oracle).

| Target | gcc build | gcc test | clang build | clang test |
|--------|-----------|----------|-------------|------------|
| microfloat (10 targets) | OK | PASS | OK | PASS |
| mxfloat (8 targets) | OK | PASS | OK | PASS |
| nvblock (5 targets) | OK | PASS | OK | PASS |
| ocp_e4m3_conformance, levels 1-4 | OK | PASS | OK | PASS |

`tools/scripts/check-ascii.sh`: clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1302

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct non-saturating `e4m3` and saturating `e4m3_saturating` formats.
  * `e4m3` now produces NaN on overflow, while `e4m3_saturating` clamps to the maximum finite value.
  * Updated MXFP8 and NVFP4 defaults to use saturating E4M3 behavior.
  * Improved handling of signed NaNs, infinities, and overflow across supported microfloat formats.

* **Documentation**
  * Clarified overflow behavior and usage for OCP, MX, NVIDIA, JAX, and PyTorch formats.

* **Tests**
  * Added comprehensive conformance and conversion coverage for rounding, overflow, NaNs, infinities, and boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->