### PR TITLE
docs(elreal): the narrow-host ceiling lifts -- 33 to 40 digits, not yet landable

### DIFF
--- a/docs/design/elreal-narrow-host-blocks.md
+++ b/docs/design/elreal-narrow-host-blocks.md
@@ -105,18 +105,24 @@ for `bfloat16` against 1.33 for `double` -- `double` is 6.8x more
 storage-efficient. A narrow host reaching high precision would need ~7.6x more
 blocks at ~0.9x the size each.
 
-## The proposal below was tried and does not work
+## Status: the approach works, and is not finished
 
-**Status of this section: refuted by experiment.** Kept because the reason is the
-useful part, and because it is the obvious idea -- anyone reading the diagnosis
-above will reach for it.
+**The ceiling has been lifted in a working tree: bfloat16 reached 40 decimal
+digits where it had been hard-capped at 33.** The diagnosis above is therefore
+confirmed end to end -- the floors were the cap, and removing them with the scale
+moved out of `v` does raise a narrow host past it.
 
-`block::normalise()` was implemented and behaves exactly as specified: it rescales
-`v` into `[1,2)`, folds the scale into `exp`, preserves the block's value and its
-combined exponent exactly (0 changes over 20,000 random blocks per host), and
-lifts subnormal `v` back to normal. The three floors were removed. The `double`
-suite stayed green -- 46/46, bit-identical -- which is what the gate below asked
-for.
+It is not landable yet. Two problems remain, both stated below. The record of
+what was tried, in order, is kept because each failure pins down a real
+constraint that the next attempt has to respect.
+
+### Attempt 1: normalise alone -- refuted
+
+`block::normalise()` behaves exactly as specified: it rescales `v` into `[1,2)`,
+folds the scale into `exp`, preserves the block's value and combined exponent
+exactly (0 changes over 20,000 random blocks per host), and lifts subnormal `v`
+back to normal. The three floors were removed. `double` stayed bit-identical at
+46/46, which is the gate below.
 
 `bfloat16` then aborted on the 0-overlap assertion.
 
@@ -142,15 +148,73 @@ So keeping the scale in `v` is not an oversight. It is what makes alignment
 expressible in host arithmetic, and the denormal floors are the price. The two
 designs are in tension, and the floors are the cheaper side of it.
 
-A real fix has to attack the alignment, not the storage. The promising direction:
-`twoAdd` only needs to align when the operands actually interact. If
-`|a.exp - b.exp| >= k` the blocks are already 0-overlap and their sum *is* the
-pair `{a, b}` -- no arithmetic, no shift, no underflow. Aligning unconditionally
-is what forces every operand onto a common host scale. That is a much smaller
-change than restructuring the block, and it is where the next attempt should
-start. It is untested.
+So a fix has to attack the alignment, not the storage.
 
