### PR TITLE
perf(elreal): make division by a single block linear instead of quadratic

### DIFF
--- a/elastic/elreal/arithmetic/online_muldiv.cpp
+++ b/elastic/elreal/arithmetic/online_muldiv.cpp
@@ -26,6 +26,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
+#include <chrono>
 #include <cmath>
 #include <iostream>
 #include <random>
@@ -392,6 +393,65 @@ int verify_dense_div_resolves_with_depth(const char* host, std::size_t depth, in
     return n;
 }
 
+// Dividing a multi-block value by a SINGLE block must stay LINEAR in the requested
+// depth. It used to be quadratic: each dividend block was divided independently to a
+// full stream and D of them were summed, each carried to the output frontier, so
+// D quotient blocks cost D^2/2 block divisions. The schoolbook carry makes it O(1)
+// per emitted block.
+//
+// Guarded by a RATIO across a 4x span rather than an absolute time, so it does not
+// depend on machine speed. Linear predicts ~4x; the quadratic form measured 16-30x
+// over the same span. The threshold sits well clear of both, so ordinary CI noise
+// cannot trip it.
+//
+// Checked on the double host only. The COUNT of block divisions is linear on both --
+// 1.00 per emitted block on double and 1.06-1.09 on float -- but float carries a
+// larger running remainder, and that per-step overhead leaves its wall-clock ratio
+// around 6-10x rather than 4x. Asserting on float would either be flaky or need a
+// threshold too loose to catch anything, so the guard rides on the host where the
+// signal is clean; a regression to the per-block-then-sum form would show on both.
+template <typename FpType>
+int verify_single_block_division_is_linear(const char* host) {
+    using namespace sw::universal;
+    using clk = std::chrono::steady_clock;
+    auto cost = [](std::size_t D) {
+        ZBCL<FpType> big = zbcl_from_blocks<FpType>(
+            div_online(from_native<FpType>(1.0), from_native<FpType>(7.0)).take(D));
+        const auto t0 = clk::now();
+        volatile std::size_t n =
+            zbcl_from_blocks<FpType>(div_online(big, from_native<FpType>(5.0)).take(D)).take(D).size();
+        const auto t1 = clk::now();
+        (void)n;
+        return std::chrono::duration<double, std::milli>(t1 - t0).count();
+    };
+    (void)cost(40);                                  // warm caches / first-touch
+    const double small = cost(40), large = cost(160);
+    const double ratio = (small > 0.0) ? large / small : 0.0;
+    constexpr double kMaxRatio = 8.0;                // linear ~4, quadratic ~16-30
+    if (ratio > kMaxRatio) {
+        std::cout << "single-block division [" << host << "] scaled x" << ratio
+                  << " over a 4x depth span (want <= " << kMaxRatio
+                  << "; the O(D^2) per-block-then-sum form is back)\n";
+        return 1;
+    }
+    return 0;
+}
+
+// ... and it must still STREAM. The quotient of 1/3 never terminates, so the
+// implementation has to keep producing blocks for as long as the caller pulls; a
+// depth-budgeted rewrite would silently cap it.
+template <typename FpType>
+int verify_single_block_division_streams(const char* host) {
+    using namespace sw::universal;
+    const std::size_t got = div_online(from_native<FpType>(1.0), from_native<FpType>(3.0)).take(400).size();
+    if (got < 400) {
+        std::cout << "single-block division [" << host << "] produced only " << got
+                  << " blocks of 1/3, expected the stream to keep going to 400\n";
+        return 1;
+    }
+    return 0;
+}
+
 } // anonymous
 
 #define MANUAL_TESTING 0
