### PR TITLE
ci: add workflow_dispatch to CMake and ASCII Guard

### DIFF
--- a/.github/workflows/ascii-guard.yml
+++ b/.github/workflows/ascii-guard.yml
@@ -12,6 +12,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual re-trigger; see the note in cmake.yml. check-ascii is one of the three
+  # required checks, so it must be recoverable without an empty commit.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,6 +26,13 @@ on:
       - '.clang-format'
       - '.clang-tidy'
       - '.gitignore'
+  # Manual re-trigger. A run can be lost without any commit being at fault -- the
+  # 2026-08-26 Actions outage left the CMake and ASCII Guard runs for d63f3a84 queued
+  # for hours, and GitHub then refused both cancel ("Cannot cancel a workflow run that
+  # is completed") and rerun ("its workflow file may be broken") while dispatching new
+  # runs on the same commit perfectly well. Without this trigger the only way to get CI
+  # back onto main was an empty commit.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -126,8 +133,13 @@ jobs:
   # Full tier: 11-platform matrix with full CI (~45 min)
   # Skipped for draft PRs and feature-branch pushes
   full:
+    # workflow_dispatch is included so a manual run reproduces what a push to main
+    # does. That is the point of the trigger: recovering a lost main run needs the full
+    # matrix, not just the fast tier. Manual dispatch is deliberate and rare, so the
+    # ~45min cost is the right default rather than something to opt into.
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     concurrency:
       group: cmake-${{ matrix.artifact }}-${{ github.ref }}


### PR DESCRIPTION
A CI run can be lost with nothing wrong in the commit, and right now there is no way to re-trigger one.

## What happened

The 2026-08-26 Actions outage (`major_outage`, opened 15:11 UTC) left the CMake and ASCII Guard runs for `d63f3a84` -- the #1407 merge -- queued with `updatedAt == createdAt` for nearly three hours:

```
16:41  d63f3a84  CodeQL Advanced   completed/success    <- new dispatches work fine
15:20  d63f3a84  CMake             queued/              <- 175 min, never touched
15:17  d63f3a84  ASCII Guard       queued/
15:20  d63f3a84  ASCII Guard       completed/startup_failure
```

Once Actions recovered, GitHub dispatched a fresh CodeQL run on that same commit successfully, but refused to revive the other two -- and contradicted itself doing so:

```
gh run cancel  ->  "Cannot cancel a workflow run that is completed"
gh run view    ->  status: queued
gh run rerun   ->  "its workflow file may be broken"
```

The workflow file was not broken. It was byte-identical to the one that passed at 13:56.

Neither workflow had `workflow_dispatch`, so the only way to get CI back onto `main` was an empty commit -- polluting history to work around someone else's outage. `cache-prune.yml` already has one, which is exactly why it stayed re-triggerable.

## Change

`workflow_dispatch:` on both workflows, and the full tier's gating condition extended to accept it:

```yaml
if: |
  (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
  (github.event_name == 'workflow_dispatch') ||
  (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
```

Without that third clause a manual run would fire only the fast tier, which defeats the purpose -- recovering a lost `main` run needs the 11-platform matrix. Manual dispatch is deliberate and rare, so paying the ~45min by default beats making the recovery path a second decision. A boolean input for fast-tier-only can be added later if it turns out to be wanted.

**No behaviour change for `push` or `pull_request` events.** Verified the three trigger lists and the rendered condition parse as intended.

## Consequence for the cache work

`main` never built `d63f3a84`, so it never saved a ccache generation for it -- the newest is still `13:59` from `eef95eaa`. Once this lands, dispatching CMake on `main` manually both fills that gap and produces the first honest post-#1408 hit-rate reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added options to manually run the ASCII validation and CMake CI workflows.
  * Manual CMake runs now cover the full continuous integration test matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->