### PR TITLE
refactor(lns): split lns into core / manipulators / iostream / debug layers (#1334)

### DIFF
--- a/include/sw/universal/internal/abstract/triple.hpp
+++ b/include/sw/universal/internal/abstract/triple.hpp
@@ -5,11 +5,11 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <cassert>
-#include <iomanip>
+#include <iosfwd>    // std::ostream/std::istream in the friend declarations (#1334)
 #include <limits>
 #include <tuple>
 
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // the bit-manipulation half (#1334)
 #include <universal/internal/blockbinary/blockbinary.hpp>
 
 namespace sw { namespace universal {
@@ -281,24 +281,6 @@ private:
 	friend bool operator>=(const triple<nfbits,nbt>& lhs, const triple<nfbits,nbt>& rhs);
 };
 
-////////////////////// VALUE operators
-template<size_t nfbits, typename nbt>
-inline std::ostream& operator<<(std::ostream& ostr, const triple<nfbits,nbt>& v) {
-	if (v._inf) {
-		ostr << FP_INFINITE;
-	}
-	else {
-		ostr << (long double)v;
-	}
-	return ostr;
-}
-
-template<size_t nfbits, typename nbt>
-inline std::istream& operator>> (std::istream& istr, const triple<nfbits,nbt>& v) {
-	istr >> v._fraction;
-	return istr;
-}
-
 template<size_t nfbits, typename nbt>
 inline bool operator==(const triple<nfbits,nbt>& lhs, const triple<nfbits,nbt>& rhs) { 
 	return lhs._sign == rhs._sign && lhs._scale == rhs._scale && lhs._fraction == rhs._fraction && lhs._zero == rhs._zero && lhs._inf == rhs._inf; 
@@ -379,21 +361,6 @@ template<size_t nfbits, typename nbt>
 inline bool operator<=(const triple<nfbits,nbt>& lhs, const triple<nfbits,nbt>& rhs) { return !operator> (lhs, rhs); }
 template<size_t nfbits, typename nbt>
 inline bool operator>=(const triple<nfbits,nbt>& lhs, const triple<nfbits,nbt>& rhs) { return !operator< (lhs, rhs); }
-
-template<size_t fbits, typename BlockType>
-inline std::string components(const triple<fbits,BlockType>& v) {
-	std::stringstream s;
-	if (v.iszero()) {
-		s << "(+,0," << std::setw(fbits) << v.fraction() << ')';
-		return s.str();
-	}
-	else if (v.isinf()) {
-		s << "(inf," << std::setw(fbits) << v.fraction() << ')';
-		return s.str();
-	}
-	s << "(" << (v.sign() ? "-" : "+") << "," << v.scale() << "," << v.fraction() << ')';
-	return s.str();
-}
 
 /// Magnitude of a scientific notation triple (equivalent to turning the sign bit off).
 template<size_t nfbits, typename BlockType>

--- a/include/sw/universal/internal/abstract/triple_io.hpp
+++ b/include/sw/universal/internal/abstract/triple_io.hpp
@@ -1,0 +1,56 @@
+#pragma once
+// triple_io.hpp: the text layer for the abstract scientific-notation triple
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// operator<<, operator>> and components() for triple<> (#1334). triple.hpp is included
+// by six number-system impl headers -- lns, takum, dbns, rational, faithful and the
+// one-parameter skeleton -- so leaving three text producers in it put <iomanip>,
+// <sstream>, <ostream> and <istream> into every one of their arithmetic cores. Same
+// split blockbinary, blocksignificand, blockfraction and blocktriple already had
+// (#1394, #1401, #1403).
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <universal/internal/abstract/triple.hpp>
+
+namespace sw { namespace universal {
+
+////////////////////// VALUE operators
+template<size_t nfbits, typename nbt>
+inline std::ostream& operator<<(std::ostream& ostr, const triple<nfbits,nbt>& v) {
+	if (v._inf) {
+		ostr << FP_INFINITE;
+	}
+	else {
+		ostr << (long double)v;
+	}
+	return ostr;
+}
+
+template<size_t nfbits, typename nbt>
+inline std::istream& operator>> (std::istream& istr, const triple<nfbits,nbt>& v) {
+	istr >> v._fraction;
+	return istr;
+}
+template<size_t fbits, typename BlockType>
+inline std::string components(const triple<fbits,BlockType>& v) {
+	std::stringstream s;
+	if (v.iszero()) {
+		s << "(+,0," << std::setw(fbits) << v.fraction() << ')';
+		return s.str();
+	}
+	else if (v.isinf()) {
+		s << "(inf," << std::setw(fbits) << v.fraction() << ')';
+		return s.str();
+	}
+	s << "(" << (v.sign() ? "-" : "+") << "," << v.scale() << "," << v.fraction() << ')';
+	return s.str();
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/lns/attributes.hpp
+++ b/include/sw/universal/number/lns/attributes.hpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
+#include <iomanip>       // std::setw
 #include <cmath> // for std:pow()
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/lns/core.hpp
+++ b/include/sw/universal/number/lns/core.hpp
@@ -1,0 +1,31 @@
+#pragma once
+// core.hpp: the lns arithmetic core -- no I/O, no text
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the lns headers (#1334, Phase 2). Storage, arithmetic, comparison,
+// numeric_limits and traits -- everything a compute kernel needs and nothing that
+// turns an lns into text.
+//
+//     #include <universal/number/lns/lns.hpp>    // everything, as before
+//     #include <universal/number/lns/core.hpp>   // arithmetic only
+//
+// lns.hpp includes this plus manipulators.hpp, iostream.hpp and debug.hpp, so existing
+// code is unaffected.
+//
+// NOTE: traits/arithmetic_traits.hpp and common/number_traits_reports.hpp are
+// deliberately NOT included -- they build report strings and pull <sstream>/<iomanip>.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/traits/number_traits.hpp>
+
+#include <universal/number/lns/exceptions.hpp>
+#include <universal/number/lns/lns_fwd.hpp>
+#include <universal/number/lns/lns_impl.hpp>
+#include <universal/number/lns/lns_traits.hpp>
+#include <universal/number/lns/numeric_limits.hpp>

--- a/include/sw/universal/number/lns/debug.hpp
+++ b/include/sw/universal/number/lns/debug.hpp
@@ -1,0 +1,47 @@
+#pragma once
+// debug.hpp: introspection for lns
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 3 of the lns headers (#1334). lns_impl.hpp DECLARES debugConstexprParameters()
+// and the LnsArithmeticStatistics printer but does not define them, so the arithmetic
+// core needs no <iostream>. Include this header to call either.
+#include <iostream>
+#include <universal/native/integers.hpp>   // to_binary on a native limb, used by the dump
+#include <universal/number/lns/core.hpp>
+#include <universal/number/lns/manipulators.hpp>   // type_tag / to_binary used by the dump
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
+void lns<nbits, rbits, bt, xtra...>::debugConstexprParameters() {
+	std::cout << "constexpr parameters for " << type_tag(*this) << '\n';
+	std::cout << "scaling               " << scaling << '\n';
+	std::cout << "bitsInByte            " << bitsInByte << '\n';
+	std::cout << "bitsInBlock           " << bitsInBlock << '\n';
+	std::cout << "nrBlocks              " << nrBlocks << '\n';
+	std::cout << "storageMask           " << to_binary(storageMask, bitsInBlock) << '\n';
+	std::cout << "MSU                   " << MSU << '\n';
+	std::cout << "MSU_MASK              " << to_binary(MSU_MASK, bitsInBlock) << '\n';
+	std::cout << "MSB_UNIT              " << MSB_UNIT << '\n';
+	std::cout << "SPECIAL_BITS_TOGETHER " << (SPECIAL_BITS_TOGETHER ? "yes" : "no") << '\n';
+	std::cout << "SIGN_BIT_MASK         " << to_binary(SIGN_BIT_MASK, bitsInBlock) << '\n';
+	std::cout << "MSB_BIT_MASK          " << to_binary(MSB_BIT_MASK, bitsInBlock) << '\n';
+	std::cout << "BLOCK_MSB_MASK        " << to_binary(BLOCK_MSB_MASK, bitsInBlock) << '\n';
+	std::cout << "MSU_ZERO              " << to_binary(MSU_ZERO, bitsInBlock) << '\n';
+	std::cout << "MSU_NAN               " << to_binary(MSU_NAN, bitsInBlock) << '\n';
+	std::cout << "maxShift              " << maxShift << '\n';
+	std::cout << "leftShift             " << leftShift << '\n';
+	std::cout << "min_exponent          " << min_exponent << '\n';
+	std::cout << "max_exponent          " << max_exponent << '\n';
+}
+
+inline std::ostream& operator<<(std::ostream& ostr, const LnsArithmeticStatistics& stats) {
+	ostr << "Conversions                     : " << stats.conversionEvents << '\n';
+	return ostr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/lns/exceptions.hpp
+++ b/include/sw/universal/number/lns/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/lns/fdp.hpp
+++ b/include/sw/universal/number/lns/fdp.hpp
@@ -35,6 +35,8 @@
 //
 // Relates to #345, #549, #1203
 
+#include <cstddef>       // std::size_t
+#include <type_traits>   // std::enable_if_t
 #include <vector>
 #include <cmath>
 #include <stdexcept>

--- a/include/sw/universal/number/lns/iostream.hpp
+++ b/include/sw/universal/number/lns/iostream.hpp
@@ -1,0 +1,31 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for lns
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the lns headers (#1334): the <iostream> half. lns_impl.hpp declares these
+// as friend templates but does not define them, so the core needs only <iosfwd>.
+#include <iostream>
+#include <universal/internal/abstract/triple_io.hpp>   // operator<< / components() on triple<> (#1334)
+#include <universal/number/lns/core.hpp>
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
+inline std::ostream& operator<<(std::ostream& ostr, const lns<nbits, rbits, bt, xtra...>& r) {
+	ostr << double(r);
+	return ostr;
+}
+
+template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>
+inline std::istream& operator>>(std::istream& istr, lns<nbits, rbits, bt, xtra...>& r) {
+	double item;
+	istr >> item;
+	r = item;
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/lns/lns.hpp
+++ b/include/sw/universal/number/lns/lns.hpp
@@ -12,8 +12,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// required std libraries 
-#include <iostream>
-#include <iomanip>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
@@ -49,14 +47,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/lns/exceptions.hpp>
-#include <universal/number/lns/lns_fwd.hpp>
-#include <universal/number/lns/lns_impl.hpp>
-#include <universal/number/lns/lns_traits.hpp>
-#include <universal/number/lns/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
+#include <universal/number/lns/core.hpp>
 
 // useful functions to work with logarithmic numbers
+// layer 2a: the string producers
 #include <universal/number/lns/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/lns/iostream.hpp>
+// layer 3: introspection -- debugConstexprParameters, the statistics printer
+#include <universal/number/lns/debug.hpp>
 #include <universal/number/lns/attributes.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/lns/lns_impl.hpp
+++ b/include/sw/universal/number/lns/lns_impl.hpp
@@ -1,5 +1,19 @@
 #pragma once
-#include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+#include <cstdint>       // the fixed-width integer types
+#include <cmath>         // std::frexp / std::ldexp
+#include <type_traits>   // std::is_same_v
+// Behavioural switches default HERE, beside the #if blocks that test them, rather than
+// in the lns.hpp umbrella: including core.hpp directly would otherwise leave them
+// undefined, #if would evaluate them as 0, and the literal operators would silently
+// disappear from that path -- the trap #1390 hit with POSIT_ENABLE_LITERALS (#1334).
+#if !defined(LNS_ENABLE_LITERALS)
+#define LNS_ENABLE_LITERALS 1
+#endif
+#if !defined(LNS_THROW_ARITHMETIC_EXCEPTION)
+#define LNS_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+
+#include <iosfwd>     // std::ostream/std::istream in the friend declarations (#1334)
 #include <universal/utility/icf_array_bounds.hpp>
 #include <string>
 // lns_impl.hpp: implementation of an arbitrary logarithmic number system configuration
@@ -12,7 +26,7 @@
 #include <limits>
 
 #include <math/constexpr_math.hpp>
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // extractFields / ieee754_parameter; the text layer is not needed here (#1334)
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/internal/abstract/triple.hpp>
@@ -34,10 +48,7 @@ namespace sw { namespace universal {
 		}
 		int conversionEvents;
 	};
-	inline std::ostream& operator<<(std::ostream& ostr, const LnsArithmeticStatistics& stats) {
-		ostr << "Conversions                     : " << stats.conversionEvents << '\n';
-		return ostr;
-	}
+	std::ostream& operator<<(std::ostream& ostr, const LnsArithmeticStatistics& stats);
 	static LnsArithmeticStatistics lnsStats;
 
 // convert a floating-point value to a specific lns configuration. Semantically, p = v, return reference to p
@@ -513,27 +524,9 @@ public:
 	explicit constexpr operator long double()       const noexcept { return to_ieee754<long double>(); }
 #endif
 
-	void debugConstexprParameters() {
-		std::cout << "constexpr parameters for " << type_tag(*this) << '\n';
-		std::cout << "scaling               " << scaling << '\n';
-		std::cout << "bitsInByte            " << bitsInByte << '\n';
-		std::cout << "bitsInBlock           " << bitsInBlock << '\n';
-		std::cout << "nrBlocks              " << nrBlocks << '\n';
-		std::cout << "storageMask           " << to_binary(storageMask, bitsInBlock) << '\n';
-		std::cout << "MSU                   " << MSU << '\n';
-		std::cout << "MSU_MASK              " << to_binary(MSU_MASK, bitsInBlock) << '\n';
-		std::cout << "MSB_UNIT              " << MSB_UNIT << '\n';
-		std::cout << "SPECIAL_BITS_TOGETHER " << (SPECIAL_BITS_TOGETHER ? "yes" : "no") << '\n';
-		std::cout << "SIGN_BIT_MASK         " << to_binary(SIGN_BIT_MASK, bitsInBlock) << '\n';
-		std::cout << "MSB_BIT_MASK          " << to_binary(MSB_BIT_MASK, bitsInBlock) << '\n';
-		std::cout << "BLOCK_MSB_MASK        " << to_binary(BLOCK_MSB_MASK, bitsInBlock) << '\n';
-		std::cout << "MSU_ZERO              " << to_binary(MSU_ZERO, bitsInBlock) << '\n';
-		std::cout << "MSU_NAN               " << to_binary(MSU_NAN, bitsInBlock) << '\n';
-		std::cout << "maxShift              " << maxShift << '\n';
-		std::cout << "leftShift             " << leftShift << '\n';
-		std::cout << "min_exponent          " << min_exponent << '\n';
-		std::cout << "max_exponent          " << max_exponent << '\n';
-	}
+	// DECLARED here, DEFINED in lns/debug.hpp, so the arithmetic core needs no
+	// <iostream> (#1334). Include debug.hpp to call it.
+	void debugConstexprParameters();
 
 	// normalize: decompose lns value into a blocktriple<rbits, REP> for quire accumulation.
 	// LNS stores values in logarithmic domain; materializing to linear domain is inherently
@@ -840,16 +833,14 @@ private:
 
 	/// stream operators
 
-	friend std::ostream& operator<< (std::ostream& ostr, const lns& r) {
-		ostr << double(r);
-		return ostr;
-	}
-	friend std::istream& operator>> (std::istream& istr, lns& r) {
-		double item;
-		istr >> item;
-		r = item;
-		return istr;
-	}
+	// Declared, not defined: the definitions live in lns/iostream.hpp so the core needs
+	// only <iosfwd> (#1334). Declaring them as templates -- rather than the in-class
+	// non-template friends they were -- is what lets the definition sit at namespace
+	// scope in another header.
+	template<unsigned nnbits, unsigned nrbits, typename nbt, auto... nxtra>
+	friend std::ostream& operator<<(std::ostream& ostr, const lns<nnbits, nrbits, nbt, nxtra...>& r);
+	template<unsigned nnbits, unsigned nrbits, typename nbt, auto... nxtra>
+	friend std::istream& operator>>(std::istream& istr, lns<nnbits, nrbits, nbt, nxtra...>& r);
 
 	// lns - logic operators
 

--- a/include/sw/universal/number/lns/lns_traits.hpp
+++ b/include/sw/universal/number/lns/lns_traits.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <type_traits>   // std::enable_if_t
 #include <universal/traits/integral_constant.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/lns/manipulators.hpp
+++ b/include/sw/universal/number/lns/manipulators.hpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
+#include <cstdint>       // the fixed-width integer types
+#include <cmath>         // std::ldexp
+#include <type_traits>   // std::enable_if_t
 #include <iomanip>
 #include <typeinfo>  // for typeid()
 

--- a/include/sw/universal/number/lns/math/complex.hpp
+++ b/include/sw/universal/number/lns/math/complex.hpp
@@ -11,6 +11,7 @@
 // The std::complex<lns> overloads are retained for backward compatibility on compilers
 // that do not strictly enforce ISO C++ 26.2/2.
 
+#include <type_traits>   // std::true_type
 #include <complex>
 #include <universal/math/complex.hpp>
 

--- a/include/sw/universal/number/lns/math/exponent.hpp
+++ b/include/sw/universal/number/lns/math/exponent.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // std::exp
 namespace sw { namespace universal {
 
 // the current shims are NON-COMPLIANT with the Universal standard, which says that every function must be

--- a/include/sw/universal/number/lns/math/hypot.hpp
+++ b/include/sw/universal/number/lns/math/hypot.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // std::hypot
 /*
 Computes the square root of the sum of the squares of x and y, without undue overflow or underflow at intermediate stages of the computation.
 

--- a/include/sw/universal/number/lns/math/logarithm.hpp
+++ b/include/sw/universal/number/lns/math/logarithm.hpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // std::log
 namespace sw { namespace universal {
 
 // Natural logarithm of x

--- a/include/sw/universal/number/lns/math/minmax.hpp
+++ b/include/sw/universal/number/lns/math/minmax.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <algorithm>     // std::min / std::max
 namespace sw { namespace universal {
 
 template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>

--- a/include/sw/universal/number/lns/math/pow.hpp
+++ b/include/sw/universal/number/lns/math/pow.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // std::pow
 namespace sw { namespace universal {
 
 template<unsigned nbits, unsigned rbits, typename bt, auto... xtra>

--- a/include/sw/universal/number/lns/math/sqrt_tables.hpp
+++ b/include/sw/universal/number/lns/math/sqrt_tables.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>       // std::size_t
+#include <cmath>         // std::sqrt
 #include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 #include <iomanip>
 // sqrt_tables.hpp: specialized logarithmic floating-point 

--- a/include/sw/universal/number/lns/math/trigonometry.hpp
+++ b/include/sw/universal/number/lns/math/trigonometry.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cmath>         // the trigonometric functions
 #include <math/constants/double_constants.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/lns/math/truncate.hpp
+++ b/include/sw/universal/number/lns/math/truncate.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cmath>         // std::trunc
 namespace sw { namespace universal {
 
 // Truncate value by rounding toward zero, returning the nearest integral value that is not larger in magnitude than x

--- a/include/sw/universal/number/lns/mathlib.hpp
+++ b/include/sw/universal/number/lns/mathlib.hpp
@@ -6,6 +6,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cstdint>       // the fixed-width integer types
 #include <universal/number/lns/math/classify.hpp>
 #include <universal/number/lns/math/complex.hpp>
 #include <universal/number/lns/math/error_and_gamma.hpp>

--- a/include/sw/universal/number/lns/table.hpp
+++ b/include/sw/universal/number/lns/table.hpp
@@ -6,6 +6,10 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cstddef>       // std::size_t
+#include <cstdint>       // std::uint8_t
+#include <ostream>       // std::ostream
+#include <iomanip>       // std::setw
 namespace sw { namespace universal {
 
 // generate a full binary representation table for a given posit configuration


### PR DESCRIPTION
Phase 2 continues after cfloat.

| header | lines | headers | I/O |
|---|---|---|---|
| `lns/lns.hpp` (before) | 89909 | 450 | 5 |
| **`lns/core.hpp` (new)** | **74762** | **364** | **0** |

Criterion 1 met. Criterion 2 not, for the usual reason — blocktriple.

Preceded by the #1389 sweep over the lns subtree (30 gaps across 29 headers), using the **hardened** script from #1418, so the split could be judged on layering rather than transitive breakage.

## Two things that differ from cfloat and posit

**lns defined its stream operators inline in the class, as non-template friends.** An in-class friend definition can't be relocated as-is, so they're now declared as friend *templates* and defined at namespace scope in `iostream.hpp` — the shape posit's field headers already use.

**`internal/abstract/triple.hpp` was the binding constraint.** After all the lns work the core was still at **4 I/O**, all entering through triple.hpp's `operator<<`, `operator>>` and `components()`.

That header is included by **six** impl headers — `lns`, `takum`, `dbns`, `rational`, `faithful` and the one-parameter skeleton — so three text producers were putting `<iomanip>`, `<sstream>`, `<ostream>` and `<istream>` into every one of their arithmetic cores. The text moves to `internal/abstract/triple_io.hpp`, the same split blockbinary / blocksignificand / blockfraction / blocktriple already had (#1394, #1401, #1403); triple.hpp drops `<iomanip>` and switches to `ieee754_core.hpp`.

**That is what takes lns from 4 I/O to 0 — and it unblocks `takum`, which is next in the rollout.**

## Also out of the core

`debugConstexprParameters()` and the `LnsArithmeticStatistics` printer -> new `debug.hpp`. `native/ieee754.hpp` -> `ieee754_core.hpp` (lns needs only `extractFields` and `ieee754_parameter`). Behavioural switches move into `lns_impl.hpp` beside the `#if` blocks that test them.

## Verified

- Both gates pass on gcc and clang.
- lns + takum + dbns + rational suites: **67 pass, 0 fail**.
- Every `api.cpp`: **55 pass, 0 fail**. clang spot-check: **20 pass, 0 fail**.
- Hardened #1389 sweep: **0 gaps across all 32 lns headers**.
- ASCII clean.

One pre-existing breakage confirmed unrelated: `skeleton_1param/oneparam_impl.hpp` includes a mistyped `universal/native/ieee-754.hpp` and fails identically at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)