### PR TITLE
ci: document coverage/coveralls as advisory, not a gate

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -93,9 +93,27 @@ jobs:
             --ignore-errors unused,unused
           lcov --list coverage.info --ignore-errors unused,unused || true
 
+      # ADVISORY, NOT A GATE. Two separate things carry the name "coverage":
+      #
+      #   Coverage            this job. Required to pass -- it builds instrumented
+      #                       and runs the suite.
+      #   coverage/coveralls  a commit status posted by coveralls.io AFTER this
+      #                       step uploads. Advisory only: it is not in the
+      #                       branch-protection required list for main
+      #                       (check-ascii, build, lint-pr-title).
+      #
+      # coveralls.io fails that status on ANY decrease, including -0.01%, and its
+      # threshold is a coveralls.io repo setting rather than anything in this file
+      # -- continue-on-error below governs this step, not the posted status.
+      #
+      # A red coverage/coveralls with this job green usually means nothing changed
+      # about what is tested. Splitting a header into layers (see #1334) moves
+      # lines between files, and the tool re-apportions them; two hundredths of a
+      # percent against a gate that fires at one hundredth. Check the delta before
+      # treating it as a finding.
       - name: Upload to Coveralls
         uses: coverallsapp/github-action@v2
-        continue-on-error: true  # Don't fail the workflow if coveralls.io is unreachable
+        continue-on-error: true  # coveralls.io being unreachable must not fail the job
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage.info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,16 @@ CI is tiered based on PR draft status:
 | Coverage (~29 min) | **Skipped** | Runs | Runs |
 | Clang-Tidy (~7 min) | **Skipped** | Runs | Runs |
 
+**Advisory checks** -- these post a status but are NOT in the branch-protection
+required list for `main`, which is only `check-ascii`, `build`, `lint-pr-title`:
+
+| Check | Why it goes red without anything being wrong |
+|-------|----------------------------------------------|
+| `coverage/coveralls` | Fails on any decrease, including `-0.01%`. Re-apportioning lines between files (a header split, a function moved) shifts the number without changing what is tested. The threshold lives in coveralls.io's repo settings, not in `.github/workflows/coverage.yml`. Distinct from the `Coverage` job, which IS required. |
+| `Codacy Static Code Analysis` | Pattern-based; flags idioms the tree uses deliberately. |
+
+Read the delta before treating either as a finding. Neither blocks a merge.
+
 Workflow:
 1. Create draft PR — iterate on CodeRabbit feedback and fast CI only
 2. When clean, promote: `gh pr ready NNN`


### PR DESCRIPTION
## Summary

`coverage/coveralls` **already is** advisory — branch protection on `main` requires only `check-ascii`, `build`, `lint-pr-title`. A red coveralls has never blocked a merge. That is the first thing worth writing down, because it was not written down anywhere.

What it is not is quiet. It went red on #1388 at **-0.01%** and #1390 at **-0.02%**, both times for a non-reason: splitting a header moves lines between files and coveralls re-apportions them, so the percentage shifts without anything changing about what is tested. Epic #1334 has 43 more per-type splits queued, so this would fire on nearly every one.

## What I could and could not do

**Could not:** make it lenient from the repo. The threshold is a coveralls.io repo setting, and the `continue-on-error: true` already in `coverage.yml` governs the upload *step*, not the commit status coveralls.io posts afterwards. The comment says that plainly rather than implying the file controls it. **If you want the red X gone, that is one switch in coveralls.io's repo settings** — not something a PR can reach.

**Did:** document it where someone reading the red X will actually look.

- `coverage.yml` now separates the two things sharing the name: the **`Coverage` job**, which is required and passes, from the **`coverage/coveralls` status**, which is not.
- `CLAUDE.md`'s CI section gains an advisory-checks table — coveralls and Codacy — with the required list stated explicitly.

## Changes

- `.github/workflows/coverage.yml` — comment block above the upload step
- `CLAUDE.md` — advisory-checks table under the CI tier table

No workflow behaviour changes. Valid YAML verified; `check-ascii` clean.

## Test plan

- [ ] Fast CI passes (docs/CI-comment change only)

Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that coverage workflows are required while Coveralls reporting is advisory.
  * Documented coverage-threshold behavior and potential reporting changes.
  * Added guidance for interpreting Coveralls and Codacy status checks, including that they do not block merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->