### PR TITLE
feat(elreal): lift the narrow-host ceiling -- float 37 -> 319 digits

### DIFF
--- a/docs/design/elreal-narrow-host-blocks.md
+++ b/docs/design/elreal-narrow-host-blocks.md
@@ -105,127 +105,135 @@ for `bfloat16` against 1.33 for `double` -- `double` is 6.8x more
 storage-efficient. A narrow host reaching high precision would need ~7.6x more
 blocks at ~0.9x the size each.
 
-## The proposal below was tried and does not work
+## Status: DONE. The ceiling is gone on both narrow hosts.
 
-**Status of this section: refuted by experiment.** Kept because the reason is the
-useful part, and because it is the obvious idea -- anyone reading the diagnosis
-above will reach for it.
+| host | k | before | after | blocks | digits/block |
+|------|---|--------|-------|--------|--------------|
+| `double` | 53 | ~306 | ~306, **bit-identical** | 19 | 16.1 |
+| `float` | 24 | **37 (hard cap)** | **319** | 50 | 6.4 |
+| `bfloat16` | 7 | **33 (hard cap)** | **146 and climbing** | 53 | 2.8 |
 
-`block::normalise()` was implemented and behaves exactly as specified: it rescales
-`v` into `[1,2)`, folds the scale into `exp`, preserves the block's value and its
-combined exponent exactly (0 changes over 20,000 random blocks per host), and
-lifts subnormal `v` back to normal. The three floors were removed. The `double`
-suite stayed green -- 46/46, bit-identical -- which is what the gate below asked
-for.
+float now reaches essentially the full 320-digit reference. bfloat16 grows
+linearly with depth with no ceiling in sight: 28 / 45 / 78 / 112 / 146 digits at
+depths 8 / 16 / 32 / 48 / 64. The prediction in the section above was that a
+narrow host would need roughly `53/k` times as many blocks -- 2.2x for float
+against 2.6x measured, 7.6x for bfloat16 against 5.9x measured.
 
-`bfloat16` then aborted on the 0-overlap assertion.
+`double` is untouched **by construction**, not by testing: the change sits behind
+`if constexpr (needs_scale_normalisation)` and compiles away entirely for a
+wide-exponent host. Verified bit-for-bit all the same -- every block's mantissa
+and exponent, across pi, e, sqrt2, division and ln2 -- against the pre-change
+build.
 
-The cause is not the 0-overlap comparison, which was the risk flagged below:
-`zero_overlap` compares `exponent()`, and `normalise()` preserves that exactly.
-It is **operand alignment**. `twoAdd` brings two blocks to a common scale before
-the EFT (`threeAdd.hpp`):
+46/46 elreal tests pass under gcc 13.3 and clang 18.1, in 17s against a 7s
+baseline. The increase is real work: float now computes 319 digits where it used
+to stop at 37.
+
+## What it took
+
+Three things. The order they were found in is the useful part, because two of the
+wrong turns came from reasoning ahead of the measurement.
+
+### 1. Normalise OPERANDS, not results
+
+This is the general rule, and it is the whole fix in one line. An EFT that runs at
+the operands' natural scale has already lost bits to the subnormal range by the
+time it returns; normalising its outputs cannot put them back.
 
 ```
-auto   e_max = std::max(a.exp, b.exp);
-FpType va    = (a.exp == e_max) ? a.v : ldexp_block(a.v, int(a.exp - e_max));
+x.normalise();
+y.normalise();
+auto se = block_two_div_rem(x, y);
 ```
 
-That shift is applied to the host value. In the current representation the scale
-lives in `v` and the `exp` fields stay close together -- the instrumentation above
-shows `min combined exponent` within 1 of the minimum `v` scale, i.e. `exp` is
-carrying nearly nothing -- so the alignment shift is small and harmless.
-Normalising inverts that: the scale moves into `exp`, the `exp` fields spread
-apart by hundreds of binades, and the alignment shift underflows `v` to a
-subnormal or to zero. The operand is destroyed before the EFT sees it.
+Applied at all three sites -- `twoSumRN`, `block_two_mult` through
+`singleMultHelper`, and `block_two_div_rem` through `twoDivZBCL`. Fixing only the
+divide lifted bfloat16 from 33 to 40 digits and then plateaued; only with all
+three does it become unbounded.
 
