### PR TITLE
refactor(blocktriple): split the text layer out of the core (#1334)

### DIFF
--- a/education/internal/blocktriple.cpp
+++ b/education/internal/blocktriple.cpp
@@ -7,6 +7,8 @@
 #include <universal/utility/directives.hpp>
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/iostream.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
 #include <iostream>
 #include <string>
 

--- a/education/number/posit/extract.cpp
+++ b/education/number/posit/extract.cpp
@@ -6,6 +6,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/number/posit/posit.hpp>
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
 
 /*
 Laid out as bits, floating point numbers look like this:

--- a/education/number/posit/values.cpp
+++ b/education/number/posit/values.cpp
@@ -6,6 +6,8 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/number/posit/posit.hpp>
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/iostream.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
 
 /*-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //

--- a/include/sw/universal/internal/blocktriple/blocktriple.hpp
+++ b/include/sw/universal/internal/blocktriple/blocktriple.hpp
@@ -9,19 +9,16 @@
 #include <cstdio>
 #include <cmath>
 #include <string>
-#include <iomanip>
-#include <sstream>
+#include <ios>      // std::streamsize in the to_string declaration
 #include <limits>
 #include <algorithm>
 #include <vector>
 
 // dependent types for stand-alone use of this class
-#include <universal/native/integers.hpp> // to_binary(uint64_t)
 #include <universal/native/ieee754_core.hpp>   // bit manipulation only; the text layer is not needed here (#1334)
 #include <universal/native/subnormal.hpp>
 #include <universal/utility/find_msb.hpp>
 #include <universal/internal/blocksignificand/blocksignificand.hpp>
-#include <universal/number/support/decimal.hpp>
 // blocktriple operation trace options
 #include <universal/internal/blocktriple/trace_constants.hpp>
 
@@ -56,28 +53,6 @@ TBD SQRT      iiii.ffff'ffff'ffff         4 integer bits, 2*f fraction bits
 
  // operator specialization tag for blocktriple
 enum class BlockTripleOperator { REP, ADD, MUL, DIV, SQRT };
-inline std::ostream& operator<<(std::ostream& ostr, const BlockTripleOperator& op) {
-	switch (op) {
-	case BlockTripleOperator::REP:
-		ostr << "REP";
-		break;
-	case BlockTripleOperator::ADD:
-		ostr << "ADD";
-		break;
-	case BlockTripleOperator::MUL:
-		ostr << "MUL";
-		break;
-	case BlockTripleOperator::DIV:
-		ostr << "DIV";
-		break;
-	case BlockTripleOperator::SQRT:
-		ostr << "SQRT";
-		break;
-	default:
-		ostr << "NOP";
-	}
-	return ostr;
-}
 
 // Forward definitions
 template<unsigned fbits, BlockTripleOperator op, typename bt> class blocktriple;
@@ -88,16 +63,6 @@ blocktriple<fbits, op, bt>& convert(unsigned long long uint, blocktriple<fbits, 
 	return tgt;
 }
 
-// Generate a type tag for this type: blocktriple<fbits, operator, unsigned int>
-template<unsigned fbits, BlockTripleOperator op, typename bt>
-std::string type_tag(const blocktriple<fbits, op, bt>& = {}) {
-	std::stringstream s;
-	s << "blocktriple<"
-	  << std::setw(3) << fbits << ", "
-      << op << ", "
-	  << type_tag(bt{}) << '>';
-	return s.str();
-}
 
 /// <summary>
 /// Generalized blocktriple representing a (sign, scale, significand) with unrounded arithmetic
@@ -418,6 +383,14 @@ public:
 
 	// helper debug function; defined out-of-line in blocktriple_debug.hpp so this
 	// header needs no <iostream>. Include that header to call it.
+public:
+	// to_string: defined out-of-line in internal/blocktriple/manipulators.hpp so
+	// this header needs no <sstream>. Include that header to call it.
+	std::string to_string(std::streamsize precision = 7, std::streamsize width = 0,
+		bool fixed = false, bool scientific = true, bool internal = false,
+		bool left = false, bool showpos = false, bool uppercase = false,
+		char fill = ' ') const;
+
 	void constexprClassParameters() const;
 
 	/////////////////////////////////////////////////////////////
@@ -864,265 +837,8 @@ private:
 	}
 
 public:
-	// convert blocktriple to a formatted decimal string
-	// Follows the same interface as ereal::to_string() for consistency.
-	// Uses support::decimal for exact binary-to-decimal conversion.
-	std::string to_string(std::streamsize precision = 7, std::streamsize width = 0,
-		bool fixed = false, bool scientific = true, bool internal = false,
-		bool left = false, bool showpos = false, bool uppercase = false,
-		char fill = ' ') const
-	{
-		std::string s;
-		if (fixed && scientific) fixed = false; // scientific takes precedence
-		if (!fixed && !scientific) scientific = true; // defaultfloat -> scientific
-
-		if (_nan) {
-			s = _sign ? (uppercase ? "SNAN" : "snan") : (uppercase ? "QNAN" : "qnan");
-			goto apply_width;
-		}
-
-		{
-			// sign prefix for non-NaN values
-			if (_sign) { s += '-'; } else { if (showpos) s += '+'; }
-
-			if (_inf) {
-				s += uppercase ? "INF" : "inf";
-			}
-			else if (_zero) {
-				s += '0';
-				if (precision > 0) {
-					s += '.';
-					s.append(static_cast<size_t>(precision), '0');
-				}
-				if (!fixed) {
-					s += uppercase ? "E+00" : "e+00";
-				}
-			}
-			else {
-				// Normal value: exact binary-to-decimal via support::decimal
-				// Value = significand * 2^(scale - radix)
-				// where significand is stored as an integer with radix point at position 'radix'
-
-				// Step 1: accumulate significand bits into a decimal integer
-				support::decimal sig;
-				sig.setzero();
-				support::decimal bitWeight;
-				bitWeight.setdigit(1);
-				for (unsigned i = 0; i < bfbits; ++i) {
-					if (_significand.at(i)) {
-						support::add(sig, bitWeight);
-					}
-					support::add(bitWeight, bitWeight); // bitWeight *= 2
-				}
-
-				// Step 2: compute effective exponent
-				long long effExp = static_cast<long long>(_scale) - static_cast<long long>(radix);
-
-				// Step 3: scale the significand to get exact decimal digits
-				// sig * 2^effExp = exact value
-				// If effExp >= 0: multiply sig by 2^effExp
-				// If effExp < 0:  sig * 2^(-|e|) = sig * 5^|e| / 10^|e|
-				//   so multiply sig by 5^|e| and remember |e| implied fractional digits
-
-				long long impliedFracDigits = 0;
-
-				if (effExp > 0) {
-					if (effExp > 100000) {
-						// Extreme case: compute approximate scientific notation
-						// from significand and binary exponent directly.
-						// decimal exponent = effExp * log10(2) + log10(sig_value)
-						double sigVal = static_cast<double>(_significand);
-						double log10Val = effExp * 0.30102999566398119521 + std::log10(sigVal);
-						long long decExp = static_cast<long long>(std::floor(log10Val));
-						double mantissa = std::pow(10.0, log10Val - decExp);
-						if (mantissa >= 10.0) { mantissa /= 10.0; ++decExp; }
-						if (mantissa < 1.0) { mantissa *= 10.0; --decExp; }
-						std::ostringstream oss;
-						oss.precision(precision);
-						oss << std::fixed << mantissa;
-						if (!fixed) {
-							s += oss.str();
-							s += uppercase ? 'E' : 'e';
-							append_exponent(s, decExp);
-						} else {
-							// fixed with extreme exponent: just show the approximate value
-							s += oss.str();
-							s += uppercase ? 'E' : 'e';
-							append_exponent(s, decExp);
-						}
-						goto apply_width;
-					}
-					support::decimal pow2;
-					pow2.powerOf2(static_cast<size_t>(effExp));
-					support::mul(sig, pow2);
-				}
-				else if (effExp < 0) {
-					long long absExp = -effExp;
-					if (absExp > 100000) {
-						// Extreme case: compute approximate scientific notation
-						double sigVal = static_cast<double>(_significand);
-						double log10Val = effExp * 0.30102999566398119521 + std::log10(sigVal);
-						long long decExp = static_cast<long long>(std::floor(log10Val));
-						double mantissa = std::pow(10.0, log10Val - decExp);
-						if (mantissa >= 10.0) { mantissa /= 10.0; ++decExp; }
-						if (mantissa < 1.0) { mantissa *= 10.0; --decExp; }
-						std::ostringstream oss;
-						oss.precision(precision);
-						oss << std::fixed << mantissa;
-						s += oss.str();
-						s += uppercase ? 'E' : 'e';
-						append_exponent(s, decExp);
-						goto apply_width;
-					}
-					support::decimal pow5 = power_of_five(static_cast<size_t>(absExp));
-					support::mul(sig, pow5);
-					impliedFracDigits = absExp;
-				}
-
-				sig.unpad();
-
-				// Step 4: determine digit layout
-				// sig now represents the exact value * 10^impliedFracDigits
-				// Total decimal digits in sig
-				long long totalDigits = static_cast<long long>(sig.size());
-				// Position of decimal point: sciExponent is the power-of-10 of the MSD
-				long long sciExponent = (totalDigits - 1) - impliedFracDigits;
-
-				// Step 5: extract digits MSD-first into a vector
-				std::vector<int> digits(static_cast<size_t>(totalDigits));
-				for (long long i = 0; i < totalDigits; ++i) {
-					digits[static_cast<size_t>(i)] = sig[static_cast<size_t>(totalDigits - 1 - i)];
-				}
-
-				// Step 6: determine how many digits we need and round
-				long long neededDigits;
-				if (fixed) {
-					// fixed: we need (sciExponent + 1) integer digits + precision fraction digits
-					neededDigits = sciExponent + 1 + precision;
-					if (neededDigits < 1) neededDigits = 1;
-				}
-				else {
-					// scientific: 1 integer digit + precision fraction digits
-					neededDigits = 1 + precision;
-				}
-
-				// Round at the boundary
-				if (neededDigits < totalDigits) {
-					int roundDigit = digits[static_cast<size_t>(neededDigits)];
-					if (roundDigit >= 5) {
-						// propagate carry
-						long long k = neededDigits - 1;
-						while (k >= 0) {
-							digits[static_cast<size_t>(k)]++;
-							if (digits[static_cast<size_t>(k)] < 10) break;
-							digits[static_cast<size_t>(k)] = 0;
-							--k;
-						}
-						if (k < 0) {
-							// carry out of MSD: insert a 1 at front
-							digits.insert(digits.begin(), 1);
-							totalDigits++;
-							sciExponent++;
-							// neededDigits stays same, but we may have one more digit
-						}
-					}
-					digits.resize(static_cast<size_t>(neededDigits));
-					totalDigits = neededDigits;
-				}
-				else if (neededDigits > totalDigits) {
-					// pad with trailing zeros
-					digits.resize(static_cast<size_t>(neededDigits), 0);
-					totalDigits = neededDigits;
-				}
-
-				// Step 7: format the digits
-				if (fixed) {
-					long long intDigits = sciExponent + 1;
-					if (intDigits <= 0) {
-						s += "0.";
-						for (long long z = 0; z < -intDigits && z < precision; ++z) s += '0';
-						long long remaining = precision - (-intDigits);
-						if (remaining < 0) remaining = 0;
-						for (long long i = 0; i < remaining && i < totalDigits; ++i) {
-							s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
-						}
-						// pad if needed
-						long long written = (-intDigits) + std::min(remaining, totalDigits);
-						for (long long i = written; i < precision; ++i) s += '0';
-					}
-					else {
-						for (long long i = 0; i < intDigits && i < totalDigits; ++i) {
-							s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
-						}
-						// pad integer part if digits ran out
-						for (long long i = totalDigits; i < intDigits; ++i) s += '0';
-						if (precision > 0) {
-							s += '.';
-							for (long long i = intDigits; i < intDigits + precision; ++i) {
-								if (i < totalDigits)
-									s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
-								else
-									s += '0';
-							}
-						}
-					}
-				}
-				else {
-					// scientific: d.dddddde+/-EEE
-					if (totalDigits > 0)
-						s += static_cast<char>('0' + digits[0]);
-					else
-						s += '0';
-					if (precision > 0) {
-						s += '.';
-						for (long long i = 1; i <= precision; ++i) {
-							if (i < totalDigits)
-								s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
-							else
-								s += '0';
-						}
-					}
-					s += uppercase ? 'E' : 'e';
-					append_exponent(s, sciExponent);
-				}
-			}
-		}
-
-	apply_width:
-		// process width/fill/alignment
-		if (width > 0 && s.length() < static_cast<size_t>(width)) {
-			size_t nrCharsToFill = static_cast<size_t>(width) - s.length();
-			if (internal) {
-				const bool hasSign = !s.empty() && (s[0] == '-' || s[0] == '+');
-				s.insert(hasSign ? static_cast<std::string::size_type>(1)
-				                 : static_cast<std::string::size_type>(0),
-				         nrCharsToFill, fill);
-			}
-			else if (left) {
-				s.append(nrCharsToFill, fill);
-			}
-			else {
-				s.insert(static_cast<std::string::size_type>(0), nrCharsToFill, fill);
-			}
-		}
-
-		return s;
-	}
 
 private:
-	// Compute 5^n using repeated squaring with support::decimal
-	static support::decimal power_of_five(size_t n) {
-		support::decimal result;
-		result.setdigit(1);
-		support::decimal base;
-		base.setdigit(5);
-		while (n > 0) {
-			if (n & 1) support::mul(result, base);
-			if (n > 1) support::mul(base, base);
-			n >>= 1;
-		}
-		return result;
-	}
 
 	// Format exponent as +/-NNN (handles arbitrarily large exponents)
 	static void append_exponent(std::string& str, long long e) {
@@ -1138,10 +854,13 @@ private:
 
 public:
 
-	// template parameters need names different from class template parameters (for gcc and clang)
-	template<unsigned ffbits, BlockTripleOperator oop, typename bbt>
-	friend std::istream& operator>> (std::istream& istr, blocktriple<ffbits, oop, bbt>& a);
 
+	// no friend declaration for operator>>: it is defined in
+	// internal/blocktriple/iostream.hpp and needs no private access (it assigns
+	// through the public constructor). See #1334.
+	//
+	// to_binary and to_triple DO keep theirs: they read _sign, _scale and
+	// _significand directly, so friendship is load-bearing there.
 	// declare as friends to avoid needing a marshalling function to get significand bits out
 	template<unsigned ffbits, BlockTripleOperator oop, typename bbt>
 	friend std::string to_binary(const blocktriple<ffbits, oop, bbt>&, bool);
@@ -1165,30 +884,7 @@ public:
 
 ////////////////////// operators
 
-// blocktriple ostream operator: honors all standard formatting flags
-template<unsigned fbits, BlockTripleOperator op, typename bt>
-inline std::ostream& operator<<(std::ostream& ostr, const blocktriple<fbits, op, bt>& a) {
-	std::ios_base::fmtflags fmt = ostr.flags();
-	std::streamsize precision = ostr.precision();
-	std::streamsize width = ostr.width();
-	char fillChar = ostr.fill();
-	bool bShowpos    = fmt & std::ios_base::showpos;
-	bool bUppercase  = fmt & std::ios_base::uppercase;
-	bool bFixed      = fmt & std::ios_base::fixed;
-	bool bScientific = fmt & std::ios_base::scientific;
-	bool bInternal   = fmt & std::ios_base::internal;
-	bool bLeft       = fmt & std::ios_base::left;
-	return ostr << a.to_string(precision, width, bFixed, bScientific,
-	                            bInternal, bLeft, bShowpos, bUppercase, fillChar);
-}
 
-template<unsigned fbits, BlockTripleOperator op, typename bt>
-inline std::istream& operator>> (std::istream& istr, blocktriple<fbits, op, bt>& a) {
-	double v{};
-	istr >> v;
-	a = blocktriple<fbits, op, bt>(v);
-	return istr;
-}
 
 template<unsigned fbits, BlockTripleOperator op, typename bt>
 inline bool operator==(const blocktriple<fbits, op, bt>& lhs, const blocktriple<fbits, op, bt>& rhs) { return lhs._sign == rhs._sign && lhs._scale == rhs._scale && lhs._significand == rhs._significand && lhs._zero == rhs._zero && lhs._inf == rhs._inf; }
@@ -1271,19 +967,7 @@ inline bool operator>=(const blocktriple<fbits, op, bt>& lhs, const blocktriple<
 
 ////////////////////////////////// string conversion functions //////////////////////////////
 
-template<unsigned fbits, BlockTripleOperator op, typename bt>
-std::string to_binary(const sw::universal::blocktriple<fbits, op, bt>& a, bool nibbleMarker = false) {
-	return to_triple(a, nibbleMarker);
-}
 
-template<unsigned fbits, BlockTripleOperator op, typename bt>
-std::string to_triple(const blocktriple<fbits, op, bt>& a, bool nibbleMarker = true) {
-	std::stringstream s;
-	s << (a._sign ? "(-, " : "(+, ");
-	s << std::setw(3) << a._scale << ", ";
-	s << to_binary(a._significand, nibbleMarker) << ')';
-	return s.str();
-}
 
 template<unsigned fbits, BlockTripleOperator op, typename bt>
 blocktriple<fbits> abs(const blocktriple<fbits, op, bt>& a) {

--- a/include/sw/universal/internal/blocktriple/blocktriple.hpp
+++ b/include/sw/universal/internal/blocktriple/blocktriple.hpp
@@ -56,6 +56,17 @@ enum class BlockTripleOperator { REP, ADD, MUL, DIV, SQRT };
 
 // Forward definitions
 template<unsigned fbits, BlockTripleOperator op, typename bt> class blocktriple;
+// to_binary and to_triple are defined in internal/blocktriple/manipulators.hpp.
+// Their DEFAULT ARGUMENTS are established here, at namespace scope, and not on
+// the definitions: the in-class friend declarations below cannot carry defaults
+// (a friend declaration may only do so when it is also a definition), and once
+// the friend declaration is the first one clang sees, adding defaults later is
+// an error -- "default arguments cannot be added". gcc accepts it; clang does
+// not, which is why this only appeared in CI. See #1334.
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+std::string to_binary(const blocktriple<fbits, op, bt>& a, bool nibbleMarker = false);
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+std::string to_triple(const blocktriple<fbits, op, bt>& a, bool nibbleMarker = true);
 template<unsigned fbits, BlockTripleOperator op, typename bt> blocktriple<fbits, op, bt> abs(const blocktriple<fbits, op, bt>& v);
 
 template<unsigned fbits, BlockTripleOperator op, typename bt>

--- a/include/sw/universal/internal/blocktriple/blocktriple_debug.hpp
+++ b/include/sw/universal/internal/blocktriple/blocktriple_debug.hpp
@@ -15,6 +15,8 @@
 #include <iostream>
 #include <typeinfo>
 #include <universal/internal/blocktriple/blocktriple.hpp>
+#include <universal/internal/blocktriple/manipulators.hpp>   // type_tag, to_binary (#1334)
+#include <universal/internal/blocktriple/iostream.hpp>       // operator<< for BlockTripleOperator (#1334)
 
 namespace sw { namespace universal {
 

--- a/include/sw/universal/internal/blocktriple/iostream.hpp
+++ b/include/sw/universal/internal/blocktriple/iostream.hpp
@@ -1,0 +1,50 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for blocktriple
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The <iostream> half of blocktriple's text layer (#1334). manipulators.hpp is
+// the <iomanip> half; operator<< delegates to blocktriple::to_string and the enum
+// printer to to_string(BlockTripleOperator), both defined there.
+#include <ios>
+#include <ostream>
+#include <istream>
+#include <universal/internal/blocktriple/blocktriple.hpp>
+#include <universal/internal/blocktriple/manipulators.hpp>
+
+namespace sw { namespace universal {
+
+// the operator specialization tag, streamed
+inline std::ostream& operator<<(std::ostream& ostr, const BlockTripleOperator& op) {
+	return ostr << to_string(op);
+}
+
+// blocktriple ostream operator: honors all standard formatting flags
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+inline std::ostream& operator<<(std::ostream& ostr, const blocktriple<fbits, op, bt>& a) {
+	std::ios_base::fmtflags fmt = ostr.flags();
+	std::streamsize precision = ostr.precision();
+	std::streamsize width = ostr.width();
+	char fillChar = ostr.fill();
+	bool bShowpos    = fmt & std::ios_base::showpos;
+	bool bUppercase  = fmt & std::ios_base::uppercase;
+	bool bFixed      = fmt & std::ios_base::fixed;
+	bool bScientific = fmt & std::ios_base::scientific;
+	bool bInternal   = fmt & std::ios_base::internal;
+	bool bLeft       = fmt & std::ios_base::left;
+	return ostr << a.to_string(precision, width, bFixed, bScientific,
+	                            bInternal, bLeft, bShowpos, bUppercase, fillChar);
+}
+
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+inline std::istream& operator>> (std::istream& istr, blocktriple<fbits, op, bt>& a) {
+	double v{};
+	istr >> v;
+	a = blocktriple<fbits, op, bt>(v);
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/internal/blocktriple/manipulators.hpp
+++ b/include/sw/universal/internal/blocktriple/manipulators.hpp
@@ -1,0 +1,332 @@
+#pragma once
+// manipulators.hpp: text produced from a blocktriple
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// The <iomanip> half of blocktriple's text layer (#1334): type_tag, to_binary,
+// to_triple, and the out-of-line definition of blocktriple::to_string, declared
+// in blocktriple.hpp but defined here so the core needs no <sstream>.
+//
+// to_binary and to_triple read _sign, _scale and _significand directly, so they
+// remain friends of the class; blocktriple.hpp declares that friendship and this
+// header supplies the definitions.
+//
+// to_string(BlockTripleOperator) lives here rather than in iostream.hpp because
+// type_tag needs the operator's NAME, not a stream insertion. Keeping the string
+// form in the <iomanip> layer is what stops this header depending on that one.
+#include <cstdint>
+#include <ios>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <typeinfo>
+#include <universal/native/integers.hpp>          // to_binary(uint64_t)
+#include <universal/number/support/decimal.hpp>   // support::decimal, for power_of_five
+#include <universal/internal/blocktriple/blocktriple.hpp>
+
+namespace sw { namespace universal {
+
+// the operator tag as a string
+inline std::string to_string(BlockTripleOperator op) {
+	switch (op) {
+	case BlockTripleOperator::REP:  return "REP";
+	case BlockTripleOperator::ADD:  return "ADD";
+	case BlockTripleOperator::MUL:  return "MUL";
+	case BlockTripleOperator::DIV:  return "DIV";
+	case BlockTripleOperator::SQRT: return "SQRT";
+	default: return "NOP";
+	}
+}
+
+// Generate a type tag for this type: blocktriple<fbits, operator, unsigned int>
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+std::string type_tag(const blocktriple<fbits, op, bt>& = {}) {
+	std::stringstream s;
+	s << "blocktriple<"
+	  << std::setw(3) << fbits << ", "
+      << to_string(op) << ", "
+	  << type_tag(bt{}) << '>';
+	return s.str();
+}
+
+// convert blocktriple to a formatted decimal string
+// Follows the same interface as ereal::to_string() for consistency.
+// Uses support::decimal for exact binary-to-decimal conversion.
+// power_of_five: a decimal helper used only by to_string, which is why it lives
+// in the text layer. It was a private static member of blocktriple, and keeping
+// it there meant the core carried support/decimal.hpp (#1334).
+// Compute 5^n using repeated squaring with support::decimal
+inline support::decimal power_of_five(size_t n) {
+	support::decimal result;
+	result.setdigit(1);
+	support::decimal base;
+	base.setdigit(5);
+	while (n > 0) {
+		if (n & 1) support::mul(result, base);
+		if (n > 1) support::mul(base, base);
+		n >>= 1;
+	}
+	return result;
+}
+
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+std::string blocktriple<fbits, op, bt>::to_string(std::streamsize precision, std::streamsize width,
+		bool fixed, bool scientific, bool internal,
+		bool left, bool showpos, bool uppercase,
+		char fill) const
+{
+	std::string s;
+	if (fixed && scientific) fixed = false; // scientific takes precedence
+	if (!fixed && !scientific) scientific = true; // defaultfloat -> scientific
+
+	if (_nan) {
+		s = _sign ? (uppercase ? "SNAN" : "snan") : (uppercase ? "QNAN" : "qnan");
+		goto apply_width;
+	}
+
+	{
+		// sign prefix for non-NaN values
+		if (_sign) { s += '-'; } else { if (showpos) s += '+'; }
+
+		if (_inf) {
+			s += uppercase ? "INF" : "inf";
+		}
+		else if (_zero) {
+			s += '0';
+			if (precision > 0) {
+				s += '.';
+				s.append(static_cast<size_t>(precision), '0');
+			}
+			if (!fixed) {
+				s += uppercase ? "E+00" : "e+00";
+			}
+		}
+		else {
+			// Normal value: exact binary-to-decimal via support::decimal
+			// Value = significand * 2^(scale - radix)
+			// where significand is stored as an integer with radix point at position 'radix'
+
+			// Step 1: accumulate significand bits into a decimal integer
+			support::decimal sig;
+			sig.setzero();
+			support::decimal bitWeight;
+			bitWeight.setdigit(1);
+			for (unsigned i = 0; i < bfbits; ++i) {
+				if (_significand.at(i)) {
+					support::add(sig, bitWeight);
+				}
+				support::add(bitWeight, bitWeight); // bitWeight *= 2
+			}
+
+			// Step 2: compute effective exponent
+			long long effExp = static_cast<long long>(_scale) - static_cast<long long>(radix);
+
+			// Step 3: scale the significand to get exact decimal digits
+			// sig * 2^effExp = exact value
+			// If effExp >= 0: multiply sig by 2^effExp
+			// If effExp < 0:  sig * 2^(-|e|) = sig * 5^|e| / 10^|e|
+			//   so multiply sig by 5^|e| and remember |e| implied fractional digits
+
+			long long impliedFracDigits = 0;
+
+			if (effExp > 0) {
+				if (effExp > 100000) {
+					// Extreme case: compute approximate scientific notation
+					// from significand and binary exponent directly.
+					// decimal exponent = effExp * log10(2) + log10(sig_value)
+					double sigVal = static_cast<double>(_significand);
+					double log10Val = effExp * 0.30102999566398119521 + std::log10(sigVal);
+					long long decExp = static_cast<long long>(std::floor(log10Val));
+					double mantissa = std::pow(10.0, log10Val - decExp);
+					if (mantissa >= 10.0) { mantissa /= 10.0; ++decExp; }
+					if (mantissa < 1.0) { mantissa *= 10.0; --decExp; }
+					std::ostringstream oss;
+					oss.precision(precision);
+					oss << std::fixed << mantissa;
+					if (!fixed) {
+						s += oss.str();
+						s += uppercase ? 'E' : 'e';
+						append_exponent(s, decExp);
+					} else {
+						// fixed with extreme exponent: just show the approximate value
+						s += oss.str();
+						s += uppercase ? 'E' : 'e';
+						append_exponent(s, decExp);
+					}
+					goto apply_width;
+				}
+				support::decimal pow2;
+				pow2.powerOf2(static_cast<size_t>(effExp));
+				support::mul(sig, pow2);
+			}
+			else if (effExp < 0) {
+				long long absExp = -effExp;
+				if (absExp > 100000) {
+					// Extreme case: compute approximate scientific notation
+					double sigVal = static_cast<double>(_significand);
+					double log10Val = effExp * 0.30102999566398119521 + std::log10(sigVal);
+					long long decExp = static_cast<long long>(std::floor(log10Val));
+					double mantissa = std::pow(10.0, log10Val - decExp);
+					if (mantissa >= 10.0) { mantissa /= 10.0; ++decExp; }
+					if (mantissa < 1.0) { mantissa *= 10.0; --decExp; }
+					std::ostringstream oss;
+					oss.precision(precision);
+					oss << std::fixed << mantissa;
+					s += oss.str();
+					s += uppercase ? 'E' : 'e';
+					append_exponent(s, decExp);
+					goto apply_width;
+				}
+				support::decimal pow5 = power_of_five(static_cast<size_t>(absExp));
+				support::mul(sig, pow5);
+				impliedFracDigits = absExp;
+			}
+
+			sig.unpad();
+
+			// Step 4: determine digit layout
+			// sig now represents the exact value * 10^impliedFracDigits
+			// Total decimal digits in sig
+			long long totalDigits = static_cast<long long>(sig.size());
+			// Position of decimal point: sciExponent is the power-of-10 of the MSD
+			long long sciExponent = (totalDigits - 1) - impliedFracDigits;
+
+			// Step 5: extract digits MSD-first into a vector
+			std::vector<int> digits(static_cast<size_t>(totalDigits));
+			for (long long i = 0; i < totalDigits; ++i) {
+				digits[static_cast<size_t>(i)] = sig[static_cast<size_t>(totalDigits - 1 - i)];
+			}
+
+			// Step 6: determine how many digits we need and round
+			long long neededDigits;
+			if (fixed) {
+				// fixed: we need (sciExponent + 1) integer digits + precision fraction digits
+				neededDigits = sciExponent + 1 + precision;
+				if (neededDigits < 1) neededDigits = 1;
+			}
+			else {
+				// scientific: 1 integer digit + precision fraction digits
+				neededDigits = 1 + precision;
+			}
+
+			// Round at the boundary
+			if (neededDigits < totalDigits) {
+				int roundDigit = digits[static_cast<size_t>(neededDigits)];
+				if (roundDigit >= 5) {
+					// propagate carry
+					long long k = neededDigits - 1;
+					while (k >= 0) {
+						digits[static_cast<size_t>(k)]++;
+						if (digits[static_cast<size_t>(k)] < 10) break;
+						digits[static_cast<size_t>(k)] = 0;
+						--k;
+					}
+					if (k < 0) {
+						// carry out of MSD: insert a 1 at front
+						digits.insert(digits.begin(), 1);
+						totalDigits++;
+						sciExponent++;
+						// neededDigits stays same, but we may have one more digit
+					}
+				}
+				digits.resize(static_cast<size_t>(neededDigits));
+				totalDigits = neededDigits;
+			}
+			else if (neededDigits > totalDigits) {
+				// pad with trailing zeros
+				digits.resize(static_cast<size_t>(neededDigits), 0);
+				totalDigits = neededDigits;
+			}
+
+			// Step 7: format the digits
+			if (fixed) {
+				long long intDigits = sciExponent + 1;
+				if (intDigits <= 0) {
+					s += "0.";
+					for (long long z = 0; z < -intDigits && z < precision; ++z) s += '0';
+					long long remaining = precision - (-intDigits);
+					if (remaining < 0) remaining = 0;
+					for (long long i = 0; i < remaining && i < totalDigits; ++i) {
+						s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
+					}
+					// pad if needed
+					long long written = (-intDigits) + std::min(remaining, totalDigits);
+					for (long long i = written; i < precision; ++i) s += '0';
+				}
+				else {
+					for (long long i = 0; i < intDigits && i < totalDigits; ++i) {
+						s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
+					}
+					// pad integer part if digits ran out
+					for (long long i = totalDigits; i < intDigits; ++i) s += '0';
+					if (precision > 0) {
+						s += '.';
+						for (long long i = intDigits; i < intDigits + precision; ++i) {
+							if (i < totalDigits)
+								s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
+							else
+								s += '0';
+						}
+					}
+				}
+			}
+			else {
+				// scientific: d.dddddde+/-EEE
+				if (totalDigits > 0)
+					s += static_cast<char>('0' + digits[0]);
+				else
+					s += '0';
+				if (precision > 0) {
+					s += '.';
+					for (long long i = 1; i <= precision; ++i) {
+						if (i < totalDigits)
+							s += static_cast<char>('0' + digits[static_cast<size_t>(i)]);
+						else
+							s += '0';
+					}
+				}
+				s += uppercase ? 'E' : 'e';
+				append_exponent(s, sciExponent);
+			}
+		}
+	}
+
+apply_width:
+	// process width/fill/alignment
+	if (width > 0 && s.length() < static_cast<size_t>(width)) {
+		size_t nrCharsToFill = static_cast<size_t>(width) - s.length();
+		if (internal) {
+			const bool hasSign = !s.empty() && (s[0] == '-' || s[0] == '+');
+			s.insert(hasSign ? static_cast<std::string::size_type>(1)
+			                 : static_cast<std::string::size_type>(0),
+			         nrCharsToFill, fill);
+		}
+		else if (left) {
+			s.append(nrCharsToFill, fill);
+		}
+		else {
+			s.insert(static_cast<std::string::size_type>(0), nrCharsToFill, fill);
+		}
+	}
+
+	return s;
+}
+
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+std::string to_binary(const sw::universal::blocktriple<fbits, op, bt>& a, bool nibbleMarker = false) {
+	return to_triple(a, nibbleMarker);
+}
+
+template<unsigned fbits, BlockTripleOperator op, typename bt>
+std::string to_triple(const blocktriple<fbits, op, bt>& a, bool nibbleMarker = true) {
+	std::stringstream s;
+	s << (a._sign ? "(-, " : "(+, ");
+	s << std::setw(3) << a._scale << ", ";
+	s << to_binary(a._significand, nibbleMarker) << ')';
+	return s.str();
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/internal/blocktriple/manipulators.hpp
+++ b/include/sw/universal/internal/blocktriple/manipulators.hpp
@@ -316,12 +316,12 @@ apply_width:
 }
 
 template<unsigned fbits, BlockTripleOperator op, typename bt>
-std::string to_binary(const sw::universal::blocktriple<fbits, op, bt>& a, bool nibbleMarker = false) {
+std::string to_binary(const sw::universal::blocktriple<fbits, op, bt>& a, bool nibbleMarker) {
 	return to_triple(a, nibbleMarker);
 }
 
 template<unsigned fbits, BlockTripleOperator op, typename bt>
-std::string to_triple(const blocktriple<fbits, op, bt>& a, bool nibbleMarker = true) {
+std::string to_triple(const blocktriple<fbits, op, bt>& a, bool nibbleMarker) {
 	std::stringstream s;
 	s << (a._sign ? "(-, " : "(+, ");
 	s << std::setw(3) << a._scale << ", ";

--- a/include/sw/universal/internal/blocktriple/manipulators.hpp
+++ b/include/sw/universal/internal/blocktriple/manipulators.hpp
@@ -17,12 +17,16 @@
 // to_string(BlockTripleOperator) lives here rather than in iostream.hpp because
 // type_tag needs the operator's NAME, not a stream insertion. Keeping the string
 // form in the <iomanip> layer is what stops this header depending on that one.
+#include <algorithm>   // std::min
+#include <cmath>       // std::pow, std::log10, std::floor
+#include <cstddef>     // size_t
 #include <cstdint>
 #include <ios>
 #include <iomanip>
 #include <sstream>
 #include <string>
 #include <typeinfo>
+#include <vector>      // std::vector
 #include <universal/native/integers.hpp>          // to_binary(uint64_t)
 #include <universal/number/support/decimal.hpp>   // support::decimal, for power_of_five
 #include <universal/internal/blocktriple/blocktriple.hpp>

--- a/include/sw/universal/number/posit/iostream.hpp
+++ b/include/sw/universal/number/posit/iostream.hpp
@@ -12,6 +12,8 @@
 // only what genuinely needs the stream types: operator<< and operator>>.
 //
 // posit.hpp includes both, so existing code is unaffected.
+// blocktriple::to_string, called on the value from to_value<> (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>
 #include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 #include <ios>

--- a/include/sw/universal/number/posit/manipulators.hpp
+++ b/include/sw/universal/number/posit/manipulators.hpp
@@ -6,6 +6,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+// blocktriple::to_string, called on the value from to_value<> (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>
 #include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <cctype>
 #include <cstdint>

--- a/internal/blocktriple/api/constexpr.cpp
+++ b/internal/blocktriple/api/constexpr.cpp
@@ -14,6 +14,7 @@
 
 // minimum set of include files to reflect source code dependencies
 #include <universal/internal/blocktriple/blocktriple.hpp>
+#include <universal/internal/blocktriple/iostream.hpp>   // (#1334)
 
 namespace sw::experiment {
 	template<size_t nbits, typename bt = uint32_t>

--- a/internal/blocktriple/api/ostream_formatting.cpp
+++ b/internal/blocktriple/api/ostream_formatting.cpp
@@ -10,6 +10,7 @@
 #include <universal/verification/test_reporters.hpp>
 
 #include <universal/internal/blocktriple/blocktriple.hpp>
+#include <universal/internal/blocktriple/iostream.hpp>   // (#1334)
 
 namespace sw { namespace universal {
 

--- a/internal/blocktriple/conversion/conversion.cpp
+++ b/internal/blocktriple/conversion/conversion.cpp
@@ -17,6 +17,8 @@
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/verification/test_suite.hpp>
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/iostream.hpp>   // operator<< on blocktriple (#1334)
 
 namespace sw { namespace universal { 
 

--- a/internal/blocktriple/conversion/rounding.cpp
+++ b/internal/blocktriple/conversion/rounding.cpp
@@ -17,6 +17,7 @@
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/verification/test_suite.hpp>
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
 
 namespace sw { namespace universal {
 

--- a/internal/blocktriple/conversion/tables.cpp
+++ b/internal/blocktriple/conversion/tables.cpp
@@ -17,6 +17,8 @@
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/verification/test_suite.hpp>
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/iostream.hpp>   // operator<< on blocktriple (#1334)
 
 namespace sw::universal {
 

--- a/internal/blocktriple/conversion/teju.cpp
+++ b/internal/blocktriple/conversion/teju.cpp
@@ -20,6 +20,7 @@
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/number/support/teju_formatter.hpp>
 #include <universal/verification/test_suite.hpp>
+#include <universal/internal/blocktriple/manipulators.hpp>   // blocktriple::to_string (#1334)
 
 // Regression testing guards
 #define MANUAL_TESTING 0

--- a/internal/blocktriple/logic/logic.cpp
+++ b/internal/blocktriple/logic/logic.cpp
@@ -10,6 +10,7 @@
 // minimum set of include files to reflect source code dependencies
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/verification/test_status.hpp>
+#include <universal/internal/blocktriple/iostream.hpp>   // (#1334)
 
 namespace sw::universal {
 

--- a/static/tapered/posit/api/api.cpp
+++ b/static/tapered/posit/api/api.cpp
@@ -24,6 +24,8 @@
 #include <universal/verification/test_case.hpp>
 #include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/iostream.hpp>   // operator<< on blocktriple (#1334)
 
 // File-level helper for the constexpr smoke tests below: compares the raw
 // bit pattern of two posits limb-by-limb. Used by both the integer and the

--- a/static/tapered/posit/api/attributes.cpp
+++ b/static/tapered/posit/api/attributes.cpp
@@ -20,6 +20,8 @@
 #include <universal/verification/test_reporters.hpp>
 #include <universal/internal/blockbinary/manipulators.hpp>   // to_binary on the blockbinary from bits() (#1334)
 #include <universal/internal/blocksignificand/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/manipulators.hpp>   // (#1334)
+#include <universal/internal/blocktriple/iostream.hpp>   // operator<< on blocktriple (#1334)
 
 template<unsigned nbits, unsigned es, typename BlockType>
 void PositComponents(const sw::universal::posit<nbits, es, BlockType>& p) {


### PR DESCRIPTION
## Summary

The last of the five internal cores. **All of them are now stream-free:**

| header | lines | I/O-family |
|---|---|---|
| `blocksignificand.hpp` | 25,687 | **0** |
| `blockfraction.hpp` | 25,659 | **0** |
| `blockbinary.hpp` | 33,243 | **0** |
| `ieee754_core.hpp` | 43,486 | **0** |
| `blocktriple.hpp` | **69,791** (was 98,844) | **0** (was 4) |

`type_tag`, the member `to_string`, `to_binary`, `to_triple` and the enum's string form move to `manipulators.hpp`; `operator<<`, `operator>>` and the enum printer to `iostream.hpp`. `power_of_five` moves too — a decimal helper used only by `to_string`, and keeping it in the class is what made the core carry `support/decimal.hpp`. With it gone the core needs neither `decimal.hpp` nor `native/integers.hpp`.

**On the 45,000 target:** blocktriple sits above it, and that is a floor rather than waste — it is essentially the sum of its two clean dependencies (43,486 + 25,687, partially overlapping). The target was calibrated for a leaf header; for a composite the meaningful criterion is 0 I/O.

## This split has a failure mode the other four do not

Worth stating plainly, because it recurs wherever a **member** moves out-of-line.

For free functions — `operator<<`, `to_binary` — deleting the friend declaration turns a missing include into a **compile** error, findable by the cheap sweep. That is why the `blockbinary`, `blocksignificand` and `blockfraction` splits were verifiable with `-fsyntax-only`.

`to_string` is a member. Its declaration must stay in the class, so any call compiles whether or not the definition is reachable, and the failure surfaces **only at link, only in targets that actually get built**. The 1057-TU sweep passes completely and proves nothing about it.

Three link errors turned up this way, each found by building:

```
bt_teju      internal/blocktriple/conversion/teju.cpp
posit_ulp    via number/posit/iostream.hpp and manipulators.hpp, both of which
             call to_string on the blocktriple returned by to_value<>
```

The last two were fixed in the **headers** rather than the TUs, which is what stops the chase — one header fix took the sweep from 306 failures to 28.

Mitigations: the full CI tier builds far more than CI_LITE, and the linker names the symbol unambiguously. I also built the `education` and `benchmark` trees locally, since CI_LITE does not cover them.

## The `abs()` check paid off

Before extracting, I classified every function in the string-conversion region by return type and found **`abs()`** — pure arithmetic sitting inside the text region, exactly like `urdiv` (#1402) and `twosComplementFree` before it. **Caught before the mistake this time rather than after.** All eight text headers across the five cores are now audited by return type and contain only text.

## Four orphaned `template<>` lines, and the fix that worked

Each extraction left the `template<...>` header behind, because the capture started at the signature. I patched three one at a time, then wrote a general cleanup that was **too aggressive** and deleted legitimate single-line forward declarations (`template<...> class blocktriple;`).

I reverted the file to `main` and redid the extraction with the template header included in the capture from the start. Zero orphans that time. **Patching instances was the wrong move; fixing the extractor was the right one** — the same lesson as `urdiv`, where auditing the whole set beat fixing the one function a test happened to catch.

## Test Results

| check | result |
|---|---|
| 3 headers + 38 umbrellas | clean on gcc 13.3, clang 18.1, riscv64 cross |
| 1057-TU sweep, ten source trees | **17 failures, identical to the `main` baseline** |
| CI_LITE build + `ctest -j4` | **456/456 passed** |
| `education` + `benchmark` build | clean (CI_LITE does not cover them) |
| all 8 text headers audited by return type | contain only text |
| `check-ascii.sh`, lines over 120 columns | clean, 0 |

## Test plan

- [ ] Fast CI passes
- [ ] CodeRabbit review

Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stream input/output support for blocktriple values.
  - Added binary, triple, and decimal string formatting with standard stream controls.
  - Improved handling of special values, rounding, alignment, width, fill characters, and scientific notation.
  - Posit and educational examples now use the enhanced blocktriple formatting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Post-review update

### Clang build failure and fix (`57207a81`)

The first CI run failed on `Linux x64 (Clang) [fast]`:

```
manipulators.hpp:319:80: error: default arguments cannot be added to a
                               function template that has already been declared
blocktriple.hpp:866:21: note: previous template declaration is here
        friend std::string to_binary(const blocktriple<ffbits, oop, bbt>&, bool);
```

Moving the definitions out made the in-class `friend` declaration the first
declaration clang sees; the definition in `manipulators.hpp` then *added*
defaults to it. gcc accepts this, clang does not. A friend declaration may
only carry default arguments when it is also a definition, so the defaults
moved to a namespace-scope forward declaration ahead of the class and the
definitions dropped them. `to_binary(a)` / `to_triple(a)` still work.

**Why local verification missed it.** The diagnostic only fires in a TU that
*instantiates* `blocktriple`. Mutation-tested against the true pre-fix tree:

| state | `lns/api.cpp` (CI's failing TU) | header standalone |
|---|---|---|
| pre-fix, clang | FAILS -- reproduces CI | passes  <-- blind spot |
| pre-fix, gcc | passes | passes |
| post-fix, both | passes | passes |

CI clang is 18.1.3, the same version used locally, so this was a gap in
method, not toolchain: the clang check compiled headers standalone, and the
1057-TU sweep ran gcc only.

**Closing the gap.** A clang `-fsyntax-only` sweep now covers all 1057 TUs on
both sides:

| tree | TUs | failures |
|---|---|---|
| this branch | 1057 | 17 |
| `origin/main` | 1057 | 17 |

Failure sets are identical -- 0 regressions, 0 newly fixed, 17 shared
pre-existing, matching the gcc baseline.

**No siblings.** `blockbinary`, `blocksignificand` and `blockfraction` declare
no `friend std::string` functions, so their manipulators' defaults are the
first declaration seen. This bug class was unique to `blocktriple`.

### CodeRabbit review

1. **Missing direct std includes** -- valid, fixed in `80ede247`. Added
   `<algorithm>`, `<cmath>`, `<cstddef>`, `<vector>`. No include-cost impact:
   `manipulators.hpp` is a text-layer header already pulling `<sstream>` and
   `<iomanip>`. The core is untouched at 69,791 lines / 0 I/O headers.
2. **Negative-precision out-of-bounds read** -- confirmed real but
   **pre-existing**, verified identical on `main` at `blocktriple.hpp:1001-1011`.
   Filed as #1404 rather than fixed here, to keep this PR a pure move.

This PR adds zero lines over 120 columns (all 22 in the touched files
pre-exist on `main`).
