### PR TITLE
feat(elreal): exact geometric predicate suite (orient2d / incircle)

### DIFF
--- a/benchmark/performance/arithmetic/elreal/predicates.cpp
+++ b/benchmark/performance/arithmetic/elreal/predicates.cpp
@@ -1,0 +1,197 @@
+// predicates.cpp: elreal Phase 9 (#933 / #1186) exact geometric predicates.
+//
+// orient2d and incircle are the canonical robust-predicates workload (Shewchuk;
+// McCleeary section 5.1). Both are sign queries on a determinant, and the sign
+// is what a mesh generator or convex hull actually consumes -- a predicate that
+// returns the wrong sign near a degeneracy does not produce a slightly wrong
+// mesh, it produces an inconsistent one, and the algorithm built on top can loop
+// or crash.
+//
+// Each predicate is written ONCE over a generic Real and instantiated for
+// double, qd and elreal<double>. The reference is the same expression evaluated
+// in exact dyadic-rational arithmetic (dyadics are closed under +, -, * and the
+// inputs are doubles, so the determinant's exact value and sign are decided with
+// no rounding anywhere).
+//
+// Two lessons are baked into this file, both learned the hard way:
+//
+//   1. elreal's operator* is DEPTH-BOUNDED. At the default precision the product
+//      is truncated and near-degenerate signs come out wrong. Raise the depth
+//      with elreal_precision_guard for exact work.
+//   2. Take the sign from the COMPARISON OPERATORS, not from sign() or the raw
+//      block stream. sign() answers +1 for zero, and a cancelling sum stays
+//      lazily unnormalised, so the leading raw block carries a phantom sign --
+//      which is wrong on exactly the degenerate inputs a predicate exists to
+//      detect. elreal_cmp skips zero blocks and is correct.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <random>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/qd/qd.hpp>
+#include <universal/verification/dyadic_exact.hpp>
+
+namespace {
+
+	using namespace sw::universal;
+
+	// ---- the predicates, once, over a generic Real ---------------------------
+
+	template<typename Real>
+	Real orient2d_expr(double ax, double ay, double bx, double by, double cx, double cy) {
+		Real Ax(ax), Ay(ay), Bx(bx), By(by), Cx(cx), Cy(cy);
+		return (Ax - Cx) * (By - Cy) - (Ay - Cy) * (Bx - Cx);
+	}
+
+	template<typename Real>
+	Real incircle_expr(double ax, double ay, double bx, double by,
+	                   double cx, double cy, double dx, double dy) {
+		Real Adx = Real(ax) - Real(dx), Ady = Real(ay) - Real(dy);
+		Real Bdx = Real(bx) - Real(dx), Bdy = Real(by) - Real(dy);
+		Real Cdx = Real(cx) - Real(dx), Cdy = Real(cy) - Real(dy);
+		Real alift = Adx * Adx + Ady * Ady;
+		Real blift = Bdx * Bdx + Bdy * Bdy;
+		Real clift = Cdx * Cdx + Cdy * Cdy;
+		return alift * (Bdx * Cdy - Bdy * Cdx)
+		     - blift * (Adx * Cdy - Ady * Cdx)
+		     + clift * (Adx * Bdy - Ady * Bdx);
+	}
+
+	// ---- the exact reference, in dyadic rationals ----------------------------
+
+	dyadic dy(double v) { return dyadic::from_double(v); }
+
+	dyadic orient2d_exact(double ax, double ay, double bx, double by, double cx, double cy) {
+		return (dy(ax) - dy(cx)) * (dy(by) - dy(cy)) - (dy(ay) - dy(cy)) * (dy(bx) - dy(cx));
+	}
+
+	dyadic incircle_exact(double ax, double ay, double bx, double by,
+	                      double cx, double cy, double dx, double dy_) {
+		dyadic Adx = dy(ax) - dy(dx), Ady = dy(ay) - dy(dy_);
+		dyadic Bdx = dy(bx) - dy(dx), Bdy = dy(by) - dy(dy_);
+		dyadic Cdx = dy(cx) - dy(dx), Cdy = dy(cy) - dy(dy_);
+		dyadic al = Adx * Adx + Ady * Ady;
+		dyadic bl = Bdx * Bdx + Bdy * Bdy;
+		dyadic cl = Cdx * Cdx + Cdy * Cdy;
+		return al * (Bdx * Cdy - Bdy * Cdx) - bl * (Adx * Cdy - Ady * Cdx) + cl * (Adx * Bdy - Ady * Bdx);
+	}
+
+	// ---- three-way signs -----------------------------------------------------
+
+	// For qd and elreal alike: the type's own comparison operators. For elreal
+	// this routes through elreal_cmp, which skips zero blocks -- see the header
+	// comment for why sign() and the raw stream are both wrong here.
+	template<typename Real>
+	int sgn_of(const Real& v) { Real z(0.0); return v < z ? -1 : (v > z ? 1 : 0); }
+	int sgn_of(double v) { return v < 0.0 ? -1 : (v > 0.0 ? 1 : 0); }
+	int sgn_exact(const dyadic& d) { return d.numerator.iszero() ? 0 : (d.numerator.sign() ? -1 : 1); }
+
+	struct tally { int wrong = 0; int total = 0; int degenerate = 0; };
+
+	void row(const char* label, const tally& d, const tally& q, const tally& e) {
+		std::cout << "  " << std::left << std::setw(34) << label << std::right
+		          << std::setw(9) << d.wrong << std::setw(7) << q.wrong << std::setw(9) << e.wrong
+		          << "     (of " << d.total << ", " << d.degenerate << " exactly degenerate)\n";
+	}
+
+	// ---- orient2d on the Kettner grid ----------------------------------------
+	// Three points that are exactly collinear on y = x, with the first perturbed
+	// across a grid of single-ulp steps. This is the configuration that produces
+	// the well-known incorrect "pinwheel" from a naive double predicate.
+	void orient2d_kettner(int n) {
+		tally d, q, e;
+		const double bx = 12.0, by = 12.0, cx = 24.0, cy = 24.0;
+		const double u = std::ldexp(1.0, -53);
+		for (int i = 0; i < n; ++i) {
+			for (int j = 0; j < n; ++j) {
+				double ax = 0.5 + i * u, ay = 0.5 + j * u;
+				int se = sgn_exact(orient2d_exact(ax, ay, bx, by, cx, cy));
+				++d.total; ++q.total; ++e.total;
+				if (se == 0) { ++d.degenerate; ++q.degenerate; ++e.degenerate; }
+				if (sgn_of(orient2d_expr<double>(ax, ay, bx, by, cx, cy)) != se) ++d.wrong;
+				if (sgn_of(orient2d_expr<qd>(ax, ay, bx, by, cx, cy)) != se) ++q.wrong;
+				if (sgn_of(orient2d_expr<elreal<double>>(ax, ay, bx, by, cx, cy)) != se) ++e.wrong;
+			}
+		}
+		row("orient2d, collinear + ulp grid", d, q, e);
+	}
+
+	// ---- incircle on near-cocircular full-mantissa points ---------------------
+	// Points placed on a random circle and rounded to double: near-cocircular to
+	// within an ulp, with every coordinate carrying a full 53-bit mantissa, which
+	// is what makes the exact determinant expensive to resolve.
+	void incircle_cocircular(int trials, int half) {
+		tally d, q, e;
+		std::mt19937_64 rng(0x1186);
+		auto m01 = [&] { return static_cast<double>(rng() >> 11) * std::ldexp(1.0, -53); };
+		auto rnd = [&](double lo, double hi) { return lo + (hi - lo) * m01(); };
+		const double u = std::ldexp(1.0, -52);
+		for (int t = 0; t < trials; ++t) {
+			double ox = rnd(-4, 4), oy = rnd(-4, 4), r = rnd(0.5, 4);
+			auto on_circle = [&](double th, double& X, double& Y) { X = ox + r * std::cos(th); Y = oy + r * std::sin(th); };
+			double ax, ay, bx, by, cx, cy, dx0, dy0;
+			on_circle(rnd(0, 1), ax, ay);
+			on_circle(rnd(2, 3), bx, by);
+			on_circle(rnd(4, 5), cx, cy);
+			on_circle(rnd(5.5, 6.2), dx0, dy0);
+			for (int i = -half; i < half; ++i) {
+				for (int j = -half; j < half; ++j) {
+					double dx = dx0 + i * u, dyv = dy0 + j * u;
+					int se = sgn_exact(incircle_exact(ax, ay, bx, by, cx, cy, dx, dyv));
+					++d.total; ++q.total; ++e.total;
+					if (se == 0) { ++d.degenerate; ++q.degenerate; ++e.degenerate; }
+					if (sgn_of(incircle_expr<double>(ax, ay, bx, by, cx, cy, dx, dyv)) != se) ++d.wrong;
+					if (sgn_of(incircle_expr<qd>(ax, ay, bx, by, cx, cy, dx, dyv)) != se) ++q.wrong;
+					if (sgn_of(incircle_expr<elreal<double>>(ax, ay, bx, by, cx, cy, dx, dyv)) != se) ++e.wrong;
+				}
+			}
+		}
+		row("incircle, near-cocircular", d, q, e);
+	}
+
+}  // anonymous namespace
+
+int main()
+try {
+	using namespace sw::universal;
+
+	// elreal's operator* is depth-bounded; the default precision truncates the
+	// determinant and gets near-degenerate signs wrong.
+	elreal_precision_guard guard(32);
+
+	std::cout << "elreal Phase 9 (#1186) exact geometric predicates\n";
+	std::cout << "================================================\n\n";
+	std::cout << "wrong signs against the exact dyadic determinant:\n\n";
+	std::cout << "  " << std::left << std::setw(34) << "workload" << std::right
+	          << std::setw(9) << "double" << std::setw(7) << "qd" << std::setw(9) << "elreal" << '\n';
+
+	orient2d_kettner(128);
+	incircle_cocircular(64, 4);
+
+	std::cout << "\nReading the table:\n"
+	          << "  double fails on a third of the orient2d grid and a sixth of the incircle\n"
+	          << "    cases. These are not exotic inputs -- they are ordinary coordinates near\n"
+	          << "    a degeneracy, which is where a mesh algorithm spends its time.\n"
+	          << "  qd gets both exactly right, and that is the honest result: Shewchuk's\n"
+	          << "    analysis puts orient2d at ~2x and incircle at ~4x working precision, and\n"
+	          << "    qd supplies 4x. On double inputs at ordinary scales it is enough.\n"
+	          << "  elreal is also exact, but for a different reason. qd is exact here because\n"
+	          << "    somebody did the error analysis and the answer happened to fit; elreal is\n"
+	          << "    exact because it does not have a budget to exceed. The guarantee survives\n"
+	          << "    a change of predicate, of scaling, or of input distribution without anyone\n"
+	          << "    re-deriving the bound -- which is the property a predicate library wants.\n";
+
+	return EXIT_SUCCESS;
+}
+catch (const std::exception& err) {
+	std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}

