### PR TITLE
fix(cfloat): move <iosfwd> out of the CFLOAT_TRACE_ENABLED guard (#1389)

### DIFF
--- a/include/sw/universal/number/cfloat/cfloat_impl.hpp
+++ b/include/sw/universal/number/cfloat/cfloat_impl.hpp
@@ -10,7 +10,6 @@
  || defined(ALGORITHM_TRACE_SUB)      || defined(ALGORITHM_TRACE_MUL) \
  || defined(ALGORITHM_TRACE_DIV)      || defined(ALGORITHM_TRACE_SQRT)
 #define CFLOAT_TRACE_ENABLED 1
-#include <iosfwd>        // std::ostream/std::istream in the friend declarations
 #include <iostream>
 #include <iomanip>
 #else
@@ -38,6 +37,9 @@
 #define CFLOAT_NATIVE_SQRT 0
 #endif
 
+#include <iosfwd>        // std::ostream/std::istream in the friend declarations. UNCONDITIONAL:
+                         // the declarations exist whether or not tracing is on, so this must not
+                         // sit inside the CFLOAT_TRACE_ENABLED guard above.
 #include <cstdint>       // the fixed-width integer types
 #include <cstdio>        // fprintf(stderr,...) for the diagnostics; keeps <iostream> out of the core
 #include <cmath>         // the <cmath> functions used below

--- a/include/sw/universal/number/cfloat/fdp.hpp
+++ b/include/sw/universal/number/cfloat/fdp.hpp
@@ -16,6 +16,7 @@
 // Relates to #345, #547
 
 #include <type_traits>   // std::is_same / std::true_type
+#include <cstddef>     // std::size_t in the fdp_qc signatures
 #include <vector>
 #include <cassert>
 #include <universal/traits/cfloat_traits.hpp>
@@ -140,9 +141,9 @@ quire_resolve(const quire<cfloat<nbits, es, bt, hasSubnormals, hasMaxExpValues, 
 /// Accumulates products into an existing quire without resolving.
 /// The quire must be parameterized on the same scalar type as the vectors.
 template<typename Qy, typename Vector>
-void fdp_qc(Qy& sum_of_products, size_t n,
-            const Vector& x, size_t incx,
-            const Vector& y, size_t incy,
+void fdp_qc(Qy& sum_of_products, std::size_t n,
+            const Vector& x, std::size_t incx,
+            const Vector& y, std::size_t incy,
             std::enable_if_t<is_cfloat<typename Vector::value_type>, int> = 0) {
 	using Scalar = typename Vector::value_type;
 	static_assert(std::is_same<Qy, quire<Scalar>>::value,
@@ -150,7 +151,7 @@ void fdp_qc(Qy& sum_of_products, size_t n,
 	if (n == 0) return;
 	assert(incx > 0 && "fdp_qc: incx must be positive");
 	assert(incy > 0 && "fdp_qc: incy must be positive");
-	size_t ix, iy;
+	std::size_t ix, iy;
 	for (ix = 0, iy = 0; ix < n && iy < n; ix += incx, iy += incy) {
 		assert(ix < x.size() && iy < y.size() && "fdp_qc: index out of bounds");
 		sum_of_products += quire_mul(x[ix], y[iy]);
@@ -162,14 +163,14 @@ void fdp_qc(Qy& sum_of_products, size_t n,
 /// via blocktriple conversion (no double intermediate, supports all cfloat widths).
 template<typename Vector>
 enable_if_cfloat<typename Vector::value_type>
-fdp_stride(size_t n, const Vector& x, size_t incx, const Vector& y, size_t incy) {
+fdp_stride(std::size_t n, const Vector& x, std::size_t incx, const Vector& y, std::size_t incy) {
 	using Scalar = typename Vector::value_type;
 	quire<Scalar> q;
 
 	if (n == 0) return Scalar(0);
 	assert(incx > 0 && "fdp_stride: incx must be positive");
 	assert(incy > 0 && "fdp_stride: incy must be positive");
-	size_t ix, iy;
+	std::size_t ix, iy;
 	for (ix = 0, iy = 0; ix < n && iy < n; ix += incx, iy += incy) {
 		assert(ix < x.size() && iy < y.size() && "fdp_stride: index out of bounds");
 		q += quire_mul(x[ix], y[iy]);
@@ -187,9 +188,9 @@ fdp(const Vector& x, const Vector& y) {
 	using Scalar = typename Vector::value_type;
 	quire<Scalar> q;
 
-	size_t n = size(x);
+	std::size_t n = size(x);
 	assert(n <= size(y) && "fdp: y vector must be at least as long as x");
-	for (size_t i = 0; i < n; ++i) {
+	for (std::size_t i = 0; i < n; ++i) {
 		q += quire_mul(x[i], y[i]);
 	}
 


### PR DESCRIPTION
**A defect I introduced and merged in #1417, and reported as fixed when it was not.**

CodeRabbit's review asked for `<iosfwd>` in `cfloat_impl.hpp` for the `operator<<`/`operator>>` friend declarations at 3326/3328. I added it — at line 13, **inside** the `CFLOAT_TRACE_ENABLED` block, next to the `<iostream>` that is deliberately guarded there:

```cpp
#define CFLOAT_TRACE_ENABLED 1
#include <iosfwd>        // <- never included, since tracing is off by default
#include <iostream>
#include <iomanip>
#else
#define CFLOAT_TRACE_ENABLED 0
#endif
```

Tracing is off by default, so the include never fired. The finding was not fixed, and my reply on that thread saying it was is wrong.

It still compiled because `cfloat.hpp` includes `<ostream>` ahead of `cfloat_impl.hpp` — **the exact include-order dependency the finding was about**. Anyone including `number/cfloat/core.hpp` where nothing else had declared `std::ostream` would have hit it.

`<iosfwd>` is now unconditional. Those declarations exist whether or not tracing is on.

Also fixes `cfloat/fdp.hpp`, which used bare `size_t` in the `fdp_qc` signatures without `<cstddef>`.

## How it was found — the sweep script was lying

I ran an IWYU sweep over cfloat in #1416 and reported "0 gaps". CodeRabbit then found five real ones in the same subtree. Rather than treat that as bad luck, I hardened the script, and it immediately found this. Three defects in it, all fixed:

- it counted a **conditionally-included** header as satisfying an unconditional use — precisely how this bug hid;
- it matched `std::enable_if` but not `std::enable_if_t`, and missed `std::tolower`;
- it let `<string>`/`<sstream>` satisfy `size_t`, which the standard does not guarantee.

Uses inside a conditional block are now excluded symmetrically, so a guarded trace statement isn't reported against unguarded includes.

Regression check on the script itself:

```
unfixed tree -> 3 gaps found (the two friend declarations + fdp.hpp)
fixed tree   -> 0 gaps
```

**Implication for #1389:** the remaining ~148 headers should be swept with the hardened script, not the original.

## Verified

- `core.hpp` compiles alone on gcc and clang.
- All three layering gates pass on both.
- cfloat suite: **97 pass, 0 fail**.
- `core.hpp` holds at 78330 lines, 0 I/O-family headers.
- ASCII clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when tracing is disabled by ensuring stream declarations remain available.
  * Clarified size handling for FDP operations using standard size types, with no change to runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->