### PR TITLE
ci(cmake): report prune reclaim from the deletions, not the usage endpoint

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -51,11 +51,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          usage() { gh api "repos/$REPO/actions/cache/usage" \
-                      --jq '"\(.active_caches_size_in_bytes) \(.active_caches_count)"'; }
-          read -r before before_n <<<"$(usage)"
-          awk -v b="$before" -v n="$before_n" \
-            'BEGIN {printf "cache usage before: %.2f GB in %d entries\n", b/1073741824, n}'
+          # Informational only -- see the note on the closing report. /actions/cache/usage
+          # is eventually consistent and can read high by a GB or more.
+          gh api "repos/$REPO/actions/cache/usage" \
+            --jq '"cache usage before (lags reality): \(.active_caches_size_in_bytes/1073741824*100|floor/100) GB in \(.active_caches_count) entries"'
 
           # No "|| true": if the listing fails we must abort, not fall through to
           # "nothing to do" on empty input and exit green having pruned nothing.
@@ -110,7 +109,11 @@ jobs:
             gh api -X DELETE "repos/$REPO/actions/caches/$id" >/dev/null
           done < stale.tsv
 
-          read -r after after_n <<<"$(usage)"
-          awk -v a="$after" -v b="$before" -v n="$after_n" \
-            'BEGIN {printf "cache usage after: %.2f GB in %d entries (reclaimed %.2f GB)\n", \
-                    a/1073741824, n, (b-a)/1073741824}'
+          # Report what we reclaimed from the sizes of the entries we actually deleted,
+          # NOT by re-reading /actions/cache/usage. That endpoint is eventually
+          # consistent: the first live run deleted four generations totalling 2.83GB and
+          # the re-read still returned the pre-prune figure, so the job reported
+          # "reclaimed 0.00 GB" on a prune that had worked. An honest number here matters
+          # -- a run that always looks like a no-op invites someone to "fix" a workflow
+          # that is doing its job.
+          awk -F'\t' '{n++; s+=$3} END {printf "deleted %d superseded generations, reclaimed %.2f GB\n", n, s/1073741824}' stale.tsv

--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -53,8 +53,17 @@ jobs:
 
           # Informational only -- see the note on the closing report. /actions/cache/usage
           # is eventually consistent and can read high by a GB or more.
-          gh api "repos/$REPO/actions/cache/usage" \
-            --jq '"cache usage before (lags reality): \(.active_caches_size_in_bytes/1073741824*100|floor/100) GB in \(.active_caches_count) entries"'
+          #
+          # Guarded, unlike the listing below, and for the opposite reason: nothing
+          # consumes this value, so under "set -e" a transient API blip on a decorative
+          # readout would abort the job before it prunes anything -- backwards for a
+          # workflow whose whole purpose is keeping the repo under the cache ceiling.
+          # The listing IS load-bearing, so it must still abort rather than fall through
+          # to a green no-op.
+          if ! gh api "repos/$REPO/actions/cache/usage" \
+                 --jq '"cache usage before (lags reality): \(.active_caches_size_in_bytes/1073741824*100|floor/100) GB in \(.active_caches_count) entries"'; then
+            echo "warning: could not read cache usage; it is informational only, continuing"
+          fi
 
           # No "|| true": if the listing fails we must abort, not fall through to
           # "nothing to do" on empty input and exit green having pruned nothing.


### PR DESCRIPTION
Follow-up to #1408. The prune workflow's **first live run worked** -- it deleted the four generations stranded by the post-merge `main` build -- but reported a no-op:

```
cache usage before: 11.09 GB in 1306 entries
superseded generations to delete:
    0.84 GB  ccache-linux-x64-gcc-2026-08-25T23:15:27.181Z
    0.71 GB  ccache-linux-x64-clang-2026-08-25T23:12:41.091Z
    0.80 GB  ccache-linux-x64-gcc-fast-2026-08-25T23:04:34.755Z
    0.48 GB  ccache-linux-x64-clang-fast-2026-08-25T23:02:49.218Z
...
cache usage after: 11.09 GB in 1306 entries (reclaimed 0.00 GB)
```

`/actions/cache/usage` is **eventually consistent**. Read back immediately after the DELETE calls it still returned the pre-prune figure.

Checking the cache list directly a few minutes later confirmed the deletions landed:

```
11 ccache entries, 8.00 GB (independently summed) -- exactly one per artifact
usage endpoint: 8.26 GB
```

The four fresh `08-26T12:3x` generations remain; the stale `08-25T23:xx` ones are gone.

## Change

Reclaim is computed from the sizes of the entries actually deleted -- already in `stale.tsv` -- rather than by re-reading the endpoint. The "before" reading stays, labelled as lagging.

Simulated against the real deletion set from the live run:

```
4 superseded generations, reclaimed 2.83 GB
```

## Why it matters

A run that always reports a no-op invites someone to "fix" a workflow that is doing its job, or to conclude the prune is ineffective and revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cache cleanup reporting for more accurate, consistent results.
  * Pruning summaries now clearly reflect the generations removed and storage reclaimed during cleanup.
  * Cache usage information is presented as an informational estimate, reducing the risk of misleading before-and-after comparisons.
  * No changes were made to application functionality or the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->