-So keeping the scale in `v` is not an oversight. It is what makes alignment
-expressible in host arithmetic, and the denormal floors are the price. The two
-designs are in tension, and the floors are the cheaper side of it.
+### 2. The nonadjacent (k+1) shortcut in twoSumRN
 
-A real fix has to attack the alignment, not the storage. The promising direction:
-`twoAdd` only needs to align when the operands actually interact. If
-`|a.exp - b.exp| >= k` the blocks are already 0-overlap and their sum *is* the
-pair `{a, b}` -- no arithmetic, no shift, no underflow. Aligning unconditionally
-is what forces every operand onto a common host scale. That is a much smaller
-change than restructuring the block, and it is where the next attempt should
-start. It is untested.
+Blocks already `k+1` apart need no arithmetic at all: their exact sum is the pair,
+in decreasing order. Skipping there bounds every surviving alignment shift, which
+is what makes normalised operands safe to align.
 
-## Superseded proposal: scale-normalised blocks
+The threshold is `k+1`, not `k`. `twoSumRN` owes its callers its property 5 --
+the residual is at most half an ulp, i.e. the round-to-nearest decomposition --
+and `threeAdd` (Definition 4.2.1) is a fixed chain whose 0-overlap proof rests on
+it. Plain 0-overlap allows `b` up to just under `ulp(a)`, so anything above half
+an ulp carries and `RN(a+b) != a`; returning `{a,b}` there is exact but not
+round-to-nearest, and the chain does not survive it. Measured on a `double` host
+at `E(a) = 0`:
 
-Maintain `v` in `[1,2)` (or `[1,2)` in magnitude) and carry all scale in the
-`integer<256>` `exp` field, which is unbounded by construction.
+| `b` | `RN(a+b) == a`? |
+|-----|------------------|
+| quarter-ulp | yes |
+| half-ulp | yes |
+| 0.75 ulp | **no** |
+| just under 1 ulp | **no** |
 
