### PR TITLE
fix(elreal): stop the lazy producers owning themselves

### DIFF
--- a/elastic/elreal/arithmetic/division_scaling.cpp
+++ b/elastic/elreal/arithmetic/division_scaling.cpp
@@ -1,0 +1,139 @@
+// division_scaling.cpp: division by a single block must stay LINEAR in depth (#1061).
+//
+// singleDiv once followed FCL.hs literally -- divide EACH dividend block independently
+// to a full stream, then infSum the D of them. Correct, but O(D^2): term i has to be
+// carried down to the output frontier, so D quotient blocks cost D^2/2 block divisions.
+// The schoolbook carry (one running remainder) makes it O(1) per emitted block.
+//
+// WHY THIS MEASURES ALLOCATIONS AND NOT TIME. The first version of this guard compared
+// wall-clock across a 4x depth span. It passed locally at x4.2 against a threshold of
+// 8, and then failed on two CI runners at x11.0 and x12.4 -- and passed on rerun. A
+// shared runner can stretch either measurement, and a ratio of two noisy numbers is
+// noisier than each, so no threshold both catches the regression and survives
+// contention. Allocation counts are deterministic: identical on every run and every
+// platform, because they are a property of the algorithm rather than of the machine.
+//
+// The assertion is dimensionless -- allocations PER EMITTED BLOCK must not grow with
+// depth. Linear work is flat; quadratic work grows with D. Measured:
+//
+//     implementation        allocs/block @D=40   @D=160   growth
+//     per-block-then-sum          3060            23559    x7.7
+//     schoolbook carry              48               49    x1.02
+//
+// so a threshold of 3 clears the current form by ~3x and catches the old one by ~2.5x,
+// with no dependence on machine speed at all.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+// ---- global allocation counter (cumulative; never decremented) -------------------
+namespace {
+long g_totalAllocations = 0;
+}
+void* operator new(std::size_t n) {
+    void* p = std::malloc(n ? n : 1);
+    if (!p) throw std::bad_alloc();
+    ++g_totalAllocations;
+    return p;
+}
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void* operator new[](std::size_t n) { return operator new(n); }
+void operator delete[](void* p) noexcept { operator delete(p); }
+void operator delete[](void* p, std::size_t) noexcept { operator delete(p); }
+
+namespace {
+
+using namespace sw::universal;
+
+// allocations consumed producing D quotient blocks of (1/7 at D blocks) / 5
+template <typename FpType>
+double allocations_per_block(std::size_t D) {
+    ZBCL<FpType> big = zbcl_from_blocks<FpType>(
+        div_online(from_native<FpType>(1.0), from_native<FpType>(7.0)).take(D));
+    const long before = g_totalAllocations;
+    const std::size_t produced =
+        zbcl_from_blocks<FpType>(div_online(big, from_native<FpType>(5.0)).take(D)).take(D).size();
+    const long used = g_totalAllocations - before;
+    if (produced == 0) return 0.0;
+    return double(used) / double(produced);
+}
+
+template <typename FpType>
+int verify_division_scaling(const char* host, bool reportTestCases) {
+    const double shallow = allocations_per_block<FpType>(40);
+    const double deep    = allocations_per_block<FpType>(160);
+    if (shallow <= 0.0) {
+        std::cout << "  FAIL [" << host << "] the shallow division produced no blocks\n";
+        return 1;
+    }
+    const double growth = deep / shallow;
+    constexpr double kMaxGrowth = 3.0;
+    if (growth > kMaxGrowth) {
+        std::cout << "  FAIL [" << host << "] per-block cost grew x" << growth
+                  << " over a 4x depth span (" << shallow << " -> " << deep
+                  << " allocations per block; want <= " << kMaxGrowth
+                  << ") -- division by a single block is no longer linear\n";
+        return 1;
+    }
+    if (reportTestCases) {
+        std::cout << "  ok   [" << host << "] per-block cost flat: " << shallow << " -> " << deep
+                  << " allocations per block (x" << growth << ")\n";
+    }
+    return 0;
+}
+
+} // anonymous
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal single-block division scales linearly (#1061)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+    nrOfFailedTestCases += verify_division_scaling<double>("double", reportTestCases);
+    nrOfFailedTestCases += verify_division_scaling<float>("float", reportTestCases);
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/elastic/elreal/arithmetic/online_muldiv.cpp
+++ b/elastic/elreal/arithmetic/online_muldiv.cpp
@@ -26,7 +26,6 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
-#include <chrono>
 #include <cmath>
 #include <iostream>
 #include <random>
@@ -394,57 +393,6 @@ int verify_dense_div_resolves_with_depth(const char* host, std::size_t depth, in
     return n;
 }
 
-// Dividing a multi-block value by a SINGLE block must stay LINEAR in the requested
-// depth. It used to be quadratic: each dividend block was divided independently to a
-// full stream and D of them were summed, each carried to the output frontier, so
-// D quotient blocks cost D^2/2 block divisions. The schoolbook carry makes it O(1)
-// per emitted block.
-//
-// Guarded by a RATIO across a 4x span rather than an absolute time, so it does not
-// depend on machine speed. Linear predicts ~4x; the quadratic form measured 16-30x
-// over the same span. The threshold sits well clear of both, so ordinary CI noise
-// cannot trip it.
-//
-// Checked on the double host only. The COUNT of block divisions is linear on both --
-// 1.00 per emitted block on double and 1.06-1.09 on float -- but float carries a
-// larger running remainder, and that per-step overhead leaves its wall-clock ratio
-// around 6-10x rather than 4x. Asserting on float would either be flaky or need a
-// threshold too loose to catch anything, so the guard rides on the host where the
-// signal is clean; a regression to the per-block-then-sum form would show on both.
-template <typename FpType>
-int verify_single_block_division_is_linear(const char* host) {
-    using namespace sw::universal;
-    using clk = std::chrono::steady_clock;
-    // The produced block count is checked, not discarded: a divider that terminated
-    // early would do less work and sail through a pure timing ratio.
-    int shortfall = 0;
-    auto cost = [&shortfall](std::size_t D) {
-        ZBCL<FpType> big = zbcl_from_blocks<FpType>(
-            div_online(from_native<FpType>(1.0), from_native<FpType>(7.0)).take(D));
-        const auto t0 = clk::now();
-        const std::size_t n =
-            zbcl_from_blocks<FpType>(div_online(big, from_native<FpType>(5.0)).take(D)).take(D).size();
-        const auto t1 = clk::now();
-        if (n < D) {
-            std::cout << "single-block division: asked for " << D << " blocks, got " << n << '\n';
-            ++shortfall;
-        }
-        return std::chrono::duration<double, std::milli>(t1 - t0).count();
-    };
-    (void)cost(40);                                  // warm caches / first-touch
-    const double small = cost(40), large = cost(160);
-    if (shortfall) return shortfall;
-    const double ratio = (small > 0.0) ? large / small : 0.0;
-    constexpr double kMaxRatio = 8.0;                // linear ~4, quadratic ~16-30
-    if (ratio > kMaxRatio) {
-        std::cout << "single-block division [" << host << "] scaled x" << ratio
-                  << " over a 4x depth span (want <= " << kMaxRatio
-                  << "; the O(D^2) per-block-then-sum form is back)\n";
-        return 1;
-    }
-    return 0;
-}
-
 // ... and it must still STREAM. The quotient of 1/3 never terminates, so the
 // implementation has to keep producing blocks for as long as the caller pulls; a
 // depth-budgeted rewrite would silently cap it.
@@ -569,7 +517,6 @@ try {
     // keeping the check affordable for the fast CI tier.
     nrOfFailedTestCases += verify_dense_div_resolves_with_depth<double>("double", 40, 513);
     nrOfFailedTestCases += verify_dense_div_resolves_with_depth<float>("float", 24, 62);
-    nrOfFailedTestCases += verify_single_block_division_is_linear<double>("double");
     nrOfFailedTestCases += verify_single_block_division_streams<double>("double");
     nrOfFailedTestCases += verify_single_block_division_streams<float>("float");
     nrOfFailedTestCases += verify_narrow_host_division<elreal_half>("half");

--- a/elastic/elreal/zbcl/lazy_lifetime.cpp
+++ b/elastic/elreal/zbcl/lazy_lifetime.cpp
@@ -1,0 +1,138 @@
+// lazy_lifetime.cpp: elreal's lazy producers must release their state (#1378).
+//
+// add(), infsum() and singleDiv() each hand back a ZBCL whose tail is a thunk over a
+// shared state. If that thunk is built as a std::function that captures a shared_ptr
+// to the control block owning it, the function object owns itself: dropping the
+// returned ZBCL can never bring the count to zero, and every single call strands its
+// state for the life of the process. All three used to do exactly that. Measured
+// before the fix, RSS grew 0.29 kB per add(), 6.33 kB per singleDiv() and 41.28 kB
+// per mul_online() -- 80,000 dropped mul_online streams took a process from 3.5 MB
+// to 2.3 GB.
+//
+// The guard here counts live heap allocations rather than reading RSS, because RSS is
+// not portable across the CI matrix (no /proc on macOS or Windows) and an allocator
+// counter is exact rather than sampled. A leaking producer shows up as a live count
+// that never returns to its pre-loop level.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/test_suite.hpp>
+
+// ---- global allocation counter -------------------------------------------------
+// Deliberately simple: a signed live-block count, incremented in operator new and
+// decremented in operator delete. It only ever has to answer "did the count come back
+// down", so it needs no size tracking and no thread safety (the test is single
+// threaded).
+namespace {
+long g_liveAllocations = 0;
+}
+void* operator new(std::size_t n) {
+    void* p = std::malloc(n ? n : 1);
+    if (!p) throw std::bad_alloc();
+    ++g_liveAllocations;
+    return p;
+}
+void operator delete(void* p) noexcept { if (p) { --g_liveAllocations; std::free(p); } }
+void operator delete(void* p, std::size_t) noexcept { if (p) { --g_liveAllocations; std::free(p); } }
+void* operator new[](std::size_t n) { return operator new(n); }
+void operator delete[](void* p) noexcept { operator delete(p); }
+void operator delete[](void* p, std::size_t) noexcept { operator delete(p); }
+
+namespace {
+
+using namespace sw::universal;
+
+// Run `body` `iterations` times, each creating a lazy stream, pulling a few blocks and
+// dropping it. Reports the growth in live allocations across the loop.
+template <typename Body>
+long leaked_over(Body body, int iterations) {
+    body();                                   // warm: the first call may populate statics
+    const long before = g_liveAllocations;
+    for (int i = 0; i < iterations; ++i) body();
+    return g_liveAllocations - before;
+}
+
+template <typename FpType>
+int verify_lazy_producers_release(const char* host, bool reportTestCases) {
+    int n = 0;
+    const int iterations = 500;
+    ZBCL<FpType> a = zbcl_from_blocks<FpType>(
+        div_online(from_native<FpType>(1.0), from_native<FpType>(7.0)).take(8));
+    ZBCL<FpType> b = zbcl_from_blocks<FpType>(
+        div_online(from_native<FpType>(1.0), from_native<FpType>(11.0)).take(8));
+
+    const long addLeak = leaked_over([&]{ (void)add(a, b).take(5).size(); }, iterations);
+    const long mulLeak = leaked_over([&]{ (void)mul_online(a, b).take(5).size(); }, iterations);
+    const long divLeak = leaked_over([&]{ (void)div_online(a, from_native<FpType>(3.0)).take(5).size(); }, iterations);
+
+    const char* names[]  = { "add", "mul_online", "div_online" };
+    const long  leaks[]  = { addLeak, mulLeak, divLeak };
+    for (int i = 0; i < 3; ++i) {
+        if (leaks[i] != 0) {
+            std::cout << "  FAIL [" << host << "] " << names[i] << ": " << leaks[i]
+                      << " allocations still live after " << iterations
+                      << " streams were created and dropped ("
+                      << (double(leaks[i]) / iterations)
+                      << " per call) -- a lazy producer is not releasing its state (#1378)\n";
+            ++n;
+        }
+        else if (reportTestCases) {
+            std::cout << "  ok   [" << host << "] " << names[i] << ": all state released\n";
+        }
+    }
+    return n;
+}
+
+} // anonymous
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal lazy producers release their state (#1378)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+    nrOfFailedTestCases += verify_lazy_producers_release<double>("double", reportTestCases);
+    nrOfFailedTestCases += verify_lazy_producers_release<float>("float", reportTestCases);
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/infsum.hpp
+++ b/include/sw/universal/number/elreal/infsum.hpp
@@ -186,6 +186,22 @@ infsumRec_step(infsumRec_state<FpType>& st) {
         "sw::universal::infsumRec_step: safety counter exhausted (non-convergence bug)");
 }
 
+// infsumRec_stream(st): pull one block and defer the rest.
+//
+// The thunk captures ONLY the state. It used to be a std::function holding a
+// shared_ptr to the control block that owned it -- the function object owned itself,
+// so releasing the returned ZBCL could never bring the count to zero and every stream
+// stranded its state. Measured before the fix: 41 kB per mul_online() stream, so
+// 80,000 streams created and dropped took RSS from 3.5 MB to 2.3 GB
+// (universal#1378).
+template <typename FpType>
+inline ZBCL<FpType> infsumRec_stream(std::shared_ptr<infsumRec_state<FpType>> st) {
+    auto nxt = infsumRec_step(*st);
+    if (!nxt) return ZBCL<FpType>{};
+    block<FpType> head = *nxt;
+    return ZBCL<FpType>::cons(head, [st]() { return infsumRec_stream<FpType>(st); });
+}
+
 // infsum(s): streaming sum of the series `s`. Direct translation of FCL.hs infSum.
 template <typename FpType>
 inline ZBCL<FpType> infsum(series<FpType> s) {
@@ -209,16 +225,7 @@ inline ZBCL<FpType> infsum(series<FpType> s) {
     auto st = std::make_shared<infsumRec_state<FpType>>(
         infsumRec_state<FpType>{ std::move(rest), std::move(nprevs), bound });
 
-    auto loop = std::make_shared<std::function<Z()>>();
-    *loop = [st, loop]() -> Z {
-        auto nxt = infsumRec_step(*st);
-        if (!nxt) return Z{};
-        return Z::cons(*nxt, [loop]() { return (*loop)(); });
-    };
-
-    auto first = infsumRec_step(*st);
-    if (!first) return Z{};
-    return Z::cons(*first, [loop]() { return (*loop)(); });
+    return infsumRec_stream<FpType>(std::move(st));
 }
 
 // drop_zeros(z): lazily drop every zero block from z. The EFTs leave exact (zero-residual)

--- a/include/sw/universal/number/elreal/threeAdd.hpp
+++ b/include/sw/universal/number/elreal/threeAdd.hpp
@@ -743,24 +743,28 @@ inline std::optional<block<FpType>> addRec_step(addRec_state<FpType>& st) {
 	                         "See threeAdd.hpp for diagnosis.");
 }
 
+// addRec_stream(st): pull one block and defer the rest.
+//
+// The thunk captures ONLY the state. It used to be a std::function holding a
+// shared_ptr to the control block that owned it -- the function object owned itself,
+// so releasing the returned ZBCL could never bring the count to zero and every add()
+// stranded its state for the life of the process. Measured before the fix: 0.29 kB
+// per add() and 41 kB per infsum()-based stream, growing without bound
+// (universal#1378).
+template<typename FpType>
+inline ZBCL<FpType> addRec_stream(std::shared_ptr<addRec_state<FpType>> st) {
+	auto nxt = addRec_step(*st);
+	if (!nxt)
+		return ZBCL<FpType>{};
+	block<FpType> head = *nxt;
+	return ZBCL<FpType>::cons(head, [st]() { return addRec_stream<FpType>(st); });
+}
+
 // add(x, y): the dissertation's add (Algorithm 4.2.1) wrapped as a lazy ZBCL.
 template<typename FpType>
 inline ZBCL<FpType> add(ZBCL<FpType> x, ZBCL<FpType> y) {
-	using Z = ZBCL<FpType>;
 	auto st = std::make_shared<addRec_state<FpType>>(addRec_state<FpType>{std::move(x), std::move(y), {}, 0, false});
-
-	auto loop = std::make_shared<std::function<Z()>>();
-	*loop     = [st, loop]() -> Z {
-		auto nxt = addRec_step(*st);
-		if (!nxt)
-			return Z{};
-		return Z::cons(*nxt, [loop]() { return (*loop)(); });
-	};
-
-	auto first = addRec_step(*st);
-	if (!first)
-		return Z{};
-	return Z::cons(*first, [loop]() { return (*loop)(); });
+	return addRec_stream<FpType>(std::move(st));
 }
 
 }  // namespace universal


### PR DESCRIPTION
## Summary

`add()` and `infsum()` built their tail thunk as a `std::function` holding a `shared_ptr` to the control block that owned it. The function object owned itself, so releasing the returned `ZBCL` could never bring the count to zero — **every call stranded its state for the life of the process.**

```cpp
auto loop = std::make_shared<std::function<Z()>>();
*loop = [st, loop]() -> Z {                     // <-- owns itself
    ...
    return Z::cons(*nxt, [loop]() { return (*loop)(); });
};
```

## Measured

Live heap allocations per stream created and immediately dropped:

| operation | before | after |
|---|---|---|
| `add` | 4 per call | **0** |
| `div_online` | 72 per call | **0** |
| `mul_online` | 243 per call | **0** |

In RSS terms that was 0.29 kB, 6.33 kB and 41.28 kB per call. 80,000 dropped `mul_online` streams took a process from **3.5 MB to 2.3 GB**, growing linearly and never released:

```
before                              after
baseline        =    3528 kB        baseline        = 3456 kB
after 20000 str =  579372 kB        after 20000 str = 3668 kB
after 40000 str = 1155012 kB        after 40000 str = 3668 kB
after 60000 str = 1730648 kB        after 60000 str = 3668 kB
after 80000 str = 2306288 kB        after 80000 str = 3668 kB
```

Every elreal operation goes through `add()`, and every multiply and divide through `infsum()`, so a long-running high-precision computation leaked in proportion to the block operations it performed.

## The fix

Both now use a free function whose thunk captures only the state — the same shape #1377 adopted for `singleDiv` after review:

```cpp
template<typename FpType>
inline ZBCL<FpType> addRec_stream(std::shared_ptr<addRec_state<FpType>> st) {
    auto nxt = addRec_step(*st);
    if (!nxt) return ZBCL<FpType>{};
    block<FpType> head = *nxt;
    return ZBCL<FpType>::cons(head, [st]() { return addRec_stream<FpType>(st); });
}
```

Laziness and streaming behaviour are unchanged — the thunk does the same work, it just no longer owns the object holding it.

**This is a memory fix, not a speed one.** The LEVEL_4 transcendental suite runs 2m03.5s against 2m06.0s before, which is noise. I mention it because less allocation pressure might have been expected to help, and it did not measurably.

## Test Results

New regression `elastic/elreal/zbcl/lazy_lifetime.cpp` counts live heap allocations across 500 created-and-dropped streams and fails if the count does not return to its pre-loop level.

It counts allocations rather than reading RSS deliberately: `/proc` is not available across the CI matrix (macOS, Windows), and an allocator counter is exact rather than sampled.

**Mutation-tested.** Against the previous implementation all six checks fail:

```
FAIL [double] add: 2000 allocations still live after 500 streams (4 per call)
FAIL [double] mul_online: 121500 allocations still live (243 per call)
FAIL [double] div_online: 36000 allocations still live (72 per call)
FAIL [float]  add / mul_online / div_online: 4 / 262 / 72 per call
```

| | gcc | clang |
|---|---|---|
| full `el_*` ctest (48 tests) | 48/48 PASS (19.0s) | 48/48 PASS (18.3s) |

ASCII Guard clean. Indentation matches each file as it stands — `threeAdd.hpp` is tab-indented and `infsum.hpp` space-indented, and the additions follow suit.

Resolves #1378

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: also fixes a flaky test I introduced in #1377

CI on this PR failed on two runners -- `Linux x64 (GCC)` and `macOS ARM64` -- both in `el_arith_online_muldiv`, and both **passed on rerun**:

```
single-block division [double] scaled x10.9943 over a 4x depth span (want <= 8)
single-block division [double] scaled x12.4495 over a 4x depth span (want <= 8)
```

That is the wall-clock scaling guard #1377 added, and it is already on `main`. It measures x4.2 locally. A shared runner can stretch either end of the ratio, and a ratio of two noisy numbers is noisier than either -- using a ratio instead of an absolute time was not sufficient, which I had assumed it would be.

Replaced with a measurement that has no machine dependence: **allocations per emitted block**, which must not grow with depth. Linear work is flat, quadratic work grows with D.

| implementation | allocs/block @D=40 | @D=160 | growth |
|---|---|---|---|
| per-block-then-sum (pre-#1377) | 3060 | 23559 | **x7.7** |
| schoolbook carry (current) | 48 | 49 | **x1.02** |

Threshold 3: clears the current form by ~3x, catches the old by ~2.5x. Mutation-tested against the pre-#1377 implementation -- fails at x7.70 (double) and x17.72 (float).

It moves to its own file (`division_scaling.cpp`), since counting allocations means replacing global `operator new`/`delete`, which does not belong in a shared test TU. Cost went from ~2s to **0.015s**. The deterministic checks #1377 added -- block count, streaming, canonical output -- are unaffected and stay where they are.
