### PR TITLE
fix: removing urdiv from block{fraction|significand}

### DIFF
--- a/include/sw/universal/internal/blockbinary/blockbinary.hpp
+++ b/include/sw/universal/internal/blockbinary/blockbinary.hpp
@@ -7,6 +7,7 @@
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
 #include <cstdint>
+#include <universal/utility/icf_array_bounds.hpp>
 #include <string>   // the std::string constructor
 #include <type_traits>
 #include <universal/number/shared/specific_value_encoding.hpp>
@@ -832,7 +833,11 @@ public:
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false; // fail silently as no-op
 		unsigned blockIndex = bitIndex / bitsInBlock;
+		// in bounds: bitIndex < nbits => blockIndex <= nrBlocks-1. The pragma silences a
+		// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+		UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 		bt limb = _block[blockIndex];
+		UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (limb & mask);
 	}

--- a/include/sw/universal/internal/blockfraction/blockfraction.hpp
+++ b/include/sw/universal/internal/blockfraction/blockfraction.hpp
@@ -104,7 +104,8 @@ public:
 	constexpr blockfraction& operator=(const blockfraction&) noexcept = default;
 	constexpr blockfraction& operator=(blockfraction&&) noexcept = default;
 
-#ifdef NEVER
+/*
+  DESIGN NOTES
 	// disable the ability to copy different blockfractions to catch any
 	// unintended (implicit) copies when working with blockfractions.
 	// For performance, the blockfraction is used in-place.
@@ -112,31 +113,14 @@ public:
 	// uses in add/sub/mul/div/sqrt will directly access the bits of the encapsulated blockfraction.
 
 	/// construct a blockfraction from another: bt must be the same
-	template<unsigned nnbits>
-	blockfraction(const blockfraction<nnbits, bt>& rhs) { this->assign(rhs); }
+	// template<unsigned nnbits> blockfraction(const blockfraction<nnbits, bt>& rhs) { this->assign(rhs); }
 
 	// blockfraction cannot have decorated constructors or assignment
 	// as blockfraction does not have all the information to interpret a value
 	// So by design, the class interface does not interact with values
-	constexpr blockfraction(long long initial_value) noexcept : _block{ 0 } { *this = initial_value; }
-
-	constexpr blockfraction& operator=(long long rhs) noexcept {
-		if constexpr (1 < nrBlocks) {
-			for (unsigned i = 0; i < nrBlocks; ++i) {
-				_block[i] = rhs & storageMask;
-				rhs >>= bitsInBlock;
-			}
-			// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
-			_block[MSU] &= MSU_MASK;
-		} 
-		else if constexpr (1 == nrBlocks) {
-			_block[0] = rhs & storageMask;
-			// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
-			_block[MSU] &= MSU_MASK;
-		}
-		return *this;
-	}
-#endif
+	// constexpr blockfraction(long long initial_value) noexcept;
+	// constexpr blockfraction& operator=(long long rhs) noexcept;
+*/
 
 	/// explicit conversion operators
 	explicit constexpr operator float() const noexcept { return float(to_float()); }
@@ -144,9 +128,7 @@ public:
 
 #if LONG_DOUBLE_SUPPORT
 	explicit constexpr operator long double() const noexcept { return (long double)to_long_double(); }
-	constexpr long double to_long_double() const noexcept {
-		return (long double)to_double();
-	}
+	constexpr long double to_long_double() const noexcept { return (long double)to_double(); }
 #endif
 
 	/// prefix operators
@@ -623,69 +605,6 @@ public:
 	// naming the missing function is the better failure. See #1334.
 };
 
