### PR TITLE
fix(elreal): bound el_api_math's constants -- UBSan timeout on main

### DIFF
--- a/elastic/elreal/api/math.cpp
+++ b/elastic/elreal/api/math.cpp
@@ -48,6 +48,24 @@ int verify_constants() {
     if (!near(elreal_sqrt5(kConstDepth),   2.23606797749978969))  ++n;
     if (!near(elreal_phi(kConstDepth),     1.61803398874989485))  ++n;
     if (!near(elreal_log2_10(kConstDepth), 3.32192809488736235))  ++n;
+
+    // depth 0 must still mean "the generator's own default" -- the back-compat
+    // promise of the optional depth parameter. The dispatch is a single shared
+    // expression across all ten accessors, so exercising it on the two cheapest
+    // constants covers the same path pi and e would, for 0.25s instead of 31s at
+    // -O0 (elreal_e() alone is 18.8s, which is what put this test over the
+    // sanitizer build's 300s limit in the first place).
+    {
+        auto same = [](ZBCL<double> a, ZBCL<double> b) {
+            auto va = a.take(256), vb = b.take(256);
+            if (va.size() != vb.size()) return false;
+            for (std::size_t i = 0; i < va.size(); ++i)
+                if (va[i].v != vb[i].v || va[i].exp != vb[i].exp) return false;
+            return true;
+        };
+        if (!same(elreal_sqrt2().stream(), sqrt2_zbcl<double>())) ++n;
+        if (!same(elreal_phi().stream(),   phi_zbcl<double>()))   ++n;
+    }
     return n;
 }
 