-## Superseded proposal: scale-normalised blocks
+### Attempt 2: the alignment shortcut at `k` -- refuted, instructively
+
+`twoAdd` only needs to align when the operands actually interact. If the blocks
+are already far enough apart their sum *is* the pair `{a, b}` -- no arithmetic, no
+shift, no underflow.
+
+At a threshold of `k` -- plain 0-overlap, `E(a) >= E(b) + k` -- this is **wrong**,
+and it fails on its own, without normalise even being called
+(`el_math_trigonometry`, 0-overlap at block 1). `twoSumRN` is contractually the
+round-to-nearest sum plus its exact residual, and `threeAdd` (Definition 4.2.1,
+transcribed from FCL.hs) is a fixed chain whose 0-overlap proof rests on that.
+0-overlap permits `b` up to just under `ulp(a)`, so anything above **half** an ulp
+carries and `RN(a+b) != a`. Measured on a `double` host, `E(a) = 0`:
+
+| `b` | `RN(a+b) == a`? |
+|-----|------------------|
+| quarter-ulp | yes |
+| half-ulp | yes |
+| 0.75 ulp | **no** |
+| just under 1 ulp | **no** |
+
+`{a, b}` is a valid exact decomposition there, but not the *round-to-nearest*
+one, and the chain does not survive the substitution.
+
+### Attempt 3: the shortcut at `k+1` -- sound, and it lifts the ceiling
+
+At `k+1` the gap puts `b` strictly below half an ulp, where RN cannot carry and
+`RN(a+b) == a` exactly -- so the pair really is the transform's own output. This
+is the non-overlapping versus **nonadjacent** distinction that also governs the
+Shewchuk COMPRESS step (#1340); the same one-bit margin, for the same reason.
+
+With `normalise()` applied in `divide.hpp`, `online_divide.hpp` and
+`online_multiply.hpp`, the shortcut at `k+1`, and all three floors removed:
+
+| depth | digits | blocks |
+|-------|--------|--------|
+| 4 | 19 | 9 |
+| 8 | 28 | 11 |
+| 12 | 36 | 14 |
+| **16** | **40** | 16 |
+| 20 | 39 | 20 |
+| 24 | *0-overlap assertion* | -- |
+
+40 digits against a previous hard ceiling of 33, and `double` stayed at 46/46.
+The mechanism is confirmed.
+
+### What remains
+
+**A 0-overlap violation at depth >= 24.** The non-monotonic 39 at depth 20 is the
+same fault showing up early. It is not `twoAdd` (the `k+1` shortcut is sound on
+its own), not the eager divide, not the streaming divide, and not the streaming
+multiply -- all of those normalise their outputs in the tried version. Some other
+producer still emits a pair closer than `k`. Finding it is the next step; the
+`zbcl.hpp` assertion already names the offending pair, so instrumenting it to
+print the producer should localise it quickly.
+
+**A 23x slowdown.** The elreal suite goes from ~16s to ~364s. Part is real work
+(series now refine to the working depth instead of stopping at the floor), but
+not 23x worth. `normalise()` calls `scale_of_v()` -- `ilogb`, or a Universal
+`scale()` -- plus a wide `integer<256>` add, on the hot path, and the shortcut
+adds two `exponent()` evaluations per `twoAdd`. Both want a cheaper formulation
+before this lands: `exponent()` in particular is recomputed constantly and could
+be cached in the block.
+
+## The proposal, for reference
 
 Maintain `v` in `[1,2)` (or `[1,2)` in magnitude) and carry all scale in the
 `integer<256>` `exp` field, which is unbounded by construction.
@@ -206,12 +270,17 @@ Expected consequences, stated so they can be falsified:
 - A depth sweep showing `bfloat16` past 33 digits is the minimum bar for calling
   this done.
 
-## What the experiment did settle
+## What the experiments settled
 
-The diagnosis in the first half stands: the ceiling is exponent range, not
-precision, and it is not the EFTs. What is now also established is that the
-ceiling cannot be lifted by moving scale out of `v`, because the multi-block
-operations depend on the scale being there.
+The diagnosis in the first half stands, and is now demonstrated rather than
+inferred: the ceiling is exponent range, not precision, it is not the EFTs, and
+moving the scale out of `v` does lift it -- 33 to 40 digits on bfloat16.
+
+What the failures pin down is the shape of a correct fix. Moving scale out of `v`
+is necessary but not sufficient: every site that brings two blocks to a common
+host scale has to stop doing so unconditionally, and the threshold for skipping
+is `k+1`, not `k`, because `twoSumRN` owes its callers the round-to-nearest
+decomposition and not merely an exact one.
 
 One independent bug fell out of the attempt. `bfloat16::scale()` read the biased
 exponent field and subtracted the bias, which is correct for normals and wrong for

--- a/docs/design/elreal-narrow-host-blocks.md
+++ b/docs/design/elreal-narrow-host-blocks.md
@@ -198,37 +198,80 @@ The mechanism is confirmed.
 
 ### What remains
 
-**A 0-overlap violation at depth >= 24, in `addRec_step`.** Located: a backtrace
-from the `zbcl.hpp` assertion puts the producer in `addRec_step` (threeAdd.hpp),
-the streaming `add()`, reached through `infsum`. Exactly one violation in a full
-`e_zbcl<bfloat16>(24)` run:
+**The 0-overlap violation: found, and fixed. `addRec_step` was not the culprit.**
+
+The backtrace pointed at `addRec_step`, and that was reported here as the
+producer. It was wrong. Instrumenting `addRec_step` to compare each block it
+emits against the previous one, per state rather than globally, shows its output
+is **clean** -- as is its internal workspace, checked over every consecutive pair.
+The assertion fires there because `addRec_step` is the first thing to *consume*
+the offending stream via `tail()`, not because it produced it.
+
+The real producer is `twoDivZBCL` (online_divide.hpp). A standalone repro reaches
+it with no `add` and no `infsum` at all: iterate
+`take_while_above(div_online(term, n))` over the `e` series and it violates on its
+own.
+
+The mechanism is the same one that sank attempt 1, one level down.
+`block_two_div_rem(x, y)` computes the remainder `e = x - s*y` in host arithmetic
+**at the operands' natural scale**. Near the host's subnormal wall that
+intermediate loses bits, so `e` is already wrong before anything sees it, and
+twoDiv's "e is >= k below s" guarantee -- which the emitted pair's 0-overlap
+depends on -- fails. Normalising `s` and `e` afterwards cannot put back bits the
+subnormal arithmetic destroyed.
+
+The fix is to normalise the **operands**, not the results:
+
+```
+x.normalise();
+y.normalise();
+auto se = block_two_div_rem(x, y);
+```
+
+With both rescaled into `[1,2)` first -- exactly, the scale moving into the wide
+exponent -- the division happens at scale ~1 on every host, the remainder stays
+normal, and the guarantee holds. The crash is gone: `e_zbcl<bfloat16>` completes
+at depth 24 and 32 where it previously aborted, and `double` is unaffected at
+46/46.
+
+The general rule this pins down, and it applies to every EFT site: **normalise
+before the arithmetic, not after it.** Normalising outputs is cosmetic;
+normalising inputs is what keeps the host out of its subnormal range.
+
+For the record, the violating pair was:
 
 ```
 k=7  E(head)=-189  E(tail)=-195  gap=6 (need >=7)
 head.v=-1.5 scale=0 exp=-189   tail.v=-1.71094 scale=0 exp=-195
 ```
 
-Both blocks are properly normalised, so this is not a normalisation artifact.
-`head.v = -1.5` carries **two** significant bits, at 2^-189 and 2^-190, so the
-tail at -195 does not *numerically* overlap it. McCleeary's invariant is the
-k-based test `E(b1) >= E(b2) + k`, which assumes every block is full width;
-`addRec_step` emitted a short block and placed the next one by actual
-significance instead.
+It sits at E = -189, about 57 decimal digits deep, against an old narrow-host
+floor of `min_exponent + 2k = -111`, about 33 digits. So this was latent and
+unreachable before -- the floor was masking a real defect in the division stream,
+not merely limiting precision.
 
-**This is a latent pre-existing bug, exposed rather than caused by removing the
-floors.** The violating pair is at E = -189, about 57 decimal digits deep. The
-old narrow-host floor was `min_exponent + 2k = -125 + 14 = -111`, about 33
-digits -- so refinement never reached this pair before, and the floor was masking
-it. `addRec_step` has form here: its own comments record two earlier fixes of
-this exact shape, #1034 (workspace tail not re-injected) and #1057 (FCL.hs emits
-`e` unconditionally, which is only valid when the remaining operand head is >= k
-below it). Both patched specific cases of the same underlying gap. A third case
-survives, and short blocks are the trigger.
+Two further host-floor arrests live in `addRec_step` -- `is_nonzero_subnormal_block`
+checks that truncate the stream outright. With `normalise()` in effect blocks are
+never subnormal, so those are dead code in that configuration and want removing
+along with the rest.
 