-Then `v` is always normal by construction, `is_normalised()` cannot fail for a
-scale reason, and the host's `min_exponent` is never approached. The three
-`min_exponent + 2*k` floors become dead code. A narrow host's reach is then
-bounded only by the number of blocks one is willing to carry -- that is, by `k`
--- rather than by exponent range.
+This is the non-overlapping versus **nonadjacent** distinction that also governs
+the Shewchuk COMPRESS step (#1340) -- the same one-bit margin, for the same
+reason.
 
-Expected consequences, stated so they can be falsified:
+It also turned out to be the performance fix. Without it the alignment shift is
+unbounded and the suite took 1469s; with it, 17s.
 
-- `bfloat16` and `float` should reach any target precision `double` reaches,
-  needing roughly `53/k` times as many blocks (~7.6x for `bfloat16`, ~2.2x for
-  `float`).
-- The measured ceilings (33 / 37 / 307) should all lift.
-- `double` results should be **bit-identical**, since a wide host never
-  approached its floor in the first place. This is the primary regression check.
+### 3. Gate on EXPONENT RANGE, not on k
 
-### Where the work is
+The first gate copied the floors' `k >= 24` predicate. That was wrong: it excluded
+`float`, whose k is exactly 24 but whose ceiling is squarely an exponent ceiling.
+float and bfloat16 both carry an 8-bit exponent (`min_exponent` -125) and both
+exhaust it -- v runs to 2^-123 and 2^-117 respectively, within a couple of bits of
+the wall. double's 11-bit exponent gives ~1000 binades of headroom that it never
+approaches, so it is limited by block count and has nothing to gain.
 
-| area | change |
-|------|--------|
-| `block.hpp` | a `normalise()` that splits `v` into `[1,2)` mantissa plus exponent delta, folded into `exp`; apply at block construction and after each EFT result |
-| `block_eft.hpp` | renormalise `two_sum` / `two_prod` / `two_div` outputs before returning |
-| `divide.hpp`, `online_divide.hpp` | drop `exp_floor` / `host_exp_floor`; the remainder sequence no longer decays toward subnormal |
-| `math/constants.hpp` | drop the narrow-host branch of `series_stop_exp`; the target term becomes the only stop |
-| `zbcl.hpp` | confirm the 0-overlap comparison is expressed in combined exponents, not raw `v` scales |
+```
+static constexpr bool needs_scale_normalisation =
+    (std::numeric_limits<FpType>::min_exponent > -500);
+```
 
-### Risks
+## Wrong turns, kept
 
-- **The 0-overlap invariant is stated in terms of block exponents.** If any
-  comparison uses `scale_of_v()` rather than `combined_exponent()`,
-  renormalisation silently changes its meaning. This is the main correctness
-  risk and should be settled by reading before writing.
-- **Cost.** A renormalisation per EFT result is a `frexp`/`ldexp` pair on the
-  hot path. `double` must not regress; if it does, gate renormalisation to
-  `k < 24` hosts, which is where it is needed.
-- **Exact-zero and non-finite blocks** have no meaningful mantissa scale and
-  must bypass renormalisation.
-- **`from_native`** already asserts `is_normalised()`; it would need to
-  renormalise rather than reject, which changes an existing contract (#1136).
+**Normalise alone.** Moving scale out of `v` spreads the `exp` fields, and
+`twoSumRN`'s then-unconditional alignment underflowed the operand before the EFT
+saw it. The lesson became rule 2.
 
-### Validation
+**The shortcut at threshold `k`.** Refuted on its own, before normalise was
+involved, by `el_math_trigonometry`. The lesson is in rule 2 above.
 
-- `double` bit-identity across the existing suites is the gate. If `double`
-  moves at all, the change is wrong.
-- The dyadic oracle sweep (`elastic/elreal/oracle/sweep.cpp`) extended to
-  `bfloat16`, asserting exact `add`/`sub` as it already does for `float`.
-- The block-shape study (`benchmark/performance/arithmetic/elreal/performance.cpp`)
-  re-run; section B's narrow-host rows are the headline result and section H's
-  matrix should change qualitatively.
-- A depth sweep showing `bfloat16` past 33 digits is the minimum bar for calling
-  this done.
+**"The producer is `addRec_step`."** Reported from a backtrace, and wrong: the
+assertion fires there because `addRec_step` is the first thing to *consume* the
+offending stream via `tail()`. Instrumented per state rather than through a
+shared thread_local -- which was contaminating the first pass with cross-stream
+pairs -- its output is clean, as is its workspace over every consecutive pair. The
+real producer was `twoDivZBCL`, reproducible with no `add` and no `infsum` at all.
 
-## What the experiment did settle
+**The plateau at 40 digits** was the add path: `twoSumRN` had neither the shortcut
+nor operand normalisation, because the script meant to add them asserted on a
+stale function name and never wrote the file.
 
-The diagnosis in the first half stands: the ceiling is exponent range, not
-precision, and it is not the EFTs. What is now also established is that the
-ceiling cannot be lifted by moving scale out of `v`, because the multi-block
-operations depend on the scale being there.
+## A note on the test suite
 
-One independent bug fell out of the attempt. `bfloat16::scale()` read the biased
-exponent field and subtracted the bias, which is correct for normals and wrong for
-all 254 subnormals: it answered -127 for every one of them, where the true scale
-runs from -127 down to -133. `block<FpType>::scale_of_v()` calls it, and the
-block's combined exponent is `scale_of_v() + exp`, so any block holding a
-subnormal carried a combined exponent up to 6 binades wrong -- and the 0-overlap
-accounting built on it was wrong with it. Fixed and now guarded exhaustively over
-all 65536 encodings (`static/float/bfloat16/api/scale.cpp`).
+`el_math_sqrt` went from 2.3s to not finishing in 500s, and the fix was in the
+test, not the library: it took sqrt's default `depth = 64` while checking a 1e-4
+tolerance. That was only ever cheap because the refinement floor stopped the
+underlying division early. Passing the depth the test actually needs restores it
+to 2.3s.
 
-## What a working fix would settle
+That is the same accidental coupling this whole exercise is about -- something
+that was fast because of an implementation limit rather than because it asked for
+little. Worth watching for elsewhere.
 
-If it works, the block-shape study can finally answer the question it exists to
-ask -- what a narrow block shape costs in blocks and time at a *fixed* precision
-target -- instead of reporting that narrow hosts cannot reach the target at all.
-That is the missing half of #1188's design matrix, and it does it without
-computing anything in a wider type.
+## What this unblocks
+
+The block-shape study can now ask its real question -- what a narrow block shape
+costs in blocks and time at a *fixed* precision target -- instead of reporting
+that narrow hosts cannot reach the target at all. That is the missing half of
+#1188's design matrix, and it is answered without computing anything in a wider
+type: the limbs stay true to their FpType and every EFT runs in host arithmetic.
+
+Note that this does not change the user-facing recommendation in section H of the
+block-shape study. Narrow hosts remain dominated for any actual precision target
+-- `dd` and `qd` cover their range as compile-time constants and beat them on
+throughput. What changes is that the silicon question can now be measured.

--- a/docs/design/elreal-narrow-host-blocks.md
+++ b/docs/design/elreal-narrow-host-blocks.md
@@ -140,7 +140,7 @@ This is the general rule, and it is the whole fix in one line. An EFT that runs 
 the operands' natural scale has already lost bits to the subnormal range by the
 time it returns; normalising its outputs cannot put them back.
 
-```
+```cpp
 x.normalise();
 y.normalise();
 auto se = block_two_div_rem(x, y);
@@ -188,7 +188,7 @@ exhaust it -- v runs to 2^-123 and 2^-117 respectively, within a couple of bits 
 the wall. double's 11-bit exponent gives ~1000 binades of headroom that it never
 approaches, so it is limited by block count and has nothing to gain.
 
-```
+```cpp
 static constexpr bool needs_scale_normalisation =
     (std::numeric_limits<FpType>::min_exponent > -500);
 ```

--- a/elastic/elreal/math/sqrt.cpp
+++ b/elastic/elreal/math/sqrt.cpp
@@ -26,6 +26,14 @@ namespace {
 
 namespace est = sw::universal::elreal_oracle;
 
+// `depth` is passed explicitly rather than taking sqrt's default of 64. The
+// tolerances checked here are 1e-12 at worst, which every host clears at a small
+// depth; depth 64 was only ever cheap because the narrow-host refinement floor
+// stopped the underlying division early. With that floor gone the default is
+// honoured, so a test that does not need it should not ask for it
+// (universal#1051).
+constexpr std::size_t kVerifyDepth = 16;
+
 template <typename FpType>
 int verify_all(double tol, const std::string& host) {
     using namespace sw::universal;
@@ -36,7 +44,7 @@ int verify_all(double tol, const std::string& host) {
         {4.0, 2.0}, {9.0, 3.0}, {16.0, 4.0}, {25.0, 5.0}, {100.0, 10.0}, {144.0, 12.0}
     };
     for (auto& p : perfect) {
-        ZBCL<FpType> r = sqrt(from_native<FpType>(p.sq));
+        ZBCL<FpType> r = sqrt(from_native<FpType>(p.sq), kVerifyDepth);
         if (!(est::exact_value(r) == est::exact_value(from_native<FpType>(p.root)))) {
             std::cout << host << " sqrt(" << p.sq << ") != " << p.root << '\n'; ++n;
         }
@@ -46,7 +54,7 @@ int verify_all(double tol, const std::string& host) {
     // (2) Irrational roots: value vs std::sqrt, and round-trip sqrt(a)^2 ~= a.
     for (double v : { 2.0, 3.0, 5.0, 7.0, 0.5 }) {
         ZBCL<FpType> a = from_native<FpType>(v);
-        ZBCL<FpType> r = sqrt(a);
+        ZBCL<FpType> r = sqrt(a, kVerifyDepth);
         if (std::abs(est::approx(r) - std::sqrt(v)) > tol) {
             std::cout << host << " sqrt(" << v << ") = " << est::approx(r)
                       << " != " << std::sqrt(v) << " (tol " << tol << ")\n"; ++n;

--- a/include/sw/universal/number/elreal/block.hpp
+++ b/include/sw/universal/number/elreal/block.hpp
@@ -76,6 +76,22 @@ struct has_universal_fp_api<
 template <typename T>
 inline constexpr bool has_universal_fp_api_v = has_universal_fp_api<T>::value;
 
+namespace detail_block {
+
+// Scale by a power of two, exactly, without forming the multiplier.
+template <typename FpType>
+constexpr FpType ldexp_block(FpType v, int n) {
+    if constexpr (std::is_floating_point_v<FpType>) {
+        return std::ldexp(v, n);
+    } else {
+        using std::ldexp;
+        if constexpr (requires(FpType x) { ldexp(x, 0); }) return ldexp(v, n);
+        else return static_cast<FpType>(std::ldexp(static_cast<double>(v), n));
+    }
+}
+
+}  // namespace detail_block
+
 // block<FpType>: McCleeary's (sign, exp, bv) packed into FpType's value field
 // plus an explicit wide exponent (exp_t).
 //
@@ -132,6 +148,54 @@ struct block {
 
     constexpr bool is_zero_block() const noexcept {
         return v == FpType{0};
+    }
+
+    // needs_scale_normalisation: gated on the host's EXPONENT RANGE, not on k.
+    //
+    // The floors this replaces were gated on k >= 24, and copying that predicate was
+    // wrong: it excluded float, whose k is exactly 24 but whose ceiling is squarely
+    // an exponent-range ceiling. float and bfloat16 both carry an 8-bit exponent
+    // (min_exponent -125) and both exhaust it -- measured, v runs down to 2^-123 and
+    // 2^-117 respectively, within a couple of bits of the wall, capping them at 37
+    // and 33 decimal digits. That precision differs 3.4x while the ceilings differ
+    // by 4 digits is the whole point: the binding constraint is the exponent.
+    //
+    // double's 11-bit exponent (min_exponent -1021) gives roughly a thousand binades
+    // of headroom; at its natural ~306-digit depth v only reaches 2^-988, still 33
+    // bits clear. It is limited by block count, not by its wall, so normalising it
+    // would buy nothing and cost a scale_of_v() plus a wide-integer add per operand
+    // per step. Excluding it keeps the double path bit-identical BY CONSTRUCTION --
+    // the whole change compiles away -- rather than by testing.
+    //
+    // The -500 threshold simply separates 8-bit exponents from 11-bit ones; there is
+    // nothing between them to be delicate about.
+    static constexpr bool needs_scale_normalisation =
+        (std::numeric_limits<FpType>::min_exponent > -500);
+
+    // normalise(): rescale `v` into [1,2) in magnitude, folding the scale it was
+    // carrying into `exp`. E(b) = scale_of_v() + exp is invariant, so the block's
+    // value does not change; only its split between the two fields moves. Exact --
+    // a pure exponent shift -- and it cannot overflow, since exp is unbounded.
+    //
+    // This is McCleeary's own representation: his block is (s, e, bv) with bv a
+    // normalised significand and e a separate exponent in Z. Letting the host FpType
+    // carry the scale as well is what makes the host's exponent range binding.
+    //
+    // Call this on OPERANDS, before the arithmetic -- not on results. An EFT that
+    // runs at the operands' natural scale has already lost bits to the subnormal
+    // range by the time it returns, and normalising its outputs cannot put them
+    // back. See docs/design/elreal-narrow-host-blocks.md.
+    constexpr block& normalise() noexcept {
+        if constexpr (!needs_scale_normalisation) {
+            return *this;                          // wide host: nothing to gain
+        } else {
+            if (is_zero_block()) return *this;
+            const int sc = scale_of_v();
+            if (sc == 0) return *this;             // already in [1,2)
+            v = detail_block::ldexp_block(v, -sc);
+            exp = exp + exp_t(sc);
+            return *this;
+        }
     }
 
     // is_normalised(): true iff `v` is a finite, non-zero, non-subnormal value.

--- a/include/sw/universal/number/elreal/divide.hpp
+++ b/include/sw/universal/number/elreal/divide.hpp
@@ -76,10 +76,9 @@ inline ZBCL<FpType> div(ZBCL<FpType> x, ZBCL<FpType> y, std::size_t depth = 64) 
     // denormalises a couple of block-widths above it -- there the remainder
     // reductions stop staying normalised and 0-overlap accounting breaks -- so it
     // keeps the floor (this is the same denormal floor #1044 respects).
-    constexpr int k = block<FpType>::k;
-    constexpr int exp_floor = (k >= 24)
-        ? (std::numeric_limits<int>::min() / 2)                       // wide host: no floor
-        : (std::numeric_limits<FpType>::min_exponent + 2 * k);        // narrow host: denormal floor
+    // No refinement floor: keep_normalised makes the scale invariant true rather
+    // than testing for it, and the EFTs now normalise their operands, so v never
+    // approaches the host's subnormal wall (universal#1051).
 
     // Keep only normalised blocks (drop zeros and sub-floor denormals). On a
     // priestRenorm'd (descending, 0-overlap) list this only widens gaps, so the
@@ -87,7 +86,7 @@ inline ZBCL<FpType> div(ZBCL<FpType> x, ZBCL<FpType> y, std::size_t depth = 64) 
     auto keep_normalised = [](std::vector<B> v) {
         std::vector<B> out;
         out.reserve(v.size());
-        for (const auto& b : v) if (b.is_normalised()) out.push_back(b);
+        for (auto b : v) { b.normalise(); if (b.is_normalised()) out.push_back(b); }
         return out;
     };
 
@@ -102,7 +101,7 @@ inline ZBCL<FpType> div(ZBCL<FpType> x, ZBCL<FpType> y, std::size_t depth = 64) 
     for (std::size_t step = 0; step < depth; ++step) {
         if (rem.empty()) break;                  // exact division: remainder is 0
         const B r0 = rem.front();                // leading block (descending order)
-        if (!r0.is_normalised() || r0.exponent() < exp_floor) break;
+        if (!r0.is_normalised()) break;               // zero remainder only
         const int lead = static_cast<int>(r0.exponent());
         if (havePrev && lead >= prevLead) break; // no progress -> stop refining
         prevLead = lead;

--- a/include/sw/universal/number/elreal/math/constants.hpp
+++ b/include/sw/universal/number/elreal/math/constants.hpp
@@ -51,10 +51,7 @@ constexpr std::size_t kSeriesGuard = 4;
 template <typename FpType>
 constexpr int series_stop_exp(std::size_t wdepth) {
     constexpr int k = block<FpType>::k;
-    const int target = -static_cast<int>(wdepth) * k - 8;
-    const int floor  = (k >= 24) ? (std::numeric_limits<int>::min() / 2)
-                                 : (std::numeric_limits<FpType>::min_exponent + 2 * k);
-    return target > floor ? target : floor;
+    return -static_cast<int>(wdepth) * k - 8;   // working depth is the only stop
 }
 
 // take_while_above(z, floor_exp): the prefix of z whose block exponents are >=

--- a/include/sw/universal/number/elreal/online_divide.hpp
+++ b/include/sw/universal/number/elreal/online_divide.hpp
@@ -92,6 +92,14 @@ inline ZBCL<FpType> twoDivZBCL(block<FpType> x, block<FpType> y) {
         // infSum (singleDivHelper feeds it blocks of strictly decreasing E).
         return ZBCL<FpType>::singleton(x);
     }
+    // Normalise the OPERANDS, not the results. block_two_div_rem computes the
+    // remainder e = x - s*y in host arithmetic at the operands' natural scale; near
+    // a narrow host's subnormal wall that intermediate loses bits, so e is wrong
+    // before anything sees it and twoDiv's "e is >= k below s" guarantee fails.
+    // Normalising the outputs cannot restore what the subnormal arithmetic
+    // destroyed. Rescaled first, the division runs at scale ~1 (universal#1051).
+    x.normalise();
+    y.normalise();
     auto se = block_two_div_rem(x, y);                // (s, e): x/y = s + e/y
     // Host-floor guard, gated to narrow hosts -- mirrors divide.hpp's exp_floor.
     //
@@ -113,12 +121,8 @@ inline ZBCL<FpType> twoDivZBCL(block<FpType> x, block<FpType> y) {
     // producer cannot post-renormalise (the eager div() re-runs priestRenorm +
     // keep_normalised every step), so a narrow host keeps the min_exp+2k floor
     // (the same denormal floor #1044 respects).
-    constexpr int k = block<FpType>::k;
-    constexpr int host_exp_floor = (k >= 24)
-        ? (std::numeric_limits<int>::min() / 2)                       // wide host: no floor
-        : (std::numeric_limits<FpType>::min_exponent + 2 * k);        // narrow host: denormal floor
     const block<FpType> s = se.first;
-    if (!s.is_normalised() || s.exponent() < host_exp_floor) return ZBCL<FpType>{};
+    if (!s.is_normalised()) return ZBCL<FpType>{};    // zero quotient block: done
     const block<FpType> e = se.second;                // single remainder block x - s*y
     block<FpType> ycopy = y;
     return ZBCL<FpType>::cons(s, [e, ycopy]() { return twoDivZBCL(e, ycopy); });

--- a/include/sw/universal/number/elreal/online_multiply.hpp
+++ b/include/sw/universal/number/elreal/online_multiply.hpp
@@ -45,7 +45,14 @@ namespace sw { namespace universal {
 template <typename FpType>
 inline series<FpType> singleMultHelper(const block<FpType>& f, ZBCL<FpType> gs) {
     if (gs.is_empty()) return series<FpType>{};
-    auto pr = block_two_mult(f, gs.head());               // (high, low), exact f*g
+    // Normalise the OPERANDS, not the results: block_two_mult computes its residual
+    // in host arithmetic at the operands' natural scale, and on a narrow host that
+    // denormalises near the wall -- losing bits that normalising the outputs cannot
+    // restore. Rescaled to [1,2) first, the product runs at scale ~1 and the residual
+    // stays a full k below the high block (universal#1051).
+    block<FpType> fN = f;          fN.normalise();
+    block<FpType> gN = gs.head();  gN.normalise();
+    auto pr = block_two_mult(fN, gN);                     // (high, low), exact f*g
     const auto subnormal = [](const block<FpType>& b) {
         return !b.is_zero_block() && !b.is_normalised();
     };

--- a/include/sw/universal/number/elreal/threeAdd.hpp
+++ b/include/sw/universal/number/elreal/threeAdd.hpp
@@ -90,7 +90,7 @@ UNIVERSAL_ELREAL_EFT_NOINLINE inline void host_two_sum<double>(double a, double 
 // Implementation: align both inputs to max(a.exp, b.exp), perform host EFT,
 // pack the results back as blocks at the aligned exp.
 template<typename FpType>
-inline std::pair<block<FpType>, block<FpType>> twoSumRN(const block<FpType>& a, const block<FpType>& b) {
+inline std::pair<block<FpType>, block<FpType>> twoSumRN(block<FpType> a, block<FpType> b) {
 	constexpr int k = block<FpType>::k;
 	if (a.is_zero_block()) {
 		// 0 + b = b, with zero residual at exp k below b's exponent.
@@ -99,6 +99,35 @@ inline std::pair<block<FpType>, block<FpType>> twoSumRN(const block<FpType>& a, 
 	if (b.is_zero_block()) {
 		return {a, createZero<FpType>(a.exp - k)};
 	}
+	// Already NONADJACENT: the exact sum is the pair itself, in decreasing order.
+	//
+	// The threshold is k+1, not k, and the extra bit is load-bearing. twoSumRN owes
+	// its callers property 5 above -- the residual is at most half an ulp, i.e. the
+	// ROUND-TO-NEAREST decomposition -- and threeAdd's 0-overlap proof rests on it.
+	// Plain 0-overlap allows b up to just under ulp(a), so anything above half an
+	// ulp CARRIES and RN(a+b) != a; returning {a,b} there is exact but not
+	// round-to-nearest, and the chain does not survive the substitution (measured:
+	// el_math_trigonometry fails 0-overlap at block 1). At k+1 the gap puts b
+	// strictly below half an ulp, where RN cannot carry. Same non-overlapping vs
+	// nonadjacent distinction as the Shewchuk COMPRESS step (#1340).
+	//
+	// Skipping here also bounds the alignment below: every surviving case has a gap
+	// under k+1, so a normalised v shifted by that much stays comfortably normal.
+	//
+	// Gated to narrow hosts with the rest -- a wide host never approaches its wall,
+	// so this buys it nothing and would only perturb a hot path that is already
+	// correct. With the gate the whole change is a no-op for k >= 24: double is
+	// bit-identical by construction rather than by testing.
+	if constexpr (block<FpType>::needs_scale_normalisation) {
+		if (expGreaterBy(block<FpType>::k + 1, a, b)) return {a, b};
+		if (expGreaterBy(block<FpType>::k + 1, b, a)) return {b, a};
+		// Normalise the OPERANDS before aligning them. The shift below is applied to
+		// the host value, and at the operands' natural scale it can drive v subnormal
+		// on a narrow host, losing bits before host_two_sum ever sees them.
+		a.normalise();
+		b.normalise();
+	}
+
 	auto   e_max = std::max(a.exp, b.exp);
 	FpType va    = (a.exp == e_max) ? a.v : detail_mccleeary::ldexp_block(a.v, static_cast<int>(a.exp - e_max));
 	FpType vb    = (b.exp == e_max) ? b.v : detail_mccleeary::ldexp_block(b.v, static_cast<int>(b.exp - e_max));


### PR DESCRIPTION
## Both narrow hosts are unbounded now

| host | k | before | after | blocks | digits/block |
|------|---|--------|-------|--------|--------------|
| `double` | 53 | ~306 | ~306, **bit-identical** | 19 | 16.1 |
| `float` | 24 | **37 (hard cap)** | **319** | 50 | 6.4 |
| `bfloat16` | 7 | **33 (hard cap)** | **146 and climbing** | 53 | 2.8 |

float reaches essentially the full 320-digit reference. bfloat16 grows linearly with depth — 28/45/78/112/146 at depths 8/16/32/48/64 — with no ceiling in sight. The design note predicted `53/k` times as many blocks: **2.2× predicted vs 2.6× measured** for float, **7.6× vs 5.9×** for bfloat16.

## The fix: normalise operands, not results

One rule at three sites. An EFT that runs at the operands' natural scale has **already** lost bits to the subnormal range by the time it returns — normalising its outputs cannot put them back.

```cpp
x.normalise();
y.normalise();
auto se = block_two_div_rem(x, y);
```

`block::normalise()` rescales `v` into [1,2) and folds the scale into the wide `integer<256>` exponent — exactly, value and combined exponent invariant. Applied in `twoSumRN`, `singleMultHelper`, and `twoDivZBCL`. Fixing only the divide lifted bfloat16 33→40 and then **plateaued**; all three together make it unbounded. The three `min_exponent + 2k` floors go with it.

## The nonadjacent (`k+1`) shortcut

Operands already `k+1` apart need no arithmetic — their exact sum is the pair. **The threshold is `k+1`, not `k`:** `twoSumRN` owes callers the round-to-nearest decomposition (its own property 5), and plain 0-overlap allows the lower operand up to just under an ulp, where anything above half an ulp carries and `RN(a+b) ≠ a`:

| `b` | `RN(a+b) == a`? |
|---|---|
| half-ulp | yes |
| 0.75 ulp | **no** |

Same non-overlapping vs **nonadjacent** distinction as Shewchuk COMPRESS (#1340). It also bounds every surviving alignment shift — which is what makes normalised operands safe to align — and it's **the performance fix**: without it the suite took 1469s, with it 17s.

## Gated on exponent range, not k

Copying the floors' `k >= 24` predicate was wrong — it excluded `float`, whose k is exactly 24 but whose ceiling is squarely an exponent ceiling. float and bfloat16 share an 8-bit exponent and both exhaust it; double's 11-bit exponent has ~1000 binades it never approaches.

So **`double` compiles the change away entirely** and is bit-identical *by construction*. Verified anyway — every block's mantissa and exponent across pi, e, sqrt2, division and ln2, against the pre-change build.

## One test change

`el_math_sqrt` took sqrt's default `depth = 64` while checking a **1e-4** tolerance — cheap only because the floor stopped the underlying division early. Passing the depth it actually needs: *"does not finish in 500s"* → **2.3s**. That's the same accidental coupling this whole exercise is about, and worth watching for elsewhere.

## Test Results

| | gcc 13.3 | clang 18.1 |
|---|---|---|
| elreal suite | **46/46**, 17.2s | **46/46**, 19.2s |

Baseline was 7.1s; the increase is float computing 319 digits where it used to stop at 37. `check-ascii.sh` clean.

## On the wrong turns

The design note keeps them, including two of mine that came from reasoning ahead of the measurement:

- **normalise alone** — spread the `exp` fields and made the *unconditional* alignment underflow
- **the shortcut at `k`** — refuted on its own by `el_math_trigonometry`, before normalise was involved
- **"the producer is `addRec_step`"** — reported from a backtrace and wrong; it was only the first *consumer*. Per-state instrumentation (my first pass used a shared `thread_local` and was contaminated by cross-stream pairs) showed its output clean. The real producer was `twoDivZBCL`.

## Scope note

This does **not** change the user-facing recommendation in section H of the block-shape study — narrow hosts remain dominated for any actual precision target, since `dd`/`qd` cover their range as compile-time constants and beat them on throughput. What changes is that the **silicon** question can now be measured, which is the missing half of #1188's design matrix.

Supersedes #1360 (intermediate findings; its content is folded into the design note here).

Resolves #1051. Relates to #1188, #933.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arithmetic accuracy and refinement for narrow-host floating-point types.
  * Corrected scaling behavior for very small values and subnormal ranges.
  * Expanded `float` precision to 319 digits and `bfloat16` precision to 146 digits, with continued growth.
  * Preserved bit-identical results for double-precision calculations.
  * Improved square-root verification coverage with explicit calculation depth.

* **Performance**
  * Added a shortcut for widely separated values to reduce unnecessary arithmetic work.

* **Documentation**
  * Replaced the design proposal with a completed-fix report covering benchmarks, tests, precision findings, and updated implications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->