### PR TITLE
refactor(edecimal): split edecimal into core / manipulators / iostream (#1334)

### DIFF
--- a/include/sw/universal/number/edecimal/core.hpp
+++ b/include/sw/universal/number/edecimal/core.hpp
@@ -1,0 +1,48 @@
+#pragma once
+// core.hpp: the edecimal arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the edecimal headers (#1334, Phase 2).
+//
+//     #include <universal/number/edecimal/edecimal.hpp>   // everything, as before
+//     #include <universal/number/edecimal/core.hpp>       // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// It does NOT exclude <string>. operator=(const std::string&) and parse() are part of
+// the type's arithmetic surface, exactly as integer's string constructor is, and
+// <string> is inside the epic's derived line budget. <cstdio> backs fprintf(stderr,...),
+// the Phase 0 idiom adopted specifically so diagnostics do not require <iostream>.
+// to_binary()/to_string() are in manipulators.hpp and the stream operators in
+// iostream.hpp.
+//
+// edecimal derives from std::vector<uint8_t>, so <vector> is structural here, not
+// incidental.
+//
+// NOTE: native/ieee754_core.hpp is used rather than native/ieee754.hpp -- convert_ieee754()
+// needs extractFields() and ieee754_parameter<>, which are the bit-manipulation half; the
+// text half of that header is not needed by the core (#1334).
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <cstdint>
+#include <cassert>
+#include <vector>
+#include <limits>
+#include <algorithm>
+#include <type_traits>
+
+#include <universal/native/ieee754_core.hpp>
+#include <universal/string/strmanip.hpp>          // trim(), used by parse()
+#include <universal/utility/string_parse.hpp>     // scan_decimal_float(), used by parse()
+
+#include <universal/number/edecimal/exceptions.hpp>
+#include <universal/number/edecimal/edecimal_fwd.hpp>
+#include <universal/number/edecimal/edecimal_impl.hpp>
+#include <universal/number/edecimal/numeric_limits.hpp>

--- a/include/sw/universal/number/edecimal/edecimal.hpp
+++ b/include/sw/universal/number/edecimal/edecimal.hpp
@@ -12,19 +12,6 @@
 #include <universal/utility/long_double.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////////////
-/// required std libraries 
-#include <cstdint>
-#include <cassert>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <vector>
-#include <limits>
-#include <regex>
-#include <algorithm>
-#include <type_traits>
-
-////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -43,17 +30,20 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////
-/// support functions
-#include <universal/native/ieee754.hpp>
-#include <universal/string/strmanip.hpp>
-#include <universal/utility/string_parse.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/edecimal/exceptions.hpp>
-#include <universal/number/edecimal/edecimal_fwd.hpp>
-#include <universal/number/edecimal/edecimal_impl.hpp>
-#include <universal/number/edecimal/numeric_limits.hpp>
+///
+/// Layered per #1334. The two switches above must be defined BEFORE core.hpp, which is
+/// why they precede it rather than sitting with the other directives at the top.
+///
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  to_binary / to_string
+///     iostream.hpp      operator<< / operator>>
+///
+/// A translation unit that only computes can include core.hpp directly and skip the
+/// stream headers entirely.
+#include <universal/number/edecimal/core.hpp>
+#include <universal/number/edecimal/manipulators.hpp>
+#include <universal/number/edecimal/iostream.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////
 /// math functions

--- a/include/sw/universal/number/edecimal/edecimal_impl.hpp
+++ b/include/sw/universal/number/edecimal/edecimal_impl.hpp
@@ -1,7 +1,11 @@
 #pragma once
-#include <iostream>   // std::cout/cerr used below (#1334: include what you use)
-#include <sstream>
-#include <string>
+#include <cstdint>       // uint8_t, the digit type
+#include <cassert>       // assert(), used by findMsd() and the helpers
+#include <vector>        // std::vector, the base class
+#include <algorithm>     // std::swap / std::equal
+#include <iosfwd>        // std::ostream/std::istream in the friend declarations (#1334)
+#include <string>        // std::string, used by parse() and operator=(const std::string&)
+#include <cstdio>        // fprintf(stderr,...) for the diagnostics
 // edecimal_impl.hpp: definition of adaptive precision decimal integer data type
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
@@ -14,6 +18,7 @@
 #define EDECIMAL_OPERATIONS_COUNT 0
 #endif
 #if EDECIMAL_OPERATIONS_COUNT
+#include <ostream>       // printStats() calls ops.report(ostr), which needs the complete type
 #include <universal/utility/occurrence.hpp>
 #endif
 
@@ -169,7 +174,7 @@ public:
 				borrow = 0;
 			}
 		}
