### PR TITLE
refactor(cfloat): include what the cfloat headers use (#1389)

### DIFF
--- a/include/sw/universal/number/cfloat/attributes.hpp
+++ b/include/sw/universal/number/cfloat/attributes.hpp
@@ -6,6 +6,9 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
+#include <iomanip>       // std::setw
 namespace sw { namespace universal {
 
 // functions to provide details about

--- a/include/sw/universal/number/cfloat/cfloat.hpp
+++ b/include/sw/universal/number/cfloat/cfloat.hpp
@@ -8,6 +8,8 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  COMPILATION DIRECTIVES TO DIFFERENT COMPILERS
+#include <cstdint>       // the fixed-width integer types
+#include <limits>        // std::numeric_limits
 #include <universal/utility/architecture.hpp>
 #include <universal/utility/bit_cast.hpp>
 #include <universal/utility/long_double.hpp>

--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -1,4 +1,7 @@
 #pragma once
+#include <cstdint>       // the fixed-width integer types
+#include <cmath>         // the <cmath> functions used below
+#include <utility>       // std::pair
 #include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <universal/utility/icf_array_bounds.hpp>
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)

--- a/include/sw/universal/number/cfloat/exceptions.hpp
+++ b/include/sw/universal/number/cfloat/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/cfloat/fdp.hpp
+++ b/include/sw/universal/number/cfloat/fdp.hpp
@@ -15,6 +15,7 @@
 //
 // Relates to #345, #547
 
+#include <type_traits>   // std::is_same / std::true_type
 #include <vector>
 #include <cassert>
 #include <universal/traits/cfloat_traits.hpp>

--- a/include/sw/universal/number/cfloat/manipulators.hpp
+++ b/include/sw/universal/number/cfloat/manipulators.hpp
@@ -5,6 +5,10 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
+#include <cstddef>       // std::size_t
+#include <cstdint>       // the fixed-width integer types
 #include <iostream>
 #include <iomanip>
 #include <typeinfo>  // for typeid()

--- a/include/sw/universal/number/cfloat/math/functions/complex.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/complex.hpp
@@ -11,6 +11,7 @@
 // The std::complex<cfloat> overloads are retained for backward compatibility on compilers
 // that do not strictly enforce ISO C++ 26.2/2.
 
+#include <type_traits>   // std::is_same / std::true_type
 #include <complex>
 #include <universal/math/complex.hpp>
 

--- a/include/sw/universal/number/cfloat/math/functions/exponent.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/exponent.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // the <cmath> functions used below
 namespace sw { namespace universal {
 
 // the current shims are NON-COMPLIANT with the Universal standard, which says that every function must be

--- a/include/sw/universal/number/cfloat/math/functions/hypot.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/hypot.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // the <cmath> functions used below
 /*
 Computes the square root of the sum of the squares of x and y, without undue overflow or underflow at intermediate stages of the computation.
 

--- a/include/sw/universal/number/cfloat/math/functions/logarithm.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/logarithm.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // the <cmath> functions used below
 namespace sw { namespace universal {
 
 // Natural logarithm of x

--- a/include/sw/universal/number/cfloat/math/functions/minmax.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/minmax.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <algorithm>     // std::min / std::max
 namespace sw { namespace universal {
 
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>

--- a/include/sw/universal/number/cfloat/math/functions/pow.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/pow.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // the <cmath> functions used below
 namespace sw { namespace universal {
 
 template<unsigned nbits, unsigned es, typename bt, bool hasSubnormals, bool hasMaxExpValues, bool isSaturating>

--- a/include/sw/universal/number/cfloat/math/functions/sqrt.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/sqrt.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cmath>         // the <cmath> functions used below
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 // sqrt.hpp: sqrt functions for cfloat
 //

--- a/include/sw/universal/number/cfloat/math/functions/sqrt_tables.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/sqrt_tables.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>       // std::size_t
+#include <cmath>         // the <cmath> functions used below
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 #include <iomanip>
 // sqrt_tables.hpp: specialized classic floating-point cfloat configurations 

--- a/include/sw/universal/number/cfloat/math/functions/trigonometry.hpp
+++ b/include/sw/universal/number/cfloat/math/functions/trigonometry.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>         // the <cmath> functions used below
 #include <math/constants/double_constants.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/cfloat/mathext/horners.hpp
+++ b/include/sw/universal/number/cfloat/mathext/horners.hpp
@@ -1,4 +1,8 @@
 #pragma once
+#include <limits>        // std::numeric_limits
+#include <cmath>         // the <cmath> functions used below
+#include <cassert>       // assert()
+#include <cstddef>       // std::size_t
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 // horners.hpp: Horner's polynomial evaluation and root finding functions for double-double (dd) floating-point
 //

--- a/include/sw/universal/number/cfloat/mathlib.hpp
+++ b/include/sw/universal/number/cfloat/mathlib.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cstdint>       // the fixed-width integer types
 #include <universal/number/cfloat/math/functions/classify.hpp>
 #include <universal/number/cfloat/math/functions/complex.hpp>
 #include <universal/number/cfloat/math/functions/error_and_gamma.hpp>

--- a/include/sw/universal/number/cfloat/table.hpp
+++ b/include/sw/universal/number/cfloat/table.hpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>       // std::size_t
+#include <cmath>         // the <cmath> functions used below
 #include <universal/internal/blockbinary/manipulators.hpp>   // to_binary/to_hex on blockbinary (#1334)
 #include <universal/internal/blockbinary/iostream.hpp>   // operator<< on blockbinary (#1334)
 #include <iostream>


### PR DESCRIPTION
Groundwork for the Phase 2 `cfloat` split (#1334), taking the cfloat subtree off #1389's list first.

## Why before the split, not after

Every layering PR so far has tripped over this. Removing a text header removes whatever it was transitively supplying, and the breakage surfaces on a different compiler or in a translation unit nobody swept. #1407 hit it twice:

- `native/integer_core.hpp` used unqualified `size_t` — accepted by gcc, rejected by clang with libstdc++ 14, and caught only by the Clang-Tidy job because it builds `education/`.
- `posit_regime.hpp` silently lost `<cmath>`/`<cstddef>` when the field text layer moved out; it compiled only because `posit_impl.hpp` happened to include `<cmath>` first.

Sweeping first means the cfloat split can be judged on layering rather than on transitive breakage.

## Method

Scanned all 28 cfloat headers plus `traits/cfloat_traits.hpp` for uses of a std facility whose provider is not directly included, over comment- and string-stripped source. **30 gaps in 18 headers**, each verified against the real source line before changing anything — no false positives in the spot-checks, and `horners.hpp` turned up a second one (`static_cast<size_t>`) while I was reading it.

| header | added |
|---|---|
| `attributes.hpp` | `<string> <sstream> <iomanip>` |
| `cfloat.hpp` | `<cstdint>` (the alias list), `<limits>` |
| `cfloat_impl.hpp` | `<cstdint> <cmath> <utility>` (`std::pair` in `roundingDecision`) |
| `exceptions.hpp` | `<string>` |
| `fdp.hpp` | `<type_traits>` |
| `manipulators.hpp` | `<string> <sstream> <cstddef> <cstdint>` |
| `math/functions/*` | `<cmath>`, `<algorithm>`, `<type_traits>` |
| `mathext/horners.hpp` | `<limits> <cmath> <cassert> <cstddef>` |
| `mathlib.hpp`, `table.hpp` | `<cstdint> <cstddef> <cmath>` |

## Cost

Purely additive: **31 insertions, no deletions, no reordering.**

`cfloat.hpp` goes 114316 -> 114500 preprocessed lines, 489 -> 502 headers. These are almost all already in the transitive graph, so naming them costs ~0.2% and buys headers that no longer depend on include order.

## Verified

- The sweep reports **0 remaining gaps**.
- cfloat suite: **97 pass, 0 fail on gcc and on clang**.
- The 8 warnings in `complex/arithmetic/addition.cpp` are unused locals in the test file and are present at HEAD unchanged — not from this PR.
- ASCII clean.

Part of #1389, prerequisite for the #1334 cfloat split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)