### PR TITLE
refactor(takum): split takum and takum_log into core / manipulators / iostream / debug (#1334)

### DIFF
--- a/include/sw/universal/number/takum/attributes.hpp
+++ b/include/sw/universal/number/takum/attributes.hpp
@@ -6,6 +6,9 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
+#include <iomanip>       // std::setw
 namespace sw { namespace universal {
 
 // free function sign

--- a/include/sw/universal/number/takum/core.hpp
+++ b/include/sw/universal/number/takum/core.hpp
@@ -1,0 +1,28 @@
+#pragma once
+// core.hpp: the takum arithmetic core -- no I/O, no text
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the takum headers (#1334, Phase 2). Covers BOTH takum and takum_log: the
+// takum.hpp umbrella has always included both impl headers, so they share a core.
+//
+//     #include <universal/number/takum/takum.hpp>   // everything, as before
+//     #include <universal/number/takum/core.hpp>    // arithmetic only
+//
+// NOTE: traits/arithmetic_traits.hpp and common/number_traits_reports.hpp are
+// deliberately NOT included -- they build report strings and pull <sstream>/<iomanip>.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/traits/number_traits.hpp>
+
+#include <universal/number/takum/exceptions.hpp>
+#include <universal/number/takum/takum_fwd.hpp>
+#include <universal/number/takum/takum_impl.hpp>
+#include <universal/number/takum/takum_log_impl.hpp>
+#include <universal/number/takum/takum_traits.hpp>
+#include <universal/number/takum/numeric_limits.hpp>

--- a/include/sw/universal/number/takum/debug.hpp
+++ b/include/sw/universal/number/takum/debug.hpp
@@ -1,0 +1,36 @@
+#pragma once
+// debug.hpp: introspection for takum
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 3 of the takum headers (#1334). takum_impl.hpp DECLARES
+// debugConstexprParameters() but does not define it, so the core needs no <iostream>.
+#include <iostream>
+#include <universal/native/integers.hpp>            // to_binary on a native limb
+#include <universal/number/takum/core.hpp>
+#include <universal/number/takum/manipulators.hpp>
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned rbits, typename bt>
+void takum<nbits, rbits, bt>::debugConstexprParameters() {
+	std::cout << "constexpr parameters for " << type_tag(*this) << '\n';
+	std::cout << "nbits                 " << nbits << '\n';
+	std::cout << "rbits                 " << rbits << '\n';
+	std::cout << "overhead              " << overhead << '\n';
+	std::cout << "dr_bits               " << dr_bits << '\n';
+	std::cout << "nr_dr_values          " << nr_dr_values << '\n';
+	std::cout << "max_r                 " << max_r << '\n';
+	std::cout << "maxCharBits           " << maxCharBits << '\n';
+	std::cout << "min characteristic    " << min_characteristic() << '\n';
+	std::cout << "max characteristic    " << max_characteristic() << '\n';
+	std::cout << "bitsInBlock           " << bitsInBlock << '\n';
+	std::cout << "nrBlocks              " << nrBlocks << '\n';
+	std::cout << "MSU_MASK              " << to_binary(MSU_MASK, bitsInBlock) << '\n';
+	std::cout << "SIGN_BIT_MASK         " << to_binary(SIGN_BIT_MASK, bitsInBlock) << '\n';
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/takum/exceptions.hpp
+++ b/include/sw/universal/number/takum/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/takum/iostream.hpp
+++ b/include/sw/universal/number/takum/iostream.hpp
@@ -1,0 +1,40 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for takum and takum_log
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the takum headers (#1334). The impl headers declare these as friends but
+// do not define them, so the core needs only <iosfwd>.
+#include <string>        // std::string
+#include <iostream>
+#include <universal/number/takum/core.hpp>
+
+namespace sw { namespace universal {
+
+////////////////////// operators
+template<unsigned nnbits, unsigned nrbits, typename nbt>
+inline std::ostream& operator<<(std::ostream& ostr, const takum<nnbits, nrbits, nbt>& v) {
+	ostr << double(v);
+	return ostr;
+}
+
+template<unsigned nnbits, unsigned nrbits, typename nbt>
+inline std::istream& operator>>(std::istream& istr, takum<nnbits, nrbits, nbt>& v) {
+	double d;
+	istr >> d;
+	v = d;
+	return istr;
+}
+////////////////////// operators
+template<unsigned nn, unsigned nr, typename nb>
+inline std::ostream& operator<<(std::ostream& ostr, const takum_log<nn, nr, nb>& v) { ostr << double(v); return ostr; }
+template<unsigned nn, unsigned nr, typename nb>
+inline std::istream&
+operator>>(std::istream& istr, takum_log<nn, nr, nb>& v) {
+	double d; istr >> d; v = d; return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/takum/manipulators.hpp
+++ b/include/sw/universal/number/takum/manipulators.hpp
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <sstream>       // std::stringstream
+#include <string>        // std::string
+#include <cstddef>       // std::size_t
+#include <universal/number/takum/core.hpp>
+#include <cstdint>       // the fixed-width integer types
+#include <type_traits>   // std::enable_if_t
 #include <iomanip>
 #include <typeinfo>  // for typeid()
 
@@ -12,6 +18,91 @@
 #include <universal/utility/color_print.hpp>
 
 namespace sw { namespace universal {
+template<unsigned nbits, unsigned rbits, typename bt>
+std::string to_native(const takum<nbits, rbits, bt>& number, bool nibbleMarker = false) {
+	return to_binary(number, nibbleMarker);
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+std::string to_native(const takum_log<nbits, rbits, bt>& number, bool nibbleMarker = false) {
+	return to_binary(number, nibbleMarker);
+}
+
+
+// Moved out of the impl headers (#1334): these turn a takum into a std::string.
+template<unsigned nbits, unsigned rbits, typename bt>
+std::string to_binary(const takum<nbits, rbits, bt>& number, bool nibbleMarker = false) {
+	using T = takum<nbits, rbits, bt>;
+	std::stringstream s;
+	bool negative = number.sign();
+	uint64_t mag = number.magnitude_bits();
+
+	s << "0b";
+	s << (negative ? "1." : "0.");
+
+	// Direction bit from magnitude
+	bool D = static_cast<bool>((mag >> (nbits - 2)) & 1);
+	s << (D ? "1." : "0.");
+
+	// Regime field from magnitude (rbits bits)
+	unsigned regime = static_cast<unsigned>((mag >> (nbits - T::overhead)) & T::r_mask);
+	for (int i = static_cast<int>(rbits) - 1; i >= 0; --i) {
+		s << ((regime >> i) & 1 ? '1' : '0');
+	}
+	s << '.';
+
+	// Characteristic and mantissa bits (geometry from the shared codec)
+	auto g = T::Codec::layout_of(number.dr_field());
+	unsigned p = g.p;
+	unsigned c_stored = g.c_stored_bits;
+	int bit = static_cast<int>(nbits) - static_cast<int>(T::overhead) - 1;
+
+	for (unsigned i = 0; i < c_stored && bit >= 0; ++i) {
+		s << ((mag >> bit) & 1 ? '1' : '0');
+		--bit;
+		if (i < c_stored - 1 && ((c_stored - 1 - i) % 4) == 0 && nibbleMarker) s << '\'';
+	}
+	s << '.';
+	for (unsigned i = 0; i < p && bit >= 0; ++i) {
+		s << ((mag >> bit) & 1 ? '1' : '0');
+		if (bit > 0 && (bit % 4) == 0 && nibbleMarker) s << '\'';
+		--bit;
+	}
+
+	return s.str();
+}
+
+template<unsigned nbits, unsigned rbits, typename bt>
+std::string to_binary(const takum_log<nbits, rbits, bt>& number, bool nibbleMarker = false) {
+	using T = takum_log<nbits, rbits, bt>;
+	std::stringstream s;
+	uint64_t mag = number.magnitude_bits();
+
+	s << "0b";
+	s << (number.sign() ? "1." : "0.");
+	bool D = static_cast<bool>((mag >> (nbits - 2)) & 1);
+	s << (D ? "1." : "0.");
+
+	unsigned regime = static_cast<unsigned>((mag >> (nbits - T::overhead)) & T::r_mask);
+	for (int i = static_cast<int>(rbits) - 1; i >= 0; --i) s << ((regime >> i) & 1 ? '1' : '0');
+	s << '.';
+
+	auto g = T::Codec::layout_of(number.dr_field());
+	int bit = static_cast<int>(nbits) - static_cast<int>(T::overhead) - 1;
+	for (unsigned i = 0; i < g.c_stored_bits && bit >= 0; ++i) {
+		s << ((mag >> bit) & 1 ? '1' : '0');
+		--bit;
+		if (i < g.c_stored_bits - 1 && ((g.c_stored_bits - 1 - i) % 4) == 0 && nibbleMarker) s << '\'';
+	}
+	s << '.';
+	for (unsigned i = 0; i < g.p && bit >= 0; ++i) {
+		s << ((mag >> bit) & 1 ? '1' : '0');
+		if (bit > 0 && (bit % 4) == 0 && nibbleMarker) s << '\'';
+		--bit;
+	}
+	return s.str();
+}
+
 
 	// Generate a type tag for this takum
 	template<typename TakumType,

--- a/include/sw/universal/number/takum/math/complex.hpp
+++ b/include/sw/universal/number/takum/math/complex.hpp
@@ -11,6 +11,7 @@
 // The std::complex<takum> overloads are retained for backward compatibility on compilers
 // that do not strictly enforce ISO C++ 26.2/2.
 
+#include <type_traits>   // std::true_type
 #include <complex>
 #include <universal/math/complex.hpp>
 

--- a/include/sw/universal/number/takum/math/exponent.hpp
+++ b/include/sw/universal/number/takum/math/exponent.hpp
@@ -5,6 +5,7 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #pragma once
+#include <cstdint>       // std::int64_t
 #include <cmath>
 #include <universal/number/takum/math/takum_log_domain.hpp>
 

--- a/include/sw/universal/number/takum/mathlib.hpp
+++ b/include/sw/universal/number/takum/mathlib.hpp
@@ -15,6 +15,7 @@ sin, cos, exp, and their inverse functions (including arcsin, log, x^(1/n)).
 Elementary functions were introduced by Joseph Liouville in a series of papers from 1833 to 1841. 
 An algebraic treatment of elementary functions was started by Joseph Fels Ritt in the 1930s.
 */
+#include <cstdint>       // the fixed-width integer types
 #include <universal/number/takum/math/classify.hpp>
 #include <universal/number/takum/math/complex.hpp>
 #include <universal/number/takum/math/error_and_gamma.hpp>

--- a/include/sw/universal/number/takum/table.hpp
+++ b/include/sw/universal/number/takum/table.hpp
@@ -6,6 +6,9 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cstdint>       // std::uint8_t
+#include <ostream>       // std::ostream
+#include <iomanip>       // std::setw
 namespace sw { namespace universal {
 
 // Generate a full binary representation table for a takum or takum_log

--- a/include/sw/universal/number/takum/takum.hpp
+++ b/include/sw/universal/number/takum/takum.hpp
@@ -42,15 +42,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/takum/exceptions.hpp>
-#include <universal/number/takum/takum_fwd.hpp>
-#include <universal/number/takum/takum_impl.hpp>
-#include <universal/number/takum/takum_log_impl.hpp>
-#include <universal/number/takum/takum_traits.hpp>
-#include <universal/number/takum/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
+#include <universal/number/takum/core.hpp>
 
 // useful functions to work with takum numbers
+// layer 2a: the string producers
 #include <universal/number/takum/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/takum/iostream.hpp>
+// layer 3: introspection -- debugConstexprParameters
+#include <universal/number/takum/debug.hpp>
 #include <universal/number/takum/attributes.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/takum/takum_cross_conversion.hpp
+++ b/include/sw/universal/number/takum/takum_cross_conversion.hpp
@@ -36,6 +36,7 @@
 // DEPENDENCY: this is the only takum header that reaches outside the takum family,
 // and it is deliberately NOT included by takum.hpp or takum_log.hpp.  Include it
 // explicitly when you need cross-conversion, and pay for dd_cascade then.
+#include <cmath>         // std::ldexp
 #include <cstdint>
 #include <universal/number/takum/takum.hpp>
 #include <universal/number/takum/takum_log.hpp>

--- a/include/sw/universal/number/takum/takum_impl.hpp
+++ b/include/sw/universal/number/takum/takum_impl.hpp
@@ -1,7 +1,8 @@
 #pragma once
-#include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+#include <cstdint>       // the fixed-width integer types
+#include <type_traits>   // std::is_same_v
+#include <iosfwd>     // std::ostream/std::istream in the friend declarations (#1334)
 #include <universal/utility/icf_array_bounds.hpp>
-#include <sstream>
 #include <string>
 // takum_impl.hpp: implementation of a linear takum number system
 //
@@ -47,7 +48,7 @@
 #include <limits>
 #include <cmath>
 
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // the bit-manipulation half (#1334)
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/internal/abstract/triple.hpp>
 #include <math/constexpr_math/exp2.hpp>
@@ -470,22 +471,6 @@ public:
 
 	inline std::string get() const noexcept { return std::string("tbd"); }
 
-	void debugConstexprParameters() {
-		std::cout << "constexpr parameters for " << type_tag(*this) << '\n';
-		std::cout << "nbits                 " << nbits << '\n';
-		std::cout << "rbits                 " << rbits << '\n';
-		std::cout << "overhead              " << overhead << '\n';
-		std::cout << "dr_bits               " << dr_bits << '\n';
-		std::cout << "nr_dr_values          " << nr_dr_values << '\n';
-		std::cout << "max_r                 " << max_r << '\n';
-		std::cout << "maxCharBits           " << maxCharBits << '\n';
-		std::cout << "min characteristic    " << min_characteristic() << '\n';
-		std::cout << "max characteristic    " << max_characteristic() << '\n';
-		std::cout << "bitsInBlock           " << bitsInBlock << '\n';
-		std::cout << "nrBlocks              " << nrBlocks << '\n';
-		std::cout << "MSU_MASK              " << to_binary(MSU_MASK, bitsInBlock) << '\n';
-		std::cout << "SIGN_BIT_MASK         " << to_binary(SIGN_BIT_MASK, bitsInBlock) << '\n';
-	}
 
 	// Get the raw bit pattern as a uint64_t (works for nbits <= 64)
 	constexpr uint64_t raw_bits() const noexcept {
@@ -504,6 +489,10 @@ public:
 		}
 		return raw;
 	}
+
+	// DECLARED here, DEFINED in takum/debug.hpp, so the arithmetic core needs no
+	// <iostream> (#1334). Include debug.hpp to call it.
+	void debugConstexprParameters();
 
 protected:
 
@@ -720,68 +709,9 @@ inline CONSTEXPRESSION takum<nbits, rbits, bt> ulp(const takum<nbits, rbits, bt>
 	return ++b - a;
 }
 
-template<unsigned nbits, unsigned rbits, typename bt>
-std::string to_binary(const takum<nbits, rbits, bt>& number, bool nibbleMarker = false) {
-	using T = takum<nbits, rbits, bt>;
-	std::stringstream s;
-	bool negative = number.sign();
-	uint64_t mag = number.magnitude_bits();
-
-	s << "0b";
-	s << (negative ? "1." : "0.");
-
-	// Direction bit from magnitude
-	bool D = static_cast<bool>((mag >> (nbits - 2)) & 1);
-	s << (D ? "1." : "0.");
-
-	// Regime field from magnitude (rbits bits)
-	unsigned regime = static_cast<unsigned>((mag >> (nbits - T::overhead)) & T::r_mask);
-	for (int i = static_cast<int>(rbits) - 1; i >= 0; --i) {
-		s << ((regime >> i) & 1 ? '1' : '0');
-	}
-	s << '.';
-
-	// Characteristic and mantissa bits (geometry from the shared codec)
-	auto g = T::Codec::layout_of(number.dr_field());
-	unsigned p = g.p;
-	unsigned c_stored = g.c_stored_bits;
-	int bit = static_cast<int>(nbits) - static_cast<int>(T::overhead) - 1;
-
-	for (unsigned i = 0; i < c_stored && bit >= 0; ++i) {
-		s << ((mag >> bit) & 1 ? '1' : '0');
-		--bit;
-		if (i < c_stored - 1 && ((c_stored - 1 - i) % 4) == 0 && nibbleMarker) s << '\'';
-	}
-	s << '.';
-	for (unsigned i = 0; i < p && bit >= 0; ++i) {
-		s << ((mag >> bit) & 1 ? '1' : '0');
-		if (bit > 0 && (bit % 4) == 0 && nibbleMarker) s << '\'';
-		--bit;
-	}
-
-	return s.str();
-}
 
 // native semantic representation: radix-2, delegates to to_binary
-template<unsigned nbits, unsigned rbits, typename bt>
-std::string to_native(const takum<nbits, rbits, bt>& number, bool nibbleMarker = false) {
-	return to_binary(number, nibbleMarker);
-}
 
-////////////////////// operators
-template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline std::ostream& operator<<(std::ostream& ostr, const takum<nnbits, nrbits, nbt>& v) {
-	ostr << double(v);
-	return ostr;
-}
-
-template<unsigned nnbits, unsigned nrbits, typename nbt>
-inline std::istream& operator>>(std::istream& istr, takum<nnbits, nrbits, nbt>& v) {
-	double d;
-	istr >> d;
-	v = d;
-	return istr;
-}
 
 template<unsigned nnbits, unsigned nrbits, typename nbt>
 inline constexpr bool operator==(const takum<nnbits, nrbits, nbt>& lhs, const takum<nnbits, nrbits, nbt>& rhs) noexcept {

--- a/include/sw/universal/number/takum/takum_log.hpp
+++ b/include/sw/universal/number/takum/takum_log.hpp
@@ -31,4 +31,4 @@
 /// The linear takum comes first: it defines the shared behavioral switches, the
 /// exception hierarchy and the shared codec that takum_log builds on.
 #include <universal/number/takum/takum.hpp>
-#include <universal/number/takum/takum_log_impl.hpp>
+// takum_log_impl.hpp arrives via takum.hpp -> core.hpp (#1334)

--- a/include/sw/universal/number/takum/takum_log_impl.hpp
+++ b/include/sw/universal/number/takum/takum_log_impl.hpp
@@ -43,12 +43,15 @@
 // has the same constraint and uses long double for takum_log64.  Tracked with
 // the native-arithmetic work in #1297.
 
+#include <cstdint>       // the fixed-width integer types
+#include <type_traits>   // std::enable_if
 #include <cassert>
+#include <iosfwd>     // std::ostream/std::istream in the friend declarations (#1334)
 #include <universal/utility/icf_array_bounds.hpp>
 #include <limits>
 #include <cmath>
 
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // the bit-manipulation half (#1334)
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <math/constexpr_math/exp.hpp>
 #include <math/constexpr_math/log.hpp>
@@ -632,50 +635,8 @@ inline CONSTEXPRESSION takum_log<nbits, rbits, bt> ulp(const takum_log<nbits, rb
 	return ++b - a;
 }
 
-template<unsigned nbits, unsigned rbits, typename bt>
-std::string to_binary(const takum_log<nbits, rbits, bt>& number, bool nibbleMarker = false) {
-	using T = takum_log<nbits, rbits, bt>;
-	std::stringstream s;
-	uint64_t mag = number.magnitude_bits();
 
-	s << "0b";
-	s << (number.sign() ? "1." : "0.");
-	bool D = static_cast<bool>((mag >> (nbits - 2)) & 1);
-	s << (D ? "1." : "0.");
 
-	unsigned regime = static_cast<unsigned>((mag >> (nbits - T::overhead)) & T::r_mask);
-	for (int i = static_cast<int>(rbits) - 1; i >= 0; --i) s << ((regime >> i) & 1 ? '1' : '0');
-	s << '.';
-
-	auto g = T::Codec::layout_of(number.dr_field());
-	int bit = static_cast<int>(nbits) - static_cast<int>(T::overhead) - 1;
-	for (unsigned i = 0; i < g.c_stored_bits && bit >= 0; ++i) {
-		s << ((mag >> bit) & 1 ? '1' : '0');
-		--bit;
-		if (i < g.c_stored_bits - 1 && ((g.c_stored_bits - 1 - i) % 4) == 0 && nibbleMarker) s << '\'';
-	}
-	s << '.';
-	for (unsigned i = 0; i < g.p && bit >= 0; ++i) {
-		s << ((mag >> bit) & 1 ? '1' : '0');
-		if (bit > 0 && (bit % 4) == 0 && nibbleMarker) s << '\'';
-		--bit;
-	}
-	return s.str();
-}
-
-template<unsigned nbits, unsigned rbits, typename bt>
-std::string to_native(const takum_log<nbits, rbits, bt>& number, bool nibbleMarker = false) {
-	return to_binary(number, nibbleMarker);
-}
-
-////////////////////// operators
-template<unsigned nn, unsigned nr, typename nb>
-inline std::ostream& operator<<(std::ostream& ostr, const takum_log<nn, nr, nb>& v) { ostr << double(v); return ostr; }
-template<unsigned nn, unsigned nr, typename nb>
-inline std::istream&
-operator>>(std::istream& istr, takum_log<nn, nr, nb>& v) {
-	double d; istr >> d; v = d; return istr;
-}
 
 template<unsigned nn, unsigned nr, typename nb>
 inline constexpr bool operator==(const takum_log<nn, nr, nb>& lhs, const takum_log<nn, nr, nb>& rhs) noexcept {

--- a/include/sw/universal/number/takum/takum_traits.hpp
+++ b/include/sw/universal/number/takum/takum_traits.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <type_traits>   // std::enable_if_t
 #include <universal/traits/integral_constant.hpp>
 
 namespace sw { namespace universal {


### PR DESCRIPTION
Phase 2 continues after lns. One core covers both types, since `takum.hpp` has always included both impl headers.

| header | lines | headers | I/O |
|---|---|---|---|
| `takum/takum.hpp` (before) | 71865 | 428 | 5 |
| **`takum/core.hpp` (new)** | **49429** | **301** | **0** |

## The interesting result: criterion 2 is essentially met

Every float-like so far landed near 78,000 lines:

| type | core lines |
|---|---|
| cfloat | 78330 |
| posit | 77430 |
| lns | 74762 |
| **takum** | **49429** |
| integer | 48328 |

All the first three are pinned by `blocktriple`'s ~69,800. **takum uses no blocktriple** — grep finds zero references in either impl header. Freed of that floor it lands at 49,429, within 10% of the 45,000 target and second only to integer.

Worth recording for the rest of the rollout: **the ~78k plateau is not what a layered core costs, it is what depending on blocktriple costs.** Types built directly on `blockbinary` land near 49k.

It also sharpens the blocktriple question. If 45,000 is ever made binding, blocktriple is the *entire* gap for the types that use it — nothing else needs attention.

## What moved

`debugConstexprParameters()` -> new `debug.hpp`. `to_binary` and `to_native` for **both** types -> `manipulators.hpp`. `operator<<`/`operator>>` for both -> new `iostream.hpp`. `native/ieee754.hpp` -> `ieee754_core.hpp` in both impl headers. `takum_log.hpp` now gets `takum_log_impl.hpp` through the core.

Preceded by the #1389 sweep with the hardened script: 24 gaps across 33 headers, plus 10 more that only surfaced once the text moved and its dependencies had to be named where they landed.

## A mistake worth recording

Extracting takum_log's stream operators **split `operator>>` mid-body** on the first attempt: my heuristic stopped at the last line matching `operator(<<|>>)` within a window, and the body ran past it, leaving an orphan `double d; istr >> d; ...` behind. 322 compile errors made it obvious immediately. Repaired — and a `to_native` in each impl header that the same grep had missed got picked up in the process.

## Verified

- Both gates pass on gcc and clang, exercising **takum and takum_log**.
- takum suite: **13 pass, 0 fail**.
- Every `api.cpp`: **55 pass, 0 fail**.
- Hardened #1389 sweep: **0 gaps across all 36 takum headers**.
- ASCII clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)