### PR TITLE
refactor(native): add ieee754_core.hpp -- the bit-manipulation half (#1334)

### DIFF
--- a/include/sw/universal/native/ieee754_core.hpp
+++ b/include/sw/universal/native/ieee754_core.hpp
@@ -1,0 +1,59 @@
+#pragma once
+// ieee754_core.hpp: the arithmetic and bit-manipulation half of the native IEEE-754 support
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// ieee754.hpp is the umbrella: this header plus the text layer. Include THIS one
+// from anything that only decodes, encodes or manipulates bits -- it pulls no
+// <iostream>, <sstream> or <iomanip> (#1334).
+//
+//     #include <universal/native/ieee754.hpp>        // everything, as before
+//     #include <universal/native/ieee754_core.hpp>   // bit manipulation only
+//
+// What is deliberately NOT here, and where to get it if you need it:
+//
+//   ieee754_float.hpp / ieee754_double.hpp   to_hex, to_binary, to_triple,
+//   ieee754_longdouble.hpp                   to_base2_scientific, color_print
+//                                            (the long-double dispatcher pulls
+//                                            the per-compiler headers, which are
+//                                            text; extract_fp_components comes
+//                                            from its own header, included here)
+//   ieee754_parameter_ostream.hpp            operator<< for ieee754_parameter
+//   manipulators.hpp, attributes.hpp         reporting helpers
+//   traits/arithmetic_traits.hpp             minmax_range, symmetry_range, ...
+//   integers.hpp                             MIXED: ipow/nlz are core, but
+//                                            to_binary/to_hex bring <sstream>,
+//                                            so include it directly if you need
+//                                            the integer helpers
+//
+// ieee_components() for float, double and long double IS here, via
+// ieee754_components.hpp -- that is the one core function those text headers
+// used to carry.
+#include <cmath>    // frexpf/frexp/frexpl fraction/exponent extraction
+#include <limits>
+#include <tuple>
+
+// configure the low level compiler interface for floating-point bit manipulation
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+// the database of compiler/architecture specific floating-point parameters
+#include <universal/native/ieee754_parameter.hpp>
+#include <universal/native/ieee754_decoder.hpp>
+#include <universal/native/ieee754_type_tag.hpp>
+
+// constexpr compatible bit casts where the compiler allows, else a fallback
+#include <universal/native/extract_fields.hpp>
+#include <universal/native/set_fields.hpp>
+#include <universal/native/nonconst_bitcast.hpp>
+
+// sign/exponent/fraction extraction for float, double and long double
+#include <universal/native/ieee754_components.hpp>
+#include <universal/native/nonconstexpr/extract_fp_components.hpp>
+
+// numeric helpers
+#include <universal/native/ieee754_numeric.hpp>

--- a/include/sw/universal/native/ieee754_type_tag.hpp
+++ b/include/sw/universal/native/ieee754_type_tag.hpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string in the type_tag signatures
+#include <type_traits>   // std::enable_if_t, std::is_floating_point
 
 namespace sw { namespace universal {
 


### PR DESCRIPTION
## Summary

**The first header in this epic to meet both acceptance criteria** — and it is the shared layer every number system sits on, not one internal type:

| toolchain | lines | I/O-family |
|---|---|---|
| g++ 13.3 | **43,452** | **0** |
| clang++ 18.1 | **42,704** | **0** |
| riscv64-linux-gnu cross | **43,384** | **0** |
| *target* | *under 45,000* | *0* |

`ieee754.hpp` stays the umbrella, **unchanged at 62,485 lines / 4 I/O-family**, so nothing that includes it sees any difference. `core.hpp` is purely additive and opt-in, which is why the 1057-TU sweep matches the baseline exactly.

```cpp
#include <universal/native/ieee754.hpp>        // everything, as before
#include <universal/native/ieee754_core.hpp>   // bit manipulation only
```

## What it carries, verified by running it

`ieee_components` and `extract_fp_components` for float, double **and** long double — checked functionally, not just compiled:

```
ieee_components(1.5)         -> (0, 1023, 0x8000000000000)
extract_fp_components(3.25)  -> sign 0, exponent 2, fraction 0.8125
type_tag(1.0)                -> "double"
```

## What it omits, and where each piece lives

Documented in the header itself so nobody has to rediscover it:

| omitted | contains |
|---|---|
| `ieee754_float.hpp`, `ieee754_double.hpp`, `ieee754_longdouble.hpp` | `to_hex`, `to_binary`, `to_triple`, `to_base2_scientific`, `color_print` |
| `ieee754_parameter_ostream.hpp` | `operator<<` for `ieee754_parameter` |
| `manipulators.hpp`, `attributes.hpp`, `traits/arithmetic_traits.hpp` | reporting helpers |
| `integers.hpp` | **MIXED** — `ipow`/`nlz` are core, but `to_binary`/`to_hex` bring `<sstream>`, so include it directly if you need the integer helpers |

## A correction to #1398

Its commit message and PR body both state that `ieee754_type_tag.hpp` gained `<string>` and `<type_traits>`. **That is false for what merged** — `6f8cf5ba` touched six files and this was not one of them. I made the edit during an earlier exploration, lost it to a `git checkout -- .` while shelving abandoned work, and carried the sentence forward without re-verifying against the diff.

The include is in this PR instead, where it is **load-bearing**: without it `ieee754_core.hpp` does not compile on any of the three toolchains, because `type_tag`'s signatures name `std::string` and nothing in the core path supplies it once `<sstream>` is gone.

## Where this leaves the epic

The measured chain that got here:

- `blocktriple`'s split was worth **0.3%** and 294 TUs of churn, because `native/` supplied all four I/O headers regardless — measuring that first is what redirected the work
- `ieee754_float.hpp`/`ieee754_double.hpp` turned out to be *entirely text* with one core function each; lifting that one function out (#1398) had a zero blast radius
- with the text separable, the core now measures under target

`blocktriple`'s split becomes measurable rather than 0.3% once consumers move to `ieee754_core.hpp`, and the per-type rollout can finally be judged against a target it can reach.

## Test Results

| check | result |
|---|---|
| `ieee754_core.hpp` | compiles **and runs correctly** on gcc, clang, riscv64 |
| 38 umbrellas | clean on all three toolchains |
| 1057-TU sweep, ten source trees | **17 failures, identical to the `main` baseline** — zero regressions |
| `ieee754.hpp` umbrella | unchanged, 62,485 lines / 4 I/O |
| CI_LITE build + `ctest -j4` | **456/456 passed** |
| `check-ascii.sh` | clean |
| added lines over 120 columns | 0 |

## Test plan

- [ ] Fast CI passes
- [ ] CodeRabbit review

Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Added a lightweight IEEE-754 core interface for floating-point bit manipulation, decoding, encoding, field extraction, and numeric utilities.
  - Improved type support by including the required standard-library definitions for type identification and constraints.
  - Kept the core interface focused by excluding formatting and reporting dependencies, helping maintain a smaller integration footprint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->