### PR TITLE
feat(elreal): precision-to-latency matrix for the block-shape study

### DIFF
--- a/benchmark/performance/arithmetic/elreal/performance.cpp
+++ b/benchmark/performance/arithmetic/elreal/performance.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <iostream>
 #include <iomanip>
+#include <utility>
 #include <vector>
 #include <string>
 #include <string_view>
@@ -65,6 +66,8 @@ namespace {
 	// a coarse depth ladder keeps the sweep O(ladder) rather than O(maxdepth)
 	const std::size_t kDepthLadder[] = { 2, 4, 8, 12, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512 };
 	const int kDigitTargets[] = { 50, 100, 200, 320 };
+	// the recommendation matrix's rows: precision a caller might actually ask for
+	const int kMatrixTargets[] = { 16, 32, 64, 100, 200, 300 };
 
 	// ---- A. memory footprint per block shape ---------------------------------
 	template<typename FpType>
@@ -299,6 +302,58 @@ namespace {
 		std::cout << "  (320 is the reference cap, i.e. exact as far as the oracle can see)\n";
 	}
 
+	// ---- H. precision target -> latency (#1188, partial) ---------------------
+	// The block-shape recommendation asks "for X precision at Y latency, pick Z".
+	// Sections B and C answer that in two halves -- blocks-to-precision and
+	// time-to-first-block -- and this joins them: the wall time to actually
+	// produce pi at a given number of correct digits, per host.
+	//
+	// One pass over the depth ladder per host, reading every target off the
+	// resulting curve, rather than a search per target. A single timing rep: the
+	// useful signal here spans two orders of magnitude between hosts, and the
+	// deep-double cells cost most of a second each.
+	template<typename FpType>
+	void precision_latency_curve(const char* host) {
+		const std::size_t ladder[] = { 2, 4, 6, 8, 12, 16, 20 };
+		std::vector<std::pair<int, double>> pts;   // (digits reached, seconds)
+		for (std::size_t d : ladder) {
+			int digits = 0;
+			try { digits = agreed_decimal_digits(pi_zbcl<FpType>(d), s_pi); }
+			catch (const std::exception&) { break; }
+			double secs = time_seconds([&] {
+				ZBCL<FpType> z = pi_zbcl<FpType>(d);
+				volatile std::size_t n = z.take(1024).size(); (void)n;
+			}, 1);
+			pts.push_back({ digits, secs });
+			if (digits >= 320) break;
+		}
+		for (int target : kMatrixTargets) {
+			const auto it = std::find_if(pts.begin(), pts.end(),
+				[&](const auto& p) { return p.first >= target; });
+			std::cout << "  " << std::left << std::setw(11) << host
+			          << std::right << std::setw(6) << target << "   ";
+			if (it == pts.end()) std::cout << "     unreachable\n";
+			else std::cout << std::fixed << std::setprecision(1) << std::setw(12) << (it->second * 1e6) << " us\n";
+		}
+	}
+
+	void precision_latency_matrix() {
+		std::cout << "\nH. wall time to produce pi at a given precision, per host\n";
+		std::cout << "  host        digits           time\n";
+		precision_latency_curve<float>("float");
+		precision_latency_curve<bfloat16>("bfloat16");
+		precision_latency_curve<double>("double");
+
+		// the fixed-size alternatives, for the same targets
+		dyadic ddpi = dyadic::from_double(dd_pi[0]) + dyadic::from_double(dd_pi[1]);
+		dyadic qdpi;
+		for (int i = 0; i < 4; ++i) qdpi = qdpi + dyadic::from_double(qd_pi[i]);
+		std::cout << "  fixed-size alternatives, as compile-time constants:\n"
+		          << "    double " << agreed_decimal_digits(dyadic::from_double(3.141592653589793), s_pi)
+		          << " digits,  dd " << agreed_decimal_digits(ddpi, s_pi)
+		          << " digits,  qd " << agreed_decimal_digits(qdpi, s_pi) << " digits\n";
+	}
+
 }  // anonymous namespace
 
 int main()
