### PR TITLE
ci(cmake): restore ccache to every artifact now the limit is 20GB

### DIFF
--- a/.github/workflows/cache-prune.yml
+++ b/.github/workflows/cache-prune.yml
@@ -103,13 +103,17 @@ jobs:
           # leaving no room for the artifacts that are actually being refreshed.
           # The cutoff is measured from the NEWEST ccache entry, not from wall-clock
           # "now". Wall-clock would delete the caches we are trying to protect during
-          # any quiet spell: with STALE_DAYS=2, a weekend without a push to main makes
+          # any quiet spell: at a tight STALE_DAYS, a weekend without a push to main makes
           # every entry -- including the four that still save -- older than the cutoff,
           # and the next prune would wipe them and force a cold rebuild we inflicted on
           # ourselves. Anchoring to the newest entry expresses the actual intent, which
           # is "this artifact has fallen behind the ones being maintained": on a quiet
           # weekend nothing refreshes, the anchor ages too, and the gap stays closed.
-          STALE_DAYS=2
+          # 10, not 2. Two was chosen to reclaim 5.14GB of frozen artifacts quickly
+          # while the repo was against a 10GB ceiling. The limit is now 20GB and every
+          # artifact saves again, so there is nothing to reclaim urgently and a tight
+          # window is pure downside risk.
+          STALE_DAYS=10
           newest=$(cut -f3 all.tsv | sort -r | head -1)
           cutoff=$(date -u -d "$newest - $STALE_DAYS days" +%Y-%m-%dT%H:%M:%SZ)
           echo "newest ccache entry $newest; dropping entries older than $cutoff"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -156,12 +156,10 @@ jobs:
           - os: ubuntu-latest
             name: Linux x64 (GCC)
             artifact: linux-x64-gcc
-            cache_save: "yes"   # keeps a saved ccache; see the ccache step
             cmake_flags: -DUNIVERSAL_BUILD_CI=ON
           - os: ubuntu-latest
             name: Linux x64 (Clang)
             artifact: linux-x64-clang
-            cache_save: "yes"   # keeps a saved ccache; see the ccache step
             compiler: clang
             cc: clang
             cxx: clang++
@@ -265,26 +263,25 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2.22
         with:
           key: ${{ matrix.artifact }}
-          # 2G for the configurations whose cache is kept, 1G for the rest -- whose
-          # in-run cache is discarded anyway, since they no longer save.
+          # 2G everywhere. This is a CEILING, not an allocation: ccache stores only what
+          # the build produces, so the CI_LITE configurations plateau around 1.0GB
+          # internal (~0.84GB stored) and never approach it. Only the two full-CI Linux
+          # jobs -- 912 objects against CI_LITE's 474 -- actually need the headroom, and
+          # at 1G they sat pinned at "Cache size (GB): 1.0 / 1.0 (99.96%)", evicting
+          # mid-build.
+          max-size: "2G"
+          # Save on every push to main again (#1009 still gates PR branches).
           #
-          # The full-tier Linux jobs build UNIVERSAL_BUILD_CI: 912 objects against the
-          # fast tier's 474. At 1G they reported "Cache size (GB): 1.0 / 1.0 (99.96%)"
-          # on the first main run after #1408 -- twice the objects on half the relative
-          # budget, so they were still LRU-evicting mid-build, exactly the condition
-          # #1408 set out to remove. The fast tier, raised to 2G there, came back at
-          # 32-52% and had stopped thrashing.
-          max-size: ${{ matrix.cache_save == 'yes' && '2G' || '1G' }}
-          # Save only on pushes to main (#1009), AND only for the configurations that
-          # earn their share of GitHub's 10GB per-repo cache budget.
+          # #1408 restricted saving to four artifacts because 12 of them at ~0.8GB had
+          # the repo at 9.94GB of a 10GB ceiling, and GitHub was evicting whole caches by
+          # LRU. That was triage against a limit that no longer applies: the repository
+          # cache limit is now 20GB. Projected steady state with everything saving is
+          # 9 CI_LITE x ~0.84GB + 2 full-CI x ~1.6GB + ~0.74GB of sccache/codeql/node,
+          # about 11.5GB -- comfortably inside 20GB, with the prune bounding generations.
           #
-          # 12 matrix artifacts x ~0.8GB had the repo sitting at 9.94GB of 10GB, so
-          # GitHub was LRU-evicting whole caches and a job could find its cache gone
-          # before it ran. The cross-compile and macOS jobs run only on ready PRs and
-          # main pushes -- a handful of times a day -- while the fast tier runs on every
-          # push to every branch, so the value is concentrated there. Those jobs now
-          # build cold by design; that is the trade for a fast tier that actually hits.
-          save: ${{ github.ref == 'refs/heads/main' && matrix.cache_save == 'yes' }}
+          # So the seven platforms that #1408 left cold get their caches back: both
+          # macOS, ARM64 native, POWER64, RISC-V, Android and MinGW.
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set ccache compiler launcher
         if: runner.os != 'Windows'


### PR DESCRIPTION
#1408 restricted ccache saving to four artifacts and left seven platforms building cold. That was **triage against a constraint that no longer exists**: 12 artifacts at ~0.8GB had the repo at 9.94GB of a 10GB ceiling, and GitHub was evicting whole caches by LRU.

The repository cache limit is now 20GB, so the trade is no longer worth making.

## What comes back

Both macOS jobs, ARM64 native, POWER64, RISC-V, Android and MinGW get their caches. Those were among the slowest jobs in the run that prompted this -- POWER64 `27m10s`, macOS x64 `26m1s` -- entirely because #1408 made them cold by design.

## `max-size: "2G"` uniformly

This is a **ceiling, not an allocation**. ccache stores what the build produces, so the CI_LITE configurations plateau near 1.0GB internal (~0.84GB stored, measured across all 11 artifacts today) and never approach 2G. Only the two full-CI Linux jobs need the headroom -- 912 objects against CI_LITE's 474, and at 1G they sat pinned at `Cache size (GB): 1.0 / 1.0 (99.96%)`.

Projected steady state, from what these artifacts actually reach today rather than from the cap:

| | GB |
|---|---|
| 9 CI_LITE x ~0.84 | 7.6 |
| 2 full-CI x ~1.60 | 3.2 |
| sccache + codeql + node | ~0.74 |
| **total** | **~11.5 of 20** |

## `STALE_DAYS` back to 10

Two was chosen to reclaim 5.14GB of frozen artifacts quickly while the repo was against the old ceiling. With everything saving again there is nothing frozen to reclaim, and a tight window is pure downside risk: a quiet spell with no push to `main` would put every entry past the cutoff and the next prune would wipe the caches this work exists to protect. (The newest-entry anchoring from #1414 already guards that, but there is no reason to lean on it.)

The `cache_save` matrix field is removed; it existed only to express the restriction.

## Verified

- Both workflows parse; the full-tier gate and matrix are untouched (10 full-tier entries, `workflow_dispatch` clause intact).
- Prune `run:` block passes `bash -n`; `STALE_DAYS=10` confirmed.
- No `cache_save` references remain.
- ASCII clean.

## Note on measurement

The clean post-#1408 hit-rate reading is still outstanding -- it needs a `main` push whose restored cache postdates #1407. Merging this changes the variables again, so the first `main` run after it will be cold for the seven restored artifacts by definition. The meaningful comparison is the run *after* that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build cache retention and cleanup behavior.
  * Expanded cache reuse for full-tier builds across supported platforms and architectures.
  * Increased the cache capacity available to non-Windows build jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->