### PR TITLE
perf(elreal): memoize the transcendental constants

### DIFF
--- a/docs/design/elreal-ereal-precision-defaults.md
+++ b/docs/design/elreal-ereal-precision-defaults.md
@@ -61,8 +61,23 @@ that costs 4 ms in `sqrt` costs 374 ms in `sin`. Set `precision()` per object, o
 scope it with `elreal_precision_guard`, rather than raising the global default for the
 benefit of one call site.
 
-Reducing the `log`/trig constant is separate work -- it is the series evaluation, not
-the precision machinery.
+**Update (#1383):** the numbers above were measured before the transcendental
+constants were memoized, and the attribution in the original version of this page --
+that the gap was the series evaluation -- was wrong. Almost all of it was `pi_zbcl`
+and `ln2_zbcl` being recomputed from scratch on every call: at depth 8, `pi_zbcl`
+alone cost 371.9 ms against `sin(0.5)`'s 371.8 ms in total. The constants are now
+cached per `(FpType, depth)`, and in steady state the table reads:
+
+| function | before | after |
+|---|---|---|
+| `sin` / `cos` | ~372 ms | ~5.8 ms |
+| `tan` | 374 ms | ~9.1 ms |
+| `log` | 374 ms | ~0.01 ms |
+| `exp`, `sqrt` | unchanged | unchanged (they need no constant) |
+
+The first call at a given depth still pays for the constant. What remains is the
+series cost proper, and the spread between functions is now the ordinary few-fold
+difference rather than ~90x.
 
 ## The default
 

--- a/elastic/elreal/math/constant_memoization.cpp
+++ b/elastic/elreal/math/constant_memoization.cpp
@@ -1,0 +1,168 @@
+// constant_memoization.cpp: the transcendental constants are cached, and cached in a
+// way that does not make results depend on call history (#1383).
+//
+// pi and ln2 were recomputed from scratch on every call, and that -- not the series
+// each wraps -- was essentially the whole cost of sin/cos/tan and log. Measured at
+// depth 8 on a double host before the fix: pi_zbcl alone 371.9 ms against sin(0.5)
+// 371.8 ms in total, while exp and sqrt, needing no constant, cost 9.6 and 4.0 ms.
+// After: sin 5.7 ms in steady state.
+//
+// Two properties are guarded here, and the second is the one that constrains the
+// design. Caching the DEEPEST value and truncating it for shallower requests would be
+// cheaper, and it is wrong: these constants are not prefix-stable -- pi at depth 2
+// differs from take(2) of pi at depth 8 after ~32 digits, because the deeper
+// evaluation refines the last block rather than merely extending it. Under that
+// scheme pi_zbcl(2) would return one value or another depending on whether some
+// unrelated earlier call had asked for more.
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/utility/directives.hpp>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <string>
+
+#include <universal/number/elreal/elreal.hpp>
+#include <universal/number/elreal/math/constants.hpp>
+#include <universal/verification/elreal_reference_digits.hpp>
+#include <universal/verification/test_suite.hpp>
+
+// ---- cumulative allocation counter ---------------------------------------------
+// A cached call should do essentially no work. Counting allocations says so
+// deterministically, where a wall-clock comparison would be flaky on a shared runner.
+namespace {
+long g_allocations = 0;
+}
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmismatched-new-delete"
+#endif
+void* operator new(std::size_t n) {
+    void* p = std::malloc(n ? n : 1);
+    if (!p) throw std::bad_alloc();
+    ++g_allocations;
+    return p;
+}
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void* operator new[](std::size_t n) { return operator new(n); }
+void operator delete[](void* p) noexcept { operator delete(p); }
+void operator delete[](void* p, std::size_t) noexcept { operator delete(p); }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+namespace {
+
+using namespace sw::universal;
+
+// (1) a repeat call must be served from the cache, i.e. cost essentially nothing
+template <typename FpType>
+int verify_constant_is_cached(const char* host, bool reportTestCases) {
+    int n = 0;
+    const std::size_t D = 6;
+
+    const long a0 = g_allocations;
+    (void)pi_zbcl<FpType>(D).take(D).size();          // first: computes
+    const long firstCost = g_allocations - a0;
+
+    const long a1 = g_allocations;
+    (void)pi_zbcl<FpType>(D).take(D).size();          // second: should be a lookup
+    const long repeatCost = g_allocations - a1;
+
+    // The first evaluation runs two odd_power_series; a cache hit is a vector index
+    // and a shared_ptr copy. Demanding a 100x gap keeps this immune to how the
+    // expansion happens to be shaped while still failing loudly if the memo is gone.
+    if (repeatCost * 100 > firstCost) {
+        std::cout << "  FAIL [" << host << "] pi_zbcl repeat cost " << repeatCost
+                  << " allocations against " << firstCost
+                  << " for the first call -- the constant is not being cached (#1383)\n";
+        ++n;
+    }
+    else if (reportTestCases) {
+        std::cout << "  ok   [" << host << "] pi_zbcl cached: " << firstCost
+                  << " allocations to compute, " << repeatCost << " to re-read\n";
+    }
+    return n;
+}
+
+// (2) the cached value must be the one that depth would have produced on its own --
+//     NOT a truncation of some deeper value cached earlier. This is what stops the
+//     memo from making results depend on call history.
+template <typename FpType>
+int verify_shallow_is_unaffected_by_deeper(const char* host, bool reportTestCases) {
+    int n = 0;
+    struct Case { const char* name; ZBCL<FpType> memoized; ZBCL<FpType> computed; };
+
+    // ask for a deep value FIRST, so a truncating cache would be primed to answer the
+    // shallow request from it
+    (void)pi_zbcl<FpType>(16).take(16).size();
+    (void)ln2_zbcl<FpType>(16).take(16).size();
+    (void)e_zbcl<FpType>(16).take(16).size();
+
+    const Case cases[] = {
+        { "pi",  pi_zbcl<FpType>(2),  pi_zbcl_compute<FpType>(2)  },
+        { "ln2", ln2_zbcl<FpType>(2), ln2_zbcl_compute<FpType>(2) },
+        { "e",   e_zbcl<FpType>(2),   e_zbcl_compute<FpType>(2)   },
+    };
+    for (const auto& c : cases) {
+        if (agreed_decimal_digits(c.memoized, c.computed, 4000) < 4000) {
+            std::cout << "  FAIL [" << host << "] " << c.name
+                      << " at depth 2 differs from a direct depth-2 evaluation after a deeper"
+                      << " call -- is the cache truncating a deeper value? (#1383)\n";
+            ++n;
+        }
+        else if (reportTestCases) {
+            std::cout << "  ok   [" << host << "] " << c.name << " at depth 2 is unaffected by the deeper call\n";
+        }
+    }
+    return n;
+}
+
+} // anonymous
+
+#define MANUAL_TESTING 0
+#ifndef REGRESSION_LEVEL_OVERRIDE
+#undef REGRESSION_LEVEL_1
+#undef REGRESSION_LEVEL_2
+#undef REGRESSION_LEVEL_3
+#undef REGRESSION_LEVEL_4
+#define REGRESSION_LEVEL_1 1
+#define REGRESSION_LEVEL_2 1
+#define REGRESSION_LEVEL_3 1
+#define REGRESSION_LEVEL_4 1
+#endif
+
+int main()
+try {
+    using namespace sw::universal;
+    std::string test_suite = "elreal transcendental constants are memoized (#1383)";
+    int nrOfFailedTestCases = 0;
+    bool reportTestCases = false;
+    ReportTestSuiteHeader(test_suite, reportTestCases);
+
+#if MANUAL_TESTING
+
+    // TODO: place hand-run diagnostics here (this branch ignores failures)
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return EXIT_SUCCESS;
+
+#else
+
+    nrOfFailedTestCases += verify_constant_is_cached<double>("double", reportTestCases);
+    nrOfFailedTestCases += verify_shallow_is_unaffected_by_deeper<double>("double", reportTestCases);
+
+    ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
+    return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);
+
+#endif  // MANUAL_TESTING
+}
+catch (const std::exception& err) {
+    std::cerr << "Caught unexpected exception: " << err.what() << std::endl;
+    return EXIT_FAILURE;
+}