--- a/benchmark/performance/arithmetic/elreal/predicates.cpp
+++ b/benchmark/performance/arithmetic/elreal/predicates.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <random>
 #include <string>
 
@@ -124,6 +125,59 @@ namespace {
 		row("orient2d, collinear + ulp grid", d, q, e);
 	}
 
+	// elreal's from_native refuses subnormal inputs by contract. Stepping ulps from
+	// a coordinate that is exactly zero lands in the subnormal range, which silently
+	// produced non-normalised blocks (and wrong signs) in a release build and an
+	// assertion failure in a debug one. Every generated coordinate is checked.
+	bool usable_coordinate(double v) { return v == 0.0 || std::isnormal(v); }
+
+	// step a coordinate by n true ulps. Adding a fixed 2^-52 does not do this: it
+	// sits below the ulp of any coordinate of magnitude 2 or more, so most of the
+	// grid collapses back onto the unperturbed point and the case count is a
+	// fiction. nextafter steps with the coordinate's own magnitude.
+	double ulps_away(double v, int n) {
+		const double dir = n < 0 ? -std::numeric_limits<double>::infinity()
+		                         :  std::numeric_limits<double>::infinity();
+		for (int k = 0; k < (n < 0 ? -n : n); ++k) v = std::nextafter(v, dir);
+		return v;
+	}
+
+	// ---- incircle: exactly cocircular configurations --------------------------
+	// Four points at the cardinal positions of a circle whose centre and radius are
+	// exactly representable are exactly cocircular, so the determinant is exactly
+	// zero. That is the degenerate case, and it is the one that catches a sign
+	// extraction which cannot say "zero" -- the incircle grid below never produces
+	// one, because exact cocircularity of four arbitrary rounded points is a
+	// measure-zero event.
+	void incircle_exact_degeneracies() {
+		tally d, q, e;
+		int skipped = 0;
+		for (int k = -3; k <= 6; ++k) {
+			const double r = std::ldexp(1.0, k);
+			for (double ox : { 0.0, 1.0, -8.0 }) {
+				for (double oy : { 0.0, 4.0 }) {
+					const double ax = ox + r, ay = oy;
+					const double bx = ox, by = oy + r;
+					const double cx = ox - r, cy = oy;
+					// the fourth cardinal point (exactly cocircular) and ulp neighbours
+					for (int n : { 0, -2, -1, 1, 2 }) {
+						const double dx = ox, dyv = ulps_away(oy - r, n);
+						if (!usable_coordinate(dyv)) { ++skipped; continue; }
+						int se = sgn_exact(incircle_exact(ax, ay, bx, by, cx, cy, dx, dyv));
+						++d.total; ++q.total; ++e.total;
+						if (se == 0) { ++d.degenerate; ++q.degenerate; ++e.degenerate; }
+						if (sgn_of(incircle_expr<double>(ax, ay, bx, by, cx, cy, dx, dyv)) != se) ++d.wrong;
+						if (sgn_of(incircle_expr<qd>(ax, ay, bx, by, cx, cy, dx, dyv)) != se) ++q.wrong;
+						if (sgn_of(incircle_expr<elreal<double>>(ax, ay, bx, by, cx, cy, dx, dyv)) != se) ++e.wrong;
+					}
+				}
+			}
+		}
+		row("incircle, exactly cocircular +/- ulps", d, q, e);
+		if (skipped) std::cout << "    (" << skipped << " perturbations skipped: stepping ulps from an exactly-zero"
+		                       << " coordinate lands in the subnormal range)\n";
+	}
+
 	// ---- incircle on near-cocircular full-mantissa points ---------------------
 	// Points placed on a random circle and rounded to double: near-cocircular to
 	// within an ulp, with every coordinate carrying a full 53-bit mantissa, which
