### PR TITLE
fix(elreal): keep bfloat16's two_prod in host arithmetic

### DIFF
--- a/docs/design/elreal-narrow-host-blocks.md
+++ b/docs/design/elreal-narrow-host-blocks.md
@@ -1,0 +1,170 @@
+# elreal on narrow hosts: the limit is exponent range, not precision
+
+**Status:** design proposal. Nothing here is implemented.
+**Context:** #1051, #1188, #933, epic #923.
+
+## Summary
+
+`elreal<FpType>` saturates on narrow hosts -- `bfloat16` stops near 33 decimal
+digits, `float` near 37, while `double` reaches ~307. The standing explanation
+is that the transcendental *series arithmetic* degrades below `float`, and #1051
+proposes to fix it by evaluating the series on a wider intermediate host and
+rounding the result down into narrow blocks.
+
+Measurement does not support that explanation, and the proposed fix would not
+lift the ceiling.
+
+The limit is the **host's exponent range**. It is not the host's precision, and
+it is not the error-free transforms. It is also not inherent to McCleeary's
+algorithm: the block representation already carries the field needed to remove
+it, and simply is not using it.
+
+## Evidence
+
+### The EFTs are exact on every host
+
+200,000 random operand pairs per host, scored against the exact dyadic-rational
+oracle (`verification/dyadic_exact.hpp`):
+
+| host | `two_sum` | `two_prod` |
+|------|-----------|------------|
+| `bfloat16` (k=7) | 0 inexact | 0 inexact |
+| `float` (k=24) | 0 inexact | 0 inexact |
+| `double` (k=53) | 0 inexact | 0 inexact |
+
+Whatever caps the narrow hosts, it is not the primitives.
+
+### Precision is not the binding constraint
+
+`float` carries 24 significand bits and `bfloat16` carries 7 -- a factor of 3.4.
+They saturate 4 decimal digits apart, at 37 and 33. If precision per block were
+the limit, the gap would be enormous. It is not, because they share an 8-bit
+exponent.
+
+### Every host's ceiling matches its exponent range
+
+| host | `min_exponent` | predicted ceiling | measured |
+|------|----------------|-------------------|----------|
+| `double` | -1021 | ~307 digits | 306 |
+| `float` | -125 | ~37 digits | 37 |
+| `bfloat16` | -125, plus the `+2k` narrow-host margin -> -111 | ~33 digits | 33 |
+
+The entire `float`-vs-`bfloat16` difference is the `2*k` margin the narrow path
+adds (14 bits for `bfloat16`, none for `float`): 4 decimal digits.
+
+### The mechanism
+
+A `block<FpType>` is a pair `(v: FpType, exp: integer<256>)` with
+
+```
+combined_exponent = scale_of_v() + exp
+```
+
+and the McCleeary invariant, from `block.hpp`:
+
+```
+// is_normalised(): true iff `v` is a finite, non-zero, non-subnormal value.
+// Subnormals fail this predicate; McCleeary blocks must avoid them
+// because 0-overlap accounting assumes the leading bit is set.
+```
+
+`v` is **not** renormalised into `[1,2)`; it carries its own scale. As a series
+or division refines, each successive block's `v` is smaller than the last, until
+`v` goes subnormal, `is_normalised()` fails, and refinement arrests. That is the
+`min_exponent + 2*k` floor, which appears in three places, all gated to `k < 24`:
+`series_stop_exp` (`math/constants.hpp`), `exp_floor` (`divide.hpp`), and
+`host_exp_floor` (`online_divide.hpp`).
+
+Instrumenting a depth-24 `e_zbcl` confirms it directly:
+
+| host | `v` scale range | min combined exponent | `min_exponent` |
+|------|-----------------|-----------------------|----------------|
+| `bfloat16` | `2^2` down to `2^-117` | -118 | -128 |
+| `float` | `2^2` down to `2^-123` | -124 | -125 |
+| `double` | `2^2` down to `2^-988` | -989 | -1021 |
+
+Two things follow. Each host runs `v` down to within a few bits of its own
+subnormal wall -- and `min combined exponent` is within 1 of the minimum `v`
+scale, which means the `integer<256>` `exp` field is carrying **approximately
+zero**. The unbounded exponent added in #1061 exists but is not being used to
+hold scale in these paths.
+
+## Why #1051's proposed fix does not work
+
+Evaluating the series at `double` and rounding into `bfloat16`-hosted blocks
+targets precision, which was never the constraint. The resulting blocks still
+carry their scale in `v`, so they still hit `min_exponent` at the same place, and
+the ceiling does not move. It also costs the thing the study exists to measure:
+a block-shape study whose interior arithmetic runs at `double` is not measuring a
+narrow datapath.
+
+The storage arithmetic is unfavourable too. Table A of the block-shape study
+measures `sizeof(block)` at 36 B for `bfloat16` and 40 B for `double`, because
+the wide exponent field dominates the struct. Per byte that is 0.19 payload bits
+for `bfloat16` against 1.33 for `double` -- `double` is 6.8x more
+storage-efficient. A narrow host reaching high precision would need ~7.6x more
+blocks at ~0.9x the size each.
+
+## Proposal: scale-normalised blocks
+
+Maintain `v` in `[1,2)` (or `[1,2)` in magnitude) and carry all scale in the
+`integer<256>` `exp` field, which is unbounded by construction.
+
+Then `v` is always normal by construction, `is_normalised()` cannot fail for a
+scale reason, and the host's `min_exponent` is never approached. The three
+`min_exponent + 2*k` floors become dead code. A narrow host's reach is then
+bounded only by the number of blocks one is willing to carry -- that is, by `k`
+-- rather than by exponent range.
+
+Expected consequences, stated so they can be falsified:
+
+- `bfloat16` and `float` should reach any target precision `double` reaches,
+  needing roughly `53/k` times as many blocks (~7.6x for `bfloat16`, ~2.2x for
+  `float`).
+- The measured ceilings (33 / 37 / 307) should all lift.
+- `double` results should be **bit-identical**, since a wide host never
+  approached its floor in the first place. This is the primary regression check.
+
+### Where the work is
+
+| area | change |
+|------|--------|
+| `block.hpp` | a `normalise()` that splits `v` into `[1,2)` mantissa plus exponent delta, folded into `exp`; apply at block construction and after each EFT result |
+| `block_eft.hpp` | renormalise `two_sum` / `two_prod` / `two_div` outputs before returning |
+| `divide.hpp`, `online_divide.hpp` | drop `exp_floor` / `host_exp_floor`; the remainder sequence no longer decays toward subnormal |
+| `math/constants.hpp` | drop the narrow-host branch of `series_stop_exp`; the target term becomes the only stop |
+| `zbcl.hpp` | confirm the 0-overlap comparison is expressed in combined exponents, not raw `v` scales |
+
+### Risks
+
+- **The 0-overlap invariant is stated in terms of block exponents.** If any
+  comparison uses `scale_of_v()` rather than `combined_exponent()`,
+  renormalisation silently changes its meaning. This is the main correctness
+  risk and should be settled by reading before writing.
+- **Cost.** A renormalisation per EFT result is a `frexp`/`ldexp` pair on the
+  hot path. `double` must not regress; if it does, gate renormalisation to
+  `k < 24` hosts, which is where it is needed.
+- **Exact-zero and non-finite blocks** have no meaningful mantissa scale and
+  must bypass renormalisation.
+- **`from_native`** already asserts `is_normalised()`; it would need to
+  renormalise rather than reject, which changes an existing contract (#1136).
+
+### Validation
+
+- `double` bit-identity across the existing suites is the gate. If `double`
+  moves at all, the change is wrong.
+- The dyadic oracle sweep (`elastic/elreal/oracle/sweep.cpp`) extended to
+  `bfloat16`, asserting exact `add`/`sub` as it already does for `float`.
+- The block-shape study (`benchmark/performance/arithmetic/elreal/performance.cpp`)
+  re-run; section B's narrow-host rows are the headline result and section H's
+  matrix should change qualitatively.
+- A depth sweep showing `bfloat16` past 33 digits is the minimum bar for calling
+  this done.
+
+## What this would settle
+
+If it works, the block-shape study can finally answer the question it exists to
+ask -- what a narrow block shape costs in blocks and time at a *fixed* precision
+target -- instead of reporting that narrow hosts cannot reach the target at all.
+That is the missing half of #1188's design matrix, and it does it without
+computing anything in a wider type.

--- a/include/sw/universal/number/elreal/block_eft.hpp
+++ b/include/sw/universal/number/elreal/block_eft.hpp
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <concepts>
 #include <utility>
 
 #include <universal/number/elreal/block.hpp>
@@ -95,6 +96,19 @@ inline void split_host(T a, T& hi, T& lo) {
     lo   = a - hi;
 }
 
+// eft_has_fma_v<T>: does T have a callable fma(a, b, c)?  Resolved with std::fma
+// visible, so a native type finds the standard one and a Universal type finds its
+// own by ADL. A correctly-rounded fma computes a*b + c with a SINGLE rounding, so
+// fma(a, b, -p) is the exact residual of a*b by construction -- no splitting, no
+// width arithmetic, no wider intermediate.
+namespace fma_detect {
+    using std::fma;
+    template <typename T>
+    concept callable = requires(T a, T b, T c) { { fma(a, b, c) } -> std::convertible_to<T>; };
+}
+template <typename T>
+inline constexpr bool eft_has_fma_v = fma_detect::callable<T>;
+
 // two_prod returning the rounded product p = a*b and the residual r = a*b - p.
 //
 // The generic Veltkamp/Dekker split is exact only when the precision p is EVEN:
@@ -123,17 +137,18 @@ inline void split_host(T a, T& hi, T& lo) {
 // Three residual paths, chosen at compile time:
 //   - even p: Veltkamp/Dekker, exact in host arithmetic at ANY width (the
 //     partial product a_hi*b_hi fits in p bits when p is even).
-//   - odd p, 2p > 53: a double cannot hold the exact product, so the double
-//     intermediate below would be wrong (it silently dropped the residual of a
-//     113-bit quad product -- issue #1024). Use the host's correctly-rounded
-//     fused fma instead: r = fma(a,b,-p) = a*b - p exactly (single rounding; the
-//     product's rounding error is always representable). cfloat<> has such an
-//     fma (verified at 113 bits: 0/20000 inexact against the exact dyadic
-//     oracle). This is the quad-and-up path.
-//   - odd p, 2p <= 53: a double holds the exact product, so wp - p is the exact
-//     residual (modulo the result type's representability, e.g. the cfloat<24,5>
-//     subnormal floor, #942). Covers half / cfloat<24,5> and any fma-less odd-p
-//     host in this range (e.g. bfloat16).
+//   - odd p, T has an fma: r = fma(a,b,-p) = a*b - p exactly, in host arithmetic.
+//     A correctly-rounded fma rounds once, so the residual is exact by
+//     construction at any width. This used to be gated on 2p > 53 -- a proxy for
+//     "a double cannot hold the exact product" (issue #1024, the 113-bit quad
+//     case). The proxy sent every narrow odd-p host down the wide-intermediate
+//     path below, including bfloat16, which has had a correctly-rounded fma since
+//     #1232. Dispatching on the fma itself keeps those hosts entirely in their own
+//     arithmetic, which is the binding rule at the top of this file and what a
+//     block-shape study of narrow hosts has to measure to mean anything (#1051).
+//   - odd p, no fma: fall back to a double intermediate, exact when 2p <= 53.
+//     wp - p is then the exact residual, modulo the result type's own
+//     representability (e.g. the cfloat<24,5> subnormal floor, #942).
 template <typename T>
 UNIVERSAL_ELREAL_EFT_NOINLINE
 inline void two_prod_host(T a, T b, T& p, T& r) {
@@ -144,8 +159,8 @@ inline void two_prod_host(T a, T b, T& p, T& r) {
         split_host(b, b_hi, b_lo);
         r = ((a_hi * b_hi - p) + a_hi * b_lo + a_lo * b_hi) + a_lo * b_lo;
     }
-    else if constexpr (2 * std::numeric_limits<T>::digits > 53) {
-        using std::fma;          // std::fma (native) / sw::universal::fma (cfloat)
+    else if constexpr (eft_has_fma_v<T>) {
+        using std::fma;          // std::fma (native) / sw::universal::fma (Universal types)
         r = fma(a, b, -p);
     }
     else {


### PR DESCRIPTION
## Answering the question first

> *Is there anything in the McCleeary algorithm that doesn't work with narrow types?*

**No.** The limit is the host's **exponent range**, not its precision, and not the EFTs. It also isn't inherent to the algorithm — the block representation already carries the field needed to remove it and isn't using it.

| evidence | result |
|---|---|
| EFT exactness, 200k products/host vs the dyadic oracle | `bfloat16` 0 inexact, `float` 0, `double` 0 |
| precision as the constraint | `float` (k=24) and `bfloat16` (k=7) differ **3.4× in precision**, saturate **4 digits apart** (37 / 33) — they share an 8-bit exponent |
| exponent range as the constraint | `double` −1021 → 306 digits · `float` −125 → 37 · `bfloat16` −125+2k → 33. All three match. |

**Mechanism:** a block is `(v: FpType, exp: integer<256>)` with `combined_exponent = scale_of_v() + exp`. `v` is *not* renormalised into [1,2) — it carries its own scale, so a refining series drives `v` subnormal, `is_normalised()` fails, and refinement arrests. Instrumenting a depth-24 `e_zbcl`: `v` runs to `2^-117` (bfloat16) and `2^-988` (double), each within a few bits of its host's wall, while the `integer<256>` exponent added in #1061 carries **≈ 0**.

So #1051's "compute wide, store narrow" targets precision, which was never the constraint, and would not move the ceiling.

## This PR: the one piece that is small and self-contained

`block_eft.hpp` opens with a binding rule from epic #923 — *"Use the host FpType's arithmetic directly. Do NOT promote to a wider type."* `two_prod_host` broke it for bfloat16.

The residual dispatch tested `2 * digits > 53` to choose the fma path. That's a proxy for "a double cannot hold the exact product" (the 113-bit quad case, #1024), **not** a statement about whether the type has an fma. bfloat16 has odd precision (p=7) and 2p=14, so it fell through to a `double` intermediate — despite having had a correctly-rounded fma since #1232.

The dispatch now tests for **the fma itself**, via a concept resolved with `std::fma` visible so native types find the standard one and Universal types find their own by ADL. A correctly-rounded fma rounds once, so `fma(a,b,-p)` is the exact residual by construction at any width.

### Verified against the exact dyadic oracle, 200k products per host

| host | result |
|---|---|
| `bfloat16` | 0 inexact, **bit-identical** to the old wide path |
| `float` | 0 inexact (unchanged — even p, still Veltkamp) |
| `double` | 0 inexact (unchanged — own specialisation) |
| `half` | 0 inexact, **bit-identical** to the old path (in-range operands) |

> An early run showed `half` at 90272 inexact. That was my test harness generating operands up to 128000 against half's ~65504 maximum, not a regression — with in-range operands both paths are exact and identical.

### This is a purity fix, not a convergence fix

e and pi still saturate at **33 digits on bfloat16 and 37 on float, unchanged**. The ceiling is the exponent-range problem above. What changes is that a block-shape study of narrow hosts now measures *narrow-host arithmetic* rather than double arithmetic wearing a narrow result type — the difference between the study meaning something and not.

## Also: the design proposal for the real fix

`docs/design/elreal-narrow-host-blocks.md` writes up the investigation and proposes **scale-normalised blocks** — keep `v` in [1,2), put all scale in the unbounded exponent field. Then `min_exponent` is never approached and the three `min_exponent + 2k` floors (`series_stop_exp`, `divide.hpp`, `online_divide.hpp`) become dead code.

It states its predictions as falsifiable claims — notably that **`double` must come out bit-identical**, which is the regression gate — and lists the files, the risks (chiefly whether any 0-overlap comparison uses raw `v` scale rather than the combined exponent), and the validation plan. Nothing in it is implemented.

## Test Results

| | gcc 13.3 | clang 18.1 |
|---|---|---|
| elreal suite | **46/46 pass** | **46/46 pass** |

Includes `el_block_eft_two_sum` / `two_mult` / `two_div`, the zero-overlap suite, and the dyadic oracle sweep. `check-ascii.sh` clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Relates to #1051, #1188, #933 — the fma dispatch closes the wide-type dependency in the EFT layer; #1051 itself stays open pending a decision on the design proposal.

Generated with [Claude Code](https://claude.com/claude-code)