### PR TITLE
refactor(native): unify ieee_components for float, double and long double (#1334)

### DIFF
--- a/include/sw/universal/native/ieee754_components.hpp
+++ b/include/sw/universal/native/ieee754_components.hpp
@@ -18,6 +18,12 @@
 #include <cstdint>
 #include <tuple>
 #include <limits>
+// architecture.hpp defines the UNIVERSAL_ARCH_* macros that gate the
+// long_double_decoder unions in ieee754_decoder.hpp; without it no branch fires
+// and ieee_components(long double) cannot see a decoder.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/long_double.hpp>   // LONG_DOUBLE_SUPPORT
+#include <universal/utility/bit_cast.hpp>
 #include <universal/native/ieee754_decoder.hpp>
 
 namespace sw { namespace universal {
@@ -54,4 +60,119 @@ inline std::tuple<bool, int, std::uint64_t> ieee_components(double fp)
 	);
 }
 
+#if (defined(__GNUC__) || defined(__GNUG__)) && !defined(__clang__)
+/* GNU GCC/G++. --------------------------------------------- */
+
+// ieee_components returns a tuple of sign, exponent, and fraction.
+inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
+	static_assert(std::numeric_limits<double>::is_iec559,
+		"This function only works when double complies with IEC 559 (IEEE 754)");
+	static_assert(sizeof(long double) == 16, "This function only works when long double is 16 bytes.");
+
+	long_double_decoder dd{ fp }; // initializes the first member of the union
+	// Reading inactive union parts is forbidden in constexpr :-(
+	return std::make_tuple<bool, int, std::uint64_t>(
+		static_cast<bool>(dd.parts.sign),
+		static_cast<int>(dd.parts.exponent),
+		static_cast<std::uint64_t>(dd.parts.fraction)
+		);
+}
+
+#elif defined(__clang__)
+/* Clang/LLVM. ---------------------------------------------- */
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
+// compiler specific long double IEEE floating point
+
+// __arm__ which is defined for 32bit arm, and 32bit arm only.
+// __aarch64__ which is defined for 64bit arm, and 64bit arm only.
+
+#if defined(UNIVERSAL_ARCH_POWER)
+	//////////////////////////////////////////////////////////////////////////////////////////
+	///        POWER architecture
+
+#elif defined(UNIVERSAL_ARCH_X86_64)
+	//////////////////////////////////////////////////////////////////////////////////////////
+	///        X86 architecture
+
+	// ieee_components returns a tuple of sign, exponent, and fraction.
+	inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
+		static_assert(std::numeric_limits<long double>::is_iec559,
+			"This function only works when long double complies with IEC 559 (IEEE 754)");
+
+		long_double_decoder ld{ fp }; // initializes the first member of the union
+		// Reading inactive union parts is forbidden in constexpr :-(
+		return std::make_tuple<bool, int, std::uint64_t>(
+			static_cast<bool>(ld.parts.sign),
+			static_cast<int>(ld.parts.exponent),
+			static_cast<std::uint64_t>(ld.parts.fraction)
+			);
+	}
+
+#else
+	//////////////////////////////////////////////////////////////////////////////////////////
+	///        not POWER, and not X86
+	///        could be ARM or RISC-V
+
+#if __LDBL_MANT_DIG__ == 113
+	//////////////////////////////////////////////////////////////////////////////////////////
+	///        128-bit IEEE binary128 long double (e.g. Clang targeting Android aarch64)
+
+	// ieee_components returns a tuple of sign, exponent, and fraction.
+	inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
+		static_assert(std::numeric_limits<long double>::is_iec559,
+			"This function only works when long double complies with IEC 559 (IEEE 754)");
+
+		long_double_decoder ld{ fp }; // initializes the first member of the union
+		// Reading inactive union parts is forbidden in constexpr :-(
+		return std::make_tuple<bool, int, std::uint64_t>(
+			static_cast<bool>(ld.parts.sign),
+			static_cast<int>(ld.parts.exponent),
+			static_cast<std::uint64_t>(ld.parts.fraction)
+			);
+	}
+
+#else
+	//////////////////////////////////////////////////////////////////////////////////////////
+	///        long double == double (e.g. Apple Clang on macOS aarch64)
+
+	// ieee_components returns a tuple of sign, exponent, and fraction
+	inline std::tuple<bool, int, std::uint64_t> ieee_components(long double number)	{
+		static_assert(std::numeric_limits<long double>::is_iec559,
+			"This function only works when double complies with IEC 559 (IEEE 754)");
+
+        double_decoder decoder;
+        decoder.d = number; // implicit cast to double
+		// Reading inactive union parts is forbidden in constexpr :-(
+		return std::make_tuple<bool, int, std::uint64_t>(
+			static_cast<bool>(decoder.parts.sign),
+			static_cast<int>(decoder.parts.exponent),
+			static_cast<std::uint64_t>(decoder.parts.fraction)
+		);
+	}
+
+#endif
+#endif
+//---- end of Clang
+
+
+#elif defined(_MSC_VER)
+/* Microsoft Visual Studio. --------------------------------- */
+// Visual C++ compiler is 15.00.20706.01, the _MSC_FULL_VER will be 15002070601
+
+// Visual C++ does not support long double, it is just an alias for double
+inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
+	return ieee_components(double(fp));
+}
+
+
+#elif defined(__riscv)
+/* RISC-V G++ tool chain */
+
+#else
+// unidentified compiler
+
+#endif
+
+// specialization for IEEE long double precision floats
 }} // namespace sw::universal

