### PR TITLE
fix(bfloat16): report the true scale of subnormals

### DIFF
--- a/docs/design/elreal-narrow-host-blocks.md
+++ b/docs/design/elreal-narrow-host-blocks.md
@@ -105,7 +105,52 @@ for `bfloat16` against 1.33 for `double` -- `double` is 6.8x more
 storage-efficient. A narrow host reaching high precision would need ~7.6x more
 blocks at ~0.9x the size each.
 
-## Proposal: scale-normalised blocks
+## The proposal below was tried and does not work
+
+**Status of this section: refuted by experiment.** Kept because the reason is the
+useful part, and because it is the obvious idea -- anyone reading the diagnosis
+above will reach for it.
+
+`block::normalise()` was implemented and behaves exactly as specified: it rescales
+`v` into `[1,2)`, folds the scale into `exp`, preserves the block's value and its
+combined exponent exactly (0 changes over 20,000 random blocks per host), and
+lifts subnormal `v` back to normal. The three floors were removed. The `double`
+suite stayed green -- 46/46, bit-identical -- which is what the gate below asked
+for.
+
+`bfloat16` then aborted on the 0-overlap assertion.
+
+The cause is not the 0-overlap comparison, which was the risk flagged below:
+`zero_overlap` compares `exponent()`, and `normalise()` preserves that exactly.
+It is **operand alignment**. `twoAdd` brings two blocks to a common scale before
+the EFT (`threeAdd.hpp`):
+
+```
+auto   e_max = std::max(a.exp, b.exp);
+FpType va    = (a.exp == e_max) ? a.v : ldexp_block(a.v, int(a.exp - e_max));
+```
+
+That shift is applied to the host value. In the current representation the scale
+lives in `v` and the `exp` fields stay close together -- the instrumentation above
+shows `min combined exponent` within 1 of the minimum `v` scale, i.e. `exp` is
+carrying nearly nothing -- so the alignment shift is small and harmless.
+Normalising inverts that: the scale moves into `exp`, the `exp` fields spread
+apart by hundreds of binades, and the alignment shift underflows `v` to a
+subnormal or to zero. The operand is destroyed before the EFT sees it.
+
+So keeping the scale in `v` is not an oversight. It is what makes alignment
+expressible in host arithmetic, and the denormal floors are the price. The two
+designs are in tension, and the floors are the cheaper side of it.
+
+A real fix has to attack the alignment, not the storage. The promising direction:
+`twoAdd` only needs to align when the operands actually interact. If
+`|a.exp - b.exp| >= k` the blocks are already 0-overlap and their sum *is* the
+pair `{a, b}` -- no arithmetic, no shift, no underflow. Aligning unconditionally
+is what forces every operand onto a common host scale. That is a much smaller
+change than restructuring the block, and it is where the next attempt should
+start. It is untested.
+
+## Superseded proposal: scale-normalised blocks
 
 Maintain `v` in `[1,2)` (or `[1,2)` in magnitude) and carry all scale in the
 `integer<256>` `exp` field, which is unbounded by construction.
@@ -161,7 +206,23 @@ Expected consequences, stated so they can be falsified:
 - A depth sweep showing `bfloat16` past 33 digits is the minimum bar for calling
   this done.
 
-## What this would settle
+## What the experiment did settle
+
+The diagnosis in the first half stands: the ceiling is exponent range, not
+precision, and it is not the EFTs. What is now also established is that the
+ceiling cannot be lifted by moving scale out of `v`, because the multi-block
+operations depend on the scale being there.
+
+One independent bug fell out of the attempt. `bfloat16::scale()` read the biased
+exponent field and subtracted the bias, which is correct for normals and wrong for
+all 254 subnormals: it answered -127 for every one of them, where the true scale
+runs from -127 down to -133. `block<FpType>::scale_of_v()` calls it, and the
+block's combined exponent is `scale_of_v() + exp`, so any block holding a
+subnormal carried a combined exponent up to 6 binades wrong -- and the 0-overlap
+accounting built on it was wrong with it. Fixed and now guarded exhaustively over
+all 65536 encodings (`static/float/bfloat16/api/scale.cpp`).
+
+## What a working fix would settle
 
 If it works, the block-shape study can finally answer the question it exists to
 ask -- what a narrow block shape costs in blocks and time at a *fixed* precision

--- a/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
@@ -418,7 +418,22 @@ public:
 				(InfType == INF_TYPE_POSITIVE ? isPosInf : false)));
 	}
 	constexpr bool sign()   const noexcept { return isneg(); }
