### PR TITLE
refactor(internal): make the block layer's trace includes conditional (#1334 phase 1)

### DIFF
--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -5,8 +5,23 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+// TRACE_URMUL / TRACE_DIV: compile-time tracing of the unrounded multiply and
+// divide. Both default to off. They are declared here, ahead of the includes,
+// because <iostream> is needed ONLY when one of them is on -- see below.
+// Guarded with #ifndef so a caller can enable tracing by defining the macro
+// before including this header; the previous unconditional #define silently
+// reset it to 0, so tracing could not in fact be turned on from outside.
+#ifndef TRACE_URMUL
+#define TRACE_URMUL 0
+#endif
+#ifndef TRACE_DIV
+#define TRACE_DIV 0
+#endif
+
 #include <cstdint>
+#if TRACE_URMUL || TRACE_DIV
 #include <iostream>
+#endif
 #include <iomanip>
 #include <string>
 #include <sstream>
@@ -1157,7 +1172,6 @@ constexpr blockbinary<N + 1, B, T> ursub(const blockbinary<N, B, T>& a, const bl
 	return result -= blockbinary<N + 1, B, T>(b);
 }
 
-#define TRACE_URMUL 0
 // unrounded multiplication, returns a blockbinary that is of size 2*nbits
 // using brute-force sign-extending of operands to yield correct sign-extended result for 2*nbits 2's complement.
 template<unsigned N, typename B, BinaryNumberType T>
@@ -1228,7 +1242,6 @@ constexpr blockbinary<2 * N, B, T> urmul2(const blockbinary<N, B, T>& a, const b
 	return result;
 }
 
