### PR TITLE
fix(elreal): let div_online reach the depth the caller asks for

### DIFF
--- a/elastic/elreal/arithmetic/online_muldiv.cpp
+++ b/elastic/elreal/arithmetic/online_muldiv.cpp
@@ -284,6 +284,54 @@ int verify_div_deep_reach() {
     return n;
 }
 
+// A DENSE-divisor quotient must reach the depth the CALLER asks for, on every host.
+// It used to stop at a depth derived from FpType's exponent range -- 17 blocks on
+// double, 3 on float -- regardless of how deep the caller pulled (#1371). That is the
+// premise #1362 removed elsewhere: a block carries its scale in a wide integer<256>
+// exponent, so min_exponent bounds nothing about an expansion's depth.
+template <typename FpType>
+int verify_div_dense_honours_depth(const char* host) {
+    using namespace sw::universal;
+    int n = 0;
+    // sqrt(2) is a genuinely dense multi-block divisor (no power-of-two blocks).
+    for (std::size_t d : { std::size_t(8), std::size_t(16), std::size_t(32), std::size_t(48) }) {
+        ZBCL<FpType> b = sqrt(from_native<FpType>(2.0), d);
+        if (!is_dense_divisor(b)) {           // guard the premise of this test
+            std::cout << "dense-depth [" << host << "] d=" << d
+                      << ": sqrt(2) is not classified dense -- test no longer exercises the Newton path\n";
+            ++n; continue;
+        }
+        const std::size_t got = div_online(from_native<FpType>(2.0), b, d).take(4 * d + 8).size();
+        if (got < d) {
+            std::cout << "dense-depth [" << host << "] requested " << d << " blocks, got " << got
+                      << " (the #1371 host-derived cap is back: 17 on double, 3 on float)\n";
+            ++n;
+        }
+    }
+    return n;
+}
+
+// The class facade must propagate precision() into division. Without it, elreal's
+// operator/ was pinned to that same host constant no matter what the object asked for,
+// which stalled a Newton iteration at ~282 digits on double and ~22 on float.
+template <typename FpType>
+int verify_facade_division_precision(const char* host) {
+    using namespace sw::universal;
+    int n = 0;
+    for (std::size_t d : { std::size_t(24), std::size_t(48) }) {
+        elreal<FpType> num(2.0);
+        elreal<FpType> den(ZBCL<FpType>(sqrt(from_native<FpType>(2.0), d)), d);
+        num.precision(d);
+        const std::size_t got = (num / den).stream().take(4 * d + 8).size();
+        if (got < d) {
+            std::cout << "facade-precision [" << host << "] precision(" << d << ") but quotient has "
+                      << got << " blocks (precision() not reaching div_online)\n";
+            ++n;
+        }
+    }
+    return n;
+}
+
 } // anonymous
 
 #define MANUAL_TESTING 0
@@ -325,6 +373,10 @@ try {
     nrOfFailedTestCases += verify_div_dense_shallow();
     nrOfFailedTestCases += verify_div_dense_deep();
     nrOfFailedTestCases += verify_div_deep_reach();
+    nrOfFailedTestCases += verify_div_dense_honours_depth<double>("double");
+    nrOfFailedTestCases += verify_div_dense_honours_depth<float>("float");
+    nrOfFailedTestCases += verify_facade_division_precision<double>("double");
+    nrOfFailedTestCases += verify_facade_division_precision<float>("float");
 
 #endif
 

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -54,6 +54,11 @@ namespace sw { namespace universal {
 // from it and may be changed per-scope (elreal_precision_guard).
 inline constexpr std::size_t kElrealDefaultPrecision = 8;   // ~128 decimal digits on a double host
 
+// Extra blocks requested of a dense quotient beyond the object's own precision, so a
+// boundary op that pulls `precision()` blocks is not reading the quotient's last,
+// least-settled block.
+inline constexpr std::size_t kQuotientGuard = 2;
+
 inline std::size_t& elreal_default_precision() {
     static thread_local std::size_t depth = kElrealDefaultPrecision;
     return depth;
@@ -195,7 +200,12 @@ public:
         if (rhs.iszero()) return iszero() ? become(elreal_class::qnan, nd)       // 0 / 0
                                           : become(detail::inf_with_sign(sign() * rhs.sign()), nd); // x / 0
         if (isinf()) return become(detail::inf_with_sign(sign() * rhs.sign()), nd);  // inf / finite
-        _value = div_online(_value, rhs._value); _depth = nd; return *this;
+        // Pass the working depth: div_online's DENSE path needs a budget up front, and
+        // it used to infer one from the host's exponent range -- capping a facade
+        // division at ~271 digits on double and ~22 on float no matter what precision()
+        // said (universal#1371). A small guard above nd covers the boundary op that
+        // will pull nd blocks out of this quotient.
+        _value = div_online(_value, rhs._value, nd + kQuotientGuard); _depth = nd; return *this;
     }
 
     // --- lazy API / state-machine extension ----------------------------------

--- a/include/sw/universal/number/elreal/math/trigonometry.hpp
+++ b/include/sw/universal/number/elreal/math/trigonometry.hpp
@@ -269,7 +269,11 @@ inline std::pair<ZBCL<FpType>, ZBCL<FpType>> sincos(ZBCL<FpType> x, std::size_t 
         const std::size_t reddepth = depth + 6 + static_cast<std::size_t>(ex / B::k + 2);
         ZBCL<FpType> halfpi = mul_scalar(B{ static_cast<FpType>(0.5), 0 }, pi_zbcl<FpType>(reddepth), reddepth);
 
-        ZBCL<FpType> q = div_online(ax, halfpi);                 // |x| / (pi/2), full precision
+        // |x| / (pi/2) to the reduction depth. halfpi is a DENSE multi-block divisor,
+        // so this quotient used to be capped at div_online's host-derived 17 blocks
+        // (3 on float) regardless of reddepth -- silently limiting the reduction
+        // (universal#1371).
+        ZBCL<FpType> q = div_online(ax, halfpi, reddepth);
         integer<256, std::uint32_t> N = zbcl_round_to_int(q, reddepth);
         nmod4 = static_cast<int>(N % 4);                         // N >= 0
 

--- a/include/sw/universal/number/elreal/online_divide.hpp
+++ b/include/sw/universal/number/elreal/online_divide.hpp
@@ -210,9 +210,20 @@ inline ZBCL<FpType> recip_newton(const ZBCL<FpType>& b, std::size_t depth) {
     ZBCL<FpType> r   = ZBCL<FpType>::singleton(r0blk);
     ZBCL<FpType> two = from_native<FpType>(2.0);
 
-    const std::size_t guard = depth + 1;
+    // `depth` is caller-controlled since universal#1371 (it used to be a small
+    // host-derived constant), so both of these must survive an absurd argument: at
+    // SIZE_MAX, depth + 1 wraps to 0 and would truncate every iterate to nothing, and
+    // p <<= 1 wraps to 0 and leaves `p < depth` true forever. Saturating keeps a
+    // nonsense depth to a terminating (if useless) call instead of a hang, and is
+    // exact for every depth a caller can actually afford to materialise.
+    constexpr std::size_t kSizeMax = std::numeric_limits<std::size_t>::max();
+    const std::size_t guard = (depth < kSizeMax) ? depth + 1 : kSizeMax;
     std::size_t iters = 1;                       // r0 is ~1 block correct ...
-    for (std::size_t p = 1; p < depth; p <<= 1) ++iters;   // ... double to >= depth
+    for (std::size_t p = 1; p < depth; ) {       // ... double to >= depth
+        ++iters;
+        if (p > kSizeMax / 2) break;             // one more doubling would wrap
+        p <<= 1;
+    }
     for (std::size_t i = 0; i < iters; ++i) {
         ZBCL<FpType> br = mul_online(b, r);                  // b*r ~ 1
         ZBCL<FpType> s  = add(two, negate(std::move(br)));   // 2 - b*r

--- a/include/sw/universal/number/elreal/online_divide.hpp
+++ b/include/sw/universal/number/elreal/online_divide.hpp
@@ -20,8 +20,14 @@
 //      = r_n(2 - b r_n), error squaring per step, seeded from 1/leading-block. Reuses the
 //      working mul_online + add; terminates; 0-overlap; reconstructs q*b == a exactly.
 //      This is a DELIBERATE DEVIATION from McCleeary 4.2.6 for the dense case (#1068).
-//    - DEPTH: the dense quotient refines to the host floor (~17 components / ~265 digits
-//      on a double host), the same region as the single-block path. This required the
+//    - DEPTH: the dense quotient refines to the `depth` the CALLER asks for (default
+//      kDenseQuotientDepth, matching the eager div()). It used to stop at a depth
+//      DERIVED FROM THE HOST'S EXPONENT RANGE -- 17 components / ~265 digits on double,
+//      and only 3 / ~22 digits on float -- which capped every dense division no matter
+//      how deep the caller pulled (universal#1371). That was the same mistaken premise
+//      #1362 removed elsewhere: a block carries its scale in a wide integer<256>
+//      exponent, so min_exponent bounds nothing about how deep an expansion may go.
+//      This required the
 //      streaming-multiply host-floor arrest (#1068): mul_online USED to emit subnormal
 //      blocks once a product reached ~2^-1022, and a subnormal block cannot hold its k
 //      bits, so two of them landed ~22 apart and broke 0-overlap (an earlier draft of
@@ -220,6 +226,13 @@ inline ZBCL<FpType> recip_newton(const ZBCL<FpType>& b, std::size_t depth) {
 // on the faithful long-division path (it reaches the host floor there); only the
 // genuinely DENSE case -- where divideHelper's fan-out cost-explodes past ~7 blocks
 // -- routes to Newton. A single-block divisor (e.g. 1/3) is never dense.
+// Default working depth for a DENSE-divisor quotient, in blocks. Matches the eager
+// div()'s default so the streaming and eager APIs agree, and is deliberately NOT
+// derived from FpType: the host's exponent range does not bound an expansion's depth
+// (universal#1371). Dense division costs roughly linearly in this, so callers with a
+// known working precision should pass it explicitly rather than pay for the default.
+inline constexpr std::size_t kDenseQuotientDepth = 64;
+
 template <typename FpType>
 inline bool is_dense_divisor(const ZBCL<FpType>& gs) {
     const std::vector<block<FpType>> bl = gs.take(4);
@@ -228,7 +241,7 @@ inline bool is_dense_divisor(const ZBCL<FpType>& gs) {
     return false;                                          // all power-of-two: sparse
 }
 
-// div_online(fs, gs): fs / gs. Single-block and sparse divisors use the faithful
+// div_online(fs, gs, depth): fs / gs. Single-block and sparse divisors use the faithful
 // McCleeary long division (div_raw); shiftUpToTwo normalises the divisor's leading
 // exponent to >= 1 (scaling BOTH operands, so the quotient is unchanged) for the
 // long-division series' convergence. A DENSE multi-block divisor instead uses
@@ -236,23 +249,27 @@ inline bool is_dense_divisor(const ZBCL<FpType>& gs) {
 // fan-out is correct but cost-explodes for dense divisors (#1061), so we deviate from
 // McCleeary 4.2.6 there -- tracked in #1068. 0/gs = 0; gs == 0 is the caller's
 // precondition (empty divisor).
+//
+// `depth` bounds the DENSE path only: the long-division path is genuinely streaming
+// and produces blocks for as long as the caller pulls, so passing a depth there would
+// be meaningless. The dense path cannot be lazy in the same way -- Newton recomputes
+// the whole reciprocal at each depth rather than extending it, so a deeper pull would
+// not agree block-for-block with a shallower one -- which is why it takes a budget up
+// front. Callers that know their working precision should pass it.
 template <typename FpType>
-inline ZBCL<FpType> div_online(ZBCL<FpType> fs, ZBCL<FpType> gs) {
+inline ZBCL<FpType> div_online(ZBCL<FpType> fs, ZBCL<FpType> gs,
+                               std::size_t depth = kDenseQuotientDepth) {
     if (gs.is_empty()) return ZBCL<FpType>{};   // divide-by-zero: caller's precondition
     if (fs.is_empty()) return ZBCL<FpType>{};   // 0 / gs = 0
 
     if (is_dense_divisor(gs)) {
-        // Target the host-floor depth: a 2k margin above min_exponent, so the Newton
-        // products stay normal. mul_online now ARRESTS at that same floor (#1068), so
-        // the reciprocal self-limits there and never emits a subnormal (0-overlap
-        // violating) block -- the earlier mul_canonical_cap=8 stopgap is gone, and the
-        // dense quotient reaches the host floor (~17 components for double, ~270
-        // digits) like the single-block path, instead of stopping at ~118 digits.
-        constexpr std::size_t target = static_cast<std::size_t>(
-            (-(std::numeric_limits<FpType>::min_exponent) - 2 * block<FpType>::k)
-            / block<FpType>::k);
-        ZBCL<FpType> r = recip_newton(gs, target);
-        return zbcl_truncate(mul_online(std::move(fs), std::move(r)), target);
+        // Refine the Newton reciprocal to the depth the CALLER asked for. This used to
+        // be a constant derived from the host's exponent range -- 17 blocks on double,
+        // 3 on float -- which silently capped every dense quotient regardless of how
+        // many blocks the caller pulled, stalling e.g. a Newton sqrt at ~282 digits
+        // (universal#1371). Depth is the caller's budget, not a property of FpType.
+        ZBCL<FpType> r = recip_newton(gs, depth);
+        return zbcl_truncate(mul_online(std::move(fs), std::move(r)), depth);
     }
 
     const typename block<FpType>::exp_t lead = gs.head().exponent();


### PR DESCRIPTION
## Summary

`div_online`'s dense-divisor path pinned its Newton reciprocal to a depth derived from the host's exponent range:

```cpp
target = (-min_exponent - 2*k) / k     // 17 on double, 3 on float
```

so **every division by a multi-block value stopped at 17 blocks (~271 digits) on double and 3 blocks (~22 digits) on float**, no matter how many blocks the caller pulled. Same mistaken premise #1362 removed elsewhere: a block carries its scale in a wide `integer<256>` exponent, so `min_exponent` bounds nothing about how deep an expansion may go. #1361/#1362 swept out the `min_exponent + 2k` *guards*; this one is a target *depth* rather than a guard, so it survived the sweep.

## Effect

A Newton iteration for `sqrt(2)` against the class facade, before and after:

| iter | before | after |
|---|---|---|
| 4 | 48 | 48 |
| 5 | 97 | 97 |
| 6 | 195 | 195 |
| 7 | **282** | 391 |
| 8 | **282** (stalled) | **513** |

Requested-vs-produced blocks for a dense quotient, previously a flat 17 / 3:

| requested | double | float |
|---|---|---|
| 16 | 16 | 16 |
| 32 | 32 | 32 |
| 48 | 48 | 48 |
| 72 | 72 | 72 |

## Changes

- `online_divide.hpp` -- `div_online(fs, gs, depth = kDenseQuotientDepth)`. The default is 64, matching the eager `div()`'s existing default, and is derived from no host property. Depth bounds the **dense path only**: long division is genuinely streaming and produces blocks for as long as the caller pulls. The dense path cannot be lazy the same way (Newton recomputes the whole reciprocal per depth rather than extending it, so a deeper pull would not agree block-for-block with a shallower one), which is why it takes a budget up front. The file banner documented the old belief and is corrected.
- `elreal_impl.hpp` -- `operator/=` passes `precision()` plus a small guard, so the facade's division finally honours the precision the object was given.
- `math/trigonometry.hpp` -- the Payne-Hanek reduction passes its own `reddepth`. It computes exactly how many blocks of pi/2 it needs to cover `|x|`'s binade plus the output precision, then divided at 17 blocks regardless; the comment said "full precision" and meant it, but did not get it.

## Not fixed here

A **second, independent limit inside `recip_newton`** caps convergence at ~513 digits on double and ~62 on float regardless of depth, `guard`, or iteration count -- the iteration doubles correctly and then stops dead (32 -> 64 -> 128 -> 256 -> 513 -> 513 -> 513). Ruled out: this depth constant; `mul_online` (which scales cleanly to its inputs' precision, 131 -> 784 digits as depth goes 8 -> 48); the `guard` truncation; the iteration count. Filed as **#1373** with the instrumented traces. Dense division is much better than it was, but not yet unbounded.

## Behaviour change

Flagged with a `BEHAVIOUR-CHANGE:` trailer. At the default precision of 8 blocks, a facade division now yields ~10 blocks (~160 digits on double) where it previously yielded 17 (~271). Raise `precision()` for more -- and unlike before, raising it now works.

## Test Results

New regression in `elastic/elreal/arithmetic/online_muldiv.cpp`: a dense quotient must reach the requested depth on both hosts, and the facade must propagate `precision()` into division.

**Mutation-tested.** Restoring the old host-derived constant (keeping the new signature) fails all ten checks with the measured counts:

```
dense-depth [double] requested 32 blocks, got 17
dense-depth [float]  requested  8 blocks, got  3
facade-precision [double] precision(48) but quotient has 17 blocks
facade-precision [float]  precision(48) but quotient has  3 blocks
```

| Suite | gcc | clang |
|---|---|---|
| full `el_*` ctest (47 tests) | 47/47 PASS (20.1s) | 47/47 PASS (19.4s) |

Payne-Hanek still runs in 2.37s despite now dividing to `reddepth` rather than 17 blocks. ASCII Guard clean.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Resolves #1371

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming division so dense divisors refine results to the requested precision.
  * Removed host-dependent precision limits for dense quotient calculations.
  * Ensured precision propagates correctly through high-precision arithmetic and trigonometric calculations.
  * Preserved existing behavior for single-block and sparse divisors.

* **Tests**
  * Added regression coverage for dense-divisor division using `float` and `double`.
  * Added validation for requested precision depths and precision propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->