--- a/include/sw/universal/number/elreal/math/constants.hpp
+++ b/include/sw/universal/number/elreal/math/constants.hpp
@@ -130,24 +130,70 @@ inline series<FpType> e_term_stream(ZBCL<FpType> term, double n, int floor_exp) 
 // term co-list, #1061 Phase 3b) -- ~100x faster than the previous eager form (every
 // term to full working depth + a batch priestRenorm sum), value-identical and
 // 0-overlap canonical. Carries kSeriesGuard extra working blocks like the other series.
+namespace detail {
+
+// memoize_by_depth: cache a constant that depends only on (FpType, depth).
+//
+// pi and ln2 were recomputed from scratch on EVERY call, and that -- not the series
+// each one wraps -- was essentially the whole cost of sin/cos/tan and log. Measured at
+// depth 8 on a double host: pi_zbcl alone 371.9 ms against sin(0.5) 371.8 ms in total,
+// while exp and sqrt, which need no constant, cost 9.6 ms and 4.0 ms (universal#1383).
+//
+// KEYED ON THE EXACT DEPTH, deliberately, rather than caching the deepest value and
+// truncating it for shallower requests. That would be cheaper and it is wrong: these
+// constants are NOT prefix-stable. Measured before choosing -- pi at depth 2 differs
+// from take(2) of pi at depth 8 after ~32 digits, because the deeper evaluation
+// refines the last block rather than merely extending it. Truncating a cached deeper
+// value would therefore make pi_zbcl(2) return one thing or another depending on
+// whether some unrelated earlier call happened to ask for more, i.e. results that
+// depend on call history. A numeric library cannot do that.
+//
+// thread_local, matching elreal_default_precision's runtime knob: the constants are
+// read-mostly and a shared cache would need synchronisation for no benefit.
+inline constexpr std::size_t kConstantMemoMaxDepth = 256;
+
+template <typename FpType, typename Gen>
+inline ZBCL<FpType> memoize_by_depth(std::vector<ZBCL<FpType>>& cache, std::size_t depth, Gen compute) {
+    if (depth > kConstantMemoMaxDepth) return compute(depth);   // absurd depth: do not retain
+    if (cache.size() <= depth) cache.resize(depth + 1);
+    if (cache[depth].is_empty()) cache[depth] = compute(depth);
+    return cache[depth];
+}
+
+}  // namespace detail
+
 template <typename FpType>