-// urdiv: arithmetic, not text -- same story as twosComplementFree below. It sat
-// after the "conversions to string representations" banner in the original file,
-// so the text lift caught it by position rather than by kind (#1334).
-//
-// It is also dead and does not instantiate: nothing calls it, and it uses member
-// names this type does not have. That is pre-existing -- it fails to instantiate
-// on main too. Tracked separately; left here unchanged rather than repaired in a
-// move.
-// unrounded division, returns a blockfraction that is of size 2*nbits
-template<unsigned nbits, unsigned roundingBits, typename bt>
-blockfraction<2 * nbits + roundingBits, bt> urdiv(const blockfraction<nbits, bt>& a, const blockfraction<nbits, bt>& b, blockfraction<roundingBits, bt>& r) {
-	if (b.iszero()) {
-		// division by zero
-		throw "urdiv divide by zero";
-	}
-	// generate the absolute values to do long division 
-	// 2's complement special case -max requires an signed int that is 1 bit bigger to represent abs()
-	bool a_sign = a.sign();
-	bool b_sign = b.sign();
-	bool result_negative = (a_sign ^ b_sign);
-
-	// normalize both arguments to positive in new size
-	blockfraction<nbits + 1, bt> a_new(a); // TODO optimize: now create a, create _a.bb, copy, destroy _a.bb_copy
-	blockfraction<nbits + 1, bt> b_new(b);
-	if (a_sign) a_new.twoscomplement();
-	if (b_sign) b_new.twoscomplement();
-
-	// initialize the long division
-	blockfraction<2 * nbits + roundingBits, bt> decimator(a_new);
-	blockfraction<2 * nbits + roundingBits, bt> subtractand(b_new); // prepare the subtractand
-	blockfraction<2 * nbits + roundingBits, bt> result;
-
-	int msp = nbits + roundingBits - 1; // msp = most significant position
-	decimator <<= msp; // scale the decimator to the largest possible positive value
-
-	int msb_b = subtractand.msb();
-	int msb_a = decimator.msb();
-	int shift = msb_a - msb_b;
-	int scale = shift - msp;   // scale of the result quotient
-	subtractand <<= shift;
-
-	// long division
-	for (int i = msb_a; i >= 0; --i) {
-
-		if (subtractand <= decimator) {
-			decimator -= subtractand;
-			result.set(static_cast<unsigned>(i));
-		}
-		else {
-			result.reset(static_cast<unsigned>(i));
-		}
-		subtractand >>= 1;
-
-	}
-	result <<= scale;
-	if (result_negative) result.twosComplement();
-	r.assign(result); // copy the lowest bits which represent the bits on which we need to apply the rounding test
-	return result;
-}
-
-// twosComplementFree: arithmetic, not text. It sat after the "conversions to
-// string representations" banner in the original file, so the text lift caught
-// it by position rather than by kind; it belongs here (#1334).
 // free function generator of the 2's complement of a blockfraction
 template<unsigned nbits, typename bt>
 constexpr blockfraction<nbits, bt> twosComplementFree(const blockfraction<nbits, bt>& a) noexcept {

--- a/include/sw/universal/internal/blockfraction/blockfraction.hpp
+++ b/include/sw/universal/internal/blockfraction/blockfraction.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cstdint>
+#include <universal/utility/icf_array_bounds.hpp>
 #include <cmath> // for std::pow() used in conversions to native IEEE-754 formats values
 
 
@@ -425,7 +426,11 @@ public:
 	constexpr bool test(unsigned bitIndex) const noexcept { return at(bitIndex); }
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false;
+		// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+		// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+		UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 		bt word = _block[bitIndex / bitsInBlock];
+		UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (word & mask);
 	}

--- a/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
+++ b/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cstdint>
+#include <universal/utility/icf_array_bounds.hpp>
 #include <cmath> // for std::pow() used in conversions to native IEEE-754 formats values
 
 #include <limits>
@@ -469,7 +470,11 @@ public:
 	constexpr bool test(unsigned bitIndex) const noexcept { return at(bitIndex); }
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false;
+		// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+		// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+		UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 		bt word = _block[bitIndex / bitsInBlock];
+		UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (word & mask);
 	}

--- a/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
+++ b/include/sw/universal/internal/blocksignificand/blocksignificand.hpp
@@ -522,45 +522,6 @@ public:
 		}
 	}
 
