### PR TITLE
refactor(blockbinary): split the text layer out of the core (#1334 phase N)

### DIFF
--- a/benchmark/performance/arithmetic/areal/performance.cpp
+++ b/benchmark/performance/arithmetic/areal/performance.cpp
@@ -12,6 +12,7 @@
 #include <universal/number/areal/areal.hpp>
 #include <universal/verification/test_status.hpp> // ReportTestResult
 #include <universal/benchmark/performance_runner.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary on blockbinary (#1334)
 
 /*
    The goal of the arbitrary fixed-precision reals is to provide a constrained 

--- a/education/internal/blockbinary.cpp
+++ b/education/internal/blockbinary.cpp
@@ -7,6 +7,8 @@
 #include <universal/utility/directives.hpp>
 #include <universal/native/integers.hpp>
 #include <universal/internal/blockbinary/blockbinary.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary on blockbinary (#1334)
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 #include <iostream>
 #include <string>
 

--- a/education/tables/areals.cpp
+++ b/education/tables/areals.cpp
@@ -12,6 +12,7 @@
 #define AREAL_ROUNDING_ERROR_FREE_IO_FORMAT 1
 #include <universal/number/areal/areal.hpp>
 #include <universal/number/areal/table.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary on blockbinary (#1334)
 
 #define MANUAL_TESTING 0
 

--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -21,10 +21,9 @@
 #include <cstdint>
 #if TRACE_URMUL || TRACE_DIV
 #include <iostream>
-#endif
 #include <iomanip>
-#include <string>
-#include <sstream>
+#endif
+#include <string>   // the std::string constructor
 #include <type_traits>
 #include <universal/number/shared/specific_value_encoding.hpp>
 #include <universal/internal/blocktype/carry.hpp>
@@ -1005,20 +1004,13 @@ private:
 	friend constexpr bool operator!=(const blockbinary<N, B, T>& lhs, const blockbinary<N, B, T>& rhs);
 	// the other logic operators are defined in terms of arithmetic terms
 
-	template<unsigned N, typename B, BinaryNumberType T>
-	friend std::ostream& operator<<(std::ostream& ostr, const blockbinary<N, B, T>& v);
+	// no friend declaration for operator<<: it is defined in
+	// internal/blockbinary/iostream.hpp and needs no private access (it calls
+	// to_decimal). Declaring it here would let a translation unit that forgot
+	// that include COMPILE and then fail to link -- a compile error naming the
+	// missing function is the better failure. See #1334.
 };
 
-// Generate a type tag for blockbinary
-template<unsigned N, typename B, BinaryNumberType T>
-std::string type_tag(const blockbinary<N, B, T>& = {}) {
-	std::stringstream str;
-	str << "blockbinary<"
-		<< std::setw(4) << N << ", "
-		<< typeid(B).name() << ", "
-		<< typeid(T).name() << '>';
-	return str.str();
-}
 
 //////////////////////////////////////////////////////////////////////////////////
 // logic operators
@@ -1312,91 +1304,5 @@ blockbinary<2 * nbits + roundingBits, B, T> urdiv(const blockbinary<nbits, B, T>
 	if (result_negative) result.twosComplement();
 	return result;
 }
-
-//////////////////////////////////////////////////////////////////////////////
-// conversions to string representations
-
-// create a binary representation of the storage
-template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
-std::string to_binary(const blockbinary<nbits, BlockType, NumberType>& number, bool nibbleMarker = false) {
-	std::stringstream s;
-	s << "0b";
-	for (unsigned i = 0; i < nbits; ++i) {
-		unsigned bitIndex = nbits - 1ull - i;
-		s << (number.at(bitIndex) ? '1' : '0');
-		if (bitIndex > 0 && (bitIndex % 4) == 0 && nibbleMarker) s << '\'';
-	}
-	return s.str();
-}
-
-// local helper to display the contents of a byte array
-template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
-std::string to_hex(const blockbinary<nbits, BlockType, NumberType>& number, bool nibbleMarker = true) {
-	static constexpr unsigned bitsInByte = 8;
-	static constexpr unsigned bitsInBlock = sizeof(BlockType) * bitsInByte;
-	char hexChar[16] = {
-		'0', '1', '2', '3', '4', '5', '6', '7',
-		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
-	};
-	std::stringstream ss;
-	ss << "0x" << std::hex;
-	int nrNibbles = int(1 + ((nbits - 1) >> 2));
-	for (int n = nrNibbles - 1; n >= 0; --n) {
-		uint8_t nibble = number.nibble(static_cast<unsigned>(n));
-		ss << hexChar[nibble];
-		if (nibbleMarker && n > 0 && ((n * 4ll) % bitsInBlock) == 0) ss << '\'';
-	}
-	return ss.str();
-}
-
-// decimal string conversion
-template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
-std::string to_decimal(const blockbinary<nbits, BlockType, NumberType>& number) {
-	if (number.iszero()) return "0";
-
-	std::string result;
-	blockbinary<nbits, BlockType, NumberType> dividend(number);
-	bool isNegative = false;
-
-	// Handle negative numbers for signed types
-	if constexpr (NumberType == BinaryNumberType::Signed) {
-		if (dividend.isneg()) {
-			isNegative = true;
-			dividend.twosComplement(); // Convert to positive
-		}
-	}
-
-	// Repeatedly divide by 10 and collect remainders
-	blockbinary<nbits, BlockType, NumberType> ten(10);
-	while (!dividend.iszero()) {
-		if constexpr (nbits <= 64) {
-			// For smaller sizes, use native division to avoid complexity
-			uint64_t temp = dividend.to_ull();
-			uint64_t remainder = temp % 10;
-			result = char('0' + remainder) + result;
-			dividend = temp / 10;
-		} else {
-			// For larger sizes, use blockbinary division operators
-			blockbinary<nbits, BlockType, NumberType> remainder = dividend % ten;
-			uint64_t digit = remainder.to_ull();
-			result = char('0' + digit) + result;
-			dividend /= ten;
-		}
-	}
-
-	if (isNegative) {
-		result = "-" + result;
-	}
-
-	return result;
-}
-
-// ostream operator
-template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
-std::ostream& operator<<(std::ostream& ostr, const blockbinary<nbits, BlockType, NumberType>& number) {
-	ostr << to_decimal(number);
-	return ostr;
-}
-
 
 }} // namespace sw::universal

--- a/include/sw/universal/internal/blockbinary/iostream.hpp
+++ b/include/sw/universal/internal/blockbinary/iostream.hpp
@@ -1,0 +1,25 @@
+#pragma once
+// iostream.hpp: stream insertion for blockbinary
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The <iostream> half of blockbinary's text layer (#1334). manipulators.hpp is
+// the <iomanip> half.
+#include <ostream>
+#include <universal/internal/blockbinary/blockbinary.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary, used below
+
+namespace sw { namespace universal {
+
+// ostream operator
+template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
+std::ostream& operator<<(std::ostream& ostr, const blockbinary<nbits, BlockType, NumberType>& number) {
+	ostr << to_decimal(number);
+	return ostr;
+}
+
+
+}} // namespace sw::universal

--- a/include/sw/universal/internal/blockbinary/manipulators.hpp
+++ b/include/sw/universal/internal/blockbinary/manipulators.hpp
@@ -1,0 +1,108 @@
+#pragma once
+// manipulators.hpp: text produced from a blockbinary
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The <iomanip> half of blockbinary's text layer (#1334): type_tag, to_binary,
+// to_hex, to_decimal -- everything that returns a std::string. blockbinary.hpp
+// holds the arithmetic and needs none of it, which is what keeps <sstream> and
+// <iomanip> out of every number system that builds on blockbinary.
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+#include <universal/internal/blockbinary/blockbinary.hpp>
+
+namespace sw { namespace universal {
+// Generate a type tag for blockbinary
+template<unsigned N, typename B, BinaryNumberType T>
+std::string type_tag(const blockbinary<N, B, T>& = {}) {
+	std::stringstream str;
+	str << "blockbinary<"
+		<< std::setw(4) << N << ", "
+		<< typeid(B).name() << ", "
+		<< typeid(T).name() << '>';
+	return str.str();
+}
+//////////////////////////////////////////////////////////////////////////////
+// conversions to string representations
+
+// create a binary representation of the storage
+template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
+std::string to_binary(const blockbinary<nbits, BlockType, NumberType>& number, bool nibbleMarker = false) {
+	std::stringstream s;
+	s << "0b";
+	for (unsigned i = 0; i < nbits; ++i) {
+		unsigned bitIndex = nbits - 1ull - i;
+		s << (number.at(bitIndex) ? '1' : '0');
+		if (bitIndex > 0 && (bitIndex % 4) == 0 && nibbleMarker) s << '\'';
+	}
+	return s.str();
+}
+
+// local helper to display the contents of a byte array
+template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
+std::string to_hex(const blockbinary<nbits, BlockType, NumberType>& number, bool nibbleMarker = true) {
+	static constexpr unsigned bitsInByte = 8;
+	static constexpr unsigned bitsInBlock = sizeof(BlockType) * bitsInByte;
+	char hexChar[16] = {
+		'0', '1', '2', '3', '4', '5', '6', '7',
+		'8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+	};
+	std::stringstream ss;
+	ss << "0x" << std::hex;
+	int nrNibbles = int(1 + ((nbits - 1) >> 2));
+	for (int n = nrNibbles - 1; n >= 0; --n) {
+		uint8_t nibble = number.nibble(static_cast<unsigned>(n));
+		ss << hexChar[nibble];
+		if (nibbleMarker && n > 0 && ((n * 4ll) % bitsInBlock) == 0) ss << '\'';
+	}
+	return ss.str();
+}
+
+// decimal string conversion
+template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
+std::string to_decimal(const blockbinary<nbits, BlockType, NumberType>& number) {
+	if (number.iszero()) return "0";
+
+	std::string result;
+	blockbinary<nbits, BlockType, NumberType> dividend(number);
+	bool isNegative = false;
+
+	// Handle negative numbers for signed types
+	if constexpr (NumberType == BinaryNumberType::Signed) {
+		if (dividend.isneg()) {
+			isNegative = true;
+			dividend.twosComplement(); // Convert to positive
+		}
+	}
+
+	// Repeatedly divide by 10 and collect remainders
+	blockbinary<nbits, BlockType, NumberType> ten(10);
+	while (!dividend.iszero()) {
+		if constexpr (nbits <= 64) {
+			// For smaller sizes, use native division to avoid complexity
+			uint64_t temp = dividend.to_ull();
+			uint64_t remainder = temp % 10;
+			result = char('0' + remainder) + result;
+			dividend = temp / 10;
+		} else {
+			// For larger sizes, use blockbinary division operators
+			blockbinary<nbits, BlockType, NumberType> remainder = dividend % ten;
+			uint64_t digit = remainder.to_ull();
+			result = char('0' + digit) + result;
+			dividend /= ten;
+		}
+	}
+
+	if (isNegative) {
+		result = "-" + result;
+	}
+
+	return result;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/internal/blockbinary/manipulators.hpp
+++ b/include/sw/universal/internal/blockbinary/manipulators.hpp
@@ -10,6 +10,7 @@
 // to_hex, to_decimal -- everything that returns a std::string. blockbinary.hpp
 // holds the arithmetic and needs none of it, which is what keeps <sstream> and
 // <iomanip> out of every number system that builds on blockbinary.
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 #include <string>

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 #include <string>
 // cfloat_impl.hpp: implementation of an arbitrary configuration fixed-size 'classic' floating-point representation

--- a/include/sw/universal/number/cfloat/table.hpp
+++ b/include/sw/universal/number/cfloat/table.hpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 #include <iostream>
 #include <iomanip>
 #include <typeinfo>  // for typeid()

--- a/include/sw/universal/number/dfloat/dfloat_impl.hpp
+++ b/include/sw/universal/number/dfloat/dfloat_impl.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_decimal on the significand (#1334)
 #include <cstdint>
 #include <cstring>
 #include <cmath>

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -4,6 +4,7 @@
 // Copyright (C) 2017-2022 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <string>
 #include <sstream>
 #include <iostream>

--- a/include/sw/universal/number/posit/debug.hpp
+++ b/include/sw/universal/number/posit/debug.hpp
@@ -9,6 +9,7 @@
 // Layer 3 of the posit headers (#1334). posit_impl.hpp declares
 // constexprClassParameters() and showLimbs() but does not define them, so it
 // needs no <iostream>. Include this header to call either.
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <iostream>
 #include <universal/number/posit/posit_impl.hpp>
 #include <universal/number/posit/manipulators.hpp>   // to_binary used by the dumps below

--- a/include/sw/universal/number/posit/iostream.hpp
+++ b/include/sw/universal/number/posit/iostream.hpp
@@ -12,6 +12,8 @@
 // only what genuinely needs the stream types: operator<< and operator>>.
 //
 // posit.hpp includes both, so existing code is unaffected.
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 #include <ios>
 #include <sstream>
 #include <string>

--- a/include/sw/universal/number/posit/manipulators.hpp
+++ b/include/sw/universal/number/posit/manipulators.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <cctype>
 #include <cstdint>
 #include <ios>

--- a/include/sw/universal/number/rational/rational_impl.hpp
+++ b/include/sw/universal/number/rational/rational_impl.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 #include <sstream>
 #include <string>

--- a/include/sw/universal/verification/blockbinary_test_status.hpp
+++ b/include/sw/universal/verification/blockbinary_test_status.hpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2017-2022 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <iostream>
 #include <iomanip>
 #include <universal/native/integers.hpp> // for to_binary(int)

--- a/include/sw/universal/verification/blockfraction_test_suite.hpp
+++ b/include/sw/universal/verification/blockfraction_test_suite.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 #include <iomanip>
 #include <string>

--- a/include/sw/universal/verification/blocksignificand_test_suite.hpp
+++ b/include/sw/universal/verification/blocksignificand_test_suite.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 #include <iomanip>
 #include <string>

--- a/internal/blockbinary/api/api.cpp
+++ b/internal/blockbinary/api/api.cpp
@@ -10,6 +10,8 @@
 
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/verification/test_suite.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex (#1334)
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 int main()
 try {

--- a/internal/blockbinary/api/constexpr.cpp
+++ b/internal/blockbinary/api/constexpr.cpp
@@ -10,6 +10,7 @@
 
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/verification/test_suite.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 int main()
 try {

--- a/internal/blockbinary/api/conversion.cpp
+++ b/internal/blockbinary/api/conversion.cpp
@@ -10,6 +10,7 @@
 
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/verification/test_suite.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex (#1334)
 
 int main()
 try {

--- a/internal/blockbinary/api/decimal_converter.cpp
+++ b/internal/blockbinary/api/decimal_converter.cpp
@@ -6,6 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <iostream>
 #include <universal/internal/blockbinary/blockbinary.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 using namespace sw::universal;
 

--- a/internal/blockbinary/logic/bit_patterns.cpp
+++ b/internal/blockbinary/logic/bit_patterns.cpp
@@ -13,6 +13,7 @@
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/verification/test_status.hpp>
 #include <universal/verification/test_reporters.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex (#1334)
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is set here
 #define MANUAL_TESTING 0

--- a/internal/blockbinary/logic/logic.cpp
+++ b/internal/blockbinary/logic/logic.cpp
@@ -12,6 +12,7 @@
 
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/verification/test_status.hpp> // ReportTestResult
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex (#1334)
 
 namespace sw {
 namespace universal {

--- a/internal/blockfraction/arithmetic/multiplication.cpp
+++ b/internal/blockfraction/arithmetic/multiplication.cpp
@@ -15,6 +15,7 @@
 #include <universal/internal/blockfraction/blockfraction.hpp>
 #include <universal/verification/test_reporters.hpp>
 #include <universal/verification/blockfraction_test_suite.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0

--- a/internal/blocksignificand/arithmetic/addition.cpp
+++ b/internal/blocksignificand/arithmetic/addition.cpp
@@ -13,6 +13,7 @@
 #include <universal/internal/blocksignificand/blocksignificand.hpp>
 #include <universal/verification/test_reporters.hpp>
 #include <universal/verification/blocksignificand_test_suite.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 
 // generate specific test case that you can trace with the trace conditions in blocksignificand

--- a/internal/blocksignificand/arithmetic/division.cpp
+++ b/internal/blocksignificand/arithmetic/division.cpp
@@ -15,6 +15,7 @@
 #include <universal/internal/blocksignificand/blocksignificand.hpp>
 #include <universal/verification/test_reporters.hpp>
 #include <universal/verification/blocksignificand_test_suite.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 template<unsigned nbits, typename BlockType>
 void TestMostSignificantBit() {

--- a/internal/blocksignificand/arithmetic/multiplication.cpp
+++ b/internal/blocksignificand/arithmetic/multiplication.cpp
@@ -15,6 +15,7 @@
 #include <universal/internal/blocksignificand/blocksignificand.hpp>
 #include <universal/verification/test_reporters.hpp>
 #include <universal/verification/blocksignificand_test_suite.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 // Regression testing guards: typically set by the cmake configuration, but MANUAL_TESTING is an override
 #define MANUAL_TESTING 0

--- a/internal/blocksignificand/arithmetic/subtraction.cpp
+++ b/internal/blocksignificand/arithmetic/subtraction.cpp
@@ -14,6 +14,7 @@
 #include <universal/internal/blocksignificand/blocksignificand.hpp>
 #include <universal/verification/test_reporters.hpp>
 #include <universal/verification/blocksignificand_test_suite.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 // generate specific test case that you can trace with the trace conditions in blocksignificant
 // for most bugs they are traceable with _trace_conversion and _trace_add

--- a/static/fixpnt/binary/complex/arithmetic/mod_complex_mul.cpp
+++ b/static/fixpnt/binary/complex/arithmetic/mod_complex_mul.cpp
@@ -19,6 +19,7 @@
 #include <universal/number/fixpnt/fixpnt.hpp>
 #include <universal/verification/fixpnt_test_suite.hpp>
 #include <universal/verification/test_case.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 // generate specific test case that you can trace with the trace conditions in fixed_point.hpp
 // for most bugs they are traceable with _trace_conversion and _trace_add

--- a/static/tapered/posit/api/api.cpp
+++ b/static/tapered/posit/api/api.cpp
@@ -22,6 +22,7 @@
 #include <universal/number/posit/posit.hpp>
 #include <universal/verification/test_reporters.hpp>
 #include <universal/verification/test_case.hpp>
+#include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 
 // File-level helper for the constexpr smoke tests below: compares the raw
 // bit pattern of two posits limb-by-limb. Used by both the integer and the

--- a/static/tapered/posit/api/attributes.cpp
+++ b/static/tapered/posit/api/attributes.cpp
@@ -18,6 +18,7 @@
 // minimum set of include files to reflect source code dependencies
 #include <universal/number/posit/posit.hpp>
 #include <universal/verification/test_reporters.hpp>
+#include <universal/internal/blockbinary/manipulators.hpp>   // to_binary on the blockbinary from bits() (#1334)
 
 template<unsigned nbits, unsigned es, typename BlockType>
 void PositComponents(const sw::universal::posit<nbits, es, BlockType>& p) {


### PR DESCRIPTION
## Summary

Phase N of #1334, and **the first header in this epic to hit both acceptance criteria**:

```
blockbinary.hpp alone   50,832 -> 33,280 lines   (-35%)
                           240 -> 174 headers
                    I/O-family:  5 -> 0
```

Under the 45,000-line target, with no `iostream`, `sstream`, `iomanip`, `ostream` or `istream` in its graph.

| header | contents |
|---|---|
| `blockbinary.hpp` | arithmetic, plus `<string>` for its `std::string` constructor |
| `manipulators.hpp` | `type_tag`, `to_binary`, `to_hex`, `to_decimal` |
| `iostream.hpp` | `operator<<` |

Same naming as the posit pilot (#1390).

## Removing the `friend operator<<` is the durable part

`operator<<` only calls `to_decimal()`, a public free function — friendship was never needed. And that declaration was what let a TU missing the include **compile and then fail to link**.

The effect was immediate and measurable:

| | TUs that surfaced |
|---|---|
| with the friend declaration | **2**, as link errors in CI_LITE |
| without it | **10**, as compile errors |

CI_LITE builds a subset, so 8 would have reached the full tier undetected. This is the third time in this epic that a link error slipped past `-fsyntax-only` (`bt_api` in #1388, `bb_api`/`bb_constexpr` here), so it fixes the failure *mode* rather than the instances — worth carrying into `blocktriple` and every type in the rollout.

11 headers and 12 TUs now ask for text when they want text. `<iosfwd>` is gone from `blockbinary.hpp` as well: with the friend declaration removed, no stream type appears in the file at all.

## Method, recorded because it cost five build cycles

I tried four times to find the consumers by pattern-matching source — grep the type name, grep `.bits()`, grep `<<` followed by `.bits()`/`_block`. Each missed cases, and the final miss shows why it cannot work: `cfloat/table.hpp` streams `signedValue`, a `blockbinary` variable, and nothing on that line says so. **A pattern over source text cannot know a variable's type; only the compiler can.**

The bad detour is worth flagging to a reviewer too. One attempt shotgunned the include into **35 headers**, which would have pushed `<sstream>` and `<iomanip>` *into* `dbns_impl`, `e8m0_impl`, `efloat_impl` and `hfloat_impl` — four type cores — inside a PR whose purpose is removing them. Everything still compiled, which is exactly why it was dangerous. Stripped back to the 11 where the need is proven.

**For the rollout:** build first, let the errors name the files, add includes only where named. Grep estimates scope; it never proves completeness.

## Where the cost still is

`<sstream>`/`<iomanip>` left `blockbinary` but did not leave the posit graph — they moved to `blocktriple.hpp`, which has its own text functions (#1388 relocated only its debug and trace code). `blocktriple` is a harder case: a **member** `to_string()`, an enum `operator<<` ahead of the class, `type_tag`, and a tail region. And `integer` still supplies `<iostream>` via `decimal_to_binary.hpp`. Both are queued.

## Test Results

| check | result |
|---|---|
| 3 new headers, standalone | compile on gcc 13.3, clang 18.1, riscv64 cross |
| 38 umbrellas | clean on all three |
| CI_LITE build + `ctest -j4` | **456/456 passed** |
| `check-ascii.sh` | clean |
| added lines over 120 columns | 0 |

One of those three headers did **not** compile standalone when written — a duplicate namespace close — and nothing caught it because nothing included it. Standalone compilation of every new header is now an explicit step.

## Test plan

- [ ] Fast CI passes
- [ ] CodeRabbit review

Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated formatting utilities for binary, hexadecimal, decimal, and type-tag representations of block-binary values.
  * Added stream output support for block-binary values through a separate interface.
  * Improved signed decimal formatting, including two’s-complement values and support for different bit widths.

* **Refactor**
  * Organized formatting and stream output into reusable components.
  * Limited tracing support to configurations where tracing is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->