-inline ZBCL<FpType> e_zbcl(std::size_t depth = 32) {
+inline ZBCL<FpType> e_zbcl_compute(std::size_t depth) {
     const std::size_t wdepth = depth + detail::kSeriesGuard;
     const int floor_exp = detail::series_stop_exp<FpType>(wdepth);
     return infsum(detail::e_term_stream(from_native<FpType>(1.0), 1.0, floor_exp));
 }
 
+template <typename FpType>
+inline ZBCL<FpType> e_zbcl(std::size_t depth = 32) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return e_zbcl_compute<FpType>(d); });
+}
+
 // ln2 = 2 * artanh(1/3)
 template <typename FpType>
-inline ZBCL<FpType> ln2_zbcl(std::size_t depth = 16) {
+inline ZBCL<FpType> ln2_zbcl_compute(std::size_t depth) {
     ZBCL<FpType> oneThird = div(from_native<FpType>(1.0), from_native<FpType>(3.0), depth);
     ZBCL<FpType> at = detail::odd_power_series(oneThird, false, depth);
     return mul_scalar(block<FpType>{ static_cast<FpType>(2.0), 0 }, at, depth);
 }
 
+template <typename FpType>
+inline ZBCL<FpType> ln2_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return ln2_zbcl_compute<FpType>(d); });
+}
+
 // ln10 = 3*ln2 + 2*artanh(1/9)   (since ln10 = ln2 + ln5, ln5 = 2*ln2 + 2*artanh(1/9))
 template <typename FpType>
-inline ZBCL<FpType> ln10_zbcl(std::size_t depth = 16) {
+inline ZBCL<FpType> ln10_zbcl_compute(std::size_t depth) {
     ZBCL<FpType> threeLn2 = mul_scalar(block<FpType>{ static_cast<FpType>(3.0), 0 }, ln2_zbcl<FpType>(depth), depth);
     ZBCL<FpType> oneNinth = div(from_native<FpType>(1.0), from_native<FpType>(9.0), depth);
     ZBCL<FpType> twoAt = mul_scalar(block<FpType>{ static_cast<FpType>(2.0), 0 },
@@ -155,15 +201,29 @@ inline ZBCL<FpType> ln10_zbcl(std::size_t depth = 16) {
     return add(threeLn2, twoAt);
 }
 
+template <typename FpType>
+inline ZBCL<FpType> ln10_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return ln10_zbcl_compute<FpType>(d); });
+}
+
 // log2(10) = ln10 / ln2
 template <typename FpType>
