### PR TITLE
ci(cmake): give the full-tier Linux jobs the same 2G ccache the fast tier has

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -41,7 +41,7 @@ jobs:
   prune:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete superseded ccache generations
+      - name: Delete superseded and stale ccache generations
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -120,17 +120,22 @@ jobs:
             sub(/-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z?$/, "", prefix)
             superseded = (seen[prefix]++ > 0)
             aged = ($3 < cutoff)
-            if (superseded || aged) print $1 "\t" $2 "\t" $4
+            # carry WHY each entry was selected: an aged entry may be the newest of its
+            # artifact and not superseded at all, and calling that "superseded" in the
+            # log misreports a working prune -- the same way reporting reclaim from the
+            # eventually-consistent usage endpoint did before eef95eaa.
+            reason = superseded ? (aged ? "superseded+stale" : "superseded") : (aged ? "stale" : "")
+            if (reason != "") print $1 "\t" $2 "\t" $4 "\t" reason
           }' sorted.tsv > stale.tsv
 
           count=$(wc -l < stale.tsv)
           if [ "$count" -eq 0 ]; then
-            echo "no superseded ccache generations; nothing to do"
+            echo "no superseded or stale ccache generations; nothing to do"
             exit 0
           fi
 
-          echo "superseded generations to delete:"
-          awk -F'\t' '{printf "  %6.2f GB  %s\n", $3/1073741824, $2}' stale.tsv
+          echo "to delete (superseded = a newer generation exists; stale = fallen behind the maintained artifacts):"
+          awk -F'\t' '{printf "  %-16s %6.2f GB  %s\n", $4, $3/1073741824, $2}' stale.tsv
 
           if [ "$DRY_RUN" = "1" ]; then
             echo "DRY_RUN=1, not deleting"
@@ -149,4 +154,8 @@ jobs:
           # "reclaimed 0.00 GB" on a prune that had worked. An honest number here matters
           # -- a run that always looks like a no-op invites someone to "fix" a workflow
           # that is doing its job.
-          awk -F'\t' '{n++; s+=$3} END {printf "deleted %d superseded generations, reclaimed %.2f GB\n", n, s/1073741824}' stale.tsv
+          awk -F'\t' '{n++; s+=$3; c[$4]++} END {
+            printf "deleted %d entries, reclaimed %.2f GB (", n, s/1073741824
+            sep=""; for (k in c) { printf "%s%s: %d", sep, k, c[k]; sep=", " }
+            printf ")\n"
+          }' stale.tsv

--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -101,9 +101,18 @@ jobs:
           # 7-day idle rule keys on last ACCESS, and every full-tier run restores them,
           # which resets the clock. Without this they would sit there indefinitely,
           # leaving no room for the artifacts that are actually being refreshed.
-          STALE_DAYS=10
-          cutoff=$(date -u -d "$STALE_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
-          echo "dropping entries not refreshed since $cutoff"
+          # The cutoff is measured from the NEWEST ccache entry, not from wall-clock
+          # "now". Wall-clock would delete the caches we are trying to protect during
+          # any quiet spell: with STALE_DAYS=2, a weekend without a push to main makes
+          # every entry -- including the four that still save -- older than the cutoff,
+          # and the next prune would wipe them and force a cold rebuild we inflicted on
+          # ourselves. Anchoring to the newest entry expresses the actual intent, which
+          # is "this artifact has fallen behind the ones being maintained": on a quiet
+          # weekend nothing refreshes, the anchor ages too, and the gap stays closed.
+          STALE_DAYS=2
+          newest=$(cut -f3 all.tsv | sort -r | head -1)
+          cutoff=$(date -u -d "$newest - $STALE_DAYS days" +%Y-%m-%dT%H:%M:%SZ)
+          echo "newest ccache entry $newest; dropping entries older than $cutoff"
 
           sort -t"$(printf '\t')" -k3,3r all.tsv > sorted.tsv
           awk -F'\t' -v cutoff="$cutoff" '{

--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -91,12 +91,27 @@ jobs:
             echo "note: $strays ccache entries outside refs/heads/main; left untouched"
           fi
 
-          # newest first, then keep the first occurrence of each artifact prefix
+          # newest first, then keep the first occurrence of each artifact prefix.
+          #
+          # Also drop any entry older than STALE_DAYS regardless of whether it is the
+          # newest for its artifact. Artifacts that still save refresh on every push to
+          # main -- 4-7 a day -- so an entry this old can only belong to an artifact
+          # that no longer saves, whose cache is frozen and getting staler. Those were
+          # holding 5.14GB of the 10GB budget, and they do NOT expire on their own: the
+          # 7-day idle rule keys on last ACCESS, and every full-tier run restores them,
+          # which resets the clock. Without this they would sit there indefinitely,
+          # leaving no room for the artifacts that are actually being refreshed.
+          STALE_DAYS=10
+          cutoff=$(date -u -d "$STALE_DAYS days ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "dropping entries not refreshed since $cutoff"
+
           sort -t"$(printf '\t')" -k3,3r all.tsv > sorted.tsv
-          awk -F'\t' '{
+          awk -F'\t' -v cutoff="$cutoff" '{
             prefix = $2
             sub(/-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.]+Z?$/, "", prefix)
-            if (seen[prefix]++) print $1 "\t" $2 "\t" $4
+            superseded = (seen[prefix]++ > 0)
+            aged = ($3 < cutoff)
+            if (superseded || aged) print $1 "\t" $2 "\t" $4
           }' sorted.tsv > stale.tsv
 
           count=$(wc -l < stale.tsv)

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -265,7 +265,16 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: ${{ matrix.artifact }}
-          max-size: "1G"
+          # 2G for the configurations whose cache is kept, 1G for the rest -- whose
+          # in-run cache is discarded anyway, since they no longer save.
+          #
+          # The full-tier Linux jobs build UNIVERSAL_BUILD_CI: 912 objects against the
+          # fast tier's 474. At 1G they reported "Cache size (GB): 1.0 / 1.0 (99.96%)"
+          # on the first main run after #1408 -- twice the objects on half the relative
+          # budget, so they were still LRU-evicting mid-build, exactly the condition
+          # #1408 set out to remove. The fast tier, raised to 2G there, came back at
+          # 32-52% and had stopped thrashing.
+          max-size: ${{ matrix.cache_save == 'yes' && '2G' || '1G' }}
           # Save only on pushes to main (#1009), AND only for the configurations that
           # earn their share of GitHub's 10GB per-repo cache budget.
           #