-#define TRACE_DIV 0
 // unrounded division, returns a blockbinary that is of size 2*nbits
 template<unsigned nbits, unsigned roundingBits, typename B, BinaryNumberType T>
 blockbinary<2 * nbits + roundingBits, B, T> urdiv(const blockbinary<nbits, B, T>& a, const blockbinary<nbits, B, T>& b) {

--- a/include/sw/universal/internal/blockfraction/blockfraction.hpp
+++ b/include/sw/universal/internal/blockfraction/blockfraction.hpp
@@ -7,7 +7,17 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cstdint>
 #include <cmath> // for std::pow() used in conversions to native IEEE-754 formats values
+// TRACE_DIV: compile-time tracing of the division algorithm, default off.
+// Declared ahead of the includes because <iostream> is needed only when it is
+// on. #ifndef-guarded so a caller can enable it by defining the macro first;
+// the previous unconditional #define silently reset it to 0.
+#ifndef TRACE_DIV
+#define TRACE_DIV 0
+#endif
+
+#if TRACE_DIV
 #include <iostream>
+#endif
 #include <string>
 #include <sstream>
 
@@ -669,7 +679,6 @@ std::string to_hex(const blockfraction<nbits, bt>& number, bool wordMarker = tru
 // specialty binary operators
 
 
-#define TRACE_DIV 0
 // unrounded division, returns a blockfraction that is of size 2*nbits
 template<unsigned nbits, unsigned roundingBits, typename bt>
 blockfraction<2 * nbits + roundingBits, bt> urdiv(const blockfraction<nbits, bt>& a, const blockfraction<nbits, bt>& b, blockfraction<roundingBits, bt>& r) {

--- a/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
+++ b/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
@@ -7,7 +7,17 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cstdint>
 #include <cmath> // for std::pow() used in conversions to native IEEE-754 formats values
+// TRACE_DIV: compile-time tracing of the division algorithm, default off.
+// Declared ahead of the includes because <iostream> is needed only when it is
+// on. #ifndef-guarded so a caller can enable it by defining the macro first;
+// the previous unconditional #define silently reset it to 0.
+#ifndef TRACE_DIV
+#define TRACE_DIV 0
+#endif
+
+#if TRACE_DIV
 #include <iostream>
+#endif
 #include <string>
 #include <sstream>
 #include <limits>
@@ -764,7 +774,6 @@ std::string to_hex(const blocksignificand<nbits, bt>& number, bool nibbleMarker 
 ///////////////////////////////////////////////////////////////////////////////
 // specialty binary operators
 
-#define TRACE_DIV 0
 // unrounded division, returns a blocksignificand that is of size 2*nbits
 template<unsigned nbits, unsigned roundingBits, typename bt>
 blocksignificand<2 * nbits + roundingBits, bt> urdiv(const blocksignificand<nbits, bt>& a, const blocksignificand<nbits, bt>& b, blocksignificand<roundingBits, bt>& r) {


### PR DESCRIPTION
## Summary

First step of Phase 1 (#1334). It makes three internal headers' `<iostream>` conditional on the tracing that needs it — and fixes a latent bug that made that tracing impossible to turn on.

**It does not move the headline number.** That is expected and explained below; the useful output is knowing precisely why, and what has to happen next.

## The latent bug

`blockbinary`, `blocksignificand` and `blockfraction` each did this, part-way down the file:

```cpp
#define TRACE_DIV 0
```

**Unconditionally** — so it silently overwrote whatever the caller set. Defining `TRACE_DIV` before including the header did nothing; the tracing feature could not be enabled from outside at all. Now:

```cpp
#ifndef TRACE_DIV
#define TRACE_DIV 0
#endif

#if TRACE_DIV
#include <iostream>
#endif
```

hoisted ahead of the includes, so the switch works *and* the include follows it.

Every `std::cout` in all three headers is inside a `TRACE` guard — verified by walking preprocessor nesting rather than by eye: 17 + 4 + 4 sites, zero unguarded. Checked in both directions: tracing on pulls `<iostream>` and compiles; tracing off pulls none.

## Why the number does not move yet

With these three fixed, `<iostream>` enters the posit graph one header later, via `internal/blocktriple/blocktriple.hpp`.

Its tracing is guarded differently — `if constexpr (_trace_btriple_mul)` against a constexpr bool, rather than `#if`. **A discarded `if constexpr` branch still requires its non-dependent names to be declared**, so `std::cout` must be visible whether tracing is on or off. A conditional include cannot fix `blocktriple`: its trace blocks have to become `#if`, or move out. Same for `constexprClassParameters()` — 24 `cout` sites in a public debug member called from 36 files.

Remaining sources for the posit core graph, in the order they should be taken:

| header | `cout` sites | approach |
|---|---|---|
| `internal/blocktriple/blocktriple.hpp` | 59 | `if constexpr` -> `#if`, and move the debug member |
| `number/posit/posit_impl.hpp` | 35 | the `_io` layer split (the pilot proper) |
| `number/integer/integer_impl.hpp` | 10 | same |
| `native/manipulators.hpp` | 7 | same |
| `number/support/decimal.hpp` | 1 | same |
| `traits/arithmetic_traits.hpp` | — | `<sstream>`/`<iomanip>` for its three report functions |

## Measurement

```
posit.hpp   114,727 -> 114,710 lines   5 -> 5 I/O-family headers
```

## Compatibility decision (recorded in #1334)

Phase 1 had to settle this, and measurement overturned my earlier recommendation. **927 of the 930 `.cpp` files** in the test/app tree stream a value and 309 call `to_binary`/`color_print`, so making the core take the `posit.hpp` name would have turned every rollout PR into a thousand-file mechanical diff. Decided: **the umbrella keeps its name**, and the core becomes a new opt-in `posit/core.hpp`.

## Test Results

| check | result |
|---|---|
| umbrellas, gcc 13.3 | **38/38** clean |
| umbrellas, clang 18.1 | **38/38** clean |
| umbrellas, riscv64-linux-gnu cross | **38/38** clean |
| `TRACE_URMUL=1`, `TRACE_DIV=1` | both still compile |
| CI_LITE build | no compiler errors |
| CI_LITE `ctest -j4` | **456/456 passed** |

The RISC-V cross sweep is now run locally on every header change, after #1386 broke that platform.

## Test plan

- [ ] Fast CI passes
- [ ] CodeRabbit review

Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable tracing controls for low-level multiplication and division operations.
  * Diagnostic tracing can now be enabled by callers when needed, while remaining disabled by default.
* **Performance and Compatibility**
  * Reduced unnecessary console-stream dependencies when tracing is not enabled.
  * Preserved existing tracing settings for applications that already configure these controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->