-		if (borrow) std::cout << "can this happen?" << std::endl;
+		if (borrow) std::fprintf(stderr, "can this happen?\n");
 		unpad();
 		if (this->iszero()) { // special case of zero having positive sign
 			this->setpos();
@@ -602,58 +607,6 @@ inline int findMsd(const edecimal& v) {
 
 ////////////////// DECIMAL operators
 
-/// stream operators
-
-inline std::string to_binary(const edecimal& d) {
-	std::stringstream s;
-	if (d.isneg()) s << '-';
-	for (edecimal::const_reverse_iterator rit = d.rbegin(); rit != d.rend(); ++rit) {
-		s << (int)*rit;
-	}
-	return s.str();
-}
-
-// generate an ASCII edecimal string
-inline std::string to_string(const edecimal& d) {
-	std::stringstream s;
-	if (d.isneg()) s << '-';
-	for (edecimal::const_reverse_iterator rit = d.rbegin(); rit != d.rend(); ++rit) {
-		s << (int)*rit;
-	}
-	return s.str();
-}
-
-// generate an ASCII edecimal format and send to ostream
-inline std::ostream& operator<<(std::ostream& ostr, const edecimal& d) {
-	// to make certain that setw and left/right operators work properly
-	// we need to transform the integer into a string
-	std::stringstream ss;
-
-	//std::streamsize width = ostr.width();
-	std::ios_base::fmtflags ff;
-	ff = ostr.flags();
-	ss.flags(ff);
-	if (d.isneg()) ss << '-';
-	for (edecimal::const_reverse_iterator rit = d.rbegin(); rit != d.rend(); ++rit) {
-		ss << (int)*rit;
-	}
-	return ostr << ss.str();
-}
-
-// read an ASCII edecimal format from an istream
-inline std::istream& operator>>(std::istream& istr, edecimal& p) {
-	std::string txt;
-	if (!(istr >> txt)) {
-		// extraction failed (already-bad stream or EOF); failbit set by >>.
-		return istr;
-	}
-	if (!p.parse(txt)) {
-		std::cerr << "unable to parse -" << txt << "- into an edecimal value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
-}
-
 /// edecimal binary arithmetic operators
 
 // binary addition of edecimal numbers
@@ -824,7 +777,7 @@ decintdiv decint_divide(const edecimal& _a, const edecimal& _b) {
 #if EDECIMAL_THROW_ARITHMETIC_EXCEPTION
 		throw edecimal_integer_divide_by_zero{};
 #else
-		std::cerr << "integer_divide_by_zero\n";
+		std::fprintf(stderr, "integer_divide_by_zero\n");
 #endif // EDECIMAL_THROW_ARITHMETIC_EXCEPTION
 	}
 	// generate the absolute values to do long division 

--- a/include/sw/universal/number/edecimal/exceptions.hpp
+++ b/include/sw/universal/number/edecimal/exceptions.hpp
@@ -4,6 +4,7 @@
 // Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>       // std::string, the exception message type
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/edecimal/iostream.hpp
+++ b/include/sw/universal/number/edecimal/iostream.hpp
@@ -1,0 +1,53 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for the edecimal type
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the edecimal headers (#1334): the <iostream> half. manipulators.hpp is the
+// string-producing half. operator>> reports a parse failure on std::cerr, which is why
+// this layer -- and not the core -- is where <iostream> belongs.
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <ios>           // std::ios_base::fmtflags, std::ios::failbit
+
+#include <universal/number/edecimal/core.hpp>
+#include <universal/number/edecimal/manipulators.hpp>
+
+namespace sw { namespace universal {
+
+// generate an ASCII edecimal format and send to ostream
+inline std::ostream& operator<<(std::ostream& ostr, const edecimal& d) {
+	// to make certain that setw and left/right operators work properly
+	// we need to transform the integer into a string
+	std::stringstream ss;
+
+	//std::streamsize width = ostr.width();
+	std::ios_base::fmtflags ff;
+	ff = ostr.flags();
+	ss.flags(ff);
+	if (d.isneg()) ss << '-';
+	for (edecimal::const_reverse_iterator rit = d.rbegin(); rit != d.rend(); ++rit) {
+		ss << (int)*rit;
+	}
+	return ostr << ss.str();
+}
+
+// read an ASCII edecimal format from an istream
+inline std::istream& operator>>(std::istream& istr, edecimal& p) {
+	std::string txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
+	if (!p.parse(txt)) {
+		std::cerr << "unable to parse -" << txt << "- into an edecimal value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/edecimal/manipulators.hpp
+++ b/include/sw/universal/number/edecimal/manipulators.hpp
@@ -1,0 +1,38 @@
+#pragma once
+// manipulators.hpp: definition of manipulation functions for the edecimal type
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2a of the edecimal headers (#1334): the string-producing half. These build a
+// std::string and hand it back, so they need <sstream> but not <iostream>; the stream
+// insertion and extraction operators are in iostream.hpp.
+#include <string>
+#include <sstream>
+
+#include <universal/number/edecimal/core.hpp>
+
+namespace sw { namespace universal {
+
+inline std::string to_binary(const edecimal& d) {
+	std::stringstream s;
+	if (d.isneg()) s << '-';
+	for (edecimal::const_reverse_iterator rit = d.rbegin(); rit != d.rend(); ++rit) {
+		s << (int)*rit;
+	}
+	return s.str();
+}
+
+// generate an ASCII edecimal string
+inline std::string to_string(const edecimal& d) {
+	std::stringstream s;
+	if (d.isneg()) s << '-';
+	for (edecimal::const_reverse_iterator rit = d.rbegin(); rit != d.rend(); ++rit) {
+		s << (int)*rit;
+	}
+	return s.str();
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/edecimal/math/sqrt.hpp
+++ b/include/sw/universal/number/edecimal/math/sqrt.hpp
@@ -1,11 +1,13 @@
 #pragma once
-#include <iostream>   // std::cout/cerr used below (#1334: include what you use)
 // sqrt.hpp: sqrt functions for adaptive precision decimal integers
 //
 // Copyright (C) 2017-2023 Stillwater Supercomputing, Inc.
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-#include <universal/native/ieee754.hpp>
+#include <cmath>       // std::sqrt on the double fallback path
+#include <cstdio>      // fprintf(stderr,...) for the diagnostic (#1334: no <iostream> in a math header)
+#include <universal/native/ieee754_core.hpp>
+#include <universal/number/edecimal/core.hpp>            // the edecimal type itself; this header was relying on a prior include
 #include <universal/number/edecimal/numeric_limits.hpp>
 
 #ifndef EDECIMAL_NATIVE_SQRT
@@ -38,13 +40,17 @@ namespace sw { namespace universal {
 	}
 #else
 	inline edecimal sqrt(const edecimal& f) {
-#if EDECIMAL_THROW_ARITHMETIC_EXCEPTION
+		// The negative-argument report has to be INSIDE the sign test. It was not: the
+		// #else branch ran unconditionally, so every call -- sqrt(144) included -- wrote
+		// "decimal_negative_sqrt_arg" to stderr while returning the right answer.
 		if (f.isneg()) {
+#if EDECIMAL_THROW_ARITHMETIC_EXCEPTION
 			throw edecimal_negative_sqrt_arg();
-		}
 #else
-		std::cerr << "decimal_negative_sqrt_arg\n";
+			std::fprintf(stderr, "edecimal_negative_sqrt_arg\n");
+			return edecimal(0);
 #endif
+		}
 		return edecimal(std::sqrt((double)f));
 	}
 #endif

--- a/include/sw/universal/number/edecimal/mathlib.hpp
+++ b/include/sw/universal/number/edecimal/mathlib.hpp
@@ -5,6 +5,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <universal/number/edecimal/core.hpp>   // the edecimal type the math functions operate on
+
 //#include <universal/number/edecimal/math/classify.hpp>
 //#include <universal/number/edecimal/math/complex.hpp>
 //#include <universal/number/edecimal/math/error_and_gamma.hpp>

--- a/include/sw/universal/number/edecimal/numeric_limits.hpp
+++ b/include/sw/universal/number/edecimal/numeric_limits.hpp
@@ -5,6 +5,11 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 
+#include <cstdint>     // uint64_t, used in the digits/digits10 computation
+#include <limits>      // std::numeric_limits, the template being specialised
+
+#include <universal/number/edecimal/edecimal_fwd.hpp>   // class edecimal, the type being specialised on
+
 namespace std {
 
 using namespace sw::universal;


### PR DESCRIPTION
Phase 2 of the #1334 header layering, continuing after fixpnt (#1421).

| header | lines | I/O-family |
|---|---:|---:|
| `core.hpp` | 73,040 | **0** |
| `manipulators.hpp` | 77,152 | 3 |
| `iostream.hpp` | 77,198 | 4 |
| `edecimal.hpp` (umbrella) | 79,372 | 5 |

The umbrella was **98,017 lines pulling all five** stream headers, so a translation unit that only computes now reads 25% less and none of `<iostream>`, `<sstream>`, `<iomanip>`, `<ostream>`, `<istream>`.

### What the core keeps, and why

`edecimal` derives from `std::vector<uint8_t>`, so `<vector>` is structural here rather than incidental. `<string>` stays for `operator=(const std::string&)` and `parse()` — the same arithmetic surface `integer`'s string constructor occupies, and the contract `integer/core.hpp` and `fixpnt/core.hpp` already document.

Two diagnostics were holding `<iostream>` into the arithmetic path — the `"can this happen?"` borrow check and `integer_divide_by_zero`. Both now use `fprintf(stderr, ...)`, the Phase 0 idiom adopted for exactly this. The friend declarations need only `<iosfwd>`. `printStats()` genuinely needs `<ostream>`, but it sits behind the ALPHA `EDECIMAL_OPERATIONS_COUNT` switch, so the include went inside that guard rather than into the core.

`core.hpp` takes `native/ieee754_core.hpp` rather than `native/ieee754.hpp`: `convert_ieee754()` wants `extractFields()` and `ieee754_parameter<>`, which is the bit-manipulation half added in 7b7ff3c0.

### Two fixes that are not layering

**`sqrt()` reported a negative argument on every call.** The `#else` of the `EDECIMAL_THROW_ARITHMETIC_EXCEPTION` guard was not inside the sign test:

```cpp
inline edecimal sqrt(const edecimal& f) {
#if EDECIMAL_THROW_ARITHMETIC_EXCEPTION
    if (f.isneg()) { throw edecimal_negative_sqrt_arg(); }
#else
    std::cerr << "decimal_negative_sqrt_arg\n";   // <-- unconditional
#endif
    return edecimal(std::sqrt((double)f));
}
```

so `sqrt(edecimal(144))` returned 12 and still wrote `decimal_negative_sqrt_arg` to stderr. Reproduced before and after:

```
before   stdout: sqrt(144) = 12      stderr: decimal_negative_sqrt_arg
after    stdout: sqrt(144) = 12      stderr: (empty)
after    stdout: sqrt(-9)  = 0       stderr: edecimal_negative_sqrt_arg
```

The report is now inside `if (f.isneg())`, and the non-throwing path returns zero instead of `edecimal(std::sqrt(-x))`, which was building from a NaN.

**`sqrt.hpp` and `mathlib.hpp` were not self-contained** — they used `edecimal` with no include that provides it, so they compiled only behind a prior include. Both now include `core.hpp`. Same defect class as #1422; these two are inside the subtree being split, so they are fixed here rather than filed.

### IWYU

Closed the gaps the hardened #1389 sweep found in this subtree: `<cstdint>`, `<cassert>`, `<vector>`, `<algorithm>` in `edecimal_impl.hpp`; `<string>` in `exceptions.hpp`; `<cstdint>`/`<limits>`/`edecimal_fwd.hpp` in `numeric_limits.hpp`. Sweep is clean at **0 gaps across all 10 headers**.

`edecimal_impl.hpp` remains non-self-contained by design — it is a fragment assembled by `core.hpp`, as `fixpnt_impl.hpp`, `cfloat_impl.hpp` and `integer_impl.hpp` already are.

### Verification

- Both layer gates pass on gcc and clang (core alone computes with `#error` tripwires on the stream include guards; core+manipulators produce strings without `<iostream>`)
- All **25** translation units in the tree that mention `edecimal` build and run clean on **both** compilers
- ASCII clean

Part of #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)