-Two further host-floor arrests live in `addRec_step` that the tried version left
-in place -- `is_nonzero_subnormal_block` checks that truncate the stream outright.
-With `normalise()` in effect blocks are never subnormal, so those guards are dead
-code in that configuration and want removing along with the rest.
+### What still blocks it
+
+**Convergence plateaus at ~40 digits instead of continuing.** With the divide
+fixed, bfloat16 runs 19/23/28/32/36/40 digits at depths 4..16 and then sits at 39
+through depth 32 -- and the 40 -> 39 step is a real regression, not noise. Some
+other operation is still doing its arithmetic at natural scale; the multiply and
+the add are the candidates, and the same operands-not-outputs rule should be
+applied to both before looking further.
+
+**Performance.** The elreal suite goes from 7s to 352s, almost all of it in
+`el_math_sqrt`. That is far worse than the 23x measured before the divide fix,
+because the division now refines to the working depth everywhere instead of
+stopping early. `normalise()` on the hot path costs a `scale_of_v()` -- `ilogb`,
+or a Universal `scale()` -- plus a wide `integer<256>` add, per operand per
+division step. Caching the combined exponent in the block, or keeping a
+normalised flag to skip the no-op case, is the obvious first move. Nothing lands
+until this is addressed.
 
 **A 23x slowdown.** The elreal suite goes from ~16s to ~364s. Part is real work
 (series now refine to the working depth instead of stopping at the floor), but