-inline ZBCL<FpType> log2_10_zbcl(std::size_t depth = 16) {
+inline ZBCL<FpType> log2_10_zbcl_compute(std::size_t depth) {
     return div(ln10_zbcl<FpType>(depth + 2), ln2_zbcl<FpType>(depth + 2), depth);
+}
+
+template <typename FpType>
+inline ZBCL<FpType> log2_10_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return log2_10_zbcl_compute<FpType>(d); });
 }
 
 // pi = 16*atan(1/5) - 4*atan(1/239)   (Machin)
 template <typename FpType>
-inline ZBCL<FpType> pi_zbcl(std::size_t depth = 16) {
+inline ZBCL<FpType> pi_zbcl_compute(std::size_t depth) {
     ZBCL<FpType> a5   = detail::odd_power_series(div(from_native<FpType>(1.0), from_native<FpType>(5.0),   depth), true, depth);
     ZBCL<FpType> a239 = detail::odd_power_series(div(from_native<FpType>(1.0), from_native<FpType>(239.0), depth), true, depth);
     ZBCL<FpType> t1 = mul_scalar(block<FpType>{ static_cast<FpType>(16.0), 0 }, a5,   depth);
@@ -171,19 +231,54 @@ inline ZBCL<FpType> pi_zbcl(std::size_t depth = 16) {
     return add(t1, negate(t2));
 }
 
+template <typename FpType>
+inline ZBCL<FpType> pi_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return pi_zbcl_compute<FpType>(d); });
+}
+
 // sqrt(n) radicals
 template <typename FpType>
-inline ZBCL<FpType> sqrt2_zbcl(std::size_t depth = 16) { return sqrt(from_native<FpType>(2.0), depth); }
+inline ZBCL<FpType> sqrt2_zbcl_compute(std::size_t depth) { return sqrt(from_native<FpType>(2.0), depth); }
+
 template <typename FpType>
-inline ZBCL<FpType> sqrt3_zbcl(std::size_t depth = 16) { return sqrt(from_native<FpType>(3.0), depth); }
+inline ZBCL<FpType> sqrt2_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return sqrt2_zbcl_compute<FpType>(d); });
+}
 template <typename FpType>
-inline ZBCL<FpType> sqrt5_zbcl(std::size_t depth = 16) { return sqrt(from_native<FpType>(5.0), depth); }
+inline ZBCL<FpType> sqrt3_zbcl_compute(std::size_t depth) { return sqrt(from_native<FpType>(3.0), depth); }
+
+template <typename FpType>
+inline ZBCL<FpType> sqrt3_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return sqrt3_zbcl_compute<FpType>(d); });
+}
+template <typename FpType>
+inline ZBCL<FpType> sqrt5_zbcl_compute(std::size_t depth) { return sqrt(from_native<FpType>(5.0), depth); }
+
+template <typename FpType>
+inline ZBCL<FpType> sqrt5_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return sqrt5_zbcl_compute<FpType>(d); });
+}
 
 // phi = (1 + sqrt(5)) / 2
 template <typename FpType>
-inline ZBCL<FpType> phi_zbcl(std::size_t depth = 16) {
+inline ZBCL<FpType> phi_zbcl_compute(std::size_t depth) {
     ZBCL<FpType> s = add(from_native<FpType>(1.0), sqrt5_zbcl<FpType>(depth));
     return mul_scalar(block<FpType>{ static_cast<FpType>(0.5), 0 }, s, depth);
+}
+
+template <typename FpType>
+inline ZBCL<FpType> phi_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return phi_zbcl_compute<FpType>(d); });
 }
 
 // euler_gamma via Brent-McMillan B1 (#1053): gamma = A(n)/B(n) - ln(n), with