### PR DESCRIPTION
The first `main` run after #1408 showed the fix working where it was applied, and not where it wasn't:

```
Linux x64 (GCC)  [fast]   Hits: 23 / 474 (4.85%)   Cache size: 1.0 / 2.0 (52.50%)
Linux x64 (Clang)[fast]   Hits: 23 / 474 (4.85%)   Cache size: 0.6 / 2.0 (32.15%)
Linux x64 (GCC)           Hits: 21 / 912 (2.30%)   Cache size: 1.0 / 1.0 (99.96%)
Linux x64 (Clang)         Hits: 21 / 912 (2.30%)   Cache size: 0.9 / 1.0 (94.89%)
```

The fast tier, raised to 2G in #1408, sits at 32-52% and has stopped thrashing. The full-tier Linux jobs build `UNIVERSAL_BUILD_CI` -- **912 objects against the fast tier's 474** -- and at 1G were still pinned at 99.96%. Twice the objects on half the relative budget: the exact condition #1408 set out to remove.

`max-size` is now tied to whether the cache is kept:

```yaml
max-size: ${{ matrix.cache_save == 'yes' && '2G' || '1G' }}
```

2G for the four artifacts that save, 1G for the rest, whose in-run cache is discarded anyway.

## The hit rates above prove nothing either way

That run restored caches saved *before* #1407, which rewrote `integer_impl.hpp`, `blocktriple.hpp`, `native/integers.hpp` and four posit headers -- files in nearly every TU. A perfect cache would also have missed. Removing the saturation is necessary, not sufficient. **The clean measurement is a `main` push whose restored cache postdates #1407.**

## A correction, and the second change

I previously said the seven no-longer-saved artifacts would "age out under the 7-day idle rule". That was wrong. The rule keys on last **access**, and every full-tier run *restores* them, resetting the clock. They would sit there indefinitely.

They hold **5.14 GB of the 10 GB budget**. So the prune now also drops entries older than `STALE_DAYS=10`. Artifacts that still save refresh on every main push (4-7 a day), so an entry that old can only belong to an artifact that no longer saves.

## Budget, stated honestly -- there is a gap this PR does not close

| | GB |
|---|---|
| four saving artifacts, today | 3.00 |
| four saving artifacts, at the new 2G ceiling | ~6.7 |
| seven frozen artifacts | 5.14 |
| sccache + codeql + node | ~0.74 |
| **worst case before the age rule fires** | **~12.5 > 10** |

The frozen seven are dated `08-25`, so the 10-day rule will not reach them until roughly **09-04**. Until then, if the saving artifacts grow toward their new ceiling, the repo could go back over 10 GB and GitHub would resume LRU-evicting whole caches -- the failure this all started from.

Current usage is 8.81 GB, and ccache fills gradually, so this is a risk rather than an immediate problem. **The one action that closes it is deleting the seven frozen entries now.** That makes those platform jobs fully cold immediately, which is the accepted trade from #1408 (they were going cold anyway; a frozen cache only delays it while costing half the budget) -- but it is a real cost on shared infrastructure, so I have not done it unilaterally.

If you want it: merge this, then run **Prune Actions caches** via `workflow_dispatch` with `dry_run` ticked to see the list, then again unticked.

Alternatively, lowering `STALE_DAYS` to 2 in this PR would do it automatically on the next prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated build-cache cleanup by removing entries older than 10 days and superseded cache generations.
  * Updated cache sizing for full-tier builds, allocating more space to configurations that retain cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->