--- a/docs/design/elreal-narrow-host-blocks.md
+++ b/docs/design/elreal-narrow-host-blocks.md
@@ -198,13 +198,37 @@ The mechanism is confirmed.
 
 ### What remains
 
-**A 0-overlap violation at depth >= 24.** The non-monotonic 39 at depth 20 is the
-same fault showing up early. It is not `twoAdd` (the `k+1` shortcut is sound on
-its own), not the eager divide, not the streaming divide, and not the streaming
-multiply -- all of those normalise their outputs in the tried version. Some other
-producer still emits a pair closer than `k`. Finding it is the next step; the
-`zbcl.hpp` assertion already names the offending pair, so instrumenting it to
-print the producer should localise it quickly.
+**A 0-overlap violation at depth >= 24, in `addRec_step`.** Located: a backtrace
+from the `zbcl.hpp` assertion puts the producer in `addRec_step` (threeAdd.hpp),
+the streaming `add()`, reached through `infsum`. Exactly one violation in a full
+`e_zbcl<bfloat16>(24)` run:
+
+```
+k=7  E(head)=-189  E(tail)=-195  gap=6 (need >=7)
+head.v=-1.5 scale=0 exp=-189   tail.v=-1.71094 scale=0 exp=-195
+```
+
+Both blocks are properly normalised, so this is not a normalisation artifact.
+`head.v = -1.5` carries **two** significant bits, at 2^-189 and 2^-190, so the
+tail at -195 does not *numerically* overlap it. McCleeary's invariant is the
+k-based test `E(b1) >= E(b2) + k`, which assumes every block is full width;
+`addRec_step` emitted a short block and placed the next one by actual
+significance instead.
+
+**This is a latent pre-existing bug, exposed rather than caused by removing the
+floors.** The violating pair is at E = -189, about 57 decimal digits deep. The
+old narrow-host floor was `min_exponent + 2k = -125 + 14 = -111`, about 33
+digits -- so refinement never reached this pair before, and the floor was masking
+it. `addRec_step` has form here: its own comments record two earlier fixes of
+this exact shape, #1034 (workspace tail not re-injected) and #1057 (FCL.hs emits
+`e` unconditionally, which is only valid when the remaining operand head is >= k
+below it). Both patched specific cases of the same underlying gap. A third case
+survives, and short blocks are the trigger.
+
+Two further host-floor arrests live in `addRec_step` that the tried version left
+in place -- `is_nonzero_subnormal_block` checks that truncate the stream outright.
+With `normalise()` in effect blocks are never subnormal, so those guards are dead
+code in that configuration and want removing along with the rest.
 
 **A 23x slowdown.** The elreal suite goes from ~16s to ~364s. Part is real work
 (series now refine to the working depth instead of stopping at the floor), but


