### PR TITLE
refactor(posit): split posit into core / io / debug layers (#1334 pilot)

### DIFF
--- a/include/sw/universal/number/posit/core.hpp
+++ b/include/sw/universal/number/posit/core.hpp
@@ -1,0 +1,28 @@
+#pragma once
+// core.hpp: the posit arithmetic core -- no I/O, no introspection
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the posit headers (#1334). Storage, arithmetic, comparison,
+// numeric_limits and traits -- everything a compute kernel needs and nothing
+// that turns a posit into text.
+//
+//     #include <universal/number/posit/posit.hpp>   // everything, as before
+//     #include <universal/number/posit/core.hpp>    // arithmetic only
+//
+// posit.hpp includes this header plus posit_io.hpp and posit_debug.hpp, so
+// existing code is unaffected. Reach for core.hpp in a translation unit that
+// only computes: it does not pull <iostream>, <sstream> or <iomanip>.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/posit/exceptions.hpp>
+#include <universal/number/posit/posit_fwd.hpp>
+#include <universal/number/posit/posit_scale_helpers.hpp>
+#include <universal/number/posit/posit_impl.hpp>
+#include <universal/traits/posit_traits.hpp>
+#include <universal/number/posit/numeric_limits.hpp>

--- a/include/sw/universal/number/posit/debug.hpp
+++ b/include/sw/universal/number/posit/debug.hpp
@@ -1,0 +1,41 @@
+#pragma once
+// debug.hpp: introspection for posit
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 3 of the posit headers (#1334). posit_impl.hpp declares
+// constexprClassParameters() and showLimbs() but does not define them, so it
+// needs no <iostream>. Include this header to call either.
+#include <iostream>
+#include <universal/number/posit/posit_impl.hpp>
+#include <universal/number/posit/manipulators.hpp>   // to_binary used by the dumps below
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned es, typename bt>
+void posit<nbits, es, bt>::constexprClassParameters() const noexcept {
+	std::cout << "-------------------------------------------------------------\n";
+	std::cout << "type              : " << type_tag(*this) << '\n';
+	std::cout << "nbits             : " << nbits << '\n';
+	std::cout << "es                : " << es << std::endl;
+	std::cout << "ALL_ONES          : " << to_binary(ALL_ONES, 0, true) << '\n';
+	std::cout << "BLOCK_MASK        : " << to_binary(BLOCK_MASK, 0, true) << '\n';
+	std::cout << "nrBlocks          : " << nrBlocks << '\n';
+	std::cout << "bits in MSU       : " << bitsInMSU << '\n';
+	std::cout << "MSU               : " << MSU << '\n';
+	std::cout << "MSU MASK          : " << to_binary(MSU_MASK, 0, true) << '\n';
+	std::cout << "SIGN_BIT_MASK     : " << to_binary(SIGN_BIT_MASK, 0, true) << '\n';
+	std::cout << "LSB_BIT_MASK      : " << to_binary(LSB_BIT_MASK, 0, true) << '\n';
+}
+template<unsigned nbits, unsigned es, typename bt>
+void posit<nbits, es, bt>::showLimbs() const {
+	for (unsigned b = 0; b < nrBlocks; ++b) {
+		std::cout << to_binary(_block[nrBlocks - b - 1], sizeof(bt) * 8) << ' ';
+	}
+	std::cout << '\n';
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/posit/iostream.hpp
+++ b/include/sw/universal/number/posit/iostream.hpp
@@ -12,6 +12,9 @@
 // only what genuinely needs the stream types: operator<< and operator>>.
 //
 // posit.hpp includes both, so existing code is unaffected.
+#include <ios>
+#include <sstream>
+#include <string>
 #include <iostream>
 #include <universal/number/posit/posit_impl.hpp>
 #include <universal/number/posit/manipulators.hpp>   // to_hex/parse used below

--- a/include/sw/universal/number/posit/iostream.hpp
+++ b/include/sw/universal/number/posit/iostream.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <iostream>
 #include <universal/number/posit/posit_impl.hpp>
-#include <universal/number/posit/manipulators.hpp>   // to_hex/parse used below
+#include <universal/number/posit/manipulators.hpp>   // to_hex/parse/quadrant used below
 
 namespace sw { namespace universal {
 
@@ -92,5 +92,77 @@ inline std::istream& operator>> (std::istream& istr, posit<nbits, es, bt>& p) {
 	}
 	return istr;
 }
+
+
+// pretty_print and info_print stream the posit itself, so they need operator<<
+// and belong in this layer rather than with the pure string producers in
+// manipulators.hpp. Moved here on review of #1390.
+
+	template<unsigned nbits, unsigned es, typename bt>
+	std::string pretty_print(const posit<nbits, es, bt>& p,
+			int printPrecision = std::numeric_limits<double>::max_digits10) {
+		constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);
+		std::stringstream str;
+		bool		     		     _sign;
+		positRegime<nbits, es, bt>   _regime;
+		positExponent<nbits, es, bt> _exponent;
+		positFraction<fbits, bt>     _fraction;
+		decode(p.bits(), _sign, _regime, _exponent, _fraction);
+		str << ( _sign ? "s1 r" : "s0 r" );
+		blockbinary<nbits - 1, bt, BinaryNumberType::Unsigned> r = _regime.bits();
+		int regimeBits = (int)_regime.nrBits();
+		int nrOfRegimeBitsProcessed = 0;
+		for (int i = nbits - 2; i >= 0; --i) {
+			if (regimeBits > nrOfRegimeBitsProcessed++) {
+				str << (r.test(static_cast<unsigned>(i)) ? "1" : "0");
+			}
+		}
+		str << " e";
+		std::uint32_t expBits = _exponent.bits();
+		int exponentBits = (int)_exponent.nrBits();
+		int nrOfExponentBitsProcessed = 0;
+		for (int i = int(es) - 1; i >= 0; --i) {
+			if (exponentBits > nrOfExponentBitsProcessed++) {
+				str << ((expBits >> i) & 1 ? "1" : "0");
+			}
+		}
+		str << " f";
+		if constexpr (fbits > 0) {
+			blockbinary<fbits, bt, BinaryNumberType::Unsigned> f = _fraction.bits();
+			int fractionBits = (int)_fraction.nrBits();
+			int nrOfFractionBitsProcessed = 0;
+			for (int i = int(fbits) - 1; i >= 0; --i) {
+				if (fractionBits > nrOfFractionBitsProcessed++) {
+					str << (f.test(static_cast<unsigned>(i)) ? "1" : "0");
+				}
+			}
+		}
+		str << " q";
+		str << quadrant(p) << " v"
+			<< std::setprecision(printPrecision) << p
+			<< std::setprecision(0);
+		return str.str();
+	}
+
+	template<unsigned nbits, unsigned es, typename bt>
+	std::string info_print(const posit<nbits, es, bt>& p, int printPrecision = 17) {
+		constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);
+		std::stringstream str;
+		bool		     		     _sign;
+		positRegime<nbits, es, bt>   _regime;
+		positExponent<nbits, es, bt> _exponent;
+		positFraction<fbits, bt>     _fraction;
+		decode(p.bits(), _sign, _regime, _exponent, _fraction);
+
+		str << "raw: " << p.bits() << " "
+			<< quadrant(p) << " "
+			<< (_sign ? "s1 r" : "s0 r")
+			<< _regime << " e"
+			<< _exponent << " f"
+			<< _fraction << " : value "
+			<< std::setprecision(printPrecision) << p
+			<< std::setprecision(0);
+		return str.str();
+	}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/posit/iostream.hpp
+++ b/include/sw/universal/number/posit/iostream.hpp
@@ -1,0 +1,93 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for posit
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The <iostream> half of the posit text layer (#1334). manipulators.hpp is the
+// <iomanip> half -- everything that turns a posit into a std::string, which is
+// where the library already keeps to_binary/to_hex/color_print. This header holds
+// only what genuinely needs the stream types: operator<< and operator>>.
+//
+// posit.hpp includes both, so existing code is unaffected.
+#include <iostream>
+#include <universal/number/posit/posit_impl.hpp>
+#include <universal/number/posit/manipulators.hpp>   // to_hex/parse used below
+
+namespace sw { namespace universal {
+
+// generate a posit format ASCII format nbits.esxNN...NNp
+template<unsigned nbits, unsigned es, typename bt>
+inline std::ostream& operator<<(std::ostream& ostr, const posit<nbits, es, bt>& p) {
+#if POSIT_ERROR_FREE_IO_FORMAT
+	std::stringstream ss;
+	ss << nbits << '.' << es << 'x' << to_hex(p.bits()) << 'p';
+	return ostr << ss.str();
+#else
+	std::ios_base::fmtflags fmt = ostr.flags();
+	std::streamsize prec = ostr.precision();
+	std::streamsize width = ostr.width();
+	char fillChar = ostr.fill();
+	bool bShowpos    = fmt & std::ios_base::showpos;
+	bool bUppercase  = fmt & std::ios_base::uppercase;
+	bool bFixed      = fmt & std::ios_base::fixed;
+	bool bScientific = fmt & std::ios_base::scientific;
+	bool bInternal   = fmt & std::ios_base::internal;
+	bool bLeft       = fmt & std::ios_base::left;
+
+	if (p.isnar()) {
+		std::string s = bUppercase ? "NAR" : "nar";
+		if (width > 0 && s.length() < static_cast<size_t>(width)) {
+			size_t pad = static_cast<size_t>(width) - s.length();
+			if (bLeft) { s.append(pad, fillChar); }
+			else { s.insert(static_cast<std::string::size_type>(0), pad, fillChar); }
+		}
+		return ostr << s;
+	}
+
+	constexpr unsigned pfbits = posit<nbits, es, bt>::fbits;
+	if constexpr (pfbits == 0) {
+		// degenerate posit with no fraction bits: format via double
+		std::ostringstream oss;
+		oss.precision(prec);
+		if (bFixed) oss << std::fixed;
+		if (bScientific) oss << std::scientific;
+		if (bUppercase) oss << std::uppercase;
+		if (bShowpos) oss << std::showpos;
+		oss << static_cast<double>(p);
+		std::string s = oss.str();
+		if (width > 0 && s.length() < static_cast<size_t>(width)) {
+			size_t pad = static_cast<size_t>(width) - s.length();
+			if (bInternal) {
+				bool hasSign = !s.empty() && (s[0] == '-' || s[0] == '+');
+				s.insert(hasSign ? 1u : 0u, pad, fillChar);
+			} else if (bLeft) { s.append(pad, fillChar); }
+			else { s.insert(0u, pad, fillChar); }
+		}
+		return ostr << s;
+	} else {
+		auto v = p.template to_value<BlockTripleOperator::REP>();
+		return ostr << v.to_string(prec, width, bFixed, bScientific,
+		                            bInternal, bLeft, bShowpos, bUppercase, fillChar);
+	}
+#endif
+}
+
+// parse a posit from a string in either posit hex format (nbits.esxHEXVALUEp)
+
+
+// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
+template<unsigned nbits, unsigned es, typename bt>
+inline std::istream& operator>> (std::istream& istr, posit<nbits, es, bt>& p) {
+	std::string txt;
+	istr >> txt;
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/posit/manipulators.hpp
+++ b/include/sw/universal/number/posit/manipulators.hpp
@@ -7,6 +7,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include <iomanip>
+#include <string>
+#include <sstream>
 #include <cmath>  // for frexp/frexpf
 #include <typeinfo>  // for typeid()
 
@@ -190,6 +192,243 @@ namespace sw { namespace universal {
 		str << def;
 		return str.str();
 	}
+
+
+
+// ---------------------------------------------------------------------------
+// text produced from a posit (#1334). These lived in posit_impl.hpp, which
+// made every translation unit that did arithmetic pay for <sstream>/<iomanip>.
+// manipulators.hpp is where the library already keeps to_binary/to_hex and the
+// other string producers, so they belong here rather than in a header of their own.
+// ---------------------------------------------------------------------------
+
+
+////////////////// POSIT operators
+
+// stream operators
+
+
+// generate a posit format ASCII format nbits.esxNN...NNp
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string hex_format(const posit<nbits, es, bt>& p) {
+	// we need to transform the posit into a string
+	std::stringstream ss;
+	ss << nbits << '.' << es << 'x' << to_hex(p.bits()) << 'p';
+	return ss.str();
+}
+
+template<typename Float>
+inline std::string hex_format(Float f) {
+	std::stringstream ss;
+	ss << std::hexfloat << std::setprecision(std::numeric_limits<Float>::digits10) << f;
+	return ss.str();
+}
+
+
+// convert a posit value to a string using "nar" as designation of NaR
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string to_string(const posit<nbits, es, bt>& p, std::streamsize precision = 17) {
+	if (p.isnar()) return std::string("nar");
+	constexpr unsigned pfbits = posit<nbits, es, bt>::fbits;
+	if constexpr (pfbits == 0) {
+		std::ostringstream oss;
+		oss << std::setprecision(precision) << static_cast<double>(p);
+		return oss.str();
+	} else {
+		auto v = p.template to_value<BlockTripleOperator::REP>();
+		return v.to_string(precision, 0, false, true, false, false, false, false, ' ');
+	}
+}
+
+
+// binary representation of a posit with delimiters: i.e. 0.10.00.000000 => sign.regime.exp.fraction
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string to_binary(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
+	
+	constexpr unsigned fbits = (es + 2ull >= nbits ? 0ull : nbits - 3ull - es);             // maximum number of fraction bits: derived
+
+	bool negative{ false };
+	positRegime<nbits, es, bt> r;
+	positExponent<nbits, es, bt> e;
+	positFraction<fbits, bt> f;
+	auto raw = number.bits();
+	extract_fields(raw, negative, r, e, f);
+
+	std::stringstream s;
+	s << (negative ? "0b1." : "0b0.");
+	s << to_string(r, false, nibbleMarker) << "."
+	  << to_string(e, false, nibbleMarker) << "."
+	  << to_string(f, false, nibbleMarker);
+
+	return s.str();
+}
+
+
+// native semantic representation: radix-2, delegates to to_binary
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string to_native(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
+	return to_binary(number, nibbleMarker);
+}
+
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string to_triple(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
+	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);             // maximum number of fraction bits: derived
+
+	bool s{ false };
+	positRegime<nbits, es, bt> r;
+	positExponent<nbits, es, bt> e;
+	positFraction<fbits, bt> f;
+	blockbinary<nbits, bt> raw = number.bits();
+	std::stringstream ss;
+	extract_fields(raw, s, r, e, f);
+
+	if (number.iszero()) {
+		ss << "(+, 0, ~)";
+	}
+	else if (number.isnar()) {
+		ss << "(nar)";
+	}
+	else {
+		ss << (s ? "(-, " : "(+, ");
+		ss << r.scale() + e.scale()
+		   << ", "
+		   << to_string(f, false, nibbleMarker)
+		   << ')';
+	}
+
+	return ss.str();
+}
+
+
+
+// binary exponent representation: i.e. 1.0101010e2^-37
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string to_base2_scientific(const posit<nbits, es, bt>& number) {
+	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);             // maximum number of fraction bits: derived
+	bool s{ false };
+	scale(number);
+	positRegime<nbits, es, bt> r;
+	positExponent<nbits, es, bt> e;
+	positFraction<fbits, bt> f;
+	blockbinary<nbits, bt> raw = number.bits();
+	std::stringstream ss;
+	extract_fields(raw, s, r, e, f);
+	ss << (s ? "-" : "+") << "1." << to_string(f, true) << "e2^" << std::showpos << r.scale() + e.scale();
+	return ss.str();
+}
+
+
+
+// quadrant returns a two character string indicating the quadrant of the projective reals the posit resides: from 0, SE, NE, NaR, NW, SW
+template<unsigned nbits, unsigned es, typename bt>
+std::string quadrant(const posit<nbits, es, bt>& p) {
+	posit<nbits, es, bt> pOne(1), pMinusOne(-1);
+	if (sign(p)) {
+		// west
+		if (p > pMinusOne) {
+			return "SW";
+		}
+		else {
+			return "NW";
+		}
+	}
+	else {
+		// east
+		if (p < pOne) {
+			return "SE";
+		}
+		else {
+			return "NE";
+		}
+	}
+}
+
+
+
+// or a decimal floating-point representation
+template<unsigned nbits, unsigned es, typename bt>
+bool parse(const std::string& txt, posit<nbits, es, bt>& p) {
+	// check if the txt is of the native posit form: nbits.esXhexvalue
+	std::regex posit_regex(R"(^[0-9]+\.[0-9]+[xX][0-9A-Fa-f]+p?$)");
+	if (std::regex_match(txt, posit_regex)) {
+		// found a posit representation: parse nbits.esxHEXVALUEp
+		std::string nbitsStr, esStr, bitStr;
+		auto it = txt.begin();
+		for (; it != txt.end(); ++it) {
+			if (*it == '.') break;
+			nbitsStr.append(1, *it);
+		}
+		for (++it; it != txt.end(); ++it) {
+			if (*it == 'x' || *it == 'X') break;
+			esStr.append(1, *it);
+		}
+		for (++it; it != txt.end(); ++it) {
+			if (*it == 'p') break;
+			bitStr.append(1, *it);
+		}
+		unsigned nbits_in = 0;
+		unsigned es_in = 0;
+		{
+			std::istringstream ss(nbitsStr);
+			ss >> nbits_in;
+			if (ss.fail()) return false;
+		}
+		{
+			std::istringstream ss(esStr);
+			ss >> es_in;
+			if (ss.fail()) return false;
+		}
+		// native posit form must match target configuration
+		if (nbits_in != nbits || es_in != es) return false;
+		uint64_t raw = 0;
+		std::istringstream ss(bitStr);
+		ss >> std::hex >> raw;
+		if (ss.fail()) return false;
+		ss >> std::ws;
+		if (!ss.eof()) return false;
+		p.setbits(raw);
+		return true;
+	}
+	else {
+		// Decimal floating-point representation.
+		// Route through the high-precision decimal_to_binary utility so that
+		// wide posit configurations (nbits > 64) don't lose precision through
+		// an intermediate double. The utility delivers a normalized mantissa
+		// with target_mantissa_bits bits plus guard/sticky; we feed that
+		// directly into convert_<>() so rounding is done once in the posit
+		// encoding step.
+		// Special-value literals (nan / inf in any common spelling) map to NaR.
+		{
+			std::string t; t.reserve(txt.size());
+			for (char c : txt) t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+			std::string body = t;
+			if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+			if (body == "nan" || body == "inf" || body == "infinity") {
+				p.setnar();
+				return true;
+			}
+		}
+		constexpr unsigned extractBits         = nbits + 4;
+		constexpr unsigned target_mantissa_bits = extractBits + 1;
+		auto d = ::sw::universal::decimal_to_binary::convert(
+			std::string_view{txt}, target_mantissa_bits);
+		if (!d.valid) return false;
+		if (d.is_zero) {
+			p.setzero();
+			return true;
+		}
+		blocksignificand<extractBits, bt> frac;
+		for (unsigned i = 0; i < extractBits; ++i) {
+			if (d.mantissa.at(i)) frac.setbit(i, true);
+		}
+		// Fold d2b's residual guard/sticky into the lowest bit so convert_'s
+		// own sticky accumulator picks them up.
+		if (d.guard_bit || d.sticky_bit) frac.setbit(0, true);
+		convert_<nbits, es, bt, extractBits>(d.negative,
+			static_cast<int>(d.binary_scale), frac, p);
+		return true;
+	}
+}
 
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/posit/manipulators.hpp
+++ b/include/sw/universal/number/posit/manipulators.hpp
@@ -20,6 +20,8 @@
 
 // pull in the color printing for shells utility
 #include <universal/utility/color_print.hpp>
+#include <universal/number/posit/core.hpp>        // the type itself
+#include <universal/number/posit/attributes.hpp>  // sign(), used by quadrant()
 
 // This file contains functions that manipulate a posit type
 // using posit number system knowledge.
@@ -79,71 +81,7 @@ namespace sw { namespace universal {
 		return str.str();
 	}
 
-	template<unsigned nbits, unsigned es, typename bt>
-	std::string pretty_print(const posit<nbits, es, bt>& p, int printPrecision = std::numeric_limits<double>::max_digits10) {
-		constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);
-		std::stringstream str;
-		bool		     		     _sign;
-		positRegime<nbits, es, bt>   _regime;
-		positExponent<nbits, es, bt> _exponent;
-		positFraction<fbits, bt>     _fraction;
-		decode(p.bits(), _sign, _regime, _exponent, _fraction);
-		str << ( _sign ? "s1 r" : "s0 r" );
-		blockbinary<nbits - 1, bt, BinaryNumberType::Unsigned> r = _regime.bits();
-		int regimeBits = (int)_regime.nrBits();
-		int nrOfRegimeBitsProcessed = 0;
-		for (int i = nbits - 2; i >= 0; --i) {
-			if (regimeBits > nrOfRegimeBitsProcessed++) {
-				str << (r.test(static_cast<unsigned>(i)) ? "1" : "0");
-			}
-		}
-		str << " e";
-		std::uint32_t expBits = _exponent.bits();
-		int exponentBits = (int)_exponent.nrBits();
-		int nrOfExponentBitsProcessed = 0;
-		for (int i = int(es) - 1; i >= 0; --i) {
-			if (exponentBits > nrOfExponentBitsProcessed++) {
-				str << ((expBits >> i) & 1 ? "1" : "0");
-			}
-		}
-		str << " f";
-		if constexpr (fbits > 0) {
-			blockbinary<fbits, bt, BinaryNumberType::Unsigned> f = _fraction.bits();
-			int fractionBits = (int)_fraction.nrBits();
-			int nrOfFractionBitsProcessed = 0;
-			for (int i = int(fbits) - 1; i >= 0; --i) {
-				if (fractionBits > nrOfFractionBitsProcessed++) {
-					str << (f.test(static_cast<unsigned>(i)) ? "1" : "0");
-				}
-			}
-		}
-		str << " q";
-		str << quadrant(p) << " v"
-			<< std::setprecision(printPrecision) << p
-			<< std::setprecision(0);
-		return str.str();
-	}
 
-	template<unsigned nbits, unsigned es, typename bt>
-	std::string info_print(const posit<nbits, es, bt>& p, int printPrecision = 17) {
-		constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);
-		std::stringstream str;
-		bool		     		     _sign;
-		positRegime<nbits, es, bt>   _regime;
-		positExponent<nbits, es, bt> _exponent;
-		positFraction<fbits, bt>     _fraction;
-		decode(p.bits(), _sign, _regime, _exponent, _fraction);
-
-		str << "raw: " << p.bits() << " "
-			<< quadrant(p) << " "
-			<< (_sign ? "s1 r" : "s0 r")
-			<< _regime << " e"
-			<< _exponent << " f"
-			<< _fraction << " : value "
-			<< std::setprecision(printPrecision) << p
-			<< std::setprecision(0);
-		return str.str();
-	}
 
 	template<unsigned nbits, unsigned es, typename bt>
 	std::string color_print(const posit<nbits, es, bt>& p) {

--- a/include/sw/universal/number/posit/manipulators.hpp
+++ b/include/sw/universal/number/posit/manipulators.hpp
@@ -6,6 +6,12 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cctype>
+#include <cstdint>
+#include <ios>
+#include <limits>
+#include <regex>
+#include <string_view>
 #include <iomanip>
 #include <string>
 #include <sstream>
@@ -245,7 +251,8 @@ inline std::string to_string(const posit<nbits, es, bt>& p, std::streamsize prec
 template<unsigned nbits, unsigned es, typename bt>
 inline std::string to_binary(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
 	
-	constexpr unsigned fbits = (es + 2ull >= nbits ? 0ull : nbits - 3ull - es);             // maximum number of fraction bits: derived
+	// maximum number of fraction bits: derived
+	constexpr unsigned fbits = (es + 2ull >= nbits ? 0ull : nbits - 3ull - es);
 
 	bool negative{ false };
 	positRegime<nbits, es, bt> r;
@@ -272,7 +279,8 @@ inline std::string to_native(const posit<nbits, es, bt>& number, bool nibbleMark
 
 template<unsigned nbits, unsigned es, typename bt>
 inline std::string to_triple(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
-	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);             // maximum number of fraction bits: derived
+	// maximum number of fraction bits: derived
+	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);
 
 	bool s{ false };
 	positRegime<nbits, es, bt> r;
@@ -304,7 +312,8 @@ inline std::string to_triple(const posit<nbits, es, bt>& number, bool nibbleMark
 // binary exponent representation: i.e. 1.0101010e2^-37
 template<unsigned nbits, unsigned es, typename bt>
 inline std::string to_base2_scientific(const posit<nbits, es, bt>& number) {
-	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);             // maximum number of fraction bits: derived
+	// maximum number of fraction bits: derived
+	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);
 	bool s{ false };
 	scale(number);
 	positRegime<nbits, es, bt> r;
@@ -319,7 +328,8 @@ inline std::string to_base2_scientific(const posit<nbits, es, bt>& number) {
 
 
 
-// quadrant returns a two character string indicating the quadrant of the projective reals the posit resides: from 0, SE, NE, NaR, NW, SW
+// quadrant returns a two character string indicating the quadrant of the
+// projective reals the posit resides in: from 0, SE, NE, NaR, NW, SW
 template<unsigned nbits, unsigned es, typename bt>
 std::string quadrant(const posit<nbits, es, bt>& p) {
 	posit<nbits, es, bt> pOne(1), pMinusOne(-1);

--- a/include/sw/universal/number/posit/posit.hpp
+++ b/include/sw/universal/number/posit/posit.hpp
@@ -57,17 +57,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/posit/exceptions.hpp>
-#include <universal/number/posit/posit_fwd.hpp>
-//#include <universal/number/posit/posit_parse.hpp>
-#include <universal/number/posit/posit_scale_helpers.hpp>
-#include <universal/number/posit/posit_impl.hpp>
-#include <universal/traits/posit_traits.hpp>
-#include <universal/number/posit/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a
+// translation unit that only computes -- it pulls no <iostream>/<sstream>.
+#include <universal/number/posit/core.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // useful functions to work with posits
 #include <universal/number/posit/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/posit/iostream.hpp>
+// layer 3: introspection -- constexprClassParameters, showLimbs
+#include <universal/number/posit/debug.hpp>
 #include <universal/number/posit/attributes.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -1,4 +1,22 @@
 #pragma once
+// POSIT_TRACE_ENABLED: the trace statements below print, so they need <iostream>.
+// They are compiled only when tracing is actually switched on -- the guard is a
+// preprocessor one rather than `if constexpr` because a discarded `if constexpr`
+// branch still requires std::cout to be DECLARED, which would keep <iostream> in
+// the include graph of every translation unit. See #1334.
+#if defined(ALGORITHM_VERBOSE_OUTPUT) || defined(ALGORITHM_TRACE_ALL) \
+ || defined(ALGORITHM_TRACE_DECODE)   || defined(ALGORITHM_TRACE_CONVERSION) \
+ || defined(ALGORITHM_TRACE_ROUNDING) || defined(ALGORITHM_TRACE_ADD) \
+ || defined(ALGORITHM_TRACE_SUB)      || defined(ALGORITHM_TRACE_MUL) \
+ || defined(ALGORITHM_TRACE_DIV)      || defined(ALGORITHM_TRACE_RECIPROCAL)
+#define POSIT_TRACE_ENABLED 1
+#include <iostream>
+#include <iomanip>
+#else
+#define POSIT_TRACE_ENABLED 0
+#endif
+#include <iosfwd>   // std::ostream/std::istream in the friend declarations
+
 // posit_impl.hpp: implementation of fixed-size arbitrary configuration generalized posits
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
@@ -8,11 +26,8 @@
 #include <cmath>
 #include <cassert>
 #include <cctype>
-#include <iostream>
-#include <iomanip>
 #include <limits>
 #include <regex>
-#include <sstream>
 #include <string_view>
 #include <type_traits>
 
@@ -246,26 +261,36 @@ constexpr void decode(const blockbinary<nbits, bt, BinaryNumberType::Signed>& ra
 			extract_fields(raw_bits, _sign, _regime, _exponent, _fraction);
 		}
 	}
+#if POSIT_TRACE_ENABLED
 	if constexpr (_trace_decode) std::cout << "raw bits: " << raw_bits << " posit bits: " << (_sign ? "1|" : "0|") << _regime << "|" << _exponent << "|" << _fraction << std::endl;
+#endif
 }
 
 #ifdef TBD
 // needed to avoid double rounding situations during arithmetic: TODO: does that mean the condensed version below should be removed?
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits>
 inline blockbinary<nbits, bt, BinaryNumberType::Signed>& convert_to_bb(bool _sign, int _scale, const blockbinary<fbits, bt>& fraction_in, blockbinary<nbits, bt, BinaryNumberType::Signed>& ptt) {
+#if POSIT_TRACE_ENABLED
 	if (_trace_conversion) std::cout << "------------------- CONVERT ------------------" << std::endl;
+#endif
+#if POSIT_TRACE_ENABLED
 	if (_trace_conversion) std::cout << "sign " << (_sign ? "-1 " : " 1 ") << "scale " << std::setw(3) << _scale << " fraction " << fraction_in << std::endl;
+#endif
 
 	ptt.reset(); // ptt will yield the final bits of the posit
 	// construct the posit
 	// interpolation rule checks
 	if (check_inward_projection_range<nbits, es>(_scale)) {    // regime dominated
+#if POSIT_TRACE_ENABLED
 		if (_trace_conversion) std::cout << "inward projection" << std::endl;
+#endif
 		// we are projecting to minpos/maxpos
 		int k = calculate_unconstrained_k<nbits, es>(_scale);
 		ptt = k < 0 ? minpos_pattern<nbits, es>(_sign) : maxpos_pattern<nbits, es>(_sign);
 		// we are done
+#if POSIT_TRACE_ENABLED
 		if (_trace_rounding) std::cout << "projection  rounding ";
+#endif
 	}
 	else {
 		const unsigned pt_len = nbits + 3 + es;
@@ -325,19 +350,27 @@ inline blockbinary<nbits, bt, BinaryNumberType::Signed>& convert_to_bb(bool _sig
 // needed to avoid double rounding situations during arithmetic: TODO: does that mean the condensed version below should be removed?
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits>
 constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const blocksignificand<fbits, bt>& fraction_in, posit<nbits, es, bt>& p) {
+#if POSIT_TRACE_ENABLED
 	if constexpr (_trace_conversion) std::cout << "------------------- CONVERT ------------------" << std::endl;
+#endif
+#if POSIT_TRACE_ENABLED
 	if constexpr (_trace_conversion) std::cout << "sign " << (_sign ? "-1 " : " 1 ") << "scale " << std::setw(3) << _scale << " fraction " << fraction_in << std::endl;
+#endif
 
 	p.clear();
 	// construct the posit
 	// interpolation rule checks
 	if (check_inward_projection_range<nbits, es, bt>(_scale)) {    // regime dominated
+#if POSIT_TRACE_ENABLED
 		if constexpr (_trace_conversion) std::cout << "inward projection" << std::endl;
+#endif
 		// we are projecting to minpos/maxpos or minneg/maxneg
 		int k = calculate_unconstrained_k<nbits, es>(_scale);
 		k < 0 ? (_sign ? p.minneg() : p.minpos()) : (_sign ? p.maxneg() : p.maxpos());
 		// we are done
+#if POSIT_TRACE_ENABLED
 		if constexpr (_trace_rounding) std::cout << "projection  rounding ";
+#endif
 	}
 	else {
 		constexpr unsigned pt_len = nbits + 3 + es;
@@ -400,8 +433,12 @@ constexpr inline posit<nbits, es, bt>& convert_(bool _sign, int _scale, const bl
 // convert a floating point value to a specific posit configuration. Semantically, p = v, return reference to p
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits, BlockTripleOperator op>
 constexpr inline posit<nbits, es, bt>& convert(const blocktriple<fbits, op, bt>& v, posit<nbits, es, bt>& p) {
+#if POSIT_TRACE_ENABLED
 	if constexpr (_trace_conversion) std::cout << "------------------- CONVERT ------------------" << '\n';
+#endif
+#if POSIT_TRACE_ENABLED
 	if constexpr (_trace_conversion) std::cout << to_triple(v) << " : " << v << '\n';
+#endif
 
 	if (v.iszero()) {
 		p.setzero();
@@ -444,29 +481,6 @@ constexpr inline posit<nbits, es, bt>& convert(const blocktriple<fbits, op, bt>&
 	return convert_<nbits, es, bt, extractBits>(v.sign(), realScale, frac, p);
 }
 
-// quadrant returns a two character string indicating the quadrant of the projective reals the posit resides: from 0, SE, NE, NaR, NW, SW
-template<unsigned nbits, unsigned es, typename bt>
-std::string quadrant(const posit<nbits, es, bt>& p) {
-	posit<nbits, es, bt> pOne(1), pMinusOne(-1);
-	if (sign(p)) {
-		// west
-		if (p > pMinusOne) {
-			return "SW";
-		}
-		else {
-			return "NW";
-		}
-	}
-	else {
-		// east
-		if (p < pOne) {
-			return "SE";
-		}
-		else {
-			return "NE";
-		}
-	}
-}
 
 // Construct posit from its components
 template<unsigned nbits, unsigned es, typename bt, unsigned fbits>
@@ -671,7 +685,9 @@ public:
 
 	// we model a hw pipeline with register assignments, functional block, and conversion
 	constexpr posit& operator+=(const posit& rhs) {
+#if POSIT_TRACE_ENABLED
 		if constexpr (_trace_add) std::cout << "---------------------- ADD -------------------" << std::endl;
+#endif
 		// special case handling of the inputs
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
 		if (isnar() || rhs.isnar()) {
@@ -721,7 +737,9 @@ public:
 	}
 	constexpr posit& operator*=(const posit& rhs) {
 		static_assert(fhbits > 0, "posit configuration does not support multiplication");
+#if POSIT_TRACE_ENABLED
 		if constexpr (_trace_mul) std::cout << "---------------------- MUL -------------------" << std::endl;
+#endif
 		// special case handling of the inputs
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
 		if (isnar() || rhs.isnar()) {
@@ -762,7 +780,9 @@ public:
 		return *this *= posit<nbits, es, bt>(rhs);
 	}
 	constexpr posit& operator/=(const posit& rhs) {
+#if POSIT_TRACE_ENABLED
 		if constexpr (_trace_div) std::cout << "---------------------- DIV -------------------" << std::endl;
+#endif
 #if POSIT_THROW_ARITHMETIC_EXCEPTION
 		if (rhs.iszero()) {
 			throw posit_divide_by_zero{};    // not throwing is a quiet signalling NaR
@@ -828,7 +848,9 @@ public:
 	}
 	
 	posit reciprocal() const noexcept {
+#if POSIT_TRACE_ENABLED
 		if (_trace_reciprocal) std::cout << "-------------------- RECIPROCAL ----------------" << std::endl;
+#endif
 		posit<nbits, es, bt> p;
 		// special case of NaR (Not a Real)
 		if (isnar()) {
@@ -863,22 +885,28 @@ public:
 			constexpr unsigned reciprocal_size = 3 * fbits + 4;
 			blockbinary<reciprocal_size> reciprocal;
 			divide_with_fraction(one, frac, reciprocal);
+#if POSIT_TRACE_ENABLED
 			if (_trace_reciprocal) {
 				std::cout << "one    " << one << std::endl;
 				std::cout << "frac   " << frac << std::endl;
 				std::cout << "recip  " << reciprocal << std::endl;
 			}
+#endif
 
 			// radix point falls at operand size == reciprocal_size - operand_size - 1
 			reciprocal <<= operand_size - 1;
+#if POSIT_TRACE_ENABLED
 			if (_trace_reciprocal) std::cout << "frac   " << reciprocal << std::endl;
+#endif
 			int new_scale = -scale(*this);
 			int msb = findMostSignificantBit(reciprocal);
 			if (msb > 0) {
 				int shift = static_cast<int>(reciprocal_size - static_cast<unsigned>(msb));
 				reciprocal <<= static_cast<unsigned>(shift);
 				new_scale -= (shift-1);
+#if POSIT_TRACE_ENABLED
 				if (_trace_reciprocal) std::cout << "result " << reciprocal << std::endl;
+#endif
 			}
 			//std::bitset<operand_size> tr;
 			//truncate(reciprocal, tr);
@@ -1172,26 +1200,10 @@ public:
 	}
 
 	// helper debug function
-	void constexprClassParameters() const noexcept {
-		std::cout << "-------------------------------------------------------------\n";
-		std::cout << "type              : " << type_tag(*this) << '\n';
-		std::cout << "nbits             : " << nbits << '\n';
-		std::cout << "es                : " << es << std::endl;
-		std::cout << "ALL_ONES          : " << to_binary(ALL_ONES, 0, true) << '\n';
-		std::cout << "BLOCK_MASK        : " << to_binary(BLOCK_MASK, 0, true) << '\n';
-		std::cout << "nrBlocks          : " << nrBlocks << '\n';
-		std::cout << "bits in MSU       : " << bitsInMSU << '\n';
-		std::cout << "MSU               : " << MSU << '\n';
-		std::cout << "MSU MASK          : " << to_binary(MSU_MASK, 0, true) << '\n';
-		std::cout << "SIGN_BIT_MASK     : " << to_binary(SIGN_BIT_MASK, 0, true) << '\n';
-		std::cout << "LSB_BIT_MASK      : " << to_binary(LSB_BIT_MASK, 0, true) << '\n';
-	}
-	void showLimbs() const {
-		for (unsigned b = 0; b < nrBlocks; ++b) {
-			std::cout << to_binary(_block[nrBlocks - b - 1], sizeof(bt) * 8) << ' ';
-		}
-		std::cout << '\n';
-	}
+	// helper debug functions; defined out-of-line in posit_debug.hpp so this header
+	// needs no <iostream>. Include that header to call them.
+	void constexprClassParameters() const noexcept;
+	void showLimbs() const;
 
 private:
 	blockbinary<nbits, bt, BinaryNumberType::Signed> _block;
@@ -1925,275 +1937,12 @@ inline bool ispowerof2(const posit<nbits, es, bt>& p) {
 	return p.ispowerof2();
 }
 
-////////////////// POSIT operators
-
-// stream operators
-
-// generate a posit format ASCII format nbits.esxNN...NNp
-template<unsigned nbits, unsigned es, typename bt>
-inline std::ostream& operator<<(std::ostream& ostr, const posit<nbits, es, bt>& p) {
-#if POSIT_ERROR_FREE_IO_FORMAT
-	std::stringstream ss;
-	ss << nbits << '.' << es << 'x' << to_hex(p.bits()) << 'p';
-	return ostr << ss.str();
-#else
-	std::ios_base::fmtflags fmt = ostr.flags();
-	std::streamsize prec = ostr.precision();
-	std::streamsize width = ostr.width();
-	char fillChar = ostr.fill();
-	bool bShowpos    = fmt & std::ios_base::showpos;
-	bool bUppercase  = fmt & std::ios_base::uppercase;
-	bool bFixed      = fmt & std::ios_base::fixed;
-	bool bScientific = fmt & std::ios_base::scientific;
-	bool bInternal   = fmt & std::ios_base::internal;
-	bool bLeft       = fmt & std::ios_base::left;
-
-	if (p.isnar()) {
-		std::string s = bUppercase ? "NAR" : "nar";
-		if (width > 0 && s.length() < static_cast<size_t>(width)) {
-			size_t pad = static_cast<size_t>(width) - s.length();
-			if (bLeft) { s.append(pad, fillChar); }
-			else { s.insert(static_cast<std::string::size_type>(0), pad, fillChar); }
-		}
-		return ostr << s;
-	}
-
-	constexpr unsigned pfbits = posit<nbits, es, bt>::fbits;
-	if constexpr (pfbits == 0) {
-		// degenerate posit with no fraction bits: format via double
-		std::ostringstream oss;
-		oss.precision(prec);
-		if (bFixed) oss << std::fixed;
-		if (bScientific) oss << std::scientific;
-		if (bUppercase) oss << std::uppercase;
-		if (bShowpos) oss << std::showpos;
-		oss << static_cast<double>(p);
-		std::string s = oss.str();
-		if (width > 0 && s.length() < static_cast<size_t>(width)) {
-			size_t pad = static_cast<size_t>(width) - s.length();
-			if (bInternal) {
-				bool hasSign = !s.empty() && (s[0] == '-' || s[0] == '+');
-				s.insert(hasSign ? 1u : 0u, pad, fillChar);
-			} else if (bLeft) { s.append(pad, fillChar); }
-			else { s.insert(0u, pad, fillChar); }
-		}
-		return ostr << s;
-	} else {
-		auto v = p.template to_value<BlockTripleOperator::REP>();
-		return ostr << v.to_string(prec, width, bFixed, bScientific,
-		                            bInternal, bLeft, bShowpos, bUppercase, fillChar);
-	}
-#endif
-}
-
-// parse a posit from a string in either posit hex format (nbits.esxHEXVALUEp)
-// or a decimal floating-point representation
-template<unsigned nbits, unsigned es, typename bt>
-bool parse(const std::string& txt, posit<nbits, es, bt>& p) {
-	// check if the txt is of the native posit form: nbits.esXhexvalue
-	std::regex posit_regex(R"(^[0-9]+\.[0-9]+[xX][0-9A-Fa-f]+p?$)");
-	if (std::regex_match(txt, posit_regex)) {
-		// found a posit representation: parse nbits.esxHEXVALUEp
-		std::string nbitsStr, esStr, bitStr;
-		auto it = txt.begin();
-		for (; it != txt.end(); ++it) {
-			if (*it == '.') break;
-			nbitsStr.append(1, *it);
-		}
-		for (++it; it != txt.end(); ++it) {
-			if (*it == 'x' || *it == 'X') break;
-			esStr.append(1, *it);
-		}
-		for (++it; it != txt.end(); ++it) {
-			if (*it == 'p') break;
-			bitStr.append(1, *it);
-		}
-		unsigned nbits_in = 0;
-		unsigned es_in = 0;
-		{
-			std::istringstream ss(nbitsStr);
-			ss >> nbits_in;
-			if (ss.fail()) return false;
-		}
-		{
-			std::istringstream ss(esStr);
-			ss >> es_in;
-			if (ss.fail()) return false;
-		}
-		// native posit form must match target configuration
-		if (nbits_in != nbits || es_in != es) return false;
-		uint64_t raw = 0;
-		std::istringstream ss(bitStr);
-		ss >> std::hex >> raw;
-		if (ss.fail()) return false;
-		ss >> std::ws;
-		if (!ss.eof()) return false;
-		p.setbits(raw);
-		return true;
-	}
-	else {
-		// Decimal floating-point representation.
-		// Route through the high-precision decimal_to_binary utility so that
-		// wide posit configurations (nbits > 64) don't lose precision through
-		// an intermediate double. The utility delivers a normalized mantissa
-		// with target_mantissa_bits bits plus guard/sticky; we feed that
-		// directly into convert_<>() so rounding is done once in the posit
-		// encoding step.
-		// Special-value literals (nan / inf in any common spelling) map to NaR.
-		{
-			std::string t; t.reserve(txt.size());
-			for (char c : txt) t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
-			std::string body = t;
-			if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
-			if (body == "nan" || body == "inf" || body == "infinity") {
-				p.setnar();
-				return true;
-			}
-		}
-		constexpr unsigned extractBits         = nbits + 4;
-		constexpr unsigned target_mantissa_bits = extractBits + 1;
-		auto d = ::sw::universal::decimal_to_binary::convert(
-			std::string_view{txt}, target_mantissa_bits);
-		if (!d.valid) return false;
-		if (d.is_zero) {
-			p.setzero();
-			return true;
-		}
-		blocksignificand<extractBits, bt> frac;
-		for (unsigned i = 0; i < extractBits; ++i) {
-			if (d.mantissa.at(i)) frac.setbit(i, true);
-		}
-		// Fold d2b's residual guard/sticky into the lowest bit so convert_'s
-		// own sticky accumulator picks them up.
-		if (d.guard_bit || d.sticky_bit) frac.setbit(0, true);
-		convert_<nbits, es, bt, extractBits>(d.negative,
-			static_cast<int>(d.binary_scale), frac, p);
-		return true;
-	}
-}
-
-// read an ASCII float or posit format: nbits.esxNN...NNp, for example: 32.2x80000000p
-template<unsigned nbits, unsigned es, typename bt>
-inline std::istream& operator>> (std::istream& istr, posit<nbits, es, bt>& p) {
-	std::string txt;
-	istr >> txt;
-	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a posit value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
-}
-
-// generate a posit format ASCII format nbits.esxNN...NNp
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string hex_format(const posit<nbits, es, bt>& p) {
-	// we need to transform the posit into a string
-	std::stringstream ss;
-	ss << nbits << '.' << es << 'x' << to_hex(p.bits()) << 'p';
-	return ss.str();
-}
-
-template<typename Float>
-inline std::string hex_format(Float f) {
-	std::stringstream ss;
-	ss << std::hexfloat << std::setprecision(std::numeric_limits<Float>::digits10) << f;
-	return ss.str();
-}
-
-// convert a posit value to a string using "nar" as designation of NaR
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string to_string(const posit<nbits, es, bt>& p, std::streamsize precision = 17) {
-	if (p.isnar()) return std::string("nar");
-	constexpr unsigned pfbits = posit<nbits, es, bt>::fbits;
-	if constexpr (pfbits == 0) {
-		std::ostringstream oss;
-		oss << std::setprecision(precision) << static_cast<double>(p);
-		return oss.str();
-	} else {
-		auto v = p.template to_value<BlockTripleOperator::REP>();
-		return v.to_string(precision, 0, false, true, false, false, false, false, ' ');
-	}
-}
-
-// binary representation of a posit with delimiters: i.e. 0.10.00.000000 => sign.regime.exp.fraction
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string to_binary(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
-	
-	constexpr unsigned fbits = (es + 2ull >= nbits ? 0ull : nbits - 3ull - es);             // maximum number of fraction bits: derived
-
-	bool negative{ false };
-	positRegime<nbits, es, bt> r;
-	positExponent<nbits, es, bt> e;
-	positFraction<fbits, bt> f;
-	auto raw = number.bits();
-	extract_fields(raw, negative, r, e, f);
-
-	std::stringstream s;
-	s << (negative ? "0b1." : "0b0.");
-	s << to_string(r, false, nibbleMarker) << "."
-	  << to_string(e, false, nibbleMarker) << "."
-	  << to_string(f, false, nibbleMarker);
-
-	return s.str();
-}
-
-// native semantic representation: radix-2, delegates to to_binary
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string to_native(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
-	return to_binary(number, nibbleMarker);
-}
-
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string to_triple(const posit<nbits, es, bt>& number, bool nibbleMarker = false) {
-	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);             // maximum number of fraction bits: derived
-
-	bool s{ false };
-	positRegime<nbits, es, bt> r;
-	positExponent<nbits, es, bt> e;
-	positFraction<fbits, bt> f;
-	blockbinary<nbits, bt> raw = number.bits();
-	std::stringstream ss;
-	extract_fields(raw, s, r, e, f);
-
-	if (number.iszero()) {
-		ss << "(+, 0, ~)";
-	}
-	else if (number.isnar()) {
-		ss << "(nar)";
-	}
-	else {
-		ss << (s ? "(-, " : "(+, ");
-		ss << r.scale() + e.scale()
-		   << ", "
-		   << to_string(f, false, nibbleMarker)
-		   << ')';
-	}
-
-	return ss.str();
-}
-
 // numerical helpers
 
 template<unsigned nbits, unsigned es, typename bt>
 inline posit<nbits, es, bt> ulp(const posit<nbits, es, bt>& a) {
 	posit<nbits, es, bt> b(a);
 	return ++b - a;
-}
-
-// binary exponent representation: i.e. 1.0101010e2^-37
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string to_base2_scientific(const posit<nbits, es, bt>& number) {
-	constexpr unsigned fbits = (es + 2 >= nbits ? 0 : nbits - 3 - es);             // maximum number of fraction bits: derived
-	bool s{ false };
-	scale(number);
-	positRegime<nbits, es, bt> r;
-	positExponent<nbits, es, bt> e;
-	positFraction<fbits, bt> f;
-	blockbinary<nbits, bt> raw = number.bits();
-	std::stringstream ss;
-	extract_fields(raw, s, r, e, f);
-	ss << (s ? "-" : "+") << "1." << to_string(f, true) << "e2^" << std::showpos << r.scale() + e.scale();
-	return ss.str();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/posit/posit_impl.hpp
+++ b/include/sw/universal/number/posit/posit_impl.hpp
@@ -15,7 +15,18 @@
 #else
 #define POSIT_TRACE_ENABLED 0
 #endif
+#include <cstdint>  // the fixed-width block types
 #include <iosfwd>   // std::ostream/std::istream in the friend declarations
+
+// POSIT_ENABLE_LITERALS: guarded so a caller can still turn the literal operators
+// off by defining it before the include. The default lives HERE, beside the
+// #if POSIT_ENABLE_LITERALS blocks that test it, rather than in the posit.hpp
+// umbrella -- otherwise including core.hpp directly leaves it undefined, #if
+// evaluates it as 0, and the literal operators silently disappear from that
+// include path. Two paths, two different APIs. See #1334.
+#if !defined(POSIT_ENABLE_LITERALS)
+#define POSIT_ENABLE_LITERALS 1
+#endif
 
 // posit_impl.hpp: implementation of fixed-size arbitrary configuration generalized posits
 //


### PR DESCRIPTION
## Summary

The Phase 1 pilot for #1334. `posit` is now three headers, and `posit.hpp` composes all three, so **nothing existing changes**:

```cpp
#include <universal/number/posit/posit.hpp>   // everything, as before
#include <universal/number/posit/core.hpp>    // arithmetic only
```

This is the compatibility shape decided on #1334: the umbrella keeps its name, the core is opt-in.

## The split

| header | role | contents |
|---|---|---|
| `core.hpp` | arithmetic | storage, operators, comparison, `numeric_limits`, traits |
| `manipulators.hpp` *(existing)* | the `<iomanip>` half | `to_binary`, `to_triple`, `to_native`, `to_string`, `hex_format`, `to_base2_scientific`, `quadrant`, `parse` |
| `iostream.hpp` | the `<iostream>` half | `operator<<`, `operator>>` |
| `debug.hpp` | introspection | `constexprClassParameters()`, `showLimbs()` |

`posit.hpp` orders them `core -> manipulators -> iostream -> debug`.

**The facet headers are named after what they mirror.** Every number type already carries the same unprefixed set — `attributes.hpp`, `exceptions.hpp`, `manipulators.hpp`, `mathlib.hpp`, `numeric_limits.hpp` — while the `TYPE_`-prefixed names in the same directory are implementation internals (`posit_impl`, `posit_fwd`, `posit_regime`, `posit_fraction`, `posit_exponent`, `posit_scale_helpers`). `numeric_limits.hpp` is already named for the standard header it mirrors, so `iostream.hpp` is that same move rather than a new idea, and it pairs with `manipulators.hpp` as the `<iomanip>` analogue.

My first cut named these `posit_io.hpp` and `posit_debug.hpp`, which matched neither convention.

One thing for a reviewer to weigh: a header named `iostream.hpp` on the include path. It is only ever reached as `<universal/number/posit/iostream.hpp>`, so `#include <iostream>` cannot resolve to it, and nothing in the tree does a bare `#include <iostream.hpp>`. The risk becomes real only if someone puts the posit directory itself on the include path.

**The text layer goes where the library already keeps it.** `manipulators.hpp` already held `type_tag`, `hex_print`, `components`, `pretty_print` and `color_print`; CLAUDE.md documents it as the home for `to_binary`/`to_hex`, and `lns` and `dd` already follow that. `cfloat`, `fixpnt`, `integer` and `takum` leave theirs in `_impl.hpp` — the inconsistency this epic should remove rather than add to. So the string producers join their siblings, and `posit_io.hpp` is 93 lines holding only what genuinely needs the stream types.

`parse()` sits with the manipulators rather than the streams: it is string -> posit, the inverse of `to_string`, and touches no stream.

**`ulp()` stayed in the core** — it sat inside the region that moved but is arithmetic, not text.

The 18 trace sites are wrapped in `#if POSIT_TRACE_ENABLED`, keyed on the existing `ALGORITHM_TRACE_*` macros, with `<iostream>`/`<iomanip>` conditional on the same switch. `if constexpr` cannot serve here, for the reason this epic keeps meeting: **a discarded `if constexpr` branch still requires `std::cout` to be declared**, so the include would stay in every TU's graph.

`posit_impl.hpp` is left with zero `std::cout`, zero `std::stringstream`, zero `std::string`, and `<iosfwd>` for its two friend declarations.

## The target is not met, and that is the pilot's finding

```
posit.hpp   114,656 lines   497 headers   5 I/O-family
core.hpp    107,524 lines   446 headers   5 I/O-family   (-6.2%)
```

against a target of **under 45,000 and zero I/O-family headers**.

posit's own code is clean. Its **dependencies** are not:

| still pulls | via |
|---|---|
| `<iomanip>`, `<sstream>` | `internal/blockbinary/blockbinary.hpp` — its own `to_binary`/`to_string` |
| `<iostream>` | `number/integer/integer.hpp`, reached through `posit_impl.hpp` -> `utility/decimal_to_binary.hpp` |

posit's core pulls **the entire `integer` type**, because decimal-to-binary conversion needs arbitrary-precision integers.

So reaching the target needs this same three-layer split applied to `blockbinary` and `integer`. That is the epic's "layering cost" phase, which was written as *"may not be worth doing"* — this measures it as **required**. The per-type split is necessary and not sufficient, which is exactly what a pilot exists to establish before the same work is repeated across 43 more types.

## Test Results

| check | result |
|---|---|
| umbrellas, gcc 13.3 | **38/38** clean |
| umbrellas, clang 18.1 | **38/38** clean |
| umbrellas, riscv64-linux-gnu cross | **38/38** clean |
| `core.hpp` standalone (all three toolchains) | compiles and computes |
| CI_LITE build + `ctest -j4` | **456/456 passed** |
| `check-ascii.sh` | clean |
| added lines over 120 columns | 0 |

## Test plan

- [ ] Fast CI passes
- [ ] CodeRabbit review

Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible posit formatting and parsing, including hexadecimal, decimal, binary, native, triple, and scientific representations.
  * Added stream input and output with precision, alignment, sign, width, and special-value support.
  * Added posit debugging tools for displaying configuration details and internal limb values.

* **Improvements**
  * Separated arithmetic functionality from optional I/O and debugging features, enabling lighter arithmetic-only usage.
  * Added optional tracing controls for diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->