-	constexpr int  scale()  const noexcept { int biased = static_cast<int>((_bits & 0x7F80u) >> 7); return biased - 127; }
+	// scale(): the unbiased binary exponent, i.e. the e with |value| in [2^e, 2^(e+1)).
+	// Subnormals carry a zero exponent field but are NOT all of scale -127: their
+	// magnitude is set by the leading one of the 7-bit fraction, so the scale runs
+	// from -127 (fraction MSB set) down to -133 (fraction == 1). Returning -127 for
+	// every subnormal understated the exponent by up to 6 binades, which silently
+	// corrupted any accounting built on scale() -- elreal's block combined exponent
+	// among them (universal#1051).
+	constexpr int  scale()  const noexcept {
+		int biased = static_cast<int>((_bits & 0x7F80u) >> 7);
+		if (biased != 0) return biased - 127;
+		unsigned frac = _bits & 0x007Fu;
+		if (frac == 0) return 0;                       // zero: scale is conventionally 0
+		int b = 6;
+		while (b > 0 && ((frac >> b) & 1u) == 0u) --b;
+		return b - 133;                                // -126 + b - 7
+	}
 	constexpr unsigned short bits() const noexcept { return _bits; }
 
 	constexpr bool test(unsigned bitIndex) const noexcept { return at(bitIndex); }

--- a/static/float/bfloat16/api/scale.cpp
+++ b/static/float/bfloat16/api/scale.cpp
@@ -1,0 +1,118 @@
+// scale.cpp: bfloat16 scale() across the whole encoding space, subnormals included
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// scale() returns the unbiased binary exponent: the e with |value| in
+// [2^e, 2^(e+1)). It read the biased exponent field and subtracted the bias, which
+// is right for normals and wrong for every subnormal: their exponent field is zero,
+// so it answered -127 for all 254 of them when the true scale runs from -127 down
+// to -133 with the leading one of the 7-bit fraction.
+//
+// Nothing in bfloat16's own suites noticed, because none of them asked about a
+// subnormal's scale. It surfaced from elreal, where block<FpType>::scale_of_v()
+// calls scale() and the block's combined exponent is scale_of_v() + exp -- so a
+// block holding a subnormal carried a combined exponent up to 6 binades wrong, and
+// the 0-overlap accounting built on it was wrong with it (universal#1051).
+//
+// The check here is exhaustive rather than sampled: bfloat16 has 65536 encodings,
+// so every one can be compared against std::ilogb of the exactly-equal double.
+#include <universal/utility/directives.hpp>
+#include <cmath>
+#include <string>
+#include <universal/number/bfloat16/bfloat16.hpp>
+#include <universal/verification/test_suite.hpp>
+
+namespace {
+
+	// scale() against std::ilogb of the same value widened to double. bfloat16 ->
+	// double is exact, so ilogb there is the exact answer for the bfloat16 value.
+	int VerifyScaleAgainstIlogb(bool reportTestCases) {
+		using namespace sw::universal;
+		int nrOfFailedTests = 0;
+		int subnormalsSeen = 0;
+		for (unsigned bits = 0; bits < 0x10000u; ++bits) {
+			bfloat16 v;
+			v.setbits(bits);
+			const double d = double(v);
+			if (d == 0.0 || !std::isfinite(d)) continue;      // zero/inf/nan have no scale
+			if (((bits >> 7) & 0xFFu) == 0u) ++subnormalsSeen;
+			const int expected = std::ilogb(d);
+			if (v.scale() != expected) {
+				++nrOfFailedTests;
+				if (reportTestCases && nrOfFailedTests <= 8)
+					std::cerr << "  FAIL bits=0x" << std::hex << bits << std::dec
+					          << " scale()=" << v.scale() << " expected " << expected << '\n';
+			}
+		}
+		// a run that saw no subnormal would pass vacuously
+		if (subnormalsSeen == 0) {
+			++nrOfFailedTests;
+			if (reportTestCases) std::cerr << "  FAIL no subnormal encodings were exercised\n";
+		}
+		return nrOfFailedTests;
+	}
+
+}  // anonymous namespace
+
+// Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
+#define MANUAL_TESTING 0
+// REGRESSION_LEVEL_OVERRIDE is set by the cmake file to drive a specific regression intensity
+// It is the responsibility of the regression test to organize the tests in a quartile progression.
+//#undef REGRESSION_LEVEL_OVERRIDE
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+	using namespace sw::universal;
+
+	std::string test_suite  = "bfloat16 scale() across the encoding space";
+	std::string test_tag    = "scale";
+	bool reportTestCases    = true;
+	int nrOfFailedTestCases = 0;
+
+	ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+	nrOfFailedTestCases += ReportTestResult(VerifyScaleAgainstIlogb(true), test_tag, "scale vs ilogb");
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return EXIT_SUCCESS; // ignore failures
+#else  // !MANUAL_TESTING
+
+#if REGRESSION_LEVEL_1
+	nrOfFailedTestCases += ReportTestResult(VerifyScaleAgainstIlogb(reportTestCases), test_tag, "scale vs ilogb, all 65536 encodings");
+#endif
+
+	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+#endif  // MANUAL_TESTING
+}
+catch (char const* msg) {
+	std::cerr << "Caught ad-hoc exception: " << msg << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const sw::universal::universal_arithmetic_exception& err) {
+	std::cerr << "Caught unexpected universal arithmetic exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (const std::runtime_error& err) {
+	std::cerr << "Caught runtime exception: " << err.what() << std::endl;
+	return EXIT_FAILURE;
+}
+catch (...) {
+	std::cerr << "Caught unknown exception" << std::endl;
+	return EXIT_FAILURE;
+}