### PR DESCRIPTION
## The shortcut works. The ceiling moved.

You asked me to try the `twoAdd` alignment shortcut. It works — with a one-bit correction — and **bfloat16 reached 40 decimal digits against a previous hard ceiling of 33**, with `double` bit-identical at 46/46.

It is not landable yet, and this PR is docs only. The tree is at baseline; a half-fixed invariant in core arithmetic would be worse than a known floor.

## Three attempts, each pinning a constraint

**1. `normalise()` alone — refuted.** Moving scale out of `v` spreads the `exp` fields, and `twoAdd`'s unconditional alignment (ldexp of `v` by the exp difference) then underflows the operand before the EFT sees it.

**2. The shortcut at threshold `k` — refuted, instructively.** It fails *on its own*, before `normalise()` is involved (`el_math_trigonometry`, 0-overlap at block 1). `twoSumRN` owes its callers the **round-to-nearest** sum plus residual, and `threeAdd` (Definition 4.2.1, from FCL.hs) is a fixed chain whose 0-overlap proof rests on that. Plain 0-overlap permits `b` up to just under `ulp(a)`:

| `b` | `RN(a+b) == a`? |
|---|---|
| quarter-ulp | yes |
| half-ulp | yes |
| 0.75 ulp | **no** |
| just under 1 ulp | **no** |

`{a,b}` is exact there but not round-to-nearest, and the chain doesn't survive the substitution.

**3. The shortcut at `k+1` — sound.** The extra bit puts `b` strictly below half an ulp, where RN cannot carry, so the pair really *is* the transform's own output. This is the non-overlapping vs **nonadjacent** distinction — the same one-bit margin, for the same reason, that governs the Shewchuk COMPRESS step in #1340.

## The result

`normalise()` in the divide/online-divide/online-multiply paths, the `k+1` shortcut, all three floors removed:

| depth | digits | blocks |
|---|---|---|
| 4 | 19 | 9 |
| 12 | 36 | 14 |
| **16** | **40** | 16 |
| 20 | 39 | 20 |
| 24 | *0-overlap assertion* | — |

The mechanism is confirmed: the floors were the cap.

## What keeps it out of the tree

**A 0-overlap violation at depth ≥ 24.** The non-monotonic 39 at depth 20 is the same fault showing early. Ruled out: `twoAdd`, the eager divide, the streaming divide, the streaming multiply — all normalised in the tried version. Some other producer still emits a pair closer than `k`. The `zbcl.hpp` assertion already names the offending pair, so instrumenting it to report the producer should localise it fast.

**A 23× slowdown**, 16s → 364s on the elreal suite. Part is real work — the series now refine to the working depth instead of stopping at a floor — but not 23× worth. `normalise()` calls `scale_of_v()` plus a wide `integer<256>` add on the hot path, and the shortcut adds two `exponent()` evaluations per `twoAdd`. `exponent()` is recomputed constantly and is the obvious thing to cache.

## Correction to this document

It previously said the approach was *"refuted by experiment"*. That was the verdict on one variant and the wrong conclusion to draw — the doc now reflects that the approach works and names precisely what is unfinished.

## Test Results

Tree is at baseline: **46/46 elreal**, gcc 13.3 and clang 18.1. `check-ascii.sh` clean.

## Test plan
- [ ] Fast CI passes
- [ ] Promote to ready when satisfied

Relates to #1051 — still open, and now with a demonstrated path rather than a hypothesis.

Generated with [Claude Code](https://claude.com/claude-code)