### PR TITLE
feat(elreal): evidence-based precision defaults, and fix what the sweep exposed

### DIFF
--- a/benchmark/accuracy/adaptive/baseline-characterization.txt
+++ b/benchmark/accuracy/adaptive/baseline-characterization.txt
@@ -1,0 +1,364 @@
+# adaptive-precision accuracy-vs-compute-time characterization (issue #1040)
+# elreal depth sweep 2..8 over hosts {double, float, bfloat16}, ereal limb list {2,4,8,12,16}, reps=5
+type,FpType,function,depth,time_ns,correct_digits,correct_bits,rel_error
+elreal,double,sqrt@2,2,707989,32,106,1.0e-32
+elreal,double,sqrt@2,3,249400,49,163,1.0e-49
+elreal,double,sqrt@2,4,632292,66,219,1.0e-66
+elreal,double,sqrt@2,5,1005731,83,276,1.0e-83
+elreal,double,sqrt@2,6,1492493,98,326,1.0e-98
+elreal,double,sqrt@2,7,2238254,115,382,1.0e-115
+elreal,double,sqrt@2,8,4060171,131,435,1.0e-131
+elreal,double,exp@1,2,885284,32,106,1.0e-32
+elreal,double,exp@1,3,1638275,49,163,1.0e-49
+elreal,double,exp@1,4,2649587,65,216,1.0e-65
+elreal,double,exp@1,5,3933276,81,269,1.0e-81
+elreal,double,exp@1,6,5536474,98,326,1.0e-98
+elreal,double,exp@1,7,7920402,114,379,1.0e-114
+elreal,double,exp@1,8,11175910,130,432,1.0e-130
+elreal,double,log@2,2,27766790,32,106,1.0e-32
+elreal,double,log@2,3,60069042,48,159,1.0e-48
+elreal,double,log@2,4,107745738,64,213,1.0e-64
+elreal,double,log@2,5,157986348,81,269,1.0e-81
+elreal,double,log@2,6,218302981,97,322,1.0e-97
+elreal,double,log@2,7,285713921,113,375,1.0e-113
+elreal,double,log@2,8,373892947,130,432,1.0e-130
+elreal,double,sin@0.5,2,26258317,35,116,1.0e-35
+elreal,double,sin@0.5,3,59559205,49,163,1.0e-49
+elreal,double,sin@0.5,4,105759244,66,219,1.0e-66
+elreal,double,sin@0.5,5,154962372,81,269,1.0e-81
+elreal,double,sin@0.5,6,214528483,98,326,1.0e-98
+elreal,double,sin@0.5,7,286458173,113,375,1.0e-113
+elreal,double,sin@0.5,8,371653846,130,432,1.0e-130
+elreal,double,cos@0.5,2,26286495,34,113,1.0e-34
+elreal,double,cos@0.5,3,59290543,50,166,1.0e-50
+elreal,double,cos@0.5,4,106005840,67,223,1.0e-67
+elreal,double,cos@0.5,5,154558929,83,276,1.0e-83
+elreal,double,cos@0.5,6,214128665,98,326,1.0e-98
+elreal,double,cos@0.5,7,286837783,114,379,1.0e-114
+elreal,double,cos@0.5,8,371555508,131,435,1.0e-131
+elreal,double,tan@0.5,2,26289280,31,103,1.0e-31
+elreal,double,tan@0.5,3,59569617,49,163,1.0e-49
+elreal,double,tan@0.5,4,106658316,65,216,1.0e-65
+elreal,double,tan@0.5,5,155625066,81,269,1.0e-81
+elreal,double,tan@0.5,6,215707375,98,326,1.0e-98
+elreal,double,tan@0.5,7,288766372,113,375,1.0e-113
+elreal,double,tan@0.5,8,374333165,129,429,1.0e-129
+elreal,double,sinh@0.5,2,1830525,32,106,1.0e-32
+elreal,double,sinh@0.5,3,3430835,48,159,1.0e-48
+elreal,double,sinh@0.5,4,5293687,65,216,1.0e-65
+elreal,double,sinh@0.5,5,7317239,82,272,1.0e-82
+elreal,double,sinh@0.5,6,9918984,98,326,1.0e-98
+elreal,double,sinh@0.5,7,13129489,114,379,1.0e-114
+elreal,double,sinh@0.5,8,15711990,131,435,1.0e-131
+elreal,double,cosh@0.5,2,1742209,33,110,1.0e-33
+elreal,double,cosh@0.5,3,3294192,50,166,1.0e-50
+elreal,double,cosh@0.5,4,5141924,66,219,1.0e-66
+elreal,double,cosh@0.5,5,7347916,82,272,1.0e-82
+elreal,double,cosh@0.5,6,9914065,98,326,1.0e-98
+elreal,double,cosh@0.5,7,13012553,114,379,1.0e-114
+elreal,double,cosh@0.5,8,15727768,130,432,1.0e-130
+elreal,double,tanh@0.5,2,900557,33,110,1.0e-33
+elreal,double,tanh@0.5,3,1732006,47,156,1.0e-47
+elreal,double,tanh@0.5,4,2826931,65,216,1.0e-65
+elreal,double,tanh@0.5,5,4280855,80,266,1.0e-80
+elreal,double,tanh@0.5,6,6001908,97,322,1.0e-97
+elreal,double,tanh@0.5,7,8397387,113,375,1.0e-113
+elreal,double,tanh@0.5,8,11816951,129,429,1.0e-129
+elreal,float,sqrt@2,2,105092,15,50,1.0e-15
+elreal,float,sqrt@2,3,244937,23,76,1.0e-23
+elreal,float,sqrt@2,4,604077,31,103,1.0e-31
+elreal,float,sqrt@2,5,930024,38,126,1.0e-38
+elreal,float,sqrt@2,6,1413241,46,153,1.0e-46
+elreal,float,sqrt@2,7,1967247,53,176,1.0e-53
+elreal,float,sqrt@2,8,3712471,61,203,1.0e-61
+elreal,float,exp@1,2,509003,14,47,1.0e-14
+elreal,float,exp@1,3,887722,23,76,1.0e-23
+elreal,float,exp@1,4,1482196,31,103,1.0e-31
+elreal,float,exp@1,5,2203038,38,126,1.0e-38
+elreal,float,exp@1,6,3130396,46,153,1.0e-46
+elreal,float,exp@1,7,4460021,53,176,1.0e-53
+elreal,float,exp@1,8,7094806,60,199,1.0e-60
+elreal,float,log@2,2,13126124,15,50,1.0e-15
+elreal,float,log@2,3,29680346,22,73,1.0e-22
+elreal,float,log@2,4,51134459,30,100,1.0e-30
+elreal,float,log@2,5,77683606,37,123,1.0e-37
+elreal,float,log@2,6,107838567,45,149,1.0e-45
+elreal,float,log@2,7,135142044,52,173,1.0e-52
+elreal,float,log@2,8,170926806,60,199,1.0e-60
+elreal,float,sin@0.5,2,12088451,18,60,1.0e-18
+elreal,float,sin@0.5,3,26943145,24,80,1.0e-24
+elreal,float,sin@0.5,4,47332944,31,103,1.0e-31
+elreal,float,sin@0.5,5,68671971,38,126,1.0e-38
+elreal,float,sin@0.5,6,93788211,45,149,1.0e-45
+elreal,float,sin@0.5,7,127463852,54,179,1.0e-54
+elreal,float,sin@0.5,8,165379464,60,199,1.0e-60
+elreal,float,cos@0.5,2,12065059,16,53,1.0e-16
+elreal,float,cos@0.5,3,27012936,24,80,1.0e-24
+elreal,float,cos@0.5,4,47268797,33,110,1.0e-33
+elreal,float,cos@0.5,5,68266668,38,126,1.0e-38
+elreal,float,cos@0.5,6,93474624,45,149,1.0e-45
+elreal,float,cos@0.5,7,127098501,53,176,1.0e-53
+elreal,float,cos@0.5,8,164746634,60,199,1.0e-60
+elreal,float,tan@0.5,2,12127299,15,50,1.0e-15
+elreal,float,tan@0.5,3,27428772,22,73,1.0e-22
+elreal,float,tan@0.5,4,47596497,30,100,1.0e-30
+elreal,float,tan@0.5,5,68552043,37,123,1.0e-37
+elreal,float,tan@0.5,6,94883080,45,149,1.0e-45
+elreal,float,tan@0.5,7,128199131,53,176,1.0e-53
+elreal,float,tan@0.5,8,167043625,60,199,1.0e-60
+elreal,float,sinh@0.5,2,1077518,14,47,1.0e-14
+elreal,float,sinh@0.5,3,1764713,23,76,1.0e-23
+elreal,float,sinh@0.5,4,2809840,31,103,1.0e-31
+elreal,float,sinh@0.5,5,3714240,38,126,1.0e-38
+elreal,float,sinh@0.5,6,5114468,45,149,1.0e-45
+elreal,float,sinh@0.5,7,6432026,55,183,1.0e-55
+elreal,float,sinh@0.5,8,8411075,61,203,1.0e-61
+elreal,float,cosh@0.5,2,1065546,16,53,1.0e-16
+elreal,float,cosh@0.5,3,1753449,23,76,1.0e-23
+elreal,float,cosh@0.5,4,2785724,33,110,1.0e-33
+elreal,float,cosh@0.5,5,3714215,39,130,1.0e-39
+elreal,float,cosh@0.5,6,5125702,46,153,1.0e-46
+elreal,float,cosh@0.5,7,6408152,53,176,1.0e-53
+elreal,float,cosh@0.5,8,8402944,60,199,1.0e-60
+elreal,float,tanh@0.5,2,540088,15,50,1.0e-15
+elreal,float,tanh@0.5,3,956211,22,73,1.0e-22
+elreal,float,tanh@0.5,4,1656011,30,100,1.0e-30
+elreal,float,tanh@0.5,5,2370360,37,123,1.0e-37
+elreal,float,tanh@0.5,6,3465239,46,153,1.0e-46
+elreal,float,tanh@0.5,7,5109889,53,176,1.0e-53
+elreal,float,tanh@0.5,8,7916632,60,199,1.0e-60
+elreal,bfloat16,sqrt@2,2,90696,6,20,1.0e-06
+elreal,bfloat16,sqrt@2,3,246565,8,27,1.0e-08
+elreal,bfloat16,sqrt@2,4,620252,9,30,1.0e-09
+elreal,bfloat16,sqrt@2,5,789870,12,40,1.0e-12
+elreal,bfloat16,sqrt@2,6,1283740,15,50,1.0e-15
+elreal,bfloat16,sqrt@2,7,1795552,15,50,1.0e-15
+elreal,bfloat16,sqrt@2,8,2527094,17,56,1.0e-17
+elreal,bfloat16,exp@1,2,220897,5,17,1.0e-05
+elreal,bfloat16,exp@1,3,376521,8,27,1.0e-08
+elreal,bfloat16,exp@1,4,493588,10,33,1.0e-10
+elreal,bfloat16,exp@1,5,726240,13,43,1.0e-13
+elreal,bfloat16,exp@1,6,1262706,15,50,1.0e-15
+elreal,bfloat16,exp@1,7,1890466,16,53,1.0e-16
+elreal,bfloat16,exp@1,8,3589249,19,63,1.0e-19
+elreal,bfloat16,log@2,2,3253390,4,13,1.0e-04
+elreal,bfloat16,log@2,3,6432355,8,27,1.0e-08
+elreal,bfloat16,log@2,4,10110894,10,33,1.0e-10
+elreal,bfloat16,log@2,5,15648039,13,43,1.0e-13
+elreal,bfloat16,log@2,6,20965334,16,53,1.0e-16
+elreal,bfloat16,log@2,7,26938498,19,63,1.0e-19
+elreal,bfloat16,log@2,8,31876857,21,70,1.0e-21
+elreal,bfloat16,sin@0.5,2,3399607,6,20,1.0e-06
+elreal,bfloat16,sin@0.5,3,6932058,9,30,1.0e-09
+elreal,bfloat16,sin@0.5,4,8904569,10,33,1.0e-10
+elreal,bfloat16,sin@0.5,5,15069939,12,40,1.0e-12
+elreal,bfloat16,sin@0.5,6,20854930,14,47,1.0e-14
+elreal,bfloat16,sin@0.5,7,27303899,17,56,1.0e-17
+elreal,bfloat16,sin@0.5,8,34422487,19,63,1.0e-19
+elreal,bfloat16,cos@0.5,2,3400855,6,20,1.0e-06
+elreal,bfloat16,cos@0.5,3,7183419,9,30,1.0e-09
+elreal,bfloat16,cos@0.5,4,9017558,12,40,1.0e-12
+elreal,bfloat16,cos@0.5,5,15084346,12,40,1.0e-12
+elreal,bfloat16,cos@0.5,6,20574770,14,47,1.0e-14
+elreal,bfloat16,cos@0.5,7,26896537,17,56,1.0e-17
+elreal,bfloat16,cos@0.5,8,34197584,21,70,1.0e-21
+elreal,bfloat16,tan@0.5,2,3418021,4,13,1.0e-04
+elreal,bfloat16,tan@0.5,3,6981972,7,23,1.0e-07
+elreal,bfloat16,tan@0.5,4,9093550,10,33,1.0e-10
+elreal,bfloat16,tan@0.5,5,15387879,12,40,1.0e-12
+elreal,bfloat16,tan@0.5,6,22024435,14,47,1.0e-14
+elreal,bfloat16,tan@0.5,7,28673161,17,56,1.0e-17
+elreal,bfloat16,tan@0.5,8,35707861,19,63,1.0e-19
+elreal,bfloat16,sinh@0.5,2,448512,4,13,1.0e-04
+elreal,bfloat16,sinh@0.5,3,735344,7,23,1.0e-07
+elreal,bfloat16,sinh@0.5,4,830819,10,33,1.0e-10
+elreal,bfloat16,sinh@0.5,5,1028180,12,40,1.0e-12
+elreal,bfloat16,sinh@0.5,6,1645985,15,50,1.0e-15
+elreal,bfloat16,sinh@0.5,7,2192235,16,53,1.0e-16
+elreal,bfloat16,sinh@0.5,8,2718441,19,63,1.0e-19
+elreal,bfloat16,cosh@0.5,2,444845,5,17,1.0e-05
+elreal,bfloat16,cosh@0.5,3,719186,9,30,1.0e-09
+elreal,bfloat16,cosh@0.5,4,830316,10,33,1.0e-10
+elreal,bfloat16,cosh@0.5,5,1015479,13,43,1.0e-13
+elreal,bfloat16,cosh@0.5,6,1618983,15,50,1.0e-15
+elreal,bfloat16,cosh@0.5,7,2148134,17,56,1.0e-17
+elreal,bfloat16,cosh@0.5,8,2663144,20,66,1.0e-20
+elreal,bfloat16,tanh@0.5,2,240867,5,17,1.0e-05
+elreal,bfloat16,tanh@0.5,3,445033,8,27,1.0e-08
+elreal,bfloat16,tanh@0.5,4,646927,10,33,1.0e-10
+elreal,bfloat16,tanh@0.5,5,988644,12,40,1.0e-12
+elreal,bfloat16,tanh@0.5,6,1632070,15,50,1.0e-15
+elreal,bfloat16,tanh@0.5,7,2462248,16,53,1.0e-16
+elreal,bfloat16,tanh@0.5,8,4698345,18,60,1.0e-18
+ereal,double,sqrt@2,2,2264028,128,425,1.0e-128
+ereal,double,exp@1,2,2405914,30,100,1.0e-30
+ereal,double,log@2,2,8178773,32,106,1.0e-32
+ereal,double,sin@0.5,2,1315685,35,116,1.0e-35
+ereal,double,cos@0.5,2,1188509,34,113,1.0e-34
+ereal,double,tan@0.5,2,3402427,34,113,1.0e-34
+ereal,double,sinh@0.5,2,4375125,32,106,1.0e-32
+ereal,double,cosh@0.5,2,4395135,31,103,1.0e-31
+ereal,double,tanh@0.5,2,3244991,31,103,1.0e-31
+ereal,double,sqrt@2,4,2936190,128,425,1.0e-128
+ereal,double,exp@1,4,4186492,63,209,1.0e-63
+ereal,double,log@2,4,16027859,64,213,1.0e-64
+ereal,double,sin@0.5,4,2363562,69,229,1.0e-69
+ereal,double,cos@0.5,4,2208934,67,223,1.0e-67
+ereal,double,tan@0.5,4,5509989,67,223,1.0e-67
+ereal,double,sinh@0.5,4,8263964,65,216,1.0e-65
+ereal,double,cosh@0.5,4,8117525,63,209,1.0e-63
+ereal,double,tanh@0.5,4,5166478,63,209,1.0e-63
+ereal,double,sqrt@2,8,5109851,257,854,1.0e-257
+ereal,double,exp@1,8,10921065,127,422,1.0e-127
+ereal,double,log@2,8,34201269,128,425,1.0e-128
+ereal,double,sin@0.5,8,5903592,131,435,1.0e-131
+ereal,double,cos@0.5,8,5812421,134,445,1.0e-134
+ereal,double,tan@0.5,8,12838784,131,435,1.0e-131
+ereal,double,sinh@0.5,8,21485145,127,422,1.0e-127
+ereal,double,cosh@0.5,8,21771624,129,429,1.0e-129
+ereal,double,tanh@0.5,8,11923973,127,422,1.0e-127
+ereal,double,sqrt@2,12,6102030,319,1060,1.0e-319
+ereal,double,exp@1,12,15802871,192,638,1.0e-192
+ereal,double,log@2,12,47126202,191,634,1.0e-191
+ereal,double,sin@0.5,12,8584928,199,661,1.0e-199
+ereal,double,cos@0.5,12,8305401,197,654,1.0e-197
+ereal,double,tan@0.5,12,18229931,197,654,1.0e-197
+ereal,double,sinh@0.5,12,30875370,194,644,1.0e-194
+ereal,double,cosh@0.5,12,31123661,192,638,1.0e-192
+ereal,double,tanh@0.5,12,16753811,192,638,1.0e-192
+ereal,double,sqrt@2,16,7175294,319,1060,1.0e-319
+ereal,double,exp@1,16,17679796,256,850,1.0e-256
+ereal,double,log@2,16,52882565,255,847,1.0e-255
+ereal,double,sin@0.5,16,9816084,261,867,1.0e-261
+ereal,double,cos@0.5,16,9529246,263,874,1.0e-263
+ereal,double,tan@0.5,16,20723536,261,867,1.0e-261
+ereal,double,sinh@0.5,16,34987498,256,850,1.0e-256
+ereal,double,cosh@0.5,16,34975758,258,857,1.0e-258
+ereal,double,tanh@0.5,16,18752452,256,850,1.0e-256
+elreal,double,add,2,775,-1,0,n/a
+elreal,double,mul,2,611,-1,0,n/a
+elreal,double,div,2,21878,-1,0,n/a
+elreal,double,add,3,750,-1,0,n/a
+elreal,double,mul,3,588,-1,0,n/a
+elreal,double,div,3,26085,-1,0,n/a
+elreal,double,add,4,726,-1,0,n/a
+elreal,double,mul,4,601,-1,0,n/a
+elreal,double,div,4,30363,-1,0,n/a
+elreal,double,add,5,743,-1,0,n/a
+elreal,double,mul,5,595,-1,0,n/a
+elreal,double,div,5,34295,-1,0,n/a
+elreal,double,add,6,736,-1,0,n/a
+elreal,double,mul,6,609,-1,0,n/a
+elreal,double,div,6,40803,-1,0,n/a
+elreal,double,add,7,741,-1,0,n/a
+elreal,double,mul,7,591,-1,0,n/a
+elreal,double,div,7,46900,-1,0,n/a
+elreal,double,add,8,742,-1,0,n/a
+elreal,double,mul,8,590,-1,0,n/a
+elreal,double,div,8,53839,-1,0,n/a
+elreal,float,add,2,756,-1,0,n/a
+elreal,float,mul,2,587,-1,0,n/a
+elreal,float,div,2,25831,-1,0,n/a
+elreal,float,add,3,795,-1,0,n/a
+elreal,float,mul,3,564,-1,0,n/a
+elreal,float,div,3,33722,-1,0,n/a
+elreal,float,add,4,810,-1,0,n/a
+elreal,float,mul,4,590,-1,0,n/a
+elreal,float,div,4,37484,-1,0,n/a
+elreal,float,add,5,755,-1,0,n/a
+elreal,float,mul,5,580,-1,0,n/a
+elreal,float,div,5,41708,-1,0,n/a
+elreal,float,add,6,757,-1,0,n/a
+elreal,float,mul,6,592,-1,0,n/a
+elreal,float,div,6,47538,-1,0,n/a
+elreal,float,add,7,766,-1,0,n/a
+elreal,float,mul,7,583,-1,0,n/a
+elreal,float,div,7,56152,-1,0,n/a
+elreal,float,add,8,736,-1,0,n/a
+elreal,float,mul,8,586,-1,0,n/a
+elreal,float,div,8,67221,-1,0,n/a
+elreal,bfloat16,add,2,781,-1,0,n/a
+elreal,bfloat16,mul,2,580,-1,0,n/a
+elreal,bfloat16,div,2,15018,-1,0,n/a
+elreal,bfloat16,add,3,748,-1,0,n/a
+elreal,bfloat16,mul,3,570,-1,0,n/a
+elreal,bfloat16,div,3,23281,-1,0,n/a
+elreal,bfloat16,add,4,747,-1,0,n/a
+elreal,bfloat16,mul,4,567,-1,0,n/a
+elreal,bfloat16,div,4,30026,-1,0,n/a
+elreal,bfloat16,add,5,761,-1,0,n/a
+elreal,bfloat16,mul,5,604,-1,0,n/a
+elreal,bfloat16,div,5,39006,-1,0,n/a
+elreal,bfloat16,add,6,753,-1,0,n/a
+elreal,bfloat16,mul,6,606,-1,0,n/a
+elreal,bfloat16,div,6,47808,-1,0,n/a
+elreal,bfloat16,add,7,760,-1,0,n/a
+elreal,bfloat16,mul,7,611,-1,0,n/a
+elreal,bfloat16,div,7,54387,-1,0,n/a
+elreal,bfloat16,add,8,751,-1,0,n/a
+elreal,bfloat16,mul,8,596,-1,0,n/a
+elreal,bfloat16,div,8,63490,-1,0,n/a
+ereal,double,add,2,250,-1,0,n/a
+ereal,double,mul,2,395,-1,0,n/a
+ereal,double,div,2,50799,-1,0,n/a
+ereal,double,add,4,214,-1,0,n/a
+ereal,double,mul,4,407,-1,0,n/a
+ereal,double,div,4,48419,-1,0,n/a
+ereal,double,add,8,221,-1,0,n/a
+ereal,double,mul,8,398,-1,0,n/a
+ereal,double,div,8,123243,-1,0,n/a
+ereal,double,add,12,204,-1,0,n/a
+ereal,double,mul,12,395,-1,0,n/a
+ereal,double,div,12,155894,-1,0,n/a
+ereal,double,add,16,230,-1,0,n/a
+ereal,double,mul,16,396,-1,0,n/a
+ereal,double,div,16,155071,-1,0,n/a
+
+== per-function summary (accuracy saturation + accuracy/time knee) ==
+  elreal<double>    sqrt@2    NO saturation through depth 8 (131 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (131 digits, 4060171 ns)
+  elreal<double>    exp@1     NO saturation through depth 8 (130 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (130 digits, 11175910 ns)
+  elreal<double>    log@2     NO saturation through depth 8 (130 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (130 digits, 373892947 ns)
+  elreal<double>    sin@0.5   NO saturation through depth 8 (130 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (130 digits, 371653846 ns)
+  elreal<double>    cos@0.5   NO saturation through depth 8 (131 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (131 digits, 371555508 ns)
+  elreal<double>    tan@0.5   NO saturation through depth 8 (129 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (129 digits, 374333165 ns)
+  elreal<double>    sinh@0.5  NO saturation through depth 8 (131 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (131 digits, 15711990 ns)
+  elreal<double>    cosh@0.5  NO saturation through depth 8 (130 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (130 digits, 15727768 ns)
+  elreal<double>    tanh@0.5  NO saturation through depth 8 (129 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (129 digits, 11816951 ns)
+  elreal<float>     sqrt@2    NO saturation through depth 8 (61 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (61 digits, 3712471 ns)
+  elreal<float>     exp@1     NO saturation through depth 8 (60 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (60 digits, 7094806 ns)
+  elreal<float>     log@2     NO saturation through depth 8 (60 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (60 digits, 170926806 ns)
+  elreal<float>     sin@0.5   NO saturation through depth 8 (60 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (60 digits, 165379464 ns)
+  elreal<float>     cos@0.5   NO saturation through depth 8 (60 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (60 digits, 164746634 ns)
+  elreal<float>     tan@0.5   NO saturation through depth 8 (60 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (60 digits, 167043625 ns)
+  elreal<float>     sinh@0.5  NO saturation through depth 8 (61 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (61 digits, 8411075 ns)
+  elreal<float>     cosh@0.5  NO saturation through depth 8 (60 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (60 digits, 8402944 ns)
+  elreal<float>     tanh@0.5  NO saturation through depth 8 (60 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (60 digits, 7916632 ns)
+  elreal<bfloat16>  sqrt@2    NO saturation through depth 8 (17 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (17 digits, 2527094 ns)
+  elreal<bfloat16>  exp@1     NO saturation through depth 8 (19 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (19 digits, 3589249 ns)
+  elreal<bfloat16>  log@2     saturates ~depth 7 (21 digits); knee at depth 8 (21 digits, 31876857 ns)
+  elreal<bfloat16>  sin@0.5   NO saturation through depth 8 (19 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (19 digits, 34422487 ns)
+  elreal<bfloat16>  cos@0.5   NO saturation through depth 8 (21 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (21 digits, 34197584 ns)
+  elreal<bfloat16>  tan@0.5   NO saturation through depth 8 (19 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (19 digits, 35707861 ns)
+  elreal<bfloat16>  sinh@0.5  NO saturation through depth 8 (19 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (19 digits, 2718441 ns)
+  elreal<bfloat16>  cosh@0.5  NO saturation through depth 8 (20 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (20 digits, 2663144 ns)
+  elreal<bfloat16>  tanh@0.5  NO saturation through depth 8 (18 digits, still climbing); no knee -- accuracy/time still improving at depth 8 (18 digits, 4698345 ns)
+  ereal<double>     sqrt@2    saturates ~N=12 (319 digits); knee at N=12 (319 digits, 6102030 ns)
+  ereal<double>     exp@1     NO saturation through N=16 (256 digits, still climbing); no knee -- accuracy/time still improving at N=16 (256 digits, 17679796 ns)
+  ereal<double>     log@2     NO saturation through N=16 (255 digits, still climbing); no knee -- accuracy/time still improving at N=16 (255 digits, 52882565 ns)
+  ereal<double>     sin@0.5   NO saturation through N=16 (261 digits, still climbing); no knee -- accuracy/time still improving at N=16 (261 digits, 9816084 ns)
+  ereal<double>     cos@0.5   NO saturation through N=16 (263 digits, still climbing); no knee -- accuracy/time still improving at N=16 (263 digits, 9529246 ns)
+  ereal<double>     tan@0.5   NO saturation through N=16 (261 digits, still climbing); no knee -- accuracy/time still improving at N=16 (261 digits, 20723536 ns)
+  ereal<double>     sinh@0.5  NO saturation through N=16 (256 digits, still climbing); no knee -- accuracy/time still improving at N=16 (256 digits, 34987498 ns)
+  ereal<double>     cosh@0.5  NO saturation through N=16 (258 digits, still climbing); no knee -- accuracy/time still improving at N=16 (258 digits, 34975758 ns)
+  ereal<double>     tanh@0.5  NO saturation through N=16 (256 digits, still climbing); no knee -- accuracy/time still improving at N=16 (256 digits, 18752452 ns)
+
+== elreal vs ereal: cheapest config reaching >=30 digits ==
+  sqrt@2    elreal<double> depth 3 @ 249400 ns  vs  ereal N=2 @ 2264028 ns  -> elreal cheaper
+  exp@1     elreal<double> depth 2 @ 885284 ns  vs  ereal N=2 @ 2405914 ns  -> elreal cheaper
+  log@2     elreal<double> depth 2 @ 27766790 ns  vs  ereal N=2 @ 8178773 ns  -> ereal cheaper
+  sin@0.5   elreal<double> depth 2 @ 26258317 ns  vs  ereal N=2 @ 1315685 ns  -> ereal cheaper
+  cos@0.5   elreal<double> depth 2 @ 26286495 ns  vs  ereal N=2 @ 1188509 ns  -> ereal cheaper
+  tan@0.5   elreal<double> depth 2 @ 26289280 ns  vs  ereal N=2 @ 3402427 ns  -> ereal cheaper
+  sinh@0.5  elreal<double> depth 2 @ 1830525 ns  vs  ereal N=2 @ 4375125 ns  -> elreal cheaper
+  cosh@0.5  elreal<double> depth 2 @ 1742209 ns  vs  ereal N=2 @ 4395135 ns  -> elreal cheaper
+  tanh@0.5  elreal<double> depth 2 @ 900557 ns  vs  ereal N=2 @ 3244991 ns  -> elreal cheaper

--- a/benchmark/accuracy/adaptive/characterize.cpp
+++ b/benchmark/accuracy/adaptive/characterize.cpp
@@ -279,20 +279,53 @@ namespace {
 				std::sort(rs.begin(), rs.end(), [](const Row* a, const Row* b) { return a->knob < b->knob; });
 				int maxDig = 0;
 				for (auto* r : rs) maxDig = std::max(maxDig, r->digits);
+
+				// Saturation means additional knob buys (almost) nothing, and we can
+				// only claim it if the plateau STARTED BEFORE the sweep ended. Taking
+				// "first knob within 95% of the best" on its own is not enough: for a
+				// series that is still climbing, the best IS the last row, so the test
+				// fires at the sweep limit and reports the operator's choice of maxDepth
+				// back to them as a property of the type. elreal does exactly this --
+				// since v4.9.0 its accuracy is linear in the knob and unbounded, so it
+				// has no saturation point at any depth (#1177).
 				long satKnob = rs.back()->knob;
-				for (auto* r : rs) if (r->digits >= (maxDig * 95) / 100) { satKnob = r->knob; break; }
+				bool saturated = false;
+				for (auto* r : rs) {
+					if (r->digits >= (maxDig * 95) / 100) {
+						satKnob = r->knob;
+						saturated = (r != rs.back()) && (rs.size() > 1);
+						break;
+					}
+				}
 				const Row* knee = rs.front();
 				double bestScore = -1.0;
 				for (auto* r : rs) {
 					double score = r->digits / std::max(1.0, std::log10(std::max(1.0, r->time_ns)));
 					if (score > bestScore) { bestScore = score; knee = r; }
 				}
+				// The knee has the same failure mode: digits/log10(time) rises
+				// monotonically for a series that never plateaus, so the "best" is
+				// again just the last row. Only call it a knee when a plateau was seen.
+				const bool kneeIsSweepLimit = (knee == rs.back());
+				const char* unit = (type == "elreal" ? "depth " : "N=");
 				const std::string label = type + "<" + host + ">";
-				std::cout << "  " << std::left << std::setw(17) << label << ' ' << std::setw(9) << f
-				          << " saturates ~" << (type == "elreal" ? "depth " : "N=") << satKnob
-				          << " (" << maxDig << " digits); knee at "
-				          << (type == "elreal" ? "depth " : "N=") << knee->knob
-				          << " (" << knee->digits << " digits, " << std::llround(knee->time_ns) << " ns)\n";
+				std::cout << "  " << std::left << std::setw(17) << label << ' ' << std::setw(9) << f;
+				if (saturated) {
+					std::cout << " saturates ~" << unit << satKnob << " (" << maxDig << " digits)";
+				}
+				else {
+					std::cout << " NO saturation through " << unit << rs.back()->knob
+					          << " (" << maxDig << " digits, still climbing)";
+				}
+				if (saturated || !kneeIsSweepLimit) {
+					std::cout << "; knee at " << unit << knee->knob
+					          << " (" << knee->digits << " digits, " << std::llround(knee->time_ns) << " ns)";
+				}
+				else {
+					std::cout << "; no knee -- accuracy/time still improving at " << unit << knee->knob
+					          << " (" << knee->digits << " digits, " << std::llround(knee->time_ns) << " ns)";
+				}
+				std::cout << '\n';
 			}
 		}
 

--- a/docs/design/elreal-ereal-precision-defaults.md
+++ b/docs/design/elreal-ereal-precision-defaults.md
@@ -1,0 +1,131 @@
+# Choosing a precision knob for `elreal` and `ereal`
+
+Measured guidance for the two adaptive-precision real types, from the
+characterization tool in `benchmark/accuracy/adaptive/`. The raw sweep this page is
+built from is committed beside the tool as `baseline-characterization.txt`.
+
+Regenerate with:
+
+```bash
+characterize 8 5 > baseline-characterization.txt   # maxDepth=8, 5 timing repeats
+```
+
+## The short version
+
+- **`elreal` has no saturation depth.** Accuracy is linear in the knob and unbounded:
+  every block buys another `k * log10(2)` decimal digits, for as long as you are
+  willing to pay. Pick a depth from the accuracy you need, not from where the curve
+  flattens, because it does not flatten.
+- **`ereal` does saturate**, and its knob is compile-time. Its limbs are bare
+  `double`s, so an expansion bottoms out at the host's `min_exponent` -- about 319
+  digits, reached at `N = 12` for `sqrt`.
+- **Cost varies ~90x between functions at the same depth.** `sqrt` and `exp` are
+  cheap; `log` and the trigonometric functions are not.
+
+## `elreal`: depth for a target accuracy
+
+Accuracy is `depth * k * log10(2)` digits, where `k` is the host significand width.
+Measured on `sqrt(2)`, double host:
+
+| depth | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---|---|---|---|---|---|---|---|
+| digits | 32 | 49 | 66 | 83 | 98 | 115 | 131 |
+
+That is 16.4 digits per block against a predicted `53 * log10(2) = 15.95`. So to
+reach a target, `depth ~ target_digits / (k * log10(2))`:
+
+| target | `double` (k=53) | `float` (k=24) | `bfloat16` (k=8) |
+|---|---|---|---|
+| ~16 digits (a host double) | 2 | 3 | 7 |
+| ~30 digits | 2 | 4 | 12 |
+| ~50 digits | 3 | 7 | 20 |
+| ~100 digits | 7 | 13 | 40 |
+| ~500 digits | 32 | 70 | 209 |
+
+A narrower host is not less accurate, only less dense: `float` needs about 2.2x the
+blocks of `double` for the same digits, and `bfloat16` about 6.6x.
+
+## `elreal`: cost is function-dependent, not uniform
+
+Per evaluation at depth 8 on a double host, all reaching ~130 digits:
+
+| function | time | | function | time |
+|---|---|---|---|---|
+| `sqrt` | 4.1 ms | | `log` | 373.9 ms |
+| `exp` | 11.2 ms | | `sin` | 371.7 ms |
+| `tanh` | 11.8 ms | | `cos` | 371.6 ms |
+| `sinh` / `cosh` | 15.7 ms | | `tan` | 374.3 ms |
+
+A single global depth is therefore a poor fit for code that mixes them: the same knob
+that costs 4 ms in `sqrt` costs 374 ms in `sin`. Set `precision()` per object, or
+scope it with `elreal_precision_guard`, rather than raising the global default for the
+benefit of one call site.
+
+Reducing the `log`/trig constant is separate work -- it is the series evaluation, not
+the precision machinery.
+
+## The default
+
+`kElrealDefaultPrecision` is **32 blocks** (~510 digits on a double host, ~231 on
+float, ~77 on bfloat16). Because there is no saturation point, this is a policy choice
+about how much headroom a caller gets before having to ask, not a measurement.
+
+It governs the **class facade** only -- an `elreal`'s own `_depth`, used for boundary
+operations (conversion, comparison, I/O) and for sizing facade arithmetic. The free
+ZBCL math functions take their own `depth` arguments and are unaffected by it.
+
+Cost is roughly linear in the knob. On the facade at `-O2`, double host:
+
+| operation | at 8 blocks | at 32 blocks |
+|---|---|---|
+| `a / b` | 0.114 ms | 0.576 ms |
+| `a * b` | 0.240 ms | 1.004 ms |
+| `a + b` | 0.022 ms | 0.095 ms |
+| `double(a)` | ~0 | ~0 |
+
+Override per scope when the default is the wrong trade:
+
+```cpp
+{
+    sw::universal::elreal_precision_guard guard(4);   // ~66 digits, much cheaper
+    // ... work here uses depth 4 ...
+}                                                     // restored on scope exit
+```
+
+## `ereal`: choosing `N`
+
+`ereal<N>`'s knob is a compile-time limb count, so this is guidance for choosing the
+template argument rather than a runtime setting. It genuinely saturates:
+
+| function | saturates at | digits |
+|---|---|---|
+| `sqrt` | `N = 12` | 319 |
+| `exp`, `log`, trig, hyperbolics | not within `N = 16` | 255-263 and still climbing |
+
+The ceiling is the host's exponent range, not the limb count: an expansion of
+`double`s cannot represent a term below `min_exponent`. Past `N = 12` for `sqrt`,
+further limbs buy nothing.
+
+## Which type for a given target
+
+The tool reports this directly. At >= 30 digits, measured:
+
+- `elreal` is cheaper for `sqrt`, `exp`, and the hyperbolics.
+- `ereal` is cheaper for `log` and the trigonometric functions, by an order of
+  magnitude -- which is the same `log`/trig constant noted above, seen from the other
+  side.
+
+## A note on reading the tool's summary
+
+The per-function summary distinguishes:
+
+```
+saturates ~depth K (D digits)                  -- a plateau was observed at K
+NO saturation through depth K (D digits, still climbing)
+```
+
+The second is not a failure to measure; for `elreal` it is the correct answer. An
+earlier version reported the first in both cases, because it took "the first knob
+within 95% of the best digits" and, for a series still climbing, the best is the last
+row -- so it returned the operator's choice of `maxDepth` as though it were a property
+of the type (#1177).

--- a/elastic/elreal/api/api.cpp
+++ b/elastic/elreal/api/api.cpp
@@ -84,9 +84,13 @@ int verify_lazy_api() {
     int n = 0;
     elreal<double> q = elreal<double>(1.0) / elreal<double>(3.0);    // 1/3, irrational stream
     n += (q.limbs(3).size() == 3 ? 0 : 1);                          // pull 3 limbs
-    q.refine(16);
-    n += (q.precision() == 16 ? 0 : 1);                            // incremental refine
-    n += check("1/3 approx@16", q.approx<double>(16), 1.0 / 3.0, 1e-12);
+    // refine() RAISES the pull depth; it never lowers it. Express the target relative
+    // to the nominal default so the check tests that contract rather than whatever the
+    // default happens to be (it moved from 8 to 32 in #1177).
+    const std::size_t deeper = kElrealDefaultPrecision + 8;
+    q.refine(deeper);
+    n += (q.precision() == deeper ? 0 : 1);                        // incremental refine
+    n += check("1/3 approx deeper", q.approx<double>(deeper), 1.0 / 3.0, 1e-12);
     n += (q.stream().is_empty() ? 1 : 0);                          // raw state machine handle
     {   // scoped precision override
         elreal_precision_guard g(20);
@@ -94,7 +98,7 @@ int verify_lazy_api() {
         n += (z.precision() == 20 ? 0 : 1);
     }
     elreal<double> z2;
-    n += (z2.precision() == 8 ? 0 : 1);                            // restored
+    n += (z2.precision() == kElrealDefaultPrecision ? 0 : 1);      // restored
     return n;
 }
 

--- a/elastic/elreal/api/attributes.cpp
+++ b/elastic/elreal/api/attributes.cpp
@@ -6,6 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/utility/directives.hpp>
 #include <cmath>
+#include <iostream>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -44,7 +45,28 @@ int verify_numeric_limits() {
     if (!(double(lim::max()) > 0.0)) ++n;
     if (!(double(lim::min()) > 0.0)) ++n;
     if (!(double(lim::lowest()) < 0.0)) ++n;
-    if (!(double(lim::epsilon()) > 0.0 && double(lim::epsilon()) < 1.0)) ++n;
+    // Compare epsilon AS AN ELREAL, not through a double. At the nominal default
+    // precision epsilon is 2^-digits, which is far below the host's exponent range --
+    // 2^-1696 on a double host -- so converting it to a double is a lossy operation
+    // that yields 0. That says nothing about epsilon; it is the whole reason the type
+    // carries its exponent in a wide integer (#1177).
+    if (!(lim::epsilon() > Real(0.0) && lim::epsilon() < Real(1.0))) ++n;
+    // ... and pin it structurally: epsilon must be exactly 2^-digits, i.e. a single
+    // block sitting at that exponent. The value check above only catches the zero case
+    // at a default deep enough to underflow a double (>= 21 blocks); this catches a
+    // regression to a host-computed epsilon at ANY default.
+    {
+        const auto eb = lim::epsilon().stream().take(2);
+        if (eb.size() != 1) {
+            std::cout << "  FAIL epsilon is " << eb.size() << " blocks, expected exactly 1\n";
+            ++n;
+        }
+        else if (static_cast<int>(eb.front().exponent()) != -lim::digits) {
+            std::cout << "  FAIL epsilon sits at 2^" << static_cast<int>(eb.front().exponent())
+                      << ", expected 2^-" << lim::digits << " -- was it computed through a host double?\n";
+            ++n;
+        }
+    }
     // non-finite factories now return real states (#1079 Phase 5)
     if (!std::isinf(double(lim::infinity()))) ++n;
     if (!(double(lim::infinity()) > 0.0)) ++n;       // +inf

--- a/include/sw/universal/number/elreal/elreal_impl.hpp
+++ b/include/sw/universal/number/elreal/elreal_impl.hpp
@@ -52,7 +52,26 @@ namespace sw { namespace universal {
 // The compile-time nominal default precision (in blocks). numeric_limits reports
 // its precision-dependent fields against this; the runtime default below is seeded
 // from it and may be changed per-scope (elreal_precision_guard).
-inline constexpr std::size_t kElrealDefaultPrecision = 8;   // ~128 decimal digits on a double host
+//
+// Chosen from the characterization sweep (benchmark/accuracy/adaptive, #1177). elreal
+// has NO saturation depth to key a default to -- accuracy is linear in the knob and
+// unbounded, at k*log10(2) digits per block, so the choice is a policy about how much
+// headroom a caller gets before having to ask. 32 blocks is ~510 decimal digits on a
+// double host, ~231 on float and ~77 on bfloat16.
+//
+// The cost is per-operation and roughly linear in the knob. Measured on the class
+// facade at -O2 (double host), moving from 8 to 32 blocks:
+//
+//     operation      at 8       at 32
+//     a / b        0.114 ms   0.576 ms
+//     a * b        0.240 ms   1.004 ms
+//     a + b        0.022 ms   0.095 ms
+//     double(a)     ~0         ~0
+//
+// This governs the CLASS FACADE only -- an elreal's own _depth, used for boundary
+// operations (conversion / comparison / I/O) and for sizing facade arithmetic. The
+// free ZBCL math functions carry their own depth arguments and are unaffected.
+inline constexpr std::size_t kElrealDefaultPrecision = 32;   // ~510 decimal digits on a double host
 
 // Extra blocks requested of a dense quotient beyond the object's own precision, so a
 // boundary op that pulls `precision()` blocks is not reading the quotient's last,

--- a/include/sw/universal/number/elreal/numeric_limits.hpp
+++ b/include/sw/universal/number/elreal/numeric_limits.hpp
@@ -34,8 +34,20 @@ public:
     static ElrealType min()    { return ElrealType(std::numeric_limits<FpType>::min()); }
     static ElrealType max()    { return ElrealType(std::numeric_limits<FpType>::max()); }
     static ElrealType lowest() { return ElrealType(std::numeric_limits<FpType>::lowest()); }
-    // smallest increment from 1.0 at the nominal default precision (~2^-digits).
-    static ElrealType epsilon()     { return ElrealType(std::ldexp(1.0, -digits)); }
+    // Smallest increment from 1.0 at the nominal default precision, i.e. 2^-digits.
+    //
+    // Built as a block carrying its scale in the WIDE exponent rather than as
+    // ElrealType(std::ldexp(1.0, -digits)). That formulation computed the value
+    // through a host double, so it silently underflowed to ZERO once digits exceeded
+    // the host's exponent range -- from a nominal default of 21 blocks upward on a
+    // double host (21 * 53 = 1113 > 1074), epsilon() returned 0 rather than a small
+    // number. Representing a value that far below the host's range is the entire
+    // point of the type, so epsilon must not route through it (#1177).
+    static ElrealType epsilon() {
+        using Blk = sw::universal::block<FpType>;
+        Blk b{ static_cast<FpType>(1.0), typename Blk::exp_t(-digits) };
+        return ElrealType(sw::universal::ZBCL<FpType>::singleton(b));
+    }
     static ElrealType round_error() { return ElrealType(0.5); }
     // has_denorm = denorm_absent, so the C++20 contract requires denorm_min() to
     // return the minimum positive NORMALISED value, i.e. min().


### PR DESCRIPTION
Resolves #1177 by running the characterization tool and acting on what it measured. **The answer is not the one the issue anticipated.**

## The premise changed

#1177 asks to read the tool's *"saturation knob — where accuracy stops improving"* and set defaults from it. **elreal no longer has one.** The caps that existed when the issue was filed were all removed in v4.9.0–v4.9.3 (#1076, #1371, #1373). Measured on `sqrt(2)`, double host:

| depth | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|---|---|---|---|---|---|---|---|
| digits | 32 | 49 | 66 | 83 | 98 | 115 | 131 |

16.4 digits per block against a predicted `k·log₁₀2 = 15.95`, with no plateau at any depth swept. So the default is a **policy choice, not a measurement**.

## The tool was reporting the operator's own sweep limit as a result

It picked "first knob within 95% of the best digits" as the saturation point. For a series still climbing, the best *is* the last row — so it always fired at `maxDepth`. Every elreal function claimed to saturate at whatever depth you happened to sweep to, and so did most of ereal's. It now distinguishes:

```
saturates ~depth K (D digits)
NO saturation through depth K (D digits, still climbing)
```

The knee had the identical flaw (`digits/log10(time)` rises monotonically when accuracy never plateaus) and is likewise only reported when a plateau was seen. Under corrected reporting, only `ereal`'s `sqrt` genuinely saturates (N=12, 319 digits) — its transcendentals are still climbing at N=16.

## The default: 8 → 32 blocks

~510 decimal digits on a double host. Governs the **class facade** only — an `elreal`'s own `_depth` for boundary ops and facade arithmetic; the free ZBCL math functions carry their own `depth` arguments. Cost is roughly linear in the knob:

| operation | at 8 | at 32 |
|---|---|---|
| `a / b` | 0.114 ms | 0.576 ms |
| `a * b` | 0.240 ms | 1.004 ms |
| `a + b` | 0.022 ms | 0.095 ms |

## That change exposed a real bug

`numeric_limits::epsilon()` was `ElrealType(std::ldexp(1.0, -digits))` — it computed its value **through a host double**. With `digits = 32 × 53 = 1696` the `ldexp` underflows, so **`epsilon()` returned exactly zero**.

It is wrong for any default from **21 blocks up** on a double host (21 × 53 = 1113 > 1074); the old default of 8 sat under that line, which is why it went unnoticed. Representing a value that far below the host's range is the entire point of the type, so epsilon is now built as a block carrying its scale in the wide exponent. `double(epsilon())` is still 0, which is correct — 2⁻¹⁶⁹⁶ is not a double.

Two api tests encoded the old default rather than deriving from it: a hardcoded `precision() == 8`, and a `refine(16)` that assumed 16 was *above* the default (`refine` raises, never lowers). Both now express the contract relative to `kElrealDefaultPrecision`.

## Guidance and baseline

- `docs/design/elreal-ereal-precision-defaults.md` — depth-for-target-accuracy per host, the per-function cost spread, how to read the tool's summary, and `ereal`'s genuine saturation.
- `benchmark/accuracy/adaptive/baseline-characterization.txt` — the sweep it was built from (`characterize 8 5`).

## The finding worth acting on next (out of scope here)

At depth 8 on a double host, all reaching ~130 digits:

| function | time | | function | time |
|---|---|---|---|---|
| `sqrt` | 4.1 ms | | `log` | **373.9 ms** |
| `exp` | 11.2 ms | | `sin`/`cos`/`tan` | **~372 ms** |

~90x spread. A single global default is a poor fit for code that mixes them — which is what the issue suspected. Reducing that constant is series-evaluation work, not precision machinery.

## Test Results

Regression pins epsilon **structurally** — exactly one block at exponent `-digits` — which catches a host-computed epsilon at *any* default, not only one deep enough to underflow. **Mutation-tested**: against the previous formulation it fails with `epsilon is 0 blocks, expected exactly 1`.

| Suite | gcc | clang |
|---|---|---|
| full elastic family (162 tests) | 162/162 PASS (19.7s) | 162/162 PASS (18.5s) |

ASCII Guard clean. Carries a `BEHAVIOUR-CHANGE:` trailer.

Resolves #1177

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)