### PR TITLE
fix(einteger): make the parse radix independent of the leading-zero count

### DIFF
--- a/elastic/einteger/conversion/string_parse.cpp
+++ b/elastic/einteger/conversion/string_parse.cpp
@@ -150,6 +150,19 @@ try {
 		nrOfFailedTestCases += CheckParse<std::uint32_t>("01234567",     "342391",     reportTestCases);
 		nrOfFailedTestCases += CheckParse<std::uint32_t>("037777777777", "4294967295", reportTestCases);
 		nrOfFailedTestCases += CheckParse<std::uint32_t>("-017",         "-15",        reportTestCases);
+		// A LEADING ZERO SELECTS OCTAL, however many of them there are. The pattern
+		// used to require the second character to be [1-7], so the radix depended on
+		// the number of leading zeros: "0777" was octal 511 but "00777" fell through
+		// to decimal 777, and "075" was 61 while "0075" was 75. Zero-padding a value
+		// silently changed what it meant (#1370).
+		nrOfFailedTestCases += CheckParse<std::uint32_t>("00777",        "511",        reportTestCases);
+		nrOfFailedTestCases += CheckParse<std::uint32_t>("0075",         "61",         reportTestCases);
+		nrOfFailedTestCases += CheckParse<std::uint32_t>("000075",       "61",         reportTestCases);
+		nrOfFailedTestCases += CheckParse<std::uint32_t>("00010",        "8",          reportTestCases);
+		nrOfFailedTestCases += CheckParse<std::uint32_t>("-00017",       "-15",        reportTestCases);
+		// "0" is zero in any radix
+		nrOfFailedTestCases += CheckParse<std::uint32_t>("0",            "0",          reportTestCases);
+		nrOfFailedTestCases += CheckParse<std::uint32_t>("00",           "0",          reportTestCases);
 		ReportTestResult(nrOfFailedTestCases - start, "octal parse", "einteger parse");
 	}
 
@@ -172,6 +185,14 @@ try {
 		nrOfFailedTestCases += CheckReject<std::uint32_t>("0xFF_extra", reportTestCases);
 		nrOfFailedTestCases += CheckReject<std::uint32_t>("0b1010X",    reportTestCases);
 		nrOfFailedTestCases += CheckReject<std::uint32_t>("0777!",      reportTestCases);
+		// A leading zero commits the string to octal, so a digit outside [0-7] makes it
+		// malformed -- exactly as C rejects 08 and 0749. These used to be re-read as
+		// DECIMAL, which meant "0747" was 487 while "0749" was 749: the radix depended
+		// on the digits (#1370).
+		nrOfFailedTestCases += CheckReject<std::uint32_t>("08",         reportTestCases);
+		nrOfFailedTestCases += CheckReject<std::uint32_t>("09",         reportTestCases);
+		nrOfFailedTestCases += CheckReject<std::uint32_t>("0749",       reportTestCases);
+		nrOfFailedTestCases += CheckReject<std::uint32_t>("-08",        reportTestCases);
 		ReportTestResult(nrOfFailedTestCases - start, "malformed reject", "einteger parse");
 	}
 