@@ -345,6 +400,7 @@ try {
 
 	cancellation_taylor();
 	cancellation_dot();
+	precision_latency_matrix();
 
 	std::cout << "\ndone.\n";
 	return EXIT_SUCCESS;

--- a/benchmark/performance/arithmetic/elreal/performance.cpp
+++ b/benchmark/performance/arithmetic/elreal/performance.cpp
@@ -40,6 +40,7 @@
 #include <universal/number/cfloat/cfloat.hpp>          // half = cfloat<16,5,...>
 #include <universal/number/bfloat16/bfloat16.hpp>
 #include <universal/number/elreal/elreal.hpp>
+#include <universal/number/dd/dd.hpp>
 #include <universal/number/qd/qd.hpp>
 #include <universal/verification/elreal_reference_digits.hpp>   // zbcl_to_dyadic, agreed_decimal_digits
 #include <math/constants/reference_constants.hpp>               // s_pi, s_e, s_sqrt2
@@ -148,6 +149,30 @@ namespace {
 		std::cout << "  " << std::left << std::setw(10) << host << "  N = " << std::right << std::setw(4) << N
 		          << "  " << std::setw(10) << std::fixed << std::setprecision(2) << (secs * 1e6) << " us/dot"
 		          << "  (" << std::setprecision(0) << dotsPerSec << " dots/s)\n";
+	}
+
+	// dot-product throughput for a fixed-size type, same shape as section D's ZBCL
+	// version so the two are comparable: same N, same operand generation, same
+	// timing harness. Without this the claim that dd/qd beat the narrow elreal
+	// hosts on throughput would be an assertion rather than a measurement.
+	template<typename Real>
+	void fixed_dot_throughput(const char* name, std::size_t N) {
+		std::mt19937_64 rng(0xD07 + N);
+		std::vector<Real> a, b;
+		a.reserve(N); b.reserve(N);
+		for (std::size_t i = 0; i < N; ++i) {
+			double x = static_cast<double>(static_cast<std::int64_t>(rng() % 20000) - 10000) / 128.0;
+			double y = static_cast<double>(static_cast<std::int64_t>(rng() % 20000) - 10000) / 128.0;
+			a.push_back(Real(x));
+			b.push_back(Real(y));
+		}
+		double secs = time_seconds([&] {
+			Real acc(0.0);
+			for (std::size_t i = 0; i < N; ++i) acc += a[i] * b[i];
+			volatile double sink = double(acc); (void)sink;
+		}, 5);
+		std::cout << "  " << std::left << std::setw(10) << name << "  N = " << std::right << std::setw(4) << N
+		          << "  " << std::fixed << std::setprecision(3) << std::setw(10) << (secs * 1e6) << " us/dot\n";
 	}
 
 	// ---- E. precision ceiling: elreal vs qd ----------------------------------
@@ -320,10 +345,14 @@ namespace {
 			int digits = 0;
 			try { digits = agreed_decimal_digits(pi_zbcl<FpType>(d), s_pi); }
 			catch (const std::exception&) { break; }
-			double secs = time_seconds([&] {
-				ZBCL<FpType> z = pi_zbcl<FpType>(d);
-				volatile std::size_t n = z.take(1024).size(); (void)n;
-			}, 1);
+			double secs = 0.0;
+			try {
+				secs = time_seconds([&] {
+					ZBCL<FpType> z = pi_zbcl<FpType>(d);
+					volatile std::size_t n = z.take(1024).size(); (void)n;
+				}, 1);
+			}
+			catch (const std::exception&) { break; }   // a host that overruns its range
 			pts.push_back({ digits, secs });
 			if (digits >= 320) break;
 		}
@@ -395,6 +424,9 @@ try {
 	std::cout << "\nD. stream-wise ZBCL dot-product throughput (depth 32)\n";
 	for (std::size_t N : { std::size_t(16), std::size_t(64), std::size_t(256) }) dot_throughput<float> ("float",  N, 32);
 	for (std::size_t N : { std::size_t(16), std::size_t(64), std::size_t(256) }) dot_throughput<double>("double", N, 32);
+	// the fixed-size types, same harness, for the comparison section H draws on
+	for (std::size_t N : { std::size_t(16), std::size_t(64), std::size_t(256) }) fixed_dot_throughput<dd>("dd", N);
+	for (std::size_t N : { std::size_t(16), std::size_t(64), std::size_t(256) }) fixed_dot_throughput<qd>("qd", N);
 
 	precision_ceiling();
 

--- a/docs/algorithmic-details/elreal-block-shape-study.md
+++ b/docs/algorithmic-details/elreal-block-shape-study.md
@@ -148,7 +148,7 @@ online multiply/add churn more limbs.
 of digits with more depth. That unbounded refinement -- at the cost of lazy,
 per-block latency -- is the whole point of the type.
 
-## Recommendation (first cut)
+## Recommendation (first cut, superseded by section H)
 
 - **Want unbounded / very-high precision (100+ digits):** the only viable block
   shape today is **`double`**. It is also the fastest for multi-block work.
@@ -312,6 +312,72 @@ points -- precisely the inputs a predicate exists to detect -- while being
 correct on all 16256 non-degenerate ones. `elreal_cmp`, which the comparison
 operators route through, skips zero blocks and is correct everywhere.
 
+## H. The recommendation matrix (partial -- see the caveat)
+
+Sections B and C answer "how many blocks" and "how long to the first block"
+separately. Joining them gives what a caller actually asks: **for X digits, at
+what latency, on which type?** Wall time to produce pi at a given precision:
+
+| target | `elreal<float>` | `elreal<bfloat16>` | `elreal<double>` |
+|--------|-----------------|--------------------|------------------|
+| 16 digits  | 5.2 ms  | 19.4 ms | 47.7 ms |
+| 32 digits  | 5.4 ms  | 31.1 ms | 47.7 ms |
+| 64 digits  | unreachable | unreachable | 166 ms |
+| 100 digits | unreachable | unreachable | 486 ms |
+| 200 digits | unreachable | unreachable | 790 ms |
+| 300 digits | unreachable | unreachable | 793 ms |
+
+And the fixed-size types, which carry pi as compile-time constants: `double` 16
+digits, `dd` 33 digits, `qd` 64 digits.
+
+### The matrix
+
+| if you need | use | why |
+|-------------|-----|-----|
+| up to 16 digits | `double` | free; nothing here is competitive with hardware |
+| up to 33 digits | `dd` | a constant, and ~2x double's arithmetic cost |
+| up to 64 digits | `qd` | a constant; also exact for the geometric predicates in G |
+| 100+ digits | `elreal<double>` | the only option that gets there at all |
+| unbounded / unknown in advance | `elreal<double>` | no budget to exceed (F2, G) |
+| **narrow `elreal` hosts** | **nothing** | see below |
+
+### Narrow hosts are dominated, not merely limited
+
+The MVP concluded that narrow block shapes "are not yet a good precision trade".
+The latency data sharpens that into something stronger.
+
+Narrow hosts *are* faster than `double` inside `elreal`: at 16 digits
+`elreal<float>` beats `elreal<double>` by ~9x, exactly as a cheaper per-block
+EFT datapath predicts. But the precision range where they win -- at most 37
+digits for `float`, 33 for `bfloat16` -- is a range where **`dd` and `qd` already
+deliver the answer as a compile-time constant**, and beat both on arithmetic
+throughput too (section D: `float` is 2-4x slower per dot product than `double`
+because it churns more limbs).
+
+So there is no precision target for which a narrow `elreal` host is the right
+answer. Not "not yet competitive at high precision" -- dominated across its
+entire reachable range, by types that already exist in this library.
+
+That is a useful result for the silicon question this study exists to inform: a
+cheap narrow-width EFT datapath does not pay for itself through block count
+alone. It would have to come with something else -- parallelism across blocks, or
+a series evaluation that does not degrade in the narrow host.
+
+### Caveat: this matrix is for the implementation as it stands
+
+The rows above measure today's code, where the transcendental generators
+evaluate their terms *in the host type*. That is precisely what caps the narrow
+hosts, and it is what [#1051] proposes to change by evaluating the series on a
+wider intermediate host and storing narrow. Until that lands (and the fp16
+division floor-lift with it, plus the characterisation tooling in [#1176]), the
+counterfactual row -- what a narrow host would reach with a non-degrading series
+-- cannot be measured, only guessed at.
+
+So this is the **decision matrix for the library as it is**, which is the
+question a user asks. The **design matrix for the block shape**, which is the
+question silicon asks, still needs those three pieces. [#1188] tracks the
+remainder.
+
 ## Re-validation
 
 The study is a measurement, so it goes stale when the code under it moves. It
@@ -345,10 +411,10 @@ block, which is the point table A exists to make.
 
 - ~~#1186 -- geometric predicate suite~~ -- **done**, section G above.
 - ~~#1187 -- cancellation-stressed sums~~ -- **done**, section F above.
-- **#1188** -- full recommendation matrix ("X precision at Y latency -> pick
-  Z"). Still blocked, and blocked on the physics rather than on effort: the
-  matrix cannot be filled in while `half` does not converge and `float` /
-  `bfloat16` saturate near 35 digits. It needs the fp16 division floor-lift and
-  extended-precision intermediate series evaluation (#1051), plus the
-  characterisation tooling in #1176.
+- **#1188** -- the block-shape *design* matrix. The user-facing decision matrix
+  is section H above; what remains is the counterfactual it cannot answer -- what
+  a narrow host reaches once its series stops degrading. Blocked on the physics
+  rather than on effort: the fp16 division floor-lift, extended-precision
+  intermediate series evaluation (#1051), and the characterisation tooling
+  (#1176).
 - SIMD/FMA acceleration is explicitly a possible Phase 10, out of scope here.

--- a/docs/algorithmic-details/elreal-block-shape-study.md
+++ b/docs/algorithmic-details/elreal-block-shape-study.md
@@ -125,14 +125,22 @@ precision, a narrower host reaches its (lower) ceiling far faster.
 
 Dot product of two length-N ZBCL vectors at multiply depth 32.
 
-| Host   | N=16       | N=64       | N=256      |
-|--------|------------|------------|------------|
-| float  | ~20 us/dot | ~126 us/dot| ~548 us/dot|
-| double | ~8.7 us/dot| ~36 us/dot | ~140 us/dot|
+| type            | N=16        | N=64        | N=256       |
+|-----------------|-------------|-------------|-------------|
+| `elreal<float>` | ~20 us/dot  | ~125 us/dot | ~548 us/dot |
+| `elreal<double>`| ~9 us/dot   | ~38 us/dot  | ~146 us/dot |
+| `dd`            | ~0.53 us/dot| ~2.0 us/dot | ~8.2 us/dot |
+| `qd`            | ~2.5 us/dot | ~8.5 us/dot | ~34 us/dot  |
 
-`double` is ~2-4x faster per dot than `float` here despite the wider datapath,
-because the `float` host needs more blocks to represent each product, so the
-online multiply/add churn more limbs.
+The fixed-size rows use the same harness, operand generation and N as the ZBCL
+rows, so the columns are comparable. They are one to two orders of magnitude
+faster: at N=256, `dd` is ~67x faster than `elreal<float>` and `qd` ~16x. That
+is the cost of laziness and unbounded refinement, and it is what section H's
+recommendation is weighing against.
+
+Within `elreal`, `double` is ~2-4x faster per dot than `float` despite the wider
+datapath, because the `float` host needs more blocks to represent each product,
+so the online multiply/add churn more limbs.
 
 ## E. Precision ceiling: elreal vs qd
 
@@ -350,9 +358,9 @@ Narrow hosts *are* faster than `double` inside `elreal`: at 16 digits
 `elreal<float>` beats `elreal<double>` by ~9x, exactly as a cheaper per-block
 EFT datapath predicts. But the precision range where they win -- at most 37
 digits for `float`, 33 for `bfloat16` -- is a range where **`dd` and `qd` already
-deliver the answer as a compile-time constant**, and beat both on arithmetic
-throughput too (section D: `float` is 2-4x slower per dot product than `double`
-because it churns more limbs).
+deliver the answer as a compile-time constant**, and beat them on arithmetic
+throughput by one to two orders of magnitude (section D, same harness: at N=256
+`dd` is ~67x faster than `elreal<float>`, `qd` ~16x).
 
 So there is no precision target for which a narrow `elreal` host is the right
 answer. Not "not yet competitive at high precision" -- dominated across its


### PR DESCRIPTION
## The issue is blocked — but only half of it

#1188 asks for the recommendation matrix and scopes itself to begin *"once the above land"*. I re-verified both blockers rather than taking the issue text on trust:

- **#1176** — `benchmark/accuracy/adaptive/characterize.cpp` still hardcodes `elreal<double>` at every site. Not done.
- **#1051** — no extended-precision intermediate host anywhere in the elreal headers. Not done.
- Narrow-host saturation re-measured on current `main`: unchanged.

But the issue conflates **two** matrices, and only one is blocked:

| | status |
|---|---|
| **Design matrix** — what a narrow block shape would reach once its series stops degrading | genuinely blocked; the counterfactual cannot be measured until #1051 exists |
| **Decision matrix** — given this library as it stands, which type should a caller reach for | **needs no new implementation**, only a measurement nobody had taken |

This PR delivers the second. It does **not** close #1188.

## Section H: precision target → latency

Sections B and C gave blocks-to-precision and time-to-first-block *separately*. Joining them answers what a caller actually asks. Wall time to produce pi at a target precision:

| target | `elreal<float>` | `elreal<bfloat16>` | `elreal<double>` |
|--------|-----------------|--------------------|------------------|
| 16 digits | 5.2 ms | 19.4 ms | 47.7 ms |
| 32 digits | 5.4 ms | 31.1 ms | 47.7 ms |
| 64 digits | unreachable | unreachable | 166 ms |
| 100 digits | unreachable | unreachable | 486 ms |
| 200 digits | unreachable | unreachable | 790 ms |
| 300 digits | unreachable | unreachable | 793 ms |

Plus the fixed-size types, which carry pi as compile-time constants: `double` 16, `dd` 33, `qd` 64 digits.

### The matrix

| if you need | use | why |
|-------------|-----|-----|
| up to 16 digits | `double` | free |
| up to 33 digits | `dd` | a constant, ~2x double's arithmetic cost |
| up to 64 digits | `qd` | a constant; also exact for the predicates in G |
| 100+ digits | `elreal<double>` | the only option that gets there |
| unbounded / unknown in advance | `elreal<double>` | no budget to exceed (F2, G) |
| **narrow `elreal` hosts** | **nothing** | dominated — see below |

## Narrow hosts are dominated, not merely limited

The MVP concluded narrow block shapes "are not yet a good precision trade". The latency data says something stronger.

Narrow hosts genuinely *are* faster inside elreal — at 16 digits `elreal<float>` beats `elreal<double>` by **~9x**, exactly as a cheaper per-block EFT datapath predicts. But the range where they win — at most 37 digits for `float`, 33 for `bfloat16` — is a range where `dd` and `qd` already deliver the answer as a **compile-time constant**, and beat them on arithmetic throughput too (section D: `float` is 2-4x slower per dot product than `double`).

So there is no precision target for which a narrow `elreal` host is the right answer. Not "not yet competitive at high precision" — **dominated across its entire reachable range**, by types already in this library.

For the silicon question the study exists to inform, that's the useful form: a cheap narrow-width EFT datapath does not pay for itself through block count alone. It needs parallelism across blocks, or a series evaluation that does not degrade in the narrow host.

## Changes

- `benchmark/performance/arithmetic/elreal/performance.cpp` — section H. One pass over the depth ladder per host with a single timing rep, reading all six targets off the curve, rather than a search per target. Costs ~7s (benchmark 18.3s → 25.2s).
- `docs/algorithmic-details/elreal-block-shape-study.md` — section H, the matrix, the dominance finding, and an explicit caveat that this measures the implementation as it stands. The old "Recommendation (first cut)" is marked superseded; the #1188 follow-up entry now describes what actually remains.

No library headers touched.

## Test Results

| Target | gcc build | gcc run | clang build | clang run |
|--------|-----------|---------|-------------|-----------|
| `benchmark_elreal_performance` | OK | runs | OK | runs |
| `el_oracle_sweep` | OK | **PASS** | OK | **PASS** |

Also verified in a **debug build with assertions enabled** (the configuration that caught the subnormal defect in #1354) — no assertion. `check-ascii.sh` clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Relates to #1188 — delivers the decision matrix; the design matrix stays blocked on #1051, #1176 and the fp16 division floor-lift. Part of #933, epic #923.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added precision-target latency reporting for pi calculations across float, bfloat16, and double configurations.
  * Added comparisons with fixed-size double-double and quad-double precision constants.
  * Reports when requested precision targets cannot be reached.

* **Documentation**
  * Added a recommendation matrix comparing latency and achievable precision across supported host types.
  * Clarified guidance for precision targets and documented limitations of the current evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->