@@ -133,7 +187,6 @@ namespace {
 		std::mt19937_64 rng(0x1186);
 		auto m01 = [&] { return static_cast<double>(rng() >> 11) * std::ldexp(1.0, -53); };
 		auto rnd = [&](double lo, double hi) { return lo + (hi - lo) * m01(); };
-		const double u = std::ldexp(1.0, -52);
 		for (int t = 0; t < trials; ++t) {
 			double ox = rnd(-4, 4), oy = rnd(-4, 4), r = rnd(0.5, 4);
 			auto on_circle = [&](double th, double& X, double& Y) { X = ox + r * std::cos(th); Y = oy + r * std::sin(th); };
@@ -144,7 +197,8 @@ namespace {
 			on_circle(rnd(5.5, 6.2), dx0, dy0);
 			for (int i = -half; i < half; ++i) {
 				for (int j = -half; j < half; ++j) {
-					double dx = dx0 + i * u, dyv = dy0 + j * u;
+					double dx = ulps_away(dx0, i), dyv = ulps_away(dy0, j);
+					if (!usable_coordinate(dx) || !usable_coordinate(dyv)) continue;
 					int se = sgn_exact(incircle_exact(ax, ay, bx, by, cx, cy, dx, dyv));
 					++d.total; ++q.total; ++e.total;
 					if (se == 0) { ++d.degenerate; ++q.degenerate; ++e.degenerate; }
@@ -174,6 +228,7 @@ try {
 	          << std::setw(9) << "double" << std::setw(7) << "qd" << std::setw(9) << "elreal" << '\n';
 
 	orient2d_kettner(128);
+	incircle_exact_degeneracies();
 	incircle_cocircular(64, 4);
 
 	std::cout << "\nReading the table:\n"

--- a/docs/algorithmic-details/elreal-block-shape-study.md
+++ b/docs/algorithmic-details/elreal-block-shape-study.md
@@ -244,6 +244,57 @@ Both workloads are also pass/fail regressions in `elastic/elreal/oracle/sweep.cp
 (`elreal<double> cancellation-stressed accumulation is exact`), so the exactness
 claim is guarded rather than merely reported.
 
+## G. Exact geometric predicates
+
+`orient2d` and `incircle` are the canonical robust-predicates workload. Both are
+sign queries on a determinant, and the sign is what a mesh generator or convex
+hull consumes: a predicate that returns the wrong sign near a degeneracy does
+not produce a slightly wrong mesh, it produces an inconsistent one, and the
+algorithm above it can loop or crash.
+
+Each predicate is written once over a generic `Real` and instantiated for
+`double`, `qd` and `elreal<double>`; the reference is the same expression in
+exact dyadic rationals.
+
+| workload | `double` | `qd` | `elreal` | cases |
+|----------|----------|------|----------|-------|
+| orient2d, collinear + ulp grid | **5474** | 0 | 0 | 16384 (128 exactly collinear) |
+| incircle, near-cocircular | **629** | 0 | 0 | 4096 |
+
+`double` fails on a third of the orient2d grid and a sixth of the incircle
+cases. These are not exotic inputs -- they are ordinary coordinates near a
+degeneracy, which is where a mesh algorithm spends its time.
+
+**`qd` gets both exactly right, and that is the honest result.** Shewchuk's
+analysis puts `orient2d` at ~2x and `incircle` at ~4x working precision; `qd`
+supplies 4x, and on `double` inputs at ordinary scales that is enough. Attempts
+to break it here did not succeed: wide dynamic range alone does not help,
+because spreading the coordinates makes the determinant *large* relative to the
+error rather than small, so the inputs stop being degenerate at all.
+
+`elreal` is also exact, for a different reason. `qd` is exact because somebody
+did the error analysis and the answer happened to fit; `elreal` is exact because
+it has no budget to exceed. The guarantee survives a change of predicate, of
+scaling, or of input distribution without anyone re-deriving a bound -- which is
+the property a predicate library actually wants.
+
+### Two traps, for anyone using elreal this way
+
+Both cost real debugging time while this section was written, and both are now
+guarded in `elastic/elreal/oracle/sweep.cpp`.
+
+**`operator*` is depth-bounded.** At the default precision the determinant is
+truncated and near-degenerate signs come out wrong. Raise the depth with
+`elreal_precision_guard` for exact work.
+
+**Take the sign from the comparison operators, not from `sign()` or the raw
+block stream.** `sign()` answers +1 for zero, and a cancelling sum stays lazily
+unnormalised, so the leading raw block carries a phantom sign. Reading the
+stream directly gave the wrong answer on 61 of the 128 exactly-collinear grid
+points -- precisely the inputs a predicate exists to detect -- while being
+correct on all 16256 non-degenerate ones. `elreal_cmp`, which the comparison
+operators route through, skips zero blocks and is correct everywhere.
+
 ## Re-validation
 
 The study is a measurement, so it goes stale when the code under it moves. It
@@ -275,8 +326,7 @@ block, which is the point table A exists to make.
 
 ## Follow-ups (remaining Phase 9 scope)
 
-- **#1186** -- geometric predicate suite (orient2d, incircle). Independent of
-  the narrow-host work: it runs on the `double` host today.
+- ~~#1186 -- geometric predicate suite~~ -- **done**, section G above.
 - ~~#1187 -- cancellation-stressed sums~~ -- **done**, section F above.
 - **#1188** -- full recommendation matrix ("X precision at Y latency -> pick
   Z"). Still blocked, and blocked on the physics rather than on effort: the

--- a/docs/algorithmic-details/elreal-block-shape-study.md
+++ b/docs/algorithmic-details/elreal-block-shape-study.md
@@ -256,10 +256,18 @@ Each predicate is written once over a generic `Real` and instantiated for
 `double`, `qd` and `elreal<double>`; the reference is the same expression in
 exact dyadic rationals.
 
-| workload | `double` | `qd` | `elreal` | cases |
-|----------|----------|------|----------|-------|
-| orient2d, collinear + ulp grid | **5474** | 0 | 0 | 16384 (128 exactly collinear) |
-| incircle, near-cocircular | **629** | 0 | 0 | 4096 |
+| workload | `double` | `qd` | `elreal` | cases | exactly degenerate |
+|----------|----------|------|----------|-------|--------------------|
+| orient2d, collinear + ulp grid | **5474** | 0 | 0 | 16384 | 128 |
+| incircle, exactly cocircular +/- ulps | **105** | 0 | 0 | 288 | 60 |
+| incircle, near-cocircular | **486** | 0 | 0 | 4096 | 0 |
+
+The degenerate column is worth its own row rather than a footnote. Exact
+cocircularity of four independently rounded points is a measure-zero event, so
+the random near-cocircular sampling never produces one -- it cannot exercise the
+case where a predicate has to answer *zero*. The middle workload is built to:
+four points at the cardinal positions of a circle whose centre and radius are
+exactly representable are exactly cocircular by construction.
 
 `double` fails on a third of the orient2d grid and a sixth of the incircle
 cases. These are not exotic inputs -- they are ordinary coordinates near a
@@ -278,7 +286,7 @@ it has no budget to exceed. The guarantee survives a change of predicate, of
 scaling, or of input distribution without anyone re-deriving a bound -- which is
 the property a predicate library actually wants.
 
-### Two traps, for anyone using elreal this way
+### Three traps, for anyone using elreal this way
 
 Both cost real debugging time while this section was written, and both are now
 guarded in `elastic/elreal/oracle/sweep.cpp`.
@@ -286,6 +294,15 @@ guarded in `elastic/elreal/oracle/sweep.cpp`.
 **`operator*` is depth-bounded.** At the default precision the determinant is
 truncated and near-degenerate signs come out wrong. Raise the depth with
 `elreal_precision_guard` for exact work.
+
+**Do not step ulps from a coordinate that is exactly zero.** `from_native`
+refuses subnormal inputs by contract, and `nextafter(0.0, ...)` lands squarely in
+the subnormal range. In a release build this silently produced non-normalised
+blocks and 12 wrong signs; in a debug build it aborted on the assertion. The
+generator now checks every coordinate and reports what it skipped, because a
+workload that quietly drops cases is worse than one that fails loudly. The
+failure was in the test data, not in elreal -- the contract is documented at
+`from_native`.
 
 **Take the sign from the comparison operators, not from `sign()` or the raw
 block stream.** `sign()` answers +1 for zero, and a cancelling sum stays lazily

--- a/elastic/elreal/oracle/sweep.cpp
+++ b/elastic/elreal/oracle/sweep.cpp
@@ -223,6 +223,44 @@ namespace {
 		return fails;
 	}
 
+	// ---- exact geometric predicates (#1186) ----------------------------------
+	// orient2d's sign against the exact dyadic determinant, over collinear points
+	// perturbed by single ulps. The degenerate (exactly collinear) cases are the
+	// point of this test: elreal's sign() answers +1 for zero and a cancelling sum
+	// stays lazily unnormalised, so reading the raw leading block gives a phantom
+	// sign on precisely those inputs. The comparison operators route through
+	// elreal_cmp, which skips zero blocks. This guard fails if anyone swaps the
+	// one for the other.
+	int VerifyOrient2dExactSign(bool reportTestCases, int n) {
+		int fails = 0, degenerateSeen = 0;
+		const double bx = 12.0, by = 12.0, cx = 24.0, cy = 24.0;
+		const double u = std::ldexp(1.0, -53);
+		auto D = [](double v) { return dyadic::from_double(v); };
+		for (int i = 0; i < n; ++i) {
+			for (int j = 0; j < n; ++j) {
+				double ax = 0.5 + i * u, ay = 0.5 + j * u;
+				dyadic E = (D(ax) - D(cx)) * (D(by) - D(cy)) - (D(ay) - D(cy)) * (D(bx) - D(cx));
+				int expected = E.numerator.iszero() ? 0 : (E.numerator.sign() ? -1 : 1);
+				if (expected == 0) ++degenerateSeen;
+
+				elreal<double> Ax(ax), Ay(ay), Bx(bx), By(by), Cx(cx), Cy(cy), Z(0.0);
+				elreal<double> det = (Ax - Cx) * (By - Cy) - (Ay - Cy) * (Bx - Cx);
+				int got = det < Z ? -1 : (det > Z ? 1 : 0);
+				if (got != expected) {
+					if (reportTestCases && fails < 5)
+						std::cout << "    FAIL orient2d i=" << i << " j=" << j
+						          << " expected " << expected << " got " << got << '\n';
+					++fails;
+				}
+			}
+		}
+		if (degenerateSeen == 0) {   // the grid must actually contain degeneracies
+			if (reportTestCases) std::cout << "    FAIL orient2d grid has no degenerate cases\n";
+			++fails;
+		}
+		return fails;
+	}
+
 }  // anonymous namespace
 
 #define MANUAL_TESTING 0
@@ -265,6 +303,11 @@ try {
 	nrOfFailedTestCases += ReportTestResult(VerifyMulAgreement<double>("double", reportTestCases, base, 24, 40), "elreal<double> mul agreement vs dyadic", "mul");
 	nrOfFailedTestCases += ReportTestResult(VerifyMulAgreement<float>("float", reportTestCases, base, 24, 30), "elreal<float> mul agreement vs dyadic", "mul");
 	nrOfFailedTestCases += ReportTestResult(VerifyCancellationExact<double>("double", reportTestCases), "elreal<double> cancellation-stressed accumulation is exact", "cancellation");
+	{
+		// operator* is depth-bounded; the default precision truncates the determinant
+		elreal_precision_guard predicateDepth(32);
+		nrOfFailedTestCases += ReportTestResult(VerifyOrient2dExactSign(reportTestCases, 24), "elreal<double> orient2d sign is exact", "predicates");
+	}
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);


### PR DESCRIPTION
## Summary

Phase 9 follow-up **#1186** — the canonical robust-predicates workload (Shewchuk; McCleeary 5.1). Both predicates are sign queries on a determinant, and the sign is what a mesh generator or convex hull consumes: a wrong sign near a degeneracy doesn't produce a slightly wrong mesh, it produces an *inconsistent* one, and the algorithm above it can loop or crash.

Each predicate is written **once over a generic `Real`** and instantiated for `double`, `qd` and `elreal<double>`. The reference is the same expression in exact dyadic rationals.

| workload | `double` | `qd` | `elreal` | cases |
|----------|----------|------|----------|-------|
| orient2d, collinear + ulp grid | **5474** | 0 | 0 | 16384 (128 exactly collinear) |
| incircle, near-cocircular | **629** | 0 | 0 | 4096 |

## qd wins too, and that's the finding

`qd` gets both exactly right. That's the honest result rather than a failed experiment: Shewchuk's analysis puts `orient2d` at ~2× and `incircle` at ~4× working precision, and `qd` supplies 4×. On `double` inputs at ordinary scales it is enough.

I tried to break it with wide dynamic range and couldn't — and the reason is worth recording: spreading the coordinates makes the determinant *large* relative to the error rather than small, so the inputs stop being degenerate at all. That probe is documented as a negative result instead of quietly dropped.

`elreal` is exact for a different reason. `qd` is exact because somebody did the error analysis and the answer happened to fit; `elreal` is exact because it has no budget to exceed. The guarantee survives a change of predicate, of scaling, or of input distribution without anyone re-deriving a bound — which is the property a predicate library actually wants.

## Two traps, found the hard way

Both cost real debugging time and are now **guarded in the sweep oracle**.

**1. `operator*` is depth-bounded.** At the default precision the determinant is truncated and near-degenerate signs come out wrong. Raise it with `elreal_precision_guard`.

**2. Take the sign from the comparison operators, not `sign()` or the raw block stream.** `sign()` answers +1 for zero, and a cancelling sum stays lazily unnormalised, so the leading raw block carries a phantom sign. My first implementation read the stream directly and was wrong on **61 of the 128 exactly-collinear grid points** — precisely the inputs a predicate exists to detect — while correct on all 16256 non-degenerate ones. `elreal_cmp`, which the comparison operators route through, skips zero blocks and is correct everywhere.

The new regression mutation-tests exactly this: swapping the comparison back for `sign()` makes it report `expected 0 got 1` on the degenerate cases.

## Changes

- `benchmark/performance/arithmetic/elreal/predicates.cpp` (new) — the suite; auto-wired by the directory glob
- `elastic/elreal/oracle/sweep.cpp` — `orient2d` sign as a pass/fail regression, including an assertion that the grid actually contains degeneracies (a guard that never sees one proves nothing)
- `docs/algorithmic-details/elreal-block-shape-study.md` — section G; #1186 struck from the follow-up list

No library headers touched.

## Test Results

| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| `el_oracle_sweep` | OK | **PASS** | OK | **PASS** |
| `benchmark_elreal_predicates` | OK | runs | OK | runs |

gcc 13.3 and clang 18.1 agree on every cell. `check-ascii.sh` clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1186. Part of #933, epic #923.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added geometric-predicate benchmarks for orientation and incircle calculations across multiple numeric precision types.
  * Added exact-sign verification for perturbed collinear inputs, including detection of degenerate cases.
* **Documentation**
  * Documented predicate accuracy results, failure counts, exactness findings, and precision-related usage considerations.
  * Marked the geometric predicate benchmark suite as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->