### PR DESCRIPTION
## The #1051 attempt failed. Here is what came out of it.

I implemented the scale-normalised-block proposal from `docs/design/elreal-narrow-host-blocks.md`. **It does not work**, for a reason worth recording. One real bug fell out of the attempt, and that is what this PR lands.

## The bug: `bfloat16::scale()` on subnormals

```cpp
constexpr int scale() const noexcept { int biased = (_bits & 0x7F80u) >> 7; return biased - 127; }
```

Right for normals, wrong for **all 254 subnormals**: their exponent field is zero, so it answered −127 for every one of them, where the true scale runs from −127 down to −133 with the leading one of the 7-bit fraction. Understated by up to **6 binades**.

bfloat16's own suites never caught it because none of them asked a subnormal for its scale. It surfaced from elreal: `block<FpType>::scale_of_v()` calls `scale()`, and a block's combined exponent is `scale_of_v() + exp` — so **any block holding a subnormal carried a combined exponent up to 6 binades wrong**, and the 0-overlap accounting built on it was wrong with it.

### The regression is exhaustive, not sampled

bfloat16 has 65536 encodings, so every one is compared against `std::ilogb` of the exactly-equal double. It also **fails if the sweep sees no subnormal**, since a run that never reaches one would pass vacuously.

Mutation-tested: restoring the old expression reports **126 failures**.

## Why the proposal failed

`block::normalise()` worked exactly as specified — rescales `v` into [1,2), folds the scale into `exp`, preserves value and combined exponent exactly (0 changes over 20k random blocks per host), lifts subnormals. Floors removed. **`double` stayed bit-identical, 46/46** — the gate the design doc set.

Then bfloat16 aborted on the 0-overlap assertion.

**Not** via the comparison, which is the risk the doc flagged — `zero_overlap` uses `exponent()`, which `normalise()` preserves. Via **operand alignment**:

```cpp
auto   e_max = std::max(a.exp, b.exp);
FpType va    = (a.exp == e_max) ? a.v : ldexp_block(a.v, int(a.exp - e_max));
```

`twoAdd` brings both operands to a common host scale. In the current representation the scale lives in `v` and the `exp` fields stay close — the instrumentation shows `exp` carrying nearly nothing — so that shift is small. Normalising **inverts** it: scale moves into `exp`, the `exp` fields spread hundreds of binades apart, and the shift underflows `v` to subnormal or zero. The operand is destroyed before the EFT sees it.

So keeping scale in `v` is not an oversight — it is what makes alignment expressible in host arithmetic, and the denormal floors are the price. The two designs are in tension and the floors are the cheaper side.

**Where a real fix starts** (untested, named in the doc): `twoAdd` only needs to align when the operands interact. If `|a.exp - b.exp| >= k` the blocks are already 0-overlap and their sum *is* the pair `{a,b}` — no shift, no underflow. Aligning unconditionally is what forces everything onto a common scale.

## What still stands

The diagnosis in the first half of the design doc is unaffected: the ceiling is **exponent range, not precision**, and it is not the EFTs. What is now also established is that it cannot be lifted by moving scale out of `v`.

## Changes

- `bfloat16_impl.hpp` — `scale()` handles the subnormal case
- `static/float/bfloat16/api/scale.cpp` (new) — exhaustive regression, mutation-tested
- `docs/design/elreal-narrow-host-blocks.md` — the proposal is marked **refuted by experiment**, with the mechanism and where to start instead. Kept rather than deleted: it is the obvious idea, and anyone reading the diagnosis will reach for it.

## Test Results

| suite | gcc 13.3 | clang 18.1 |
|---|---|---|
| bfloat16 | **12/12 pass** | **12/12 pass** |
| elreal | **46/46 pass** | **46/46 pass** |

`check-ascii.sh` clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Relates to #1051 — the issue stays open; its ceiling is not lifted by this.

Generated with [Claude Code](https://claude.com/claude-code)