--- a/include/sw/universal/number/einteger/einteger_impl.hpp
+++ b/include/sw/universal/number/einteger/einteger_impl.hpp
@@ -924,9 +924,19 @@ bool parse(const std::string& number, einteger<BlockType>& value) {
 	bool bSuccess = false;
 	value.clear();
 	std::regex binary_regex("^[-+]*0b[01']+");
-	// check if the txt is an integer form: [0123456789]+
-	std::regex decimal_regex("^[-+]*[0-9]+");
-	std::regex octal_regex("^[-+]*0[1-7][0-7]*$");
+	// A LEADING ZERO SELECTS OCTAL, however many of them there are.
+	//
+	// The octal pattern used to require the second character to be [1-7], so the radix
+	// depended on the number of leading zeros: "0777" parsed as octal 511 while
+	// "00777" fell through to decimal 777, and "075" was 61 while "0075" was 75. A
+	// caller could not predict the radix of its own input, and zero-padding a value
+	// silently changed it (universal#1370).
+	std::regex octal_regex("^[-+]*0[0-7]*$");
+	// Decimal excludes a leading zero, so a string that opens with '0' is committed to
+	// the octal (or 0x / 0b) reading rather than quietly falling back. Without this,
+	// "08" and "0749" -- which are not valid octal, and which C rejects outright --
+	// would be re-interpreted as decimal, so "0747" would be 487 and "0749" 749.
+	std::regex decimal_regex("^[-+]*(0|[1-9][0-9]*)$");
 	std::regex hex_regex("^[-+]*0[xX][0-9a-fA-F']+");
 	// setup associative array to map chars to nibbles
 	std::map<char, int> charLookup{

--- a/include/sw/universal/number/einteger/einteger_impl.hpp
+++ b/include/sw/universal/number/einteger/einteger_impl.hpp
@@ -964,16 +964,18 @@ bool parse(const std::string& number, einteger<BlockType>& value) {
 		{ 'F', 15 },
 	};
 	if (std::regex_match(number, octal_regex)) {
-		// Format: [+-]*0[1-7][0-7]*  (C-style octal, no separators).
-		// Walk left-to-right: skip sign(s), skip the leading '0', then
-		// accumulate value = value * 8 + digit.
+		// Format: [+-]*0[0-7]*  (C-style octal, no separators). The digits after the
+		// leading '0' are OPTIONAL, so "0" and "00" reach here and are zero, and the
+		// leading zeros of "00777" are not special -- only the first is a radix marker.
+		// Walk left-to-right: skip sign(s), skip the one marker '0', then accumulate
+		// value = value * 8 + digit. Any further zeros simply contribute nothing.
 		bool sign = false;
 		std::string::size_type pos = 0;
 		while (pos < number.size() && (number[pos] == '+' || number[pos] == '-')) {
 			if (number[pos] == '-') sign = !sign;
 			++pos;
 		}
-		// regex guarantees a leading '0' followed by an octal digit
+		// the regex guarantees a leading '0'; what follows it may be empty
 		++pos;
 		for (; pos < number.size(); ++pos) {
 			value *= 8LL;


### PR DESCRIPTION
## Summary

`parse()` decided between octal and decimal in a way no caller could predict: **a single leading zero selected octal, two or more selected decimal.**

```
"0777"  -> 511 (octal)      "00777" -> 777 (decimal)
"075"   ->  61 (octal)      "0075"  ->  75 (decimal)
```

The octal pattern required the *second* character to be `[1-7]`, so any string whose second character was `'0'` never matched it and fell through to decimal. Zero-padding a value silently changed what it meant.

The same gap made the radix depend on the **digits**: a leading-zero string containing an 8 or 9 also fell through to decimal, so `"0747"` was 487 while `"0749"` was 749. C rejects `08` and `0749` outright.

## The fix

```
octal    ^[-+]*0[1-7][0-7]*$   ->   ^[-+]*0[0-7]*$
decimal  ^[-+]*[0-9]+          ->   ^[-+]*(0|[1-9][0-9]*)$
```

A leading zero now commits the string to octal however many zeros there are, and decimal no longer accepts a leading zero — so a leading-zero string with a non-octal digit is malformed rather than quietly re-read in another radix. `"0"` and `"00"` remain zero, which they are in any radix.

## A correction to the issue

I filed #1370 and proposed, as one option, **dropping octal entirely** on the grounds that "a grep of the tree finds no such caller". That was wrong. `elastic/einteger/conversion/string_parse.cpp` has a dedicated octal section —

```
"010" -> 8    "017" -> 15    "0777" -> 511
"01234567" -> 342391    "037777777777" -> 4294967295    "-017" -> -15
```

— so octal is a deliberate, tested feature, and removing it would have broken documented behaviour. I found it on going to implement. This PR takes the other option in the issue: make the existing semantics consistent rather than remove them.

## Blast radius

The only in-tree consumer that fed `parse()` a possibly zero-padded string was `agreed_decimal_digits()` in the elreal verification oracle, which has stripped leading zeros before `assign()` since #1369. A sweep finds no other `.assign()` of a leading-zero decimal.

## Test Results

Coverage extends the existing octal and malformed-reject sections rather than adding a new file.

**Mutation-tested.** Against the previous regexes, nine of the new checks fail:

```
FAIL parse('00777') = 777 expected 511
FAIL parse('0075') = 75 expected 61
FAIL parse('000075') = 75 expected 61
FAIL parse('00010') = 10 expected 8
FAIL parse('-00017') = -17 expected -15
FAIL: '08' should be rejected, got 8
FAIL: '09' should be rejected, got 9
FAIL: '0749' should be rejected, got 749
FAIL: '-08' should be rejected, got -8
```

| Suite | gcc | clang |
|---|---|---|
| full elastic family (162 tests: einteger, edecimal, erational, ereal, efloat, elreal) | 162/162 PASS (26.8s) | 162/162 PASS (25.3s) |

ASCII Guard clean. Carries a `BEHAVIOUR-CHANGE:` trailer.

Resolves #1370

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integer parsing for values with leading zeros, treating them consistently as octal literals.
  * Decimal literals beginning with zero are no longer accepted.
  * Invalid octal values, including signed inputs and digits such as `8` or `9`, are now correctly rejected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->