--- a/elastic/elreal/api/math.cpp
+++ b/elastic/elreal/api/math.cpp
@@ -32,15 +32,22 @@ bool near(const Real& v, double ref, double tol = 1.0e-12) {
 // is validated to 320 digits by the math/constants suite.
 int verify_constants() {
     int n = 0;
-    if (!near(elreal_pi(),      3.14159265358979324))  ++n;
-    if (!near(elreal_e(),       2.71828182845904524))  ++n;
-    if (!near(elreal_ln2(),     0.69314718055994531))  ++n;
-    if (!near(elreal_ln10(),    2.30258509299404568))  ++n;
-    if (!near(elreal_sqrt2(),   1.41421356237309505))  ++n;
-    if (!near(elreal_sqrt3(),   1.73205080756887729))  ++n;
-    if (!near(elreal_sqrt5(),   2.23606797749978969))  ++n;
-    if (!near(elreal_phi(),     1.61803398874989485))  ++n;
-    if (!near(elreal_log2_10(), 3.32192809488736235))  ++n;
+    // Checked against double literals, so ~17 digits is the whole question and
+    // kConstDepth supplies it with room to spare. Taking each generator's default
+    // instead (16, and 32 for e) buys hundreds of digits nobody here looks at --
+    // cheap while the refinement floors capped it early, and 3x the runtime once
+    // they were removed (universal#1051), which pushed this test past the
+    // sanitizer build's 300s ctest limit.
+    constexpr std::size_t kConstDepth = 3;
+    if (!near(elreal_pi(kConstDepth),      3.14159265358979324))  ++n;
+    if (!near(elreal_e(kConstDepth),       2.71828182845904524))  ++n;
+    if (!near(elreal_ln2(kConstDepth),     0.69314718055994531))  ++n;
+    if (!near(elreal_ln10(kConstDepth),    2.30258509299404568))  ++n;
+    if (!near(elreal_sqrt2(kConstDepth),   1.41421356237309505))  ++n;
+    if (!near(elreal_sqrt3(kConstDepth),   1.73205080756887729))  ++n;
+    if (!near(elreal_sqrt5(kConstDepth),   2.23606797749978969))  ++n;
+    if (!near(elreal_phi(kConstDepth),     1.61803398874989485))  ++n;
+    if (!near(elreal_log2_10(kConstDepth), 3.32192809488736235))  ++n;
     return n;
 }
 

--- a/include/sw/universal/number/elreal/mathlib.hpp
+++ b/include/sw/universal/number/elreal/mathlib.hpp
@@ -88,15 +88,25 @@ inline constexpr std::size_t default_depth_euler_gamma = 16;
 // that only needs a few should be able to say so rather than pay for all of it. FpType defaults to
 // double (elreal64); supply it explicitly for other hosts, e.g. elreal_pi<float>().
 // ---------------------------------------------------------------------------
-template <typename FpType = double> inline elreal<FpType> elreal_e(std::size_t depth = 0)           { return elreal<FpType>((e_zbcl<FpType>)(depth ? depth : detail::default_depth_e)); }
-template <typename FpType = double> inline elreal<FpType> elreal_pi(std::size_t depth = 0)          { return elreal<FpType>((pi_zbcl<FpType>)(depth ? depth : detail::default_depth_pi)); }
-template <typename FpType = double> inline elreal<FpType> elreal_ln2(std::size_t depth = 0)         { return elreal<FpType>((ln2_zbcl<FpType>)(depth ? depth : detail::default_depth_ln2)); }
-template <typename FpType = double> inline elreal<FpType> elreal_ln10(std::size_t depth = 0)        { return elreal<FpType>((ln10_zbcl<FpType>)(depth ? depth : detail::default_depth_ln10)); }
-template <typename FpType = double> inline elreal<FpType> elreal_log2_10(std::size_t depth = 0)     { return elreal<FpType>((log2_10_zbcl<FpType>)(depth ? depth : detail::default_depth_log2_10)); }
-template <typename FpType = double> inline elreal<FpType> elreal_sqrt2(std::size_t depth = 0)       { return elreal<FpType>((sqrt2_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt2)); }
-template <typename FpType = double> inline elreal<FpType> elreal_sqrt3(std::size_t depth = 0)       { return elreal<FpType>((sqrt3_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt3)); }
-template <typename FpType = double> inline elreal<FpType> elreal_sqrt5(std::size_t depth = 0)       { return elreal<FpType>((sqrt5_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt5)); }
-template <typename FpType = double> inline elreal<FpType> elreal_phi(std::size_t depth = 0)         { return elreal<FpType>((phi_zbcl<FpType>)(depth ? depth : detail::default_depth_phi)); }
-template <typename FpType = double> inline elreal<FpType> elreal_euler_gamma(std::size_t depth = 0) { return elreal<FpType>((euler_gamma_zbcl<FpType>)(depth ? depth : detail::default_depth_euler_gamma)); }
+template <typename FpType = double> inline elreal<FpType> elreal_e(std::size_t depth = 0)
+    { return elreal<FpType>((e_zbcl<FpType>)(depth ? depth : detail::default_depth_e)); }
+template <typename FpType = double> inline elreal<FpType> elreal_pi(std::size_t depth = 0)
+    { return elreal<FpType>((pi_zbcl<FpType>)(depth ? depth : detail::default_depth_pi)); }
+template <typename FpType = double> inline elreal<FpType> elreal_ln2(std::size_t depth = 0)
+    { return elreal<FpType>((ln2_zbcl<FpType>)(depth ? depth : detail::default_depth_ln2)); }
+template <typename FpType = double> inline elreal<FpType> elreal_ln10(std::size_t depth = 0)
+    { return elreal<FpType>((ln10_zbcl<FpType>)(depth ? depth : detail::default_depth_ln10)); }
+template <typename FpType = double> inline elreal<FpType> elreal_log2_10(std::size_t depth = 0)
+    { return elreal<FpType>((log2_10_zbcl<FpType>)(depth ? depth : detail::default_depth_log2_10)); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt2(std::size_t depth = 0)
+    { return elreal<FpType>((sqrt2_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt2)); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt3(std::size_t depth = 0)
+    { return elreal<FpType>((sqrt3_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt3)); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt5(std::size_t depth = 0)
+    { return elreal<FpType>((sqrt5_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt5)); }
+template <typename FpType = double> inline elreal<FpType> elreal_phi(std::size_t depth = 0)
+    { return elreal<FpType>((phi_zbcl<FpType>)(depth ? depth : detail::default_depth_phi)); }
+template <typename FpType = double> inline elreal<FpType> elreal_euler_gamma(std::size_t depth = 0)
+    { return elreal<FpType>((euler_gamma_zbcl<FpType>)(depth ? depth : detail::default_depth_euler_gamma)); }
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/elreal/mathlib.hpp
+++ b/include/sw/universal/number/elreal/mathlib.hpp
@@ -63,20 +63,40 @@ inline elreal<FpType> hypot(const elreal<FpType>& x, const elreal<FpType>& y) {
     return elreal<FpType>(hypot(x.stream(), y.stream(), d), d);
 }
 
+namespace detail {
+// today's per-generator default depths, so elreal_*(0) is unchanged behaviour
+inline constexpr std::size_t default_depth_e = 32;
+inline constexpr std::size_t default_depth_pi = 16;
+inline constexpr std::size_t default_depth_ln2 = 16;
+inline constexpr std::size_t default_depth_ln10 = 16;
+inline constexpr std::size_t default_depth_log2_10 = 16;
+inline constexpr std::size_t default_depth_sqrt2 = 16;
+inline constexpr std::size_t default_depth_sqrt3 = 16;
+inline constexpr std::size_t default_depth_sqrt5 = 16;
+inline constexpr std::size_t default_depth_phi = 16;
+inline constexpr std::size_t default_depth_euler_gamma = 16;
+}  // namespace detail
+
 // ---------------------------------------------------------------------------
 // named constants -- elreal at the ZBCL factory's tuned series depth; the
-// returned object reads at the scoped default precision. FpType defaults to
+// returned object reads at the scoped default precision.
+//
+// `depth` is optional and 0 means "the generator's own default", so existing
+// callers are unaffected. It exists because those defaults are now genuinely
+// expensive: with the refinement floors gone (universal#1051) a default-depth
+// constant refines to hundreds of digits instead of stopping early, and a caller
+// that only needs a few should be able to say so rather than pay for all of it. FpType defaults to
 // double (elreal64); supply it explicitly for other hosts, e.g. elreal_pi<float>().
 // ---------------------------------------------------------------------------
-template <typename FpType = double> inline elreal<FpType> elreal_e()           { return elreal<FpType>(e_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_pi()          { return elreal<FpType>(pi_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_ln2()         { return elreal<FpType>(ln2_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_ln10()        { return elreal<FpType>(ln10_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_log2_10()     { return elreal<FpType>(log2_10_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_sqrt2()       { return elreal<FpType>(sqrt2_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_sqrt3()       { return elreal<FpType>(sqrt3_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_sqrt5()       { return elreal<FpType>(sqrt5_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_phi()         { return elreal<FpType>(phi_zbcl<FpType>()); }
-template <typename FpType = double> inline elreal<FpType> elreal_euler_gamma() { return elreal<FpType>(euler_gamma_zbcl<FpType>()); }
+template <typename FpType = double> inline elreal<FpType> elreal_e(std::size_t depth = 0)           { return elreal<FpType>((e_zbcl<FpType>)(depth ? depth : detail::default_depth_e)); }
+template <typename FpType = double> inline elreal<FpType> elreal_pi(std::size_t depth = 0)          { return elreal<FpType>((pi_zbcl<FpType>)(depth ? depth : detail::default_depth_pi)); }
+template <typename FpType = double> inline elreal<FpType> elreal_ln2(std::size_t depth = 0)         { return elreal<FpType>((ln2_zbcl<FpType>)(depth ? depth : detail::default_depth_ln2)); }
+template <typename FpType = double> inline elreal<FpType> elreal_ln10(std::size_t depth = 0)        { return elreal<FpType>((ln10_zbcl<FpType>)(depth ? depth : detail::default_depth_ln10)); }
+template <typename FpType = double> inline elreal<FpType> elreal_log2_10(std::size_t depth = 0)     { return elreal<FpType>((log2_10_zbcl<FpType>)(depth ? depth : detail::default_depth_log2_10)); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt2(std::size_t depth = 0)       { return elreal<FpType>((sqrt2_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt2)); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt3(std::size_t depth = 0)       { return elreal<FpType>((sqrt3_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt3)); }
+template <typename FpType = double> inline elreal<FpType> elreal_sqrt5(std::size_t depth = 0)       { return elreal<FpType>((sqrt5_zbcl<FpType>)(depth ? depth : detail::default_depth_sqrt5)); }
+template <typename FpType = double> inline elreal<FpType> elreal_phi(std::size_t depth = 0)         { return elreal<FpType>((phi_zbcl<FpType>)(depth ? depth : detail::default_depth_phi)); }
+template <typename FpType = double> inline elreal<FpType> elreal_euler_gamma(std::size_t depth = 0) { return elreal<FpType>((euler_gamma_zbcl<FpType>)(depth ? depth : detail::default_depth_euler_gamma)); }
 
 }} // namespace sw::universal


### PR DESCRIPTION
## main is red; this fixes it

#1362's UBSan job failed. **It is not a sanitizer diagnostic** — 889 of 890 tests passed, **zero** runtime errors reported, and the single failure is `el_api_math` hitting ctest's **300s per-test limit**.

## Cause

The same accidental coupling that hit `el_math_sqrt`. The test checks the named constants against **`double` literals** — ~17 significant digits is the whole question — but calls `elreal_pi()`, `elreal_e()` and the rest at each generator's own default depth: **16, and 32 for `e`**.

That was cheap while the refinement floors stopped the series early. With the floors gone (#1051/#1362), a default-depth constant refines to hundreds of digits.

| build | `el_api_math` at `-O0` |
|---|---|
| before #1362 | 34.2s |
| after #1362 | **113.9s** |
| after this PR | **20.8s** |

Now *below* the original baseline, so there's real margin under instrumentation rather than a borderline pass.

## Changes

- **`mathlib.hpp`** — the ten `elreal_*` constant accessors take an optional depth. `0` means "the generator's own default", so **every existing caller is unaffected**. Verified directly: `elreal_pi()` and `elreal_e()` with no argument still agree with `pi_zbcl<double>()` and `e_zbcl<double>()` digit for digit (260 and 319). The parameter exists because those defaults are now genuinely expensive and a caller needing a few digits should be able to say so.
- **`elastic/elreal/api/math.cpp`** — the constant checks pass depth 3.

## Test Results

| | gcc 13.3 | clang 18.1 |
|---|---|---|
| elreal suite | **46/46**, 18.9s | **46/46**, 18.2s |

`check-ascii.sh` clean.

## On how this got in

I merged #1362 with ASan, UBSan and Coverage still pending, having said those were the checks that mattered for it. The Debug run I did instead confirmed the 0-overlap invariant — the correctness risk I was actually worried about — but it could not have caught a per-test timeout, because a local run has no time limit. The gap was real and the check that closed it was the one I skipped.

Relates to #1051, #1362.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Named mathematical constants can now be generated at an explicitly requested precision depth.
  - Existing behavior is preserved when no precision depth is specified, using each constant’s configured default.
  - Supported constants include π, e, logarithmic values, square roots, the golden ratio, and Euler’s constant.

- **Bug Fixes**
  - Constant validation now evaluates values consistently at a defined precision, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->