### PR TITLE
feat(elreal): offer the faithful long division alongside the Newton reciprocal

### DIFF
--- a/elastic/elreal/arithmetic/division_scaling.cpp
+++ b/elastic/elreal/arithmetic/division_scaling.cpp
@@ -35,12 +35,20 @@
 #include <string>
 
 #include <universal/number/elreal/elreal.hpp>
+#include <universal/verification/elreal_reference_digits.hpp>
 #include <universal/verification/test_suite.hpp>
 
 // ---- global allocation counter (cumulative; never decremented) -------------------
 namespace {
 long g_totalAllocations = 0;
 }
+// GCC cannot see that these replacements are paired (each malloc has its free) and
+// warns about a mismatched allocation function. They are paired; the warning is a
+// false positive for a global operator replacement.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
 void* operator new(std::size_t n) {
     void* p = std::malloc(n ? n : 1);
     if (!p) throw std::bad_alloc();
@@ -52,6 +60,9 @@ void operator delete(void* p, std::size_t) noexcept { std::free(p); }
 void* operator new[](std::size_t n) { return operator new(n); }
 void operator delete[](void* p) noexcept { operator delete(p); }
 void operator delete[](void* p, std::size_t) noexcept { operator delete(p); }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace {
 
@@ -94,6 +105,49 @@ int verify_division_scaling(const char* host, bool reportTestCases) {
     return 0;
 }
 
+// The FaithfulLongDivision policy must actually reach the long division. Value alone
+// cannot show this: both policies produce bit-identical quotients, so a comparison of
+// results would pass even if the policy were ignored. Allocation count distinguishes
+// them -- the long division does materially more work (measured ~2.4x at depth 32) --
+// and is deterministic, unlike timing.
+template <typename FpType>
+int verify_dense_policy_dispatches(const char* host, bool reportTestCases) {
+    const std::size_t D = 24;
+    ZBCL<FpType> b = sqrt(from_native<FpType>(2.0), D);
+    ZBCL<FpType> a = from_native<FpType>(2.0);
+
+    const long n0 = g_totalAllocations;
+    ZBCL<FpType> qn = zbcl_from_blocks<FpType>(div_online(a, b, D).take(D));
+    const long nNewton = g_totalAllocations - n0;
+
+    const long l0 = g_totalAllocations;
+    ZBCL<FpType> ql = zbcl_from_blocks<FpType>(
+        div_online(a, b, D, DenseDivision::FaithfulLongDivision).take(D));
+    const long nLong = g_totalAllocations - l0;
+
+    int n = 0;
+    // same answer -- that is the point of offering the alternative at all
+    if (agreed_decimal_digits(qn, ql, 4000) < 4000) {
+        std::cout << "  FAIL [" << host << "] the two dense-division policies disagree\n";
+        ++n;
+    }
+    // ... reached by a DIFFERENT amount of work, which is how we know the policy was
+    // honoured. Deliberately not asserting a direction: which path is cheaper depends
+    // on the divisor's width, and long division is actually ahead once the divisor is
+    // about as wide as the depth (0.92x at 24 blocks). Asserting "long division costs
+    // more" would encode a fact that is only true for narrow divisors.
+    if (nLong == nNewton) {
+        std::cout << "  FAIL [" << host << "] both policies used " << nLong
+                  << " allocations -- the policy argument is not reaching the dense path\n";
+        ++n;
+    }
+    else if (reportTestCases) {
+        std::cout << "  ok   [" << host << "] policies agree in value, differ in work ("
+                  << (double(nLong) / double(nNewton)) << "x allocations)\n";
+    }
+    return n;
+}
+
 } // anonymous
 
 #define MANUAL_TESTING 0
@@ -127,6 +181,8 @@ try {
 
     nrOfFailedTestCases += verify_division_scaling<double>("double", reportTestCases);
     nrOfFailedTestCases += verify_division_scaling<float>("float", reportTestCases);
+    nrOfFailedTestCases += verify_dense_policy_dispatches<double>("double", reportTestCases);
+    nrOfFailedTestCases += verify_dense_policy_dispatches<float>("float", reportTestCases);
 
     ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
     return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);

--- a/include/sw/universal/number/elreal/online_divide.hpp
+++ b/include/sw/universal/number/elreal/online_divide.hpp
@@ -275,6 +275,57 @@ inline ZBCL<FpType> div_raw(ZBCL<FpType> fs, ZBCL<FpType> gs) {
     return infsum(divideHelper(std::move(fs), std::move(gs)));
 }
 
+// divideHelper_bounded / div_long_division: the FAITHFUL McCleeary long division
+// (4.2.6) for a dense divisor, with the fan-out bounded.
+//
+// divideHelper recurses with newfs = -(fs * divisorTail) and newdiv = g0 * divisor, so
+// the operands GROW every level and an unbounded recursion costs far more than the
+// output justifies. The contributions decay geometrically -- level L sits about L*k
+// bits down -- so level L only needs the precision that can still reach the frontier.
+// Truncating both operands to the remaining budget makes each level cheap while leaving
+// the result identical: verified against the unbounded form on 100 random dense
+// divisors across both hosts, matching to the expansion's full capacity, at 4-6x less
+// cost. A guard of +2 blocks is enough; +0 loses a few digits, +4 and +8 add nothing.
+template <typename FpType>
+inline series<FpType> divideHelper_bounded(ZBCL<FpType> fs, ZBCL<FpType> divisor, std::size_t budget) {
+    if (fs.is_empty() || divisor.is_empty() || budget == 0) return series<FpType>{};
+    const block<FpType> g = divisor.head();
+    if (g.is_zero_block()) {
+        ZBCL<FpType> zterm = ZBCL<FpType>::singleton(g);
+        ZBCL<FpType> drest = divisor.tail();
+        return series<FpType>::cons(zterm, [fs, drest, budget]() {
+            return divideHelper_bounded(fs, drest, budget);
+        });
+    }
+    ZBCL<FpType> qterm  = singleDiv(fs, g);
+    ZBCL<FpType> newfs  = zbcl_truncate(negate(mul_online(fs, divisor.tail())), budget);
+    ZBCL<FpType> newdiv = zbcl_truncate(singleMult(g, divisor), budget);
+    return series<FpType>::cons(qterm, [newfs, newdiv, budget]() {
+        return divideHelper_bounded(newfs, newdiv, budget - 1);
+    });
+}
+
+// Extra blocks of budget carried into the bounded long division beyond the requested
+// depth. Measured: 0 loses a few digits, 2 matches the unbounded result exactly, and
+// more buys nothing.
+inline constexpr std::size_t kLongDivisionGuard = 2;
+
+// div_long_division(fs, gs, depth): fs / gs by the faithful long division, to `depth`
+// blocks. Operands are range-reduced (shiftUpToTwo) exactly as div_online does.
+template <typename FpType>
+inline ZBCL<FpType> div_long_division(ZBCL<FpType> fs, ZBCL<FpType> gs, std::size_t depth) {
+    using B = block<FpType>;
+    if (gs.is_empty() || fs.is_empty()) return ZBCL<FpType>{};
+    const typename B::exp_t lead  = gs.head().exponent();
+    const typename B::exp_t shift = (lead < typename B::exp_t(1)) ? (typename B::exp_t(1) - lead)
+                                                                  : typename B::exp_t(0);
+    return zbcl_truncate(
+        infsum(divideHelper_bounded(zbcl_shift(std::move(fs), shift),
+                                    zbcl_shift(std::move(gs), shift),
+                                    depth + kLongDivisionGuard)),
+        depth);
+}
+
 // zbcl_truncate(z, m): the finite m-block prefix of z, rebuilt as a 0-overlap ZBCL.
 // (z is already 0-overlap, so take(m) is a canonical prefix; zbcl_from_blocks drops
 // any trailing zero blocks.) Used to keep Newton's intermediate products finite.
@@ -335,6 +386,59 @@ inline ZBCL<FpType> recip_newton(const ZBCL<FpType>& b, std::size_t depth) {
 // on the faithful long-division path (it reaches the host floor there); only the
 // genuinely DENSE case -- where divideHelper's fan-out cost-explodes past ~7 blocks
 // -- routes to Newton. A single-block divisor (e.g. 1/3) is never dense.
+// Which algorithm handles a DENSE (multi-block, non-power-of-two) divisor.
+//
+// Both are correct and both scale linearly in accuracy with depth. They are NOT a
+// fast-vs-accurate trade: measured on 8 random dense divisors per depth, reconstructing
+// q*b against a, they agree to within a few digits in a thousand --
+//
+//     depth            16     32     48     64
+//     Newton          263    528    793   1056  digits
+//     long division   264    529    795   1059
+//
+// -- so choose on cost and on what you need the result FOR:
+//
+//   NewtonReciprocal (the default)
+//       a/b as a * (1/b), the reciprocal refined by Newton-Raphson. Roughly log D
+//       iterations, each multiplying against the divisor, so its cost grows with the
+//       DIVISOR's width. A DELIBERATE DEVIATION from the dissertation, recorded in
+//       #1068, adopted because the faithful long division's fan-out was unaffordable
+//       before it was bounded.
+//
+//   FaithfulLongDivision
+//       McCleeary 4.2.6 as written, with the level operands truncated to the budget
+//       that can still reach the output frontier. Its cost is dominated by the depth
+//       rather than the divisor's width.
+//
+// WHICH IS CHEAPER DEPENDS ON THE DIVISOR'S WIDTH, not just on depth. Long division
+// relative to Newton, measured on a double host:
+//
+//     at depth 24, varying the divisor
+//         divisor blocks    2      4      6     10     16     24
+//         long div vs N   3.8x   2.4x   1.9x   1.5x   1.2x   0.92x
+//
+//     with a 6-block divisor, varying the depth
+//         depth            16     32     48     64
+//         long div vs N   1.5x   2.6x   3.2x   4.6x
+//
+// So Newton wins comfortably for a narrow divisor, the two converge as the divisor
+// widens, and long division is marginally AHEAD once the divisor is about as wide as
+// the requested depth. Newton is the default because a narrow divisor is the common
+// case -- dividing by a small constant, or by an iterate that is still shallow.
+//
+// Reach for FaithfulLongDivision when you want the dissertation's algorithm rather
+// than an equivalent: to check the Newton path against an independent implementation
+// (that is how #1373 was found), to study the algorithm, or when the divisor is wide
+// enough that it is the cheaper of the two.
+//
+// The single-block and sparse paths are unaffected: they always take the faithful long
+// division, which for them is genuinely streaming and produces blocks for as long as
+// the caller pulls.
+enum class DenseDivision {
+    NewtonReciprocal,      // default: a * (1/b), O(D log D)
+    FaithfulLongDivision   // McCleeary 4.2.6, bounded fan-out, O(D^2)
+};
+
 // Default working depth for a DENSE-divisor quotient, in blocks. Matches the eager
 // div()'s default so the streaming and eager APIs agree, and is deliberately NOT
 // derived from FpType: the host's exponent range does not bound an expansion's depth
@@ -367,11 +471,14 @@ inline bool is_dense_divisor(const ZBCL<FpType>& gs) {
 // front. Callers that know their working precision should pass it.
 template <typename FpType>
 inline ZBCL<FpType> div_online(ZBCL<FpType> fs, ZBCL<FpType> gs,
-                               std::size_t depth = kDenseQuotientDepth) {
+                               std::size_t depth = kDenseQuotientDepth,
+                               DenseDivision policy = DenseDivision::NewtonReciprocal) {
     if (gs.is_empty()) return ZBCL<FpType>{};   // divide-by-zero: caller's precondition
     if (fs.is_empty()) return ZBCL<FpType>{};   // 0 / gs = 0
 
     if (is_dense_divisor(gs)) {
+        if (policy == DenseDivision::FaithfulLongDivision)
+            return div_long_division(std::move(fs), std::move(gs), depth);
         // Refine the Newton reciprocal to the depth the CALLER asked for. This used to
         // be a constant derived from the host's exponent range -- 17 blocks on double,
         // 3 on float -- which silently capped every dense quotient regardless of how


### PR DESCRIPTION
## Summary

For a **dense** (multi-block, non-power-of-two) divisor, `div_online` has computed `a/b = a * (1/b)` with a Newton-Raphson reciprocal since #1068 — a deliberate deviation from McCleeary 4.2.6, adopted because the dissertation's long division cost-exploded before its fan-out was bounded. That issue's follow-up item ("restore a bounded faithful long division") is now available, **without changing the default**:

```cpp
div_online(a, b, depth)                                     // Newton, unchanged
div_online(a, b, depth, DenseDivision::FaithfulLongDivision)
```

## The two agree on value

Reconstructing `q*b` against `a`, over 8 random dense divisors per depth:

| depth | 16 | 32 | 48 | 64 |
|---|---|---|---|---|
| Newton | 263 | 528 | 793 | 1056 |
| long division | 264 | 529 | 795 | 1059 |

This is **not** a fast-vs-accurate trade. Both scale linearly and neither caps — Newton's former ceiling went with #1373.

## Which is cheaper depends on the divisor's width

I had this wrong until I measured across two axes instead of one. Long division relative to Newton, double host:

**at depth 24, varying the divisor**

| divisor blocks | 2 | 4 | 6 | 10 | 16 | 24 |
|---|---|---|---|---|---|---|
| long div vs Newton | 3.8x | 2.4x | 1.9x | 1.5x | 1.2x | **0.92x** |

**with a 6-block divisor, varying the depth**

| depth | 16 | 32 | 48 | 64 |
|---|---|---|---|---|
| long div vs Newton | 1.5x | 2.6x | 3.2x | 4.6x |

Newton wins comfortably for a narrow divisor, the two converge as it widens, and long division is marginally **ahead** once the divisor is about as wide as the requested depth. Newton stays the default because a narrow divisor is the common case — dividing by a small constant, or by an iterate that is still shallow.

## How to choose

Documented on the `DenseDivision` enum, where an implementer will look. The honest summary is that the alternative earns its place less on speed than on being the dissertation's algorithm and an independent check on the Newton path — comparing the two is how #1373 was found.

## Implementation

`divideHelper_bounded` truncates each level's operands to the budget that can still reach the output frontier. Contributions decay geometrically (level L sits ~L·k bits down), so a level only needs the precision that survives. Result is identical to the unbounded recursion: verified against it on 100 random dense divisors across both hosts, matching to full capacity at 4-6x less cost. A +2 block guard suffices; +0 loses a few digits, +4 and +8 add nothing.

## Test Results

New regression in `division_scaling.cpp`: the policies must agree in **value** but differ in **work** — that is how we know the argument reaches the dense path, since the quotients are bit-identical and value alone cannot show it.

It deliberately asserts only that the work *differs*, not which is larger: asserting "long division costs more" would encode a fact that holds only for narrow divisors. That is the same mistake that produced the invalid #1372, so I would rather not repeat it in a guard.

Also silences a GCC false positive (`-Wmismatched-new-delete`) on the replaced global operators in that file, which arrived with #1379.

| | gcc | clang |
|---|---|---|
| full `el_*` ctest (49 tests) | 49/49 PASS (19.0s) | 49/49 PASS (18.3s) |

ASCII Guard clean.

Relates to #1061, #1068.

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)