-#ifdef DEPRECATED
-	// copy a value over from one blocksignificand to this blocksignificand
-	// blocksignificand is a 2's complement encoding, so we sign-extend by default
-	template<unsigned srcbits>
-	inline blocksignificand<nbits, bt>& assign(const blocksignificand<srcbits, bt>& rhs) noexcept {
-		clear();
-		// since bt is the same, we can directly copy the blocks in
-		unsigned minNrBlocks = (this->nrBlocks < rhs.nrBlocks) ? this->nrBlocks : rhs.nrBlocks;
-		for (unsigned i = 0; i < minNrBlocks; ++i) {
-			_block[i] = rhs.block(i);
-		}
-		if constexpr (nbits > srcbits) { // check if we need to sign extend
-			if (rhs.sign()) {
-				for (unsigned i = srcbits; i < nbits; ++i) { // TODO: replace bit-oriented sequence with block
-					setbit(i);
-				}
-			}
-		}
-		// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
-		_block[MSU] &= MSU_MASK;
-		return *this;
-	}
-
-	// copy a value over from one blocksignificand to this without sign-extending the value
-	// blocksignificand is a 2's complement encoding, so we sign-extend by default
-	// for fraction/significent encodings, we need to turn off sign-extending.
-	template<unsigned srcbits>
-	inline blocksignificand<nbits, bt>& assignWithoutSignExtend(const blocksignificand<srcbits, bt>& rhs) noexcept {
-		clear();
-		// since bt is the same, we can simply copy the blocks in
-		unsigned minNrBlocks = (this->nrBlocks < rhs.nrBlocks) ? this->nrBlocks : rhs.nrBlocks;
-		for (unsigned i = 0; i < minNrBlocks; ++i) {
-			_block[i] = rhs.block(i);
-		}
-		// enforce precondition for fast comparison by properly nulling bits that are outside of nbits
-		_block[MSU] &= MSU_MASK;
-		return *this;
-	}
-#endif
 	// return the position of the most significant bit, -1 if v == 0
 	constexpr int msb() const noexcept {
 		for (int i = int(MSU); i >= 0; --i) {
@@ -721,71 +682,6 @@ public:
 	// naming the missing function is the better failure. See #1334.
 };
 
-// urdiv: arithmetic, not text -- same story as twosComplementFree below. It sat
-// after the "conversions to string representations" banner in the original file,
-// so the text lift caught it by position rather than by kind (#1334).
-//
-// It is also dead and does not instantiate: nothing calls it, and it uses member
-// names this type does not have. That is pre-existing -- it fails to instantiate
-// on main too. Tracked separately; left here unchanged rather than repaired in a
-// move.
-// unrounded division, returns a blocksignificand that is of size 2*nbits
-template<unsigned nbits, unsigned roundingBits, typename bt>
-blocksignificand<2 * nbits + roundingBits, bt> urdiv(const blocksignificand<nbits, bt>& a, const blocksignificand<nbits, bt>& b, blocksignificand<roundingBits, bt>& r) {
-	if (b.iszero()) {
-		// division by zero
-		throw "urdiv divide by zero";
-	}
-	// generate the absolute values to do long division 
-	// 2's complement special case -max requires an signed int that is 1 bit bigger to represent abs()
-	bool a_sign = a.sign();
-	bool b_sign = b.sign();
-	bool result_negative = (a_sign ^ b_sign);
-
-	// normalize both arguments to positive in new size
-	blocksignificand<nbits + 1, bt> a_new(a); // TODO optimize: now create a, create _a.bb, copy, destroy _a.bb_copy
-	blocksignificand<nbits + 1, bt> b_new(b);
-	if (a_sign) a_new.twoscomplement();
-	if (b_sign) b_new.twoscomplement();
-
-	// initialize the long division
-	blocksignificand<2 * nbits + roundingBits, bt> decimator(a_new);
-	blocksignificand<2 * nbits + roundingBits, bt> subtractand(b_new); // prepare the subtractand
-	blocksignificand<2 * nbits + roundingBits, bt> result;
-
-	int msp = nbits + roundingBits - 1; // msp = most significant position
-	decimator <<= msp; // scale the decimator to the largest possible positive value
-
-	int msb_b = subtractand.msb();
-	int msb_a = decimator.msb();
-	int shift = msb_a - msb_b;
-	// The quotient is produced in an oversized fixed-point workspace. `scale` recenters it so the returned
-	// bits remain the unrounded quotient, while the truncated tail is left in `r` for the caller's rounding rule.
-	int scale = shift - msp;   // scale of the result quotient
-	subtractand <<= shift;
-
-	// long division
-	for (int i = msb_a; i >= 0; --i) {
-
-		if (subtractand <= decimator) {
-			decimator -= subtractand;
-			result.set(static_cast<unsigned>(i));
-		}
-		else {
-			result.reset(static_cast<unsigned>(i));
-		}
-		subtractand >>= 1;
-
-	}
-	result <<= scale;
-	if (result_negative) result.twosComplement();
-	r.assign(result); // low bits preserve rounding information for later rounding.
-	return result;
-}
-
-// twosComplementFree: arithmetic, not text. It sat after the "conversions to
-// string representations" banner in the original file, so the text lift caught
-// it by position rather than by kind; it belongs here (#1334).
 // free function generator of the 2's complement of a blocksignificand
 template<unsigned nbits, typename bt>
 constexpr blocksignificand<nbits, bt> twosComplementFree(const blocksignificand<nbits, bt>& a) noexcept {

--- a/include/sw/universal/internal/blocktype/carry.hpp
+++ b/include/sw/universal/internal/blocktype/carry.hpp
@@ -29,14 +29,24 @@ using uint128_t = unsigned __int128;
 #endif
 
 /// add two uint64_t limbs with carry-in, producing a sum and carry-out
+///
+/// CONTRACT: carry_in is a FULL 64-bit addend, not a single carry bit. It computes
+/// a + b + carry_in as a 128-bit value, returning the low limb and setting carry_out
+/// to the high limb (0, 1 or 2). Multi-limb multiply relies on this: it feeds back
+/// the high half of a 64x64 partial product, which is an arbitrary 64-bit number.
 inline uint64_t addcarry(uint64_t a, uint64_t b, uint64_t carry_in, uint64_t& carry_out) {
 #if defined(_MSC_VER)
-	// MSVC: use _addcarry_u64 intrinsic
-	// Use local variables to avoid optimizer issues with reference-derived pointers
-	unsigned long long s;
-	unsigned char c = _addcarry_u64(static_cast<unsigned char>(carry_in), a, b, &s);
-	carry_out = c;
-	return static_cast<uint64_t>(s);
+	// _addcarry_u64's carry-in is a SINGLE BIT. Passing carry_in through it (the old
+	// static_cast<unsigned char>) silently discarded every bit but the lowest, so
+	// integer<N,uint64_t> and blockbinary multiply produced wrong products on MSVC
+	// while gcc/clang -- whose __int128 branch honours the whole value -- were correct.
+	// Add carry_in as a second operand instead of as the carry bit.
+	// Use distinct local variables to avoid optimizer issues with reference-derived pointers.
+	unsigned long long s1, s2;
+	unsigned char c1 = _addcarry_u64(0, a, b, &s1);
+	unsigned char c2 = _addcarry_u64(0, s1, carry_in, &s2);
+	carry_out = static_cast<uint64_t>(c1) + static_cast<uint64_t>(c2);
+	return static_cast<uint64_t>(s2);
 
 #elif defined(__SIZEOF_INT128__)
 	// GCC/Clang on 64-bit: use unsigned __int128 for widening add
@@ -56,24 +66,27 @@ inline uint64_t addcarry(uint64_t a, uint64_t b, uint64_t carry_in, uint64_t& ca
 }
 
 /// subtract two uint64_t limbs with borrow-in, producing a difference and borrow-out
+///
+/// CONTRACT, mirroring addcarry: borrow_in is a FULL 64-bit subtrahend, not a single
+/// borrow bit. Returns the low limb of a - b - borrow_in and sets borrow_out to the
+/// number of borrows out (0, 1 or 2).
+///
+/// No caller passes a multi-bit borrow_in today, but the MSVC branch had the same
+/// single-bit truncation that broke addcarry, and the __int128 branch capped
+/// borrow_out at 1 where the portable branch reported 2 -- three implementations,
+/// three different answers. They agree now.
 inline uint64_t subborrow(uint64_t a, uint64_t b, uint64_t borrow_in, uint64_t& borrow_out) {
 #if defined(_MSC_VER)
-	// MSVC: use _subborrow_u64 intrinsic
-	// Use local variables to avoid optimizer issues with reference-derived pointers
-	unsigned long long d;
-	unsigned char borrow = _subborrow_u64(static_cast<unsigned char>(borrow_in), a, b, &d);
-	borrow_out = borrow;
-	return static_cast<uint64_t>(d);
-
-#elif defined(__SIZEOF_INT128__)
-	// GCC/Clang on 64-bit: use unsigned __int128
-	uint128_t wide_a = static_cast<uint128_t>(a);
-	uint128_t wide_sub = static_cast<uint128_t>(b) + borrow_in;
-	borrow_out = (wide_a < wide_sub) ? 1u : 0u;
-	return static_cast<uint64_t>(wide_a - wide_sub);
+	// _subborrow_u64's borrow-in is a SINGLE BIT; subtract borrow_in as an operand.
+	// Use distinct local variables to avoid optimizer issues with reference-derived pointers.
+	unsigned long long d1, d2;
+	unsigned char b1 = _subborrow_u64(0, a, b, &d1);
+	unsigned char b2 = _subborrow_u64(0, d1, borrow_in, &d2);
+	borrow_out = static_cast<uint64_t>(b1) + static_cast<uint64_t>(b2);
+	return static_cast<uint64_t>(d2);
 
 #else
-	// Portable fallback
+	// Portable: two-step borrow detection. __int128 buys nothing for subtraction.
 	uint64_t diff = a - b;
 	uint64_t borrow1 = (a < b) ? 1u : 0u;
 	uint64_t result = diff - borrow_in;

--- a/include/sw/universal/native/manipulators.hpp
+++ b/include/sw/universal/native/manipulators.hpp
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <string>
 #include <sstream>
+#include <universal/utility/bit_cast.hpp>
 #include <universal/utility/find_msb.hpp>
 #include <universal/native/ieee754_parameter.hpp>
 #include <universal/native/ieee754_type_tag.hpp>
@@ -16,20 +17,39 @@
 
 namespace sw { namespace universal {
 
-	// internal function to extract exponent bits: TODO: needs validation for subnormal numbers
 	namespace internal {
-		// internal function to extract exponent
+		// internal function to extract the scale, that is, the de-biased exponent
+		//
+		// Mask the exponent and the fraction out of the encoding INDEPENDENTLY, each
+		// with its own mask. The earlier version cleared only the sign bit and then
+		// reused that one variable as both the exponent (after a right shift) and the
+		// fraction (captured before the shift), so its "fraction" still carried the
+		// exponent bits. That is harmless only for as long as the subnormal branch is
+		// entered exclusively for subnormals, whose exponent bits are zero -- it makes
+		// the decoder silently wrong the moment that branch is entered for anything
+		// else, which is exactly what happened on MSVC (see below).
+		//
+		// Use sw::bit_cast, and take the constexpr-ness of this function from it via
+		// BIT_CAST_CONSTEXPR, rather than the memmove-based BitCast<>. A constexpr
+		// function that can never be evaluated in a constant expression -- which is
+		// what "constexpr" plus a memmove call adds up to -- is ill-formed, no
+		// diagnostic required, and MSVC /O2 (Release only; Debug and RelWithDebInfo
+		// were fine) miscompiled the guard so the subnormal correction was applied to
+		// every normal value. gcc and clang were unaffected at every -O level. The
+		// neighbouring extractFields() in extract_fields.hpp already decodes this way
+		// and stayed correct in the same Release binary.
 		template<typename Uint, typename Real>
-		constexpr int _extractExponent(Real v) noexcept {
+		BIT_CAST_CONSTEXPR int _extractExponent(Real v) noexcept {
 			static_assert(sizeof(Real) == sizeof(Uint), "mismatched sizes");
-			Uint raw{BitCast<Uint>(v)};
-			raw &= static_cast<Uint>(~ieee754_parameter<Real>::smask);
-			Uint frac{raw};
-			raw >>= ieee754_parameter<Real>::fbits;
+			constexpr Uint emask = static_cast<Uint>(ieee754_parameter<Real>::emask);
+			constexpr Uint fmask = static_cast<Uint>(ieee754_parameter<Real>::fmask);
+			const Uint bc{ sw::bit_cast<Uint>(v) };
+			const Uint rawExponent = static_cast<Uint>((bc & emask) >> ieee754_parameter<Real>::fbits);
+			const Uint rawFraction = static_cast<Uint>(bc & fmask);
 			// de-bias
-			int e = static_cast<int>(raw) - static_cast<int>(ieee754_parameter<Real>::bias);
-			if (raw == 0) {  // a subnormal encoding
-				int msb = static_cast<int>(find_msb(frac));
+			int e = static_cast<int>(rawExponent) - static_cast<int>(ieee754_parameter<Real>::bias);
+			if (rawExponent == 0) {  // a subnormal or zero encoding
+				int msb = static_cast<int>(find_msb(rawFraction));
 				e -= (static_cast<int>(ieee754_parameter<Real>::fbits) - msb);
 			}
 			return e;
@@ -65,12 +85,11 @@ namespace sw { namespace universal {
 	}
 
 	template<typename Real, typename = typename ::std::enable_if<::std::is_floating_point<Real>::value, Real>::type>
-    constexpr int scale(Real v) noexcept {
+    BIT_CAST_CONSTEXPR int scale(Real v) noexcept {
 	    int _e{0};
 	    if constexpr (sizeof(Real) == 2) {  // half precision floating-point
 		    _e = internal::_extractExponent<std::uint16_t>(v);
-	    }
-	    if constexpr (sizeof(Real) == 4) {  // single precision floating-point
+	    } else if constexpr (sizeof(Real) == 4) {  // single precision floating-point
 		    _e = internal::_extractExponent<std::uint32_t>(v);
 	    } else if constexpr (sizeof(Real) == 8) {  // double precision floating-point
 		    _e = internal::_extractExponent<std::uint64_t>(v);
@@ -83,7 +102,7 @@ namespace sw { namespace universal {
     }
 
     template<typename Real, typename = typename ::std::enable_if<::std::is_floating_point<Real>::value, Real>::type>
-    constexpr int exponent(Real v) noexcept {
+    BIT_CAST_CONSTEXPR int exponent(Real v) noexcept {
 	    return scale(v);
     }
 

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+#include <universal/utility/icf_array_bounds.hpp>
 #include <sstream>
 #include <string>
 // areal_impl.hpp: implementation of an arbitrary configuration fixed-size floating-point representation with an uncertainty bit to represent a faithful floating-point system
@@ -1444,7 +1445,11 @@ public:
 	}
 	inline constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex < nbits) {
+			// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+			// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+			UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 			bt word = _block[bitIndex / bitsInBlock];
+			UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 			bt mask = bt(1ull << (bitIndex % bitsInBlock));
 			return (word & mask);
 		}

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
+#include <universal/utility/icf_array_bounds.hpp>
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 #include <string>
 // cfloat_impl.hpp: implementation of an arbitrary configuration fixed-size 'classic' floating-point representation
@@ -1847,7 +1848,11 @@ public:
 	}
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex < nbits) {
+			// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+			// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+			UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 			bt word = _block[bitIndex / bitsInBlock];
+			UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 			bt mask = bt(1ull << (bitIndex % bitsInBlock));
 			return (word & mask);
 		}

--- a/include/sw/universal/number/dbns/dbns_impl.hpp
+++ b/include/sw/universal/number/dbns/dbns_impl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+#include <universal/utility/icf_array_bounds.hpp>
 #include <sstream>
 #include <string>
 // dbns_impl.hpp: implementation of a fixed-size, arbitrary configuration 2-base logarithmic number system configuration
@@ -549,7 +550,11 @@ public:
 	constexpr uint64_t fraction() const noexcept { return 0; }
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false; // fail silently as no-op
+		// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+		// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+		UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 		bt word = _block[bitIndex / bitsInBlock];
+		UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (word & mask);
 	}

--- a/include/sw/universal/number/efloat/math/next.hpp
+++ b/include/sw/universal/number/efloat/math/next.hpp
@@ -88,7 +88,11 @@ constexpr efloat<nlimbs> nextafter(const efloat<nlimbs>& x, const efloat<nlimbs>
 // through double as a workaround for the constructor returning 0.)
 template<unsigned nlimbs>
 constexpr efloat<nlimbs> nexttoward(const efloat<nlimbs>& x, long double y) {
+#if LONG_DOUBLE_SUPPORT
 	return nextafter(x, efloat<nlimbs>(y));
+#else
+	return nextafter(x, efloat<nlimbs>(static_cast<double>(y)));
+#endif
 }
 
 }  // namespace universal

--- a/include/sw/universal/number/ereal/math/functions/next.hpp
+++ b/include/sw/universal/number/ereal/math/functions/next.hpp
@@ -37,7 +37,7 @@ namespace sw { namespace universal {
 	// nexttoward: return next representable value after x in direction of y (long double)
 	template<unsigned maxlimbs>
 	inline ereal<maxlimbs> nexttoward(const ereal<maxlimbs>& x, long double y) {
-#ifdef LONG_DOUBLE_SUPPORT
+#if LONG_DOUBLE_SUPPORT
 	    ereal<maxlimbs> target(y);
 #else
 	    ereal<maxlimbs> target(static_cast<double>(y));

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
+#include <universal/utility/icf_array_bounds.hpp>
 #include <string>
 #include <sstream>
 #include <iostream>
@@ -1038,7 +1039,11 @@ public:
 	constexpr bool sign()   const noexcept { return at(nbits - 1); }
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex < nbits) {
+			// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+			// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+			UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 			bt word = _block[bitIndex / bitsInBlock];
+			UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 			bt mask = bt(1ull << (bitIndex % bitsInBlock));
 			return (word & mask);
 		}

--- a/include/sw/universal/number/integer/integer_impl.hpp
+++ b/include/sw/universal/number/integer/integer_impl.hpp
@@ -447,10 +447,15 @@ public:
 							if (i + j < nrBlocks) {
 								uint64_t lo, hi;
 								mul128(base.block(i), multiplicant.block(j), lo, hi);
+								// accumulate: _block[i+j] += lo + carry
+								// two separate additions, matching blockbinary: keeps a
+								// multi-bit carry out of addcarry's carry_in slot
 								uint64_t c1 = 0;
-								uint64_t sum = addcarry(_block[i + j], lo, carry, c1);
+								uint64_t sum = addcarry(_block[i + j], lo, 0, c1);
+								uint64_t c2 = 0;
+								sum = addcarry(sum, carry, 0, c2);
 								_block[i + j] = sum;
-								carry = hi + c1;
+								carry = hi + c1 + c2;
 							}
 						}
 					}
@@ -528,10 +533,15 @@ public:
 							if (i + j < nrBlocks) {
 								uint64_t lo, hi;
 								mul128(base.block(i), multiplicant.block(j), lo, hi);
+								// accumulate: _block[i+j] += lo + carry
+								// two separate additions, matching blockbinary: keeps a
+								// multi-bit carry out of addcarry's carry_in slot
 								uint64_t c1 = 0;
-								uint64_t sum = addcarry(_block[i + j], lo, carry, c1);
+								uint64_t sum = addcarry(_block[i + j], lo, 0, c1);
+								uint64_t c2 = 0;
+								sum = addcarry(sum, carry, 0, c2);
 								_block[i + j] = sum;
-								carry = hi + c1;
+								carry = hi + c1 + c2;
 							}
 						}
 					}

--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+#include <universal/utility/icf_array_bounds.hpp>
 #include <string>
 // lns_impl.hpp: implementation of an arbitrary logarithmic number system configuration
 //
@@ -467,7 +468,11 @@ public:
 	}
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false; // fail silently as no-op
+		// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+		// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+		UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 		bt word = _block[bitIndex / bitsInBlock];
+		UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (word & mask);
 	}

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+#include <universal/utility/icf_array_bounds.hpp>
 #include <sstream>
 #include <string>
 // takum_impl.hpp: implementation of a linear takum number system
@@ -444,7 +445,11 @@ public:
 	}
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false;
+		// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+		// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+		UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 		bt word = _block[bitIndex / bitsInBlock];
+		UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (word & mask);
 	}

--- a/include/sw/universal/number/takum/takum_log_impl.hpp
+++ b/include/sw/universal/number/takum/takum_log_impl.hpp
@@ -44,6 +44,7 @@
 // the native-arithmetic work in #1297.
 
 #include <cassert>
+#include <universal/utility/icf_array_bounds.hpp>
 #include <limits>
 #include <cmath>
 
@@ -397,7 +398,11 @@ public:
 
 	constexpr bool at(unsigned bitIndex) const noexcept {
 		if (bitIndex >= nbits) return false;
+		// in bounds: bitIndex < nbits => index <= nrBlocks-1. The pragma silences a
+		// GCC -fipa-icf false positive; see utility/icf_array_bounds.hpp.
+		UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
 		bt word = _block[bitIndex / bitsInBlock];
+		UNIVERSAL_ICF_ARRAY_BOUNDS_POP
 		bt mask = bt(1ull << (bitIndex % bitsInBlock));
 		return (word & mask);
 	}

--- a/include/sw/universal/utility/icf_array_bounds.hpp
+++ b/include/sw/universal/utility/icf_array_bounds.hpp
@@ -1,0 +1,55 @@
+#pragma once
+// icf_array_bounds.hpp: narrow suppression of a GCC -Warray-bounds false positive
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+
+// Every Universal storage class indexes its limb array from a bit index the same way:
+//
+//     static constexpr unsigned nrBlocks = 1 + ((nbits - 1) / bitsInBlock);
+//     bt _block[nrBlocks];
+//
+//     constexpr bool at(unsigned bitIndex) const noexcept {
+//         if (bitIndex >= nbits) return false;
+//         bt word = _block[bitIndex / bitsInBlock];
+//         ...
+//
+// The guard makes the access in bounds for EVERY instantiation: bitIndex < nbits
+// implies bitIndex / bitsInBlock <= (nbits - 1) / bitsInBlock == nrBlocks - 1.
+//
+// GCC nonetheless reports -Warray-bounds on that access at -O2 and above, and it is a
+// false positive produced by identical-code-folding (-fipa-icf, on by default at -O2).
+// Once a caller's loop bounds prove the guard redundant, at<N> and at<M> have
+// byte-identical bodies, so GCC keeps one and aliases the rest -- then charges the
+// surviving body's subscripts against ONE instantiation's _block extent. The subscripts
+// it names are exactly the largest VALID index of the instantiation the code really came
+// from. Two observed examples:
+//
+//   blocksignificand<29,uint8_t>::_block is uint8_t[4]; GCC reported subscripts 4, 6 and
+//   10 against it -- the top blocks of nbits = 33, 56 and 87 (nrBlocks 5, 7 and 11), the
+//   ADD/MUL/DIV significands of blocktriple<27>, all folded onto at<29>.
+//
+//   cfloat<32,8,uint8_t>::_block is uint8_t[4]; GCC reported subscript 4 against it --
+//   the fifth block of cfloat<48,8,uint8_t>, which has 6.
+//
+// Confirmed diagnosis: -fno-ipa-icf removes every one of them.
+//
+// Suppress narrowly at the access, rather than building with -fno-ipa-icf: that is a
+// codegen change made to silence a diagnostic, and being a header-only library it would
+// not reach consumers of these headers anyway. Keep the scope to the single indexing
+// statement so a genuine out-of-range access anywhere else still gets diagnosed.
+//
+// clang and MSVC do not warn here.
+
+#if defined(__GNUC__) && !defined(__clang__)
+#define UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH \
+	_Pragma("GCC diagnostic push")      \
+	_Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+#define UNIVERSAL_ICF_ARRAY_BOUNDS_POP \
+	_Pragma("GCC diagnostic pop")
+#else
+#define UNIVERSAL_ICF_ARRAY_BOUNDS_PUSH
+#define UNIVERSAL_ICF_ARRAY_BOUNDS_POP
+#endif

--- a/internal/blocktriple/multiplication.cpp
+++ b/internal/blocktriple/multiplication.cpp
@@ -8,7 +8,7 @@
 #include <typeinfo>
 
 // minimum set of include files to reflect source code dependencies
-#include <universal/blocktriple/blocktriple.hpp>
+#include <universal/internal/blocktriple.hpp>
 #include <universal/verification/binaryop_status.hpp>
 #include <universal/verification/test_status.hpp> // ReportTestResult
 

--- a/playground/type_test.cpp
+++ b/playground/type_test.cpp
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-
+#include<universal/utility/long_double.hpp>
 #include <string>
 #include <iostream>
 #include <typeinfo>
@@ -70,7 +70,9 @@ try {
         
     test<float>("float");
     test<double>("double");
+#if LONG_DOUBLE_SUPPORT
     test<long double>("long double");
+#endif
 
     return 0;
 }

--- a/static/float/hfloat/api/api.cpp
+++ b/static/float/hfloat/api/api.cpp
@@ -14,7 +14,7 @@
 
 #include <iostream>
 #include <iomanip>
-#include <strstream>
+#include <sstream>   // std::stringstream, used by hfp_pair() below
 
 namespace sw::universal {
 	template<unsigned _ndigits, unsigned _es, typename bt>

--- a/static/range/interval/arithmetic/containment.cpp
+++ b/static/range/interval/arithmetic/containment.cpp
@@ -37,6 +37,22 @@ namespace sw { namespace universal {
 		default:      return x / y;
 		}
 	}
+	// A sample point that is GUARANTEED to lie in [lo,hi]. The obvious interpolation
+	// lo + s*(hi-lo) is not: evaluate it at the same precision as the endpoints and its
+	// three roundings can carry it past an endpoint. On a host where long double IS
+	// double (MSVC, ARM, RISC-V) that overshot the upper endpoint by up to 16 ulp in
+	// this fuzz -- worst when the interval is wide and the endpoint is near zero, so the
+	// absolute slop of (hi-lo) is many ulp of hi. The fuzz then demanded that a point
+	// OUTSIDE X have its image inside fl(X op Y), which is not what the Fundamental
+	// Theorem claims, and reported ~2000 bogus containment failures. Clamping restores
+	// the loop's own precondition ("sample points x in X"). On an x86-64 host, whose
+	// 80-bit long double absorbs the rounding, the clamp never fires -- so this costs
+	// no coverage, and the enclosures themselves were never at fault.
+	inline long double samplePoint(long double lo, long double hi, double s) {
+		long double p = lo + static_cast<long double>(s) * (hi - lo);
+		return (p < lo) ? lo : ((p > hi) ? hi : p);
+	}
+
 	template<typename Scalar>
 	inline interval<Scalar> apply(Op op, const interval<Scalar>& X, const interval<Scalar>& Y) {
 		switch (op) {
@@ -183,8 +199,8 @@ namespace sw { namespace universal {
 				// sample points: endpoints and a few interior points of each interval
 				for (double sx : {0.0, 1.0, S(rng), S(rng)}) {
 					for (double sy : {0.0, 1.0, S(rng), S(rng)}) {
-						long double x = (long double)a + (long double)sx * ((long double)b - a);
-						long double y = (long double)c + (long double)sy * ((long double)d - c);
+						long double x = samplePoint((long double)a, (long double)b, sx);
+						long double y = samplePoint((long double)c, (long double)d, sy);
 						long double r = apply(op, x, y);
 						if (!((long double)R.lo() <= r && r <= (long double)R.hi())) {
 							++fails;
@@ -233,8 +249,8 @@ namespace sw { namespace universal {
 				long double Rlo = (long double)double(R.lo()), Rhi = (long double)double(R.hi());
 				for (double sx : {0.0, 1.0, Sd(rng)}) {
 					for (double sy : {0.0, 1.0, Sd(rng)}) {
-						long double x = alo + (long double)sx * (ahi - alo);
-						long double y = clo + (long double)sy * (chi - clo);
+						long double x = samplePoint(alo, ahi, sx);
+						long double y = samplePoint(clo, chi, sy);
 						long double r = apply(op, x, y);
 						if (!std::isfinite((double)r) || (double)std::abs(r) > mx) continue;   // beyond range
 						if (!(Rlo <= r && r <= Rhi)) {

--- a/static/range/interval/arithmetic/containment.cpp
+++ b/static/range/interval/arithmetic/containment.cpp
@@ -78,16 +78,35 @@ namespace sw { namespace universal {
 		// so tightening must fall back to outward rounding -- the enclosure is [maxfinite, +inf]
 		// and must still contain the finite real 2e308 (#1248, regression for the EFT overflow
 		// containment bug: without the isfinite guard the sum was [+inf, +inf]).
-		{ double big = 1e308; I s = I(big) + I(big);
-		  check("1e308+1e308 overflow", s, 2.0e308L);
-		  if (!(std::isinf((double)s.hi()) && std::isfinite((double)s.lo()))) {
-			++fails; if (reportTestCases) std::cout << "    FAIL overflow enclosure not [finite,+inf]: ["
-				<< s.lo() << ", " << s.hi() << "]\n"; } }
-		{ double big = 1e308; I p = I(big) * I(big);   // 1e616 overflow on the product
-		  check("1e308*1e308 overflow", p, 1.0e616L);
-		  if (!(std::isinf((double)p.hi()) && std::isfinite((double)p.lo()))) {
-			++fails; if (reportTestCases) std::cout << "    FAIL overflow product not [finite,+inf]: ["
-				<< p.lo() << ", " << p.hi() << "]\n"; } }
+		//
+		// The truth is DERIVED from the operands rather than written as a literal: where
+		// long double is double (MSVC, ARM, RISC-V) the real results 2e308 and 1e616 are
+		// not representable and a literal is rejected outright (MSVC C2177 "constant too
+		// big"). Derived, the truth is the exact real value on a wide long double and +inf
+		// where it is not -- still a valid containment assertion, and the [finite,+inf]
+		// structural check below is what pins the #1248 regression on those platforms.
+
+		{ 
+			double big = 1e308; I s = I(big) + I(big);
+		    // check("1e308+1e308 overflow", s, 2.0e308L);  // fails on MSVC and ARM where long double is double
+															// so derive the truth from the operands
+		    check("1e308+1e308 overflow", s, (long double) big + (long double) big);
+			if (!(std::isinf((double)s.hi()) && std::isfinite((double)s.lo()))) {
+				++fails; 
+				if (reportTestCases) std::cout << "    FAIL overflow enclosure not [finite,+inf]: ["
+				<< s.lo() << ", " << s.hi() << "]\n"; 
+			} 
+		}
+		{
+			double big = 1e308; I p = I(big) * I(big);   // 1e616 overflow on the product
+			// check("1e308*1e308 overflow", p, 1.0e616L);
+		    check("1e308*1e308 overflow", p, (long double) big * (long double) big);
+			if (!(std::isinf((double)p.hi()) && std::isfinite((double)p.lo()))) {
+				++fails; 
+				if (reportTestCases) std::cout << "    FAIL overflow product not [finite,+inf]: ["
+				<< p.lo() << ", " << p.hi() << "]\n"; 
+			} 
+		}
 		// UNDERFLOW: a product that lands in the subnormal range. TwoProduct's roundoff
 		// underflows below denorm_min and is lost, so a naive EFT reports a zero-width
 		// [p,p] that does not contain the true product; the underflow-safe prod_enclose


### PR DESCRIPTION
removing the urdiv dead code in blockfraction and blocksignificand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal numeric processing by removing obsolete operations and legacy conversion helpers.
  - Improved floating-point bit interpretation and portability across supported platforms.
  - Updated navigation between adjacent numeric values for environments with or without `long double` support.

- **Tests**
  - Improved portability of `long double` validation.
  - Added shared `long double` utility coverage.
  - Strengthened interval arithmetic tests to avoid rounding-related false failures and better validate overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->