@@ -443,6 +503,9 @@ try {
     // keeping the check affordable for the fast CI tier.
     nrOfFailedTestCases += verify_dense_div_resolves_with_depth<double>("double", 40, 513);
     nrOfFailedTestCases += verify_dense_div_resolves_with_depth<float>("float", 24, 62);
+    nrOfFailedTestCases += verify_single_block_division_is_linear<double>("double");
+    nrOfFailedTestCases += verify_single_block_division_streams<double>("double");
+    nrOfFailedTestCases += verify_single_block_division_streams<float>("float");
 
 #endif
 

--- a/elastic/elreal/arithmetic/online_muldiv.cpp
+++ b/elastic/elreal/arithmetic/online_muldiv.cpp
@@ -33,6 +33,7 @@
 #include <string>
 #include <vector>
 
+#include <universal/number/cfloat/cfloat.hpp>
 #include <universal/number/elreal/elreal.hpp>
 #include <universal/verification/elreal_oracle.hpp>
 #include <universal/verification/elreal_reference_digits.hpp>   // agreed_decimal_digits
@@ -414,18 +415,25 @@ template <typename FpType>
 int verify_single_block_division_is_linear(const char* host) {
     using namespace sw::universal;
     using clk = std::chrono::steady_clock;
-    auto cost = [](std::size_t D) {
+    // The produced block count is checked, not discarded: a divider that terminated
+    // early would do less work and sail through a pure timing ratio.
+    int shortfall = 0;
+    auto cost = [&shortfall](std::size_t D) {
         ZBCL<FpType> big = zbcl_from_blocks<FpType>(
             div_online(from_native<FpType>(1.0), from_native<FpType>(7.0)).take(D));
         const auto t0 = clk::now();
-        volatile std::size_t n =
+        const std::size_t n =
             zbcl_from_blocks<FpType>(div_online(big, from_native<FpType>(5.0)).take(D)).take(D).size();
         const auto t1 = clk::now();
-        (void)n;
+        if (n < D) {
+            std::cout << "single-block division: asked for " << D << " blocks, got " << n << '\n';
+            ++shortfall;
+        }
         return std::chrono::duration<double, std::milli>(t1 - t0).count();
     };
     (void)cost(40);                                  // warm caches / first-touch
     const double small = cost(40), large = cost(160);
+    if (shortfall) return shortfall;
     const double ratio = (small > 0.0) ? large / small : 0.0;
     constexpr double kMaxRatio = 8.0;                // linear ~4, quadratic ~16-30
     if (ratio > kMaxRatio) {
@@ -443,13 +451,71 @@ int verify_single_block_division_is_linear(const char* host) {
 template <typename FpType>
 int verify_single_block_division_streams(const char* host) {
     using namespace sw::universal;
-    const std::size_t got = div_online(from_native<FpType>(1.0), from_native<FpType>(3.0)).take(400).size();
-    if (got < 400) {
-        std::cout << "single-block division [" << host << "] produced only " << got
+    int n = 0;
+    ZBCL<FpType> q = div_online(from_native<FpType>(1.0), from_native<FpType>(3.0));
+    const std::vector<block<FpType>> bl = q.take(400);
+    if (bl.size() < 400) {
+        std::cout << "single-block division [" << host << "] produced only " << bl.size()
                   << " blocks of 1/3, expected the stream to keep going to 400\n";
-        return 1;
+        ++n;
     }
-    return 0;
+    // ... and every block it hands out must be canonical. This is what the pending
+    // buffer exists for: the raw quotient blocks are 0-overlap on a double host but
+    // roughly 2 in 60 land a bit too close on float, so a length check alone would
+    // not notice the buffer being removed.
+    for (std::size_t i = 1; i < bl.size(); ++i) {
+        if (!zero_overlap(bl[i - 1], bl[i])) {
+            std::cout << "single-block division [" << host << "] block " << i
+                      << " overlaps its predecessor (exponents " << bl[i - 1].exponent()
+                      << ", " << bl[i].exponent() << "; k = " << block<FpType>::k
+                      << ") -- the quotient is not canonical\n";
+            ++n;
+            break;
+        }
+    }
+    return n;
+}
+
+// A NARROW host needs both division operands prepared with bias_for_eft(), not just
+// normalise(). block_two_div_rem forms the residual in host arithmetic, and a host
+// whose exponent span is under 2k has no room below a normalised operand for it, so
+// the residual denormalises and twoDiv's "e is >= k below s" guarantee fails.
+//
+// This only bites where block::eft_scale_bias() is non-zero -- 8 on half, 0 on
+// bfloat16, float and double -- so double/float coverage cannot see it. Measured on
+// half with the bias omitted: 13 of 80 random cases diverge and 12 get materially
+// worse, e.g. a quotient good to 139 digits collapsing to 4.
+//
+// half here is IEEE binary16 with subnormals, the configuration elreal's narrow-host
+// work (#1363/#1366) targets.
+using elreal_half = sw::universal::cfloat<16, 5, std::uint16_t, true, false, false>;
+
+template <typename FpType>
+int verify_narrow_host_division(const char* host) {
+    using namespace sw::universal;
+    int n = 0;
+    // pairs chosen from the divergent set found by sweeping the bias on/off
+    const int cases[][3] = { { 54, 51, 9 }, { 30, 29, 33 }, { 32, 31, 12 }, { 7, 3, 16 } };
+    for (const auto& c : cases) {
+        const std::size_t D = static_cast<std::size_t>(c[2]);
+        ZBCL<FpType> big = zbcl_from_blocks<FpType>(
+            div_online(from_native<FpType>(1.0), from_native<FpType>(double(c[0]))).take(D));
+        if (big.take(1).empty()) continue;
+        ZBCL<FpType> q = zbcl_from_blocks<FpType>(
+            div_online(big, from_native<FpType>(double(c[1]))).take(D));
+        // independent check: q * divisor must reproduce the dividend
+        const int agree = agreed_decimal_digits(
+            mul(q, from_native<FpType>(double(c[1])), 2 * D + 8), big, 4000);
+        const int want = static_cast<int>(0.60 * double(D) * double(block<FpType>::k) * 0.30103);
+        if (agree < want) {
+            std::cout << "narrow-host division [" << host << "] 1/" << c[0] << " / " << c[1]
+                      << " at depth " << D << ": q*divisor reproduces the dividend to only "
+                      << agree << " digits (want >= " << want
+                      << "; are both operands bias_for_eft'd?)\n";
+            ++n;
+        }
+    }
+    return n;
 }
 
 } // anonymous
@@ -506,6 +572,7 @@ try {
     nrOfFailedTestCases += verify_single_block_division_is_linear<double>("double");
     nrOfFailedTestCases += verify_single_block_division_streams<double>("double");
     nrOfFailedTestCases += verify_single_block_division_streams<float>("float");
+    nrOfFailedTestCases += verify_narrow_host_division<elreal_half>("half");
 
 #endif
 

--- a/include/sw/universal/number/elreal/online_divide.hpp
+++ b/include/sw/universal/number/elreal/online_divide.hpp
@@ -194,7 +194,17 @@ inline std::optional<block<FpType>> singleDiv_step(singleDivState<FpType>& st) {
             }
             if (st.rem.is_empty()) { st.exhausted = true; continue; }
             block<FpType> x = st.rem.head();
-            x.normalise();                              // operands, not results (#1051)
+            // Prepare the operand exactly as twoDivZBCL does. normalise() alone is not
+            // enough: block_two_div_rem forms the residual in HOST arithmetic, and on a
+            // host whose exponent span is under 2k there is no room below a normalised
+            // operand for it, so the residual denormalises and twoDiv's "e is >= k below
+            // s" guarantee fails. bias_for_eft() borrows the unused headroom above 1.0.
+            // It changes the representation, not the value (v up, exp down), so the
+            // remainder that comes back is directly comparable with the running one.
+            // The bias is 0 on float and double -- which is why omitting it passed every
+            // test on those hosts -- and 8 on half, where it is load-bearing (#1051).
+            x.normalise();
+            x.bias_for_eft();
             auto se = block_two_div_rem(x, st.gN);      // (s, e): x/g = s + e/g
             if (!se.first.is_normalised()) { st.exhausted = true; continue; }
             st.rem = zbcl_from_blocks<FpType>(
@@ -215,22 +225,25 @@ inline std::optional<block<FpType>> singleDiv_step(singleDivState<FpType>& st) {
     }
 }
 
+// Pull one block and defer the rest. The thunk captures ONLY the shared state: a
+// self-capturing std::function (the shape infsum uses) would own itself, so the
+// control block never reaches zero and every division would strand its state.
+template <typename FpType>
+inline ZBCL<FpType> singleDiv_stream(std::shared_ptr<singleDivState<FpType>> st) {
+    auto nxt = singleDiv_step(*st);
+    if (!nxt) return ZBCL<FpType>{};
+    block<FpType> head = *nxt;
+    return ZBCL<FpType>::cons(head, [st]() { return singleDiv_stream<FpType>(st); });
+}
+
 template <typename FpType>
 inline ZBCL<FpType> singleDiv(ZBCL<FpType> fs, block<FpType> g) {
     using Z = ZBCL<FpType>;
     if (fs.is_empty() || g.is_zero_block()) return Z{};
-    block<FpType> gN = g; gN.normalise();
+    block<FpType> gN = g; gN.normalise(); gN.bias_for_eft();
     auto st = std::make_shared<singleDivState<FpType>>(
         singleDivState<FpType>{ std::move(fs), Z{}, Z{}, gN, false });
-    auto loop = std::make_shared<std::function<Z()>>();
-    *loop = [st, loop]() -> Z {
-        auto nxt = singleDiv_step(*st);
-        if (!nxt) return Z{};
-        return Z::cons(*nxt, [loop]() { return (*loop)(); });
-    };
-    auto first = singleDiv_step(*st);
-    if (!first) return Z{};
-    return Z::cons(*first, [loop]() { return (*loop)(); });
+    return singleDiv_stream<FpType>(std::move(st));
 }
 
 // divideHelper: the long division. q ~= fs/g0 (leading divisor block); the residual is

--- a/include/sw/universal/number/elreal/online_divide.hpp
+++ b/include/sw/universal/number/elreal/online_divide.hpp
@@ -51,7 +51,10 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <limits>
+#include <memory>
+#include <optional>
 #include <vector>
 
 #include <universal/number/elreal/block.hpp>
@@ -135,17 +138,99 @@ inline ZBCL<FpType> twoDivZBCL(block<FpType> x, block<FpType> y) {
 }
 
 // singleDivHelper / singleDiv: a ZBCL divided by a single block g.
+//
+// FCL.hs computes this as infSum over [f_0/g, f_1/g, ...] -- each dividend block
+// divided INDEPENDENTLY to a full stream, then summed. That is correct but costs
+// O(D^2): term i must be carried down to the output frontier, i.e. D-i blocks, so
+// D terms cost D^2/2 block divisions. Measured directly: 2*D^2 twoDivZBCL calls to
+// produce D quotient blocks.
+//
+// Dividing an N-digit number by a ONE-digit divisor is a linear operation -- the
+// schoolbook carry. The observation that makes it work here is that the residual of
+// f_i/g lands at the scale of f_{i+1}, so the two add and one running remainder
+// suffices. Each emitted quotient block then costs O(1) instead of O(D):
+//
+//     rem  += next dividend block
+//     (s,e) = twoDiv(rem.head(), g)      -- one quotient block, exact residual
+//     rem   = rem.tail() + e             -- carry
+//
+// The remainder stays small (1 block on a double host, up to ~6 on float), and is
+// capped so a pathological carry cannot grow it without bound.
+//
+// PENDING BUFFER. The raw quotient blocks are not always 0-overlap: on a double host
+// they come out with gaps of k+1 and need nothing, but on float roughly 2 in 60 land
+// one bit too close. Rather than renormalising the whole expansion at the end -- a
+// pass that is itself superlinear and would dominate what we just made linear -- the
+// blocks are folded through a small canonical buffer and emitted with a lookahead, so
+// a late carry can still reach a block that has not been handed out yet. That keeps
+// the per-block cost O(1) and the output canonical.
+//
+// This stays a LAZY producer: one quotient block per pull, so an infinite quotient
+// (1/3) still streams for as long as the caller asks.
 template <typename FpType>
-inline series<FpType> singleDivHelper(ZBCL<FpType> fs, block<FpType> g) {
-    if (fs.is_empty()) return series<FpType>{};
-    ZBCL<FpType> term = twoDivZBCL(fs.head(), g);     // f_i / g
-    ZBCL<FpType> rest = fs.tail();
-    block<FpType> gcopy = g;
-    return series<FpType>::cons(term, [rest, gcopy]() { return singleDivHelper(rest, gcopy); });
+struct singleDivState {
+    ZBCL<FpType>   cur;              // dividend blocks not yet consumed
+    ZBCL<FpType>   rem;              // running remainder (small, capped)
+    ZBCL<FpType>   pending;          // quotient blocks not yet settled (small, canonical)
+    block<FpType>  gN;               // normalised divisor
+    bool           exhausted{false}; // no further raw quotient blocks
+};
+
+// Blocks of lookahead kept before a quotient block is handed out, and the cap on the
+// running remainder. Both are small constants: their only job is to bound the work per
+// emitted block, and the structures they bound are O(1) in practice.
+inline constexpr std::size_t kSingleDivLookahead = 3;
+inline constexpr std::size_t kSingleDivCarryCap  = 8;
+
+template <typename FpType>
+inline std::optional<block<FpType>> singleDiv_step(singleDivState<FpType>& st) {
+    using Z = ZBCL<FpType>;
+    for (;;) {
+        if (!st.exhausted) {
+            if (!st.cur.is_empty()) {
+                st.rem = zbcl_from_blocks<FpType>(
+                    add(st.rem, Z::singleton(st.cur.head())).take(kSingleDivCarryCap));
+                st.cur = st.cur.tail();
+            }
+            if (st.rem.is_empty()) { st.exhausted = true; continue; }
+            block<FpType> x = st.rem.head();
+            x.normalise();                              // operands, not results (#1051)
+            auto se = block_two_div_rem(x, st.gN);      // (s, e): x/g = s + e/g
+            if (!se.first.is_normalised()) { st.exhausted = true; continue; }
+            st.rem = zbcl_from_blocks<FpType>(
+                add(st.rem.tail(), Z::singleton(se.second)).take(kSingleDivCarryCap));
+            st.pending = zbcl_from_blocks<FpType>(
+                add(st.pending, Z::singleton(se.first)).take(kSingleDivCarryCap));
+            if (st.pending.take(kSingleDivLookahead + 1).size() > kSingleDivLookahead) {
+                block<FpType> out = st.pending.head();
+                st.pending = st.pending.tail();
+                return out;
+            }
+            continue;
+        }
+        if (st.pending.is_empty()) return std::nullopt;   // drained
+        block<FpType> out = st.pending.head();
+        st.pending = st.pending.tail();
+        return out;
+    }
 }
+
 template <typename FpType>
 inline ZBCL<FpType> singleDiv(ZBCL<FpType> fs, block<FpType> g) {
-    return infsum(singleDivHelper(std::move(fs), g));
+    using Z = ZBCL<FpType>;
+    if (fs.is_empty() || g.is_zero_block()) return Z{};
+    block<FpType> gN = g; gN.normalise();
+    auto st = std::make_shared<singleDivState<FpType>>(
+        singleDivState<FpType>{ std::move(fs), Z{}, Z{}, gN, false });
+    auto loop = std::make_shared<std::function<Z()>>();
+    *loop = [st, loop]() -> Z {
+        auto nxt = singleDiv_step(*st);
+        if (!nxt) return Z{};
+        return Z::cons(*nxt, [loop]() { return (*loop)(); });
+    };
+    auto first = singleDiv_step(*st);
+    if (!first) return Z{};
+    return Z::cons(*first, [loop]() { return (*loop)(); });
 }
 
 // divideHelper: the long division. q ~= fs/g0 (leading divisor block); the residual is


### PR DESCRIPTION
## Summary

`singleDiv` followed FCL.hs literally: divide **each** dividend block independently to a full stream, then `infSum` the D of them. Correct, but quadratic — term *i* must be carried down to the output frontier, so D quotient blocks cost D²/2 block divisions. Counted directly: **2·D² `twoDivZBCL` calls** to produce D blocks.

Dividing an N-digit number by a **one**-digit divisor is a linear operation. What makes the schoolbook carry work here is that the residual of `f_i/g` lands at the scale of `f_{i+1}`, so the two add and a single running remainder suffices:

```
rem  += next dividend block
(s,e) = twoDiv(rem.head(), g)      // one quotient block, exact residual
rem   = rem.tail() + e             // carry
```

## Measured

Block divisions are now linear in emitted blocks: **1.00 per block** on double, 1.06–1.09 on float, against the old D/2.

| D | before | after | speedup | growth per 2x D (before / after) |
|---|---|---|---|---|
| 20 | 14.1 ms | 0.179 ms | 79x | |
| 40 | 53.3 ms | 0.352 ms | 151x | x3.77 / **x1.97** |
| 80 | 265.2 ms | 0.704 ms | 377x | x4.97 / **x1.99** |
| 160 | 1682.7 ms | 1.423 ms | **1183x** | x6.34 / **x2.02** |

x2.02 per doubling is linear; x6.34 is not.

## Effect on the high-precision suites

Same tree, gcc -O2, all checks passing in both directions:

| suite | before | after | |
|---|---|---|---|
| `transcendentals_highprecision` (LEVEL_4) | 3m33.6s | **2m06.0s** | **1.70x** |
| `constants_highprecision` (LEVEL_4) | 0m51.6s | **0m30.1s** | **1.71x** |

Those series all divide a multi-block term by a small integer — `constants.hpp`, `exponent.hpp` and `trigonometry.hpp` each call `div_online(term, from_native(n))` — so they sat squarely on this path.

## Design notes

**Still lazy.** One quotient block per pull, so an infinite quotient (`1/3`) streams for as long as the caller asks. Verified to 400 blocks; a depth-budgeted rewrite would have silently capped it, so there is a regression test for it.

**Pending buffer.** The raw quotient blocks are not always 0-overlap: on double they arrive with gaps of k+1 and need nothing, but on float about 2 in 60 land one bit too close. Renormalising the finished expansion would have been self-defeating — `priestRenorm` over D blocks is itself superlinear (measured x5.9 per doubling) and would have dominated exactly what was just made linear. Instead the blocks are folded through a small canonical buffer and emitted with a lookahead, so a late carry can still reach a block that has not been handed out. O(1) per block, output canonical.

**Float is improved but not asymptotically fixed.** Its division count is linear, but a larger running remainder leaves the wall clock at ~x3.2 per doubling, so the gain is 51x–358x rather than unbounded. Worth revisiting separately; noted in the code.

## Test Results

New regressions in `online_muldiv.cpp`:
- **scaling guard** — compares the cost *ratio* across a 4x depth span rather than absolute time, so it does not depend on machine speed. Linear predicts ~4x; the threshold is 8. Scoped to the double host, where the signal is clean (float's constant-factor overhead would need a threshold too loose to catch anything).
- **streaming guard** — `1/3` must keep producing blocks on demand.

**Mutation-tested.** Against the previous implementation the scaling guard fails at **x32.1** versus the threshold of 8, with the new code at ~4.2 — a 4x margin either way.

| | gcc | clang |
|---|---|---|
| full `el_*` ctest (47 tests) | 47/47 PASS (18.8s) | 47/47 PASS (18.1s) |

Correctness was also checked separately against the previous implementation on 120 random dividend/divisor pairs (divisors 3..97, depths 10..106) across both hosts, with the ZBCL 0-overlap assert live: all matched. ASCII Guard clean.

## Background

This came out of #1372, which I filed and then closed as invalid — that issue claimed a host asymmetry which turned out to be a benchmark artifact (one divisor, 3, which divides `1/7`'s double blocks exactly). Underneath the bad benchmark was this real algorithmic issue, affecting both hosts equally.

Relates to #1061.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved single-block division accuracy on narrow and half-precision hosts.
  - Division now produces quotient blocks incrementally, supporting longer, nonterminating results.
  - Improved carry propagation and lookahead for more reliable streamed results.
  - Division performance scales more consistently with requested calculation depth.

- **Tests**
  - Added regression coverage for half-precision and cfloat division.
  - Verified continued output streaming through 400 blocks.
  - Added checks for accurate canonical zero results and remainder handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->