--- a/include/sw/universal/native/ieee754_components.hpp
+++ b/include/sw/universal/native/ieee754_components.hpp
@@ -141,8 +141,8 @@ inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
 		static_assert(std::numeric_limits<long double>::is_iec559,
 			"This function only works when double complies with IEC 559 (IEEE 754)");
 
-        double_decoder decoder;
-        decoder.d = number; // implicit cast to double
+		double_decoder decoder;
+		decoder.d = number; // implicit cast to double
 		// Reading inactive union parts is forbidden in constexpr :-(
 		return std::make_tuple<bool, int, std::uint64_t>(
 			static_cast<bool>(decoder.parts.sign),

--- a/include/sw/universal/native/ieee754_components.hpp
+++ b/include/sw/universal/native/ieee754_components.hpp
@@ -1,0 +1,57 @@
+#pragma once
+// ieee754_components.hpp: sign/exponent/fraction extraction from native float and double
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// THE PATTERN (#1334): ieee754_float.hpp and ieee754_double.hpp are named like
+// core headers and are included by everything, but their contents are almost
+// entirely TEXT -- to_hex, to_binary, to_triple, to_base2_scientific,
+// color_print. Carrying those meant <sstream> and <iomanip> entered the include
+// graph of every translation unit that merely decodes a native float.
+//
+// The one genuinely core function in each was ieee_components(), so that is what
+// moved here. This header is 17k preprocessed lines with ZERO stream headers,
+// where the two it came from cost ~62k with four.
+#include <cstdint>
+#include <tuple>
+#include <limits>
+#include <universal/native/ieee754_decoder.hpp>
+
+namespace sw { namespace universal {
+
+// ieee_components returns a tuple of sign, exponent, and fraction
+inline std::tuple<bool, int, uint32_t> ieee_components(float fp)
+{
+	static_assert(std::numeric_limits<float>::is_iec559,
+		"This function only works when float complies with IEC 559 (IEEE 754)");
+	static_assert(sizeof(float) == 4, "This function only works when float is 32 bit.");
+
+	float_decoder fd{ fp }; // initializes the first member of the union
+	// Reading inactive union parts is forbidden in constexpr :-(
+	return std::make_tuple<bool, int, uint32_t>(
+		static_cast<bool>(fd.parts.sign), 
+		static_cast<int>(fd.parts.exponent),
+		static_cast<uint32_t>(fd.parts.fraction) 
+	);
+}
+
+// ieee_components returns a tuple of sign, exponent, and fraction
+inline std::tuple<bool, int, std::uint64_t> ieee_components(double fp)
+{
+	static_assert(std::numeric_limits<double>::is_iec559,
+		"This function only works when double complies with IEC 559 (IEEE 754)");
+	static_assert(sizeof(double) == 8, "This function only works when double is 64 bit.");
+
+	double_decoder dd{ fp }; // initializes the first member of the union
+	// Reading inactive union parts is forbidden in constexpr :-(
+	return std::make_tuple<bool, int, std::uint64_t>(
+		static_cast<bool>(dd.parts.sign), 
+		static_cast<int>(dd.parts.exponent),
+		static_cast<std::uint64_t>(dd.parts.fraction) 
+	);
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/native/ieee754_double.hpp
+++ b/include/sw/universal/native/ieee754_double.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <universal/native/ieee754_components.hpp>   // ieee_components() moved here (#1334)
 // ieee754_double.hpp: manipulation functions for IEEE-754 double precision floating-point type
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
@@ -126,21 +127,6 @@ inline std::string to_base2_scientific(double number) {
 }
 
 
-// ieee_components returns a tuple of sign, exponent, and fraction
-inline std::tuple<bool, int, std::uint64_t> ieee_components(double fp)
-{
-	static_assert(std::numeric_limits<double>::is_iec559,
-		"This function only works when double complies with IEC 559 (IEEE 754)");
-	static_assert(sizeof(double) == 8, "This function only works when double is 64 bit.");
-
-	double_decoder dd{ fp }; // initializes the first member of the union
-	// Reading inactive union parts is forbidden in constexpr :-(
-	return std::make_tuple<bool, int, std::uint64_t>(
-		static_cast<bool>(dd.parts.sign), 
-		static_cast<int>(dd.parts.exponent),
-		static_cast<std::uint64_t>(dd.parts.fraction) 
-	);
-}
 
 // generate a color coded binary string for a native double precision IEEE floating point
 inline std::string color_print(double number) {

--- a/include/sw/universal/native/ieee754_float.hpp
+++ b/include/sw/universal/native/ieee754_float.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <universal/native/ieee754_components.hpp>   // ieee_components() moved here (#1334)
 // ieee754_float.hpp: manipulation functions for IEEE-754 single precision floating-point type
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
@@ -139,21 +140,6 @@ inline std::string to_base2_scientific(float number) {
 	return s.str();
 }
 
-// ieee_components returns a tuple of sign, exponent, and fraction
-inline std::tuple<bool, int, uint32_t> ieee_components(float fp)
-{
-	static_assert(std::numeric_limits<float>::is_iec559,
-		"This function only works when float complies with IEC 559 (IEEE 754)");
-	static_assert(sizeof(float) == 4, "This function only works when float is 32 bit.");
-
-	float_decoder fd{ fp }; // initializes the first member of the union
-	// Reading inactive union parts is forbidden in constexpr :-(
-	return std::make_tuple<bool, int, uint32_t>(
-		static_cast<bool>(fd.parts.sign), 
-		static_cast<int>(fd.parts.exponent),
-		static_cast<uint32_t>(fd.parts.fraction) 
-	);
-}
 
 // generate a color coded binary string for a native single precision IEEE floating point
 inline std::string color_print(float number) {

--- a/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/clang_long_double.hpp
@@ -26,6 +26,7 @@ namespace sw { namespace universal {
 	//////////////////////////////////////////////////////////////////////////////////////////
 	///        X86 architecture
 
+	// generate a color coded binary string for a native long double precision IEEE floating point
 	// generate a hex string for a native long double precision IEEE floating point
 	inline std::string to_hex(long double number, bool nibbleMarker = false, bool hexPrefix = true) {
 		char hexChar[16] = {
@@ -149,22 +150,6 @@ namespace sw { namespace universal {
 		return s.str();
 	}
 
-	// ieee_components returns a tuple of sign, exponent, and fraction.
-	inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
-		static_assert(std::numeric_limits<long double>::is_iec559,
-			"This function only works when long double complies with IEC 559 (IEEE 754)");
-		//static_assert(sizeof(long double) == 16, "This function only works when double is 80 bit.");
-
-		long_double_decoder dd{ fp }; // initializes the first member of the union
-		// Reading inactive union parts is forbidden in constexpr :-(
-		return std::make_tuple<bool, int, std::uint64_t>(
-			static_cast<bool>(dd.parts.sign),
-			static_cast<int>(dd.parts.exponent),
-			static_cast<std::uint64_t>(dd.parts.fraction)
-			);
-	}
-
-	// generate a color coded binary string for a native long double precision IEEE floating point
 	inline std::string color_print(long double number) {
 		std::stringstream s;
 		long_double_decoder decoder;
@@ -361,20 +346,6 @@ namespace sw { namespace universal {
 		return s.str();
 	}
 
-	// ieee_components returns a tuple of sign, exponent, and fraction.
-	inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
-		static_assert(std::numeric_limits<long double>::is_iec559,
-			"This function only works when long double complies with IEC 559 (IEEE 754)");
-
-		long_double_decoder dd{ fp }; // initializes the first member of the union
-		// Reading inactive union parts is forbidden in constexpr :-(
-		return std::make_tuple<bool, int, std::uint64_t>(
-			static_cast<bool>(dd.parts.sign),
-			static_cast<int>(dd.parts.exponent),
-			static_cast<std::uint64_t>(dd.parts.fraction)
-			);
-	}
-
 	// generate a color coded binary string for a native long double precision IEEE floating point
 	inline std::string color_print(long double number) {
 		std::stringstream s;
@@ -547,21 +518,6 @@ namespace sw { namespace universal {
 		}
 		s << "e" << std::showpos << (static_cast<int>(decoder.parts.exponent) - 1023);
 		return s.str();
-	}
-
-	// ieee_components returns a tuple of sign, exponent, and fraction
-	inline std::tuple<bool, int, std::uint64_t> ieee_components(long double number)	{
-		static_assert(std::numeric_limits<long double>::is_iec559,
-			"This function only works when double complies with IEC 559 (IEEE 754)");
-
-        double_decoder decoder;
-        decoder.d = number; // implicit cast to double
-		// Reading inactive union parts is forbidden in constexpr :-(
-		return std::make_tuple<bool, int, std::uint64_t>(
-			static_cast<bool>(decoder.parts.sign),
-			static_cast<int>(decoder.parts.exponent),
-			static_cast<std::uint64_t>(decoder.parts.fraction)
-		);
 	}
 
 	// generate a color coded binary string for a native long double precision IEEE floating point

--- a/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/gcc_long_double.hpp
@@ -14,21 +14,6 @@
 
 namespace sw { namespace universal {
 
-// ieee_components returns a tuple of sign, exponent, and fraction.
-inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
-	static_assert(std::numeric_limits<double>::is_iec559,
-		"This function only works when double complies with IEC 559 (IEEE 754)");
-	static_assert(sizeof(long double) == 16, "This function only works when long double is 16 bytes.");
-
-	long_double_decoder dd{ fp }; // initializes the first member of the union
-	// Reading inactive union parts is forbidden in constexpr :-(
-	return std::make_tuple<bool, int, std::uint64_t>(
-		static_cast<bool>(dd.parts.sign),
-		static_cast<int>(dd.parts.exponent),
-		static_cast<std::uint64_t>(dd.parts.fraction)
-		);
-}
-
 // specialization for IEEE long double precision floats
 inline std::string to_base2_scientific(long double number) {
 	std::stringstream s;
@@ -43,18 +28,6 @@ inline std::string to_base2_scientific(long double number) {
 	s << "e" << std::showpos << (static_cast<int>(decoder.parts.exponent) - 16383);
 	return s.str();
 }
-
-#ifdef DEPRECATED
-// DEPRECATED: we have standardized on raw bit hex, not field hex format
-// generate a binary string for a native double precision IEEE floating point
-inline std::string to_hex(long double number) {
-	std::stringstream s;
-	long_double_decoder decoder;
-	decoder.ld = number;
-	s << (decoder.parts.sign ? '1' : '0') << '.' << std::hex << int(decoder.parts.exponent) << '.' << decoder.parts.fraction;
-	return s.str();
-}
-#endif // DEPRECATED
 
 inline std::string to_hex(long double number, bool nibbleMarker = false, bool hexPrefix = true) {
 	char hexChar[16] = {

--- a/include/sw/universal/native/nonconstexpr/msvc_long_double.hpp
+++ b/include/sw/universal/native/nonconstexpr/msvc_long_double.hpp
@@ -16,11 +16,6 @@ namespace sw { namespace universal {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 // compiler specific long double IEEE floating point
 
-// Visual C++ does not support long double, it is just an alias for double
-inline std::tuple<bool, int, std::uint64_t> ieee_components(long double fp) {
-	return ieee_components(double(fp));
-}
-
 inline std::string to_hex(long double fp, bool nibbleMarker = false, bool hexPrefix = true) {
 	return to_hex(double(fp), nibbleMarker, hexPrefix);
 }


### PR DESCRIPTION
## Summary

`ieee754_float.hpp`, `ieee754_double.hpp` and the per-compiler long-double headers are named like core headers and included by nearly everything, but their contents are almost entirely **text**:

| | |
|---|---|
| `to_hex`, `to_binary`, `to_triple`, `to_base2_scientific`, `color_print` | text |
| `ieee_components` | core |

Carrying the text there put `<sstream>` and `<iomanip>` into the include graph of every TU that merely *decodes* a native float. **That is where the four I/O-family headers in every number system's graph come from** — not from the number systems, and not from `blocktriple`, both of which were only passing them along.

## The change: move the minority, for all three real types

```
ieee754_components.hpp   17,885 lines   0 I/O-family    <- new
```

covering **float, double and long double** across the gcc, clang, MSVC and RISC-V compiler branches. The text headers keep their text and lose the one core function each carried; they now include the components header, so **anyone who included them directly and called `ieee_components()` is unaffected** — that is what keeps the blast radius at zero. There are 18 call sites, including `internal/value/value.hpp`.

`ieee754_type_tag.hpp` also gained `<string>` and `<type_traits>`, which it uses and was getting transitively from `<sstream>`.

## The failure mode worth recording

`ieee754_components.hpp` needed `utility/architecture.hpp`. The `long_double_decoder` unions in `ieee754_decoder.hpp` are gated on `UNIVERSAL_ARCH_POWER` / `_X86_64` / `_ARM` / `_RISCV` — without `architecture.hpp` none of those macros are defined, no branch fires, and the decoder is invisible:

```
g++                     'long_double_decoder' was not declared in this scope
riscv64-linux-gnu-g++   'long_double_decoder' was not declared in this scope
clang++                 COMPILED
```

**clang passed while the other two failed**, because its branch reaches a different decoder — the same one-toolchain-passes trap that broke the RISC-V cross build in #1386. `long_double.hpp` and `bit_cast.hpp` are included alongside for the same reason.

## Checked and deliberately not fixed

`ieee754_longdouble.hpp` does not compile standalone: its per-compiler headers use `std::stringstream` without including `<sstream>`. Verified against an `origin/main` worktree — **it does not compile there either**, so this is pre-existing, not a regression. Same class as the 148 headers in #1389, and it only bites a TU that includes that header directly.

## Why this shape, and not blocktriple

An earlier attempt split `blocktriple`'s text layer instead. Measured, it was worth **0.3%** — 100,023 to 99,706 lines, with four I/O-family headers before *and* after — because `native/` supplies all four regardless of what `blocktriple` does. It would also have cost **294 TUs** their includes. Measuring before landing is what redirected the work here.

## The pattern, for whoever extends this

**Move the minority, not the majority.** These headers had 5-6 text functions and 1 core function each. Splitting the file would be churn; lifting the one core function out is a three-line change with zero blast radius, because the original then includes the new header.

1. Classify by return type — `std::string` or a stream parameter means text
2. Lift the core minority into a new header
3. Have the original include it
4. Verify by compiling, never by grepping

**Never lift a region spanning a preprocessor boundary.** A first attempt at these files took an `#endif` along with the text and left an orphaned `#ifdef DEPRECATED`. Lifts now assert the moved block contains no `#if`/`#else`/`#endif`, and `#if`-vs-`#endif` counts are checked after every edit — they balance in all four touched files here.

## Test Results

| check | result |
|---|---|
| `ieee_components` float/double/**long double** | compiles on gcc 13.3, clang 18.1, riscv64 cross |
| runtime values from the light header alone | `1.5f` -> `(0, 127, 0x400000)`, `1.5` -> `(0, 1023, 0x8000000000000)`, `1.5L` -> `(0, 16383, 0x4000000000000000)` |
| 1057-TU sweep, ten source trees | **17 failures, identical to the `main` baseline** — zero regressions |
| preprocessor balance, 4 touched files | open/`#endif` counts match |
| CI_LITE build + `ctest -j4` | **456/456 passed** |
| `check-ascii.sh` | clean |
| added lines over 120 columns | 0 |

## Test plan

- [ ] Fast CI passes
- [ ] CodeRabbit review

Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting sign, exponent, and fraction components from native single-, double-, and long-double-precision values across supported compiler architectures.
  * Added validation for compatible IEC 559 representations and expected data sizes.
* **Refactor**
  * Consolidated floating-point component handling into a shared interface for consistent behavior.
  * Standardized long-double processing, including support for compiler-specific representations and double-equivalent values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->