### PR TITLE
fix(blocktriple): clamp negative precision in to_string (#1404)

### DIFF
--- a/include/sw/universal/internal/blocktriple/manipulators.hpp
+++ b/include/sw/universal/internal/blocktriple/manipulators.hpp
@@ -85,6 +85,13 @@ std::string blocktriple<fbits, op, bt>::to_string(std::streamsize precision, std
 	std::string s;
 	if (fixed && scientific) fixed = false; // scientific takes precedence
 	if (!fixed && !scientific) scientific = true; // defaultfloat -> scientific
+	// std::ostream::precision() accepts a negative value and operator<< forwards
+	// it unchanged. A negative precision has no meaning as a digit count, and the
+	// scientific branch below would compute neededDigits = 1 + precision < 0 and
+	// then index the digits vector with static_cast<size_t>(neededDigits), which
+	// is an out-of-bounds read. Normalise here so both branches see a digit count
+	// of at least zero. See #1404.
+	if (precision < 0) precision = 0;
 
 	if (_nan) {
 		s = _sign ? (uppercase ? "SNAN" : "snan") : (uppercase ? "QNAN" : "qnan");

--- a/internal/blocktriple/api/ostream_formatting.cpp
+++ b/internal/blocktriple/api/ostream_formatting.cpp
@@ -302,6 +302,57 @@ int test_zero_output() {
 	return nrOfFailedTests;
 }
 
+int test_negative_precision() {
+	int nrOfFailedTests = 0;
+
+	// std::ostream::precision() accepts negative values and operator<< forwards
+	// them unchanged. Before #1404 the scientific branch computed
+	// neededDigits = 1 + precision, which went negative for precision <= -2 and
+	// was then used to index the digits vector -- an out-of-bounds read.
+	// A negative precision is normalised to zero, so it must format exactly as
+	// precision 0 does.
+	constexpr std::streamsize negatives[] = { -1, -2, -5, -100 };
+
+	for (std::streamsize p : negatives) {
+		{
+			blocktriple<23, BlockTripleOperator::REP> x(1.5);
+			std::string expected = capture(x, 0, std::ios_base::scientific);
+			std::string s = capture(x, p, std::ios_base::scientific);
+			if (s != expected) {
+				std::cout << "FAIL: scientific precision " << p << " = '" << s
+					<< "', expected '" << expected << "' (precision 0)\n";
+				++nrOfFailedTests;
+			}
+		}
+
+		{
+			blocktriple<23, BlockTripleOperator::REP> x(1.5);
+			std::string expected = capture(x, 0, std::ios_base::fixed);
+			std::string s = capture(x, p, std::ios_base::fixed);
+			if (s != expected) {
+				std::cout << "FAIL: fixed precision " << p << " = '" << s
+					<< "', expected '" << expected << "' (precision 0)\n";
+				++nrOfFailedTests;
+			}
+		}
+
+		{
+			// defaultfloat, and a value whose exponent drives the fixed branch
+			// negative as well
+			blocktriple<23, BlockTripleOperator::REP> x(0.001953125);
+			std::string expected = capture(x, 0);
+			std::string s = capture(x, p);
+			if (s != expected) {
+				std::cout << "FAIL: defaultfloat precision " << p << " = '" << s
+					<< "', expected '" << expected << "' (precision 0)\n";
+				++nrOfFailedTests;
+			}
+		}
+	}
+
+	return nrOfFailedTests;
+}
+
 }} // namespace sw::universal
 
 int main()
@@ -350,6 +401,9 @@ try {
 
 	std::cout << "Width and alignment\n";
 	nrOfFailedTestCases += test_width_alignment();
+
+	std::cout << "Negative precision\n";
+	nrOfFailedTestCases += test_negative_precision();
 
 	ReportTestSuiteResults(test_suite, nrOfFailedTestCases);
 	return (nrOfFailedTestCases > 0 ? EXIT_FAILURE : EXIT_SUCCESS);


### PR DESCRIPTION
## Summary

`blocktriple::to_string` clamped the digit count in the **fixed** branch but not in the **scientific** branch, so a negative stream precision indexed the `digits` vector out of bounds.

```cpp
if (fixed) {
    neededDigits = sciExponent + 1 + precision;
    if (neededDigits < 1) neededDigits = 1;   // clamped
}
else {
    neededDigits = 1 + precision;             // NOT clamped
}
...
int roundDigit = digits[static_cast<size_t>(neededDigits)];   // OOB when negative
```

`precision` comes from `ostr.precision()`, which accepts negative values, and `operator<<` forwards it unchanged. `precision == -1` was benign (`neededDigits == 0`, in range); `precision <= -2` read outside the allocation.

The fix normalises `precision` to zero once at the top of `to_string`, covering both branches and every `operator<<` caller.

## Proof it was real

Building the formatting test with `_GLIBCXX_ASSERTIONS` and the clamp removed:

```
/usr/include/c++/13/bits/stl_vector.h:1128: ... vector::operator[](size_type)
  [with _Tp = int]: Assertion '__n < this->size()' failed.
Aborted (core dumped)          exit=134
```

## Changes

- `include/sw/universal/internal/blocktriple/manipulators.hpp` -- clamp `precision` to zero, with a comment explaining why the scientific branch needed it.
- `internal/blocktriple/api/ostream_formatting.cpp` -- new `test_negative_precision`, asserting that precision `-1`, `-2`, `-5` and `-100` format identically to precision `0` across scientific, fixed and defaultfloat. Written as an equivalence against precision 0 rather than hardcoded strings, so it states the clamp's contract directly.

## Test results

Mutation-tested -- the new test fails without the fix and passes with it:

| build | with clamp | clamp removed |
|---|---|---|
| gcc, plain | PASS | abort, exit 134 |
| gcc, ASan+UBSan+`_GLIBCXX_ASSERTIONS` | PASS (exit 0) | abort |
| clang, plain | PASS | -- |
| clang, ASan+UBSan | PASS (exit 0) | -- |

No behaviour drift in the existing suites that exercise `to_string`:

| test | result |
|---|---|
| `bt_api` | PASS |
| `bt_teju` | PASS |
| `bt_decimal` | PASS |
| `bt_single_precision` | PASS |
| `posit_ostream_formatting` | PASS |
| `posit_ulp` | PASS |

The last two are the posit consumers that link-failed during the #1403 split, so they are the right regression targets for anything touching `blocktriple::to_string`.

## Note on the behaviour change

Flagged with a `BEHAVIOUR-CHANGE:` trailer. `precision == -1` previously emitted one digit fewer than precision 0; it now matches precision 0. `precision <= -2` previously read out of bounds. No caller passing a non-negative precision is affected.

Resolves #1404
Relates to #1334

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Negative precision values are now handled safely during number formatting.
  - Scientific, fixed, and default output now consistently matches zero precision when negative precision is provided.

- **Tests**
  - Added coverage for multiple negative precision values, including exponent-based formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->