@@ -202,7 +297,7 @@ inline ZBCL<FpType> phi_zbcl(std::size_t depth = 16) {
 // a double-host generator; on narrow hosts keep depth shallow (n below the overflow).
 // Validated to 305 digits on double vs the 320-digit reference (#1053, REGRESSION_LEVEL_4).
 template <typename FpType>
-inline ZBCL<FpType> euler_gamma_zbcl(std::size_t depth = 16) {
+inline ZBCL<FpType> euler_gamma_zbcl_compute(std::size_t depth) {
     using B = block<FpType>;
     const std::size_t wdepth = depth + detail::kSeriesGuard;
     const int wbits = static_cast<int>(wdepth) * block<FpType>::k;
@@ -274,6 +369,13 @@ inline ZBCL<FpType> euler_gamma_zbcl(std::size_t depth = 16) {
     ZBCL<FpType> lnN = mul_scalar(B{ static_cast<FpType>(2.0), 0 }, detail::odd_power_series(u, false, depth), depth);
     if (e != 0) lnN = add(lnN, mul_scalar(B{ static_cast<FpType>(static_cast<double>(e)), 0 }, ln2_zbcl<FpType>(depth), depth));
     return add(ratio, negate(lnN)); // gamma = A/B - ln(n)
+}
+
+template <typename FpType>
+inline ZBCL<FpType> euler_gamma_zbcl(std::size_t depth = 16) {
+    static thread_local std::vector<ZBCL<FpType>> cache;
+    return detail::memoize_by_depth<FpType>(cache, depth,
+        [](std::size_t d) { return euler_gamma_zbcl_compute<FpType>(d); });
 }
 
 }} // namespace sw::universal


### PR DESCRIPTION
## Summary

`pi` and `ln2` were recomputed from scratch on every call. That — **not** the series each one wraps — was essentially the entire cost of `sin`, `cos`, `tan` and `log`.

Measured at depth 8 on a double host, all reaching ~130 digits:

| | |
|---|---|
| `pi_zbcl(8)` **alone** | **371.90 ms** |
| `sin(0.5, 8)` **total** | **371.82 ms** |
| `ln2_zbcl(8)` **alone** | 373.17 ms |
| `log(2, 8)` **total** | 375.61 ms |
| `exp(1, 8)` — needs no constant | 9.57 ms |
| `sqrt(2, 8)` — needs no constant | 4.04 ms |

`sin` cost what `pi_zbcl` cost, to within noise. `pi_zbcl` ran two full `odd_power_series` evaluations (Machin's formula) per call with nothing retained.

## Effect

| function | before | after (steady state) |
|---|---|---|
| `sin` / `cos` | ~372 ms | **~5.8 ms** |
| `tan` | 374 ms | **~9.1 ms** |
| `log` | 374 ms | **~0.01 ms** |
| `exp`, `sqrt` | unchanged | unchanged |

The first call at a given depth still pays for the constant. Memoized: `e`, `ln2`, `ln10`, `log2_10`, `pi`, `sqrt2/3/5`, `phi`, `euler_gamma`.

This closes the ~90x spread that made a single global default precision awkward for code mixing these functions — the open question left by #1177.

## Keyed on the exact depth, deliberately

Caching the *deepest* value and truncating it for shallower requests is cheaper, and it is what **I proposed on the issue before measuring**. It is wrong: these constants are **not prefix-stable**.

```
pi d=2 vs take(2) of D=8:  differ after 32 digits
ln2 d=2 vs take(2) of D=8: differ after 32 digits
e   d=2 vs take(2) of D=8: differ after 33 digits
```

The deeper evaluation *refines* the last block rather than merely extending it. Under a truncating cache, `pi_zbcl(2)` would return one value or another depending on whether some unrelated earlier call had asked for more — results that depend on call history, which a numeric library cannot do.

Values are unchanged: the first call at a depth computes exactly what it computed before, and later calls return that same object.

## Test Results

`constant_memoization.cpp` guards both properties, counting **allocations** rather than wall clock so it cannot be flaky on a shared runner.

**Mutation-tested against both wrong designs:**

```
memo removed:                 FAIL pi_zbcl repeat cost 940102 allocations
                                   against 940102 for the first call
cache-deepest-and-truncate:   FAIL pi  at depth 2 differs from a direct depth-2 evaluation
                              FAIL ln2 at depth 2 differs ...
                              FAIL e   at depth 2 differs ...
```

| Suite | gcc | clang |
|---|---|---|
| full elastic family (163 tests) | 163/163 PASS (21.2s) | 163/163 PASS (19.8s) |

ASCII Guard clean.

## Correction to shipped documentation

`docs/design/elreal-ereal-precision-defaults.md` shipped in **v4.10.0** attributing this gap to "series evaluation, not the precision machinery". I asserted that without measuring it, and it was wrong. The page is corrected here with the real cause and the new numbers.

Resolves #1383

## Test plan
- [ ] Fast CI passes (gcc + clang CI_LITE)
- [ ] Promote to ready when satisfied

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved repeated calculations involving mathematical constants used by trigonometric and logarithmic functions.
  - Subsequent calls now require substantially less computation after the initial constant is calculated.
  - Results remain consistent across different calculation depths.

- **Documentation**
  - Updated performance guidance to clarify steady-state costs and first-call behavior for transcendental functions.

- **Tests**
  - Added regression coverage for performance improvements and numerical consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->