### PR TITLE
refactor(dd): split double-double into core / manipulators / iostream (#1334)

### DIFF
--- a/include/sw/universal/number/dd/attributes.hpp
+++ b/include/sw/universal/number/dd/attributes.hpp
@@ -10,6 +10,8 @@
 #include <string>      // std::string
 #include <universal/number/dd/core.hpp>           // the dd type these attributes report on (#1334)
 #include <universal/number/dd/manipulators.hpp>   // type_tag()
+#include <universal/number/dd/iostream.hpp>       // dd_range() and friends stream dd values
+                                                 // (maxneg/minpos/...) through operator<<
 
 namespace sw { namespace universal {
 

--- a/include/sw/universal/number/dd/attributes.hpp
+++ b/include/sw/universal/number/dd/attributes.hpp
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <sstream>     // std::stringstream
+#include <iomanip>     // std::setw
+#include <string>      // std::string
+#include <universal/number/dd/core.hpp>           // the dd type these attributes report on (#1334)
+#include <universal/number/dd/manipulators.hpp>   // type_tag()
 
 namespace sw { namespace universal {
 

--- a/include/sw/universal/number/dd/core.hpp
+++ b/include/sw/universal/number/dd/core.hpp
@@ -1,0 +1,38 @@
+#pragma once
+// core.hpp: the double-double arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the dd headers (#1334, Phase 2).
+//
+//     #include <universal/number/dd/dd.hpp>     // everything, as before
+//     #include <universal/number/dd/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// It does NOT exclude <string> or <ios>. to_string() and parse() are part of the type's
+// arithmetic surface -- parse() is what assign(const std::string&) calls -- and to_string()
+// builds its result by string concatenation, never through a stream; it takes
+// std::streamsize and std::ios_base flags, which is what <ios> is for. <cstdio> backs
+// fprintf, the Phase 0 idiom, used by both the diagnostics and the (default-off)
+// bTraceDecimal* trace prints.
+//
+// The traces are why <iostream> could not simply be dropped: a discarded
+// `if constexpr` branch still requires std::cout to be DECLARED, so <iosfwd> is not
+// enough and the branch has to stop naming std::cout at all.
+//
+// native/manipulators_core.hpp rather than the full native/manipulators.hpp: dd calls
+// scale(), which is bit manipulation, not text.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/dd/exceptions.hpp>
+#include <universal/number/dd/dd_fwd.hpp>
+#include <universal/number/dd/dd_impl.hpp>
+#include <universal/traits/dd_traits.hpp>
+#include <universal/number/dd/numeric_limits.hpp>

--- a/include/sw/universal/number/dd/dd.hpp
+++ b/include/sw/universal/number/dd/dd.hpp
@@ -13,8 +13,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// required std libraries 
-#include <iostream>
-#include <iomanip>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
@@ -50,24 +48,26 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
-#include <universal/traits/number_traits.hpp>
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  type_tag / to_binary / to_triple
+///     iostream.hpp      operator<< / operator>>
+///
+/// A translation unit that only computes can include core.hpp directly and skip the
+/// stream headers entirely. to_string() and parse() are in the CORE, not the text
+/// layers: assign(const std::string&) calls parse(), and to_string() concatenates a
+/// std::string without ever touching a stream.
+#include <universal/number/dd/core.hpp>
+#include <universal/number/dd/manipulators.hpp>
+#include <universal/number/dd/iostream.hpp>
+#include <universal/number/dd/attributes.hpp>
+
+/// the report builders stay at the umbrella: they pull <sstream>/<iomanip> by design
 #include <universal/traits/arithmetic_traits.hpp>
 #include <universal/common/number_traits_reports.hpp>
 
-////////////////////////////////////////////////////////////////////////////////////////
-/// INCLUDE FILES that make up the library
-#include <universal/number/dd/exceptions.hpp>
-#include <universal/number/dd/dd_fwd.hpp>
-#include <universal/number/dd/dd_impl.hpp>
-#include <universal/number/dd/numeric_limits.hpp>
-#include <universal/traits/dd_traits.hpp>
-
-// useful functions to work with doubledoubles
-#include <universal/number/dd/manipulators.hpp>
-#include <universal/number/dd/attributes.hpp>
-
-///////////////////////////////////////////////////////////////////////////////////////
-/// elementary math functions library
 #include <universal/number/dd/math/constants/dd_constants.hpp>
 #include <universal/number/dd/mathlib.hpp>
 #include <universal/number/dd/mathext.hpp>

--- a/include/sw/universal/number/dd/dd_impl.hpp
+++ b/include/sw/universal/number/dd/dd_impl.hpp
@@ -14,9 +14,10 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
+#include <algorithm>    // std::max, in to_string()'s fixed-format path
+#include <ios>          // std::streamsize / std::ios_base, in the to_string() signature
+#include <iosfwd>       // std::ostream in the operator<< forward declaration (#1334)
+#include <cstdio>       // fprintf(stderr,...) for the diagnostics and traces
 #include <limits>
 #include <cmath>
 #include <vector>
@@ -26,7 +27,8 @@
 // supporting types and functions
 #include <universal/utility/bit_cast.hpp>
 #include <universal/utility/decimal_to_binary.hpp>
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>          // extractFields/ieee754_parameter (#1334)
+#include <universal/native/manipulators_core.hpp>   // scale(), without the to_triple/to_hex text layer
 #include <universal/numerics/error_free_ops.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/shared/infinite_encoding.hpp>
@@ -36,13 +38,6 @@
 #include <universal/number/dd/dd_fwd.hpp>
 
 namespace sw { namespace universal {
-
-	inline std::ostream& operator<<(std::ostream& ostr, const std::vector<char>& s) {
-		for (auto c : s) {
-			ostr << c;
-		}
-		return ostr;
-	}
 
 // fwd references to free functions
 constexpr dd operator-(const dd&, const dd&);
@@ -724,10 +719,10 @@ public:
 					nrDigitsForFixedFormat = std::max(60, nrDigits); // can be much longer than the max accuracy for double-double
 
 				if constexpr (bTraceDecimalConversion) {
-					std::cout << "powerOfTenScale  : " << powerOfTenScale << '\n';
-					std::cout << "integerDigits    : " << integerDigits   << '\n';
-					std::cout << "nrDigits         : " << nrDigits        << '\n';
-					std::cout << "nrDigitsForFixedFormat  : " << nrDigitsForFixedFormat << '\n';
+					std::fprintf(stdout, "powerOfTenScale  : %d\n", powerOfTenScale);
+					std::fprintf(stdout, "integerDigits    : %d\n", integerDigits);
+					std::fprintf(stdout, "nrDigits         : %d\n", nrDigits);
+					std::fprintf(stdout, "nrDigitsForFixedFormat  : %d\n", nrDigitsForFixedFormat);
 				}
 
 
@@ -815,7 +810,7 @@ public:
 					from_string = atof(s.c_str());
 					// if this ratio is large, then the string has not been fixed
 					if (std::fabs(from_string / hi) > 3.0) {
-						std::cerr << "re-rounding unsuccessful in fixed point fix\n";
+						std::fprintf(stderr, "re-rounding unsuccessful in fixed point fix\n");
 					}
 				}
 			}
@@ -903,16 +898,16 @@ protected:
 	// precondition: string s must be all digits
 	void round_string(std::vector<char>& s, int precision, int* decimalPoint) const {
 		if constexpr(bTraceDecimalRounding) {
-			std::cout << "string       : " << s << '\n';
-			std::cout << "precision    : " << precision << '\n';
-			std::cout << "decimalPoint : " << *decimalPoint << '\n';
+			std::fprintf(stdout, "string       : %s\n", std::string(s.begin(), s.end()).c_str());
+			std::fprintf(stdout, "precision    : %d\n", precision);
+			std::fprintf(stdout, "decimalPoint : %d\n", *decimalPoint);
 		}
 
 		int nrDigits = precision;
 		// round decimal string and propagate carry
 		int lastDigit = nrDigits - 1;
 		if (s[static_cast<unsigned>(lastDigit)] >= '5') {
-			if constexpr(bTraceDecimalRounding) std::cout << "need to round\n";
+			if constexpr(bTraceDecimalRounding) std::fprintf(stdout, "need to round\n");
 			int i = nrDigits - 2;
 			s[static_cast<unsigned>(i)]++;
 			while (i > 0 && s[static_cast<unsigned>(i)] > '9') {
@@ -923,7 +918,7 @@ protected:
 
 		// if first digit is 10, shift everything.
 		if (s[0] > '9') {
-			if constexpr(bTraceDecimalRounding) std::cout << "shift right to handle overflow\n";
+			if constexpr(bTraceDecimalRounding) std::fprintf(stdout, "shift right to handle overflow\n");
 			for (int i = precision; i >= 2; --i) s[static_cast<unsigned>(i)] = s[static_cast<unsigned>(i - 1)];
 			s[0u] = '1';
 			s[1u] = '0';
@@ -1019,7 +1014,7 @@ protected:
 		}
 
 		if ((r >= _ten) || (r < _one)) {
-			std::cerr << "to_digits() failed to compute exponent\n";
+			std::fprintf(stderr, "to_digits() failed to compute exponent\n");
 			return;
 		}
 
@@ -1037,7 +1032,7 @@ protected:
 			r *= 10.0;
 
 			s[static_cast<unsigned>(i)] = static_cast<char>(mostSignificantDigit + '0');
-			if constexpr (bTraceDecimalConversion) std::cout << "to_digits  digit[" << i << "] : " << s << '\n';
+			if constexpr (bTraceDecimalConversion) std::fprintf(stdout, "to_digits  digit[%d] : %s\n", i, std::string(s.begin(), s.end()).c_str());
 		}
 
 		// Fix out of range digits
@@ -1055,7 +1050,7 @@ protected:
 		}
 
 		if (s[0] <= '0') {
-			std::cerr << "to_digits() non-positive leading digit\n";
+			std::fprintf(stderr, "to_digits() non-positive leading digit\n");
 			return;
 		}
 
@@ -1357,7 +1352,7 @@ inline dd pown(const dd& a, int n) {
 	switch (N) {
 	case 0:
 		if (a.iszero()) {
-			std::cerr << "pown: invalid argument\n";
+			std::fprintf(stderr, "pown: invalid argument\n");
 			errno = EDOM;
 			return dd(SpecificValue::qnan);
 		}
@@ -1389,37 +1384,6 @@ inline dd pown(const dd& a, int n) {
 
 	// Compute the reciprocal if n is negative.
 	return n < 0 ? reciprocal(s) : s;
-}
-
-////////////////////////  stream operators   /////////////////////////////////
-
-// stream out a decimal floating-point representation of the double-double
-inline std::ostream& operator<<(std::ostream& ostr, const dd& v) {
-	std::ios_base::fmtflags fmt = ostr.flags();
-	std::streamsize precision = ostr.precision();
-	std::streamsize width = ostr.width();
-	char fillChar = ostr.fill();
-	bool showpos = fmt & std::ios_base::showpos;
-	bool uppercase = fmt & std::ios_base::uppercase;
-	bool fixed = fmt & std::ios_base::fixed;
-	bool scientific = fmt & std::ios_base::scientific;
-	bool internal = fmt & std::ios_base::internal;
-	bool left = fmt & std::ios_base::left;
-	return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
-}
-
-// stream in an ASCII decimal floating-point format and assign it to a double-double
-inline std::istream& operator>>(std::istream& istr, dd& v) {
-	std::string txt;
-	if (!(istr >> txt)) {
-		// extraction failed (already-bad stream or EOF); failbit is set by >>.
-		return istr;
-	}
-	if (!parse(txt, v)) {
-		std::cerr << "unable to parse -" << txt << "- into a double-double value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
 }
 
 ////////////////// string operators

--- a/include/sw/universal/number/dd/exceptions.hpp
+++ b/include/sw/universal/number/dd/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>       // std::string, the exception message type
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/dd/iostream.hpp
+++ b/include/sw/universal/number/dd/iostream.hpp
@@ -6,6 +6,12 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
+// NOTE on layer order: this header does NOT include manipulators.hpp, and must not.
+// operator<< calls only the to_string() member and operator>> only parse(), both core,
+// so the dependency runs the OTHER way: dd's string builders format dd values THROUGH
+// operator<<, so manipulators.hpp includes THIS header. Keeping the include out here is
+// what stops that being a cycle.
+//
 // Layer 2b of the dd headers (#1334): the <iostream> half. manipulators.hpp is the
 // string-producing half. operator>> reports a parse failure on std::cerr, which is why
 // <iostream> belongs at this layer and not in the core.

--- a/include/sw/universal/number/dd/iostream.hpp
+++ b/include/sw/universal/number/dd/iostream.hpp
@@ -1,0 +1,66 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for double-double
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the dd headers (#1334): the <iostream> half. manipulators.hpp is the
+// string-producing half. operator>> reports a parse failure on std::cerr, which is why
+// <iostream> belongs at this layer and not in the core.
+//
+// to_string() and parse() are NOT here: they stay in the core because assign() calls
+// parse(), and to_string() concatenates a std::string without ever touching a stream.
+#include <iostream>
+#include <istream>
+#include <ostream>
+#include <string>
+#include <vector>
+#include <ios>           // std::ios_base flags, std::ios::failbit
+
+#include <universal/number/dd/core.hpp>
+
+namespace sw { namespace universal {
+
+	// stream a vector<char> digit buffer; used by the bTraceDecimal* paths when a caller
+	// wants them on an ostream rather than through the core's fprintf traces.
+	inline std::ostream& operator<<(std::ostream& ostr, const std::vector<char>& s) {
+		for (auto c : s) {
+			ostr << c;
+		}
+		return ostr;
+	}
+
+////////////////////////  stream operators   /////////////////////////////////
+
+// stream out a decimal floating-point representation of the double-double
+inline std::ostream& operator<<(std::ostream& ostr, const dd& v) {
+	std::ios_base::fmtflags fmt = ostr.flags();
+	std::streamsize precision = ostr.precision();
+	std::streamsize width = ostr.width();
+	char fillChar = ostr.fill();
+	bool showpos = fmt & std::ios_base::showpos;
+	bool uppercase = fmt & std::ios_base::uppercase;
+	bool fixed = fmt & std::ios_base::fixed;
+	bool scientific = fmt & std::ios_base::scientific;
+	bool internal = fmt & std::ios_base::internal;
+	bool left = fmt & std::ios_base::left;
+	return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
+}
+
+// stream in an ASCII decimal floating-point format and assign it to a double-double
+inline std::istream& operator>>(std::istream& istr, dd& v) {
+	std::string txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit is set by >>.
+		return istr;
+	}
+	if (!parse(txt, v)) {
+		std::cerr << "unable to parse -" << txt << "- into a double-double value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/dd/manipulators.hpp
+++ b/include/sw/universal/number/dd/manipulators.hpp
@@ -17,6 +17,10 @@
 #include <type_traits>
 
 #include <universal/number/dd/core.hpp>
+#include <universal/number/dd/iostream.hpp>   // to_triple() formats a dd fraction THROUGH operator<<,
+                                             // which is declared in the core but DEFINED there (#1334).
+                                             // Without this a caller of to_triple() that includes only
+                                             // this header gets an undefined reference at link time.
 #include <universal/traits/dd_traits.hpp>   // is_dd, the enable_if guard on every function here
 #include <string>
 #include <iomanip>

--- a/include/sw/universal/number/dd/manipulators.hpp
+++ b/include/sw/universal/number/dd/manipulators.hpp
@@ -1,9 +1,23 @@
+#pragma once
 // manipulators.hpp: definitions of helper functions for double-double (dd) type manipulation
 //
 // Copyright (C) 2017 Stillwater Supercomputing, Inc.
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2a of the dd headers (#1334): the string-producing half. These build a
+// std::string, so they need <sstream> but not <iostream>; the stream operators are in
+// iostream.hpp.
+#include <string>
+#include <sstream>
+#include <cassert>
+#include <iomanip>
+#include <cstdint>
+#include <type_traits>
+
+#include <universal/number/dd/core.hpp>
+#include <universal/traits/dd_traits.hpp>   // is_dd, the enable_if guard on every function here
 #include <string>
 #include <iomanip>
 #include <universal/number/dd/dd_fwd.hpp>

--- a/include/sw/universal/numerics/error_free_ops.hpp
+++ b/include/sw/universal/numerics/error_free_ops.hpp
@@ -5,9 +5,6 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-#include <iomanip>
-#include <string>
-#include <sstream>
 #include <cmath>
 #include <limits>
 #include <type_traits>


### PR DESCRIPTION
Phase 2 of the #1334 header layering, continuing after rational/erational (#1425).

| header | lines | I/O-family |
|---|---:|---:|
| `numerics/error_free_ops.hpp` | 25,240 | **0** (was 59,835 / 4) |
| `dd/core.hpp` | 73,665 | **0** |
| `dd.hpp` (umbrella) | 85,103 | 5 |

The umbrella was 84,970 lines pulling all five stream headers.

## dd is the first type whose text layer is member functions

So the split follows what they actually need, not what they are called. **`to_string()` and `parse()` stay in the CORE:**

- `parse()` is what `assign(const std::string&)` calls — arithmetic surface, like `integer`'s string constructor.
- `to_string()` concatenates a `std::string` directly. It never opens a stream; it only *takes* `std::streamsize` and `std::ios_base` flags, which is what `<ios>` is for.

Only the two free stream operators moved to `iostream.hpp`.

## Why `<iostream>` could not simply be dropped

The default-off `bTraceDecimalConversion` / `bTraceDecimalRounding` traces print with `std::cout`. A **discarded `if constexpr` branch still requires `std::cout` to be declared**, so `<iosfwd>` is not enough — the branch has to stop naming `std::cout` at all. All of them, plus four `std::cerr` diagnostics, now use `fprintf`. The `operator<<(ostream, vector<char>)` helper existed solely to feed two of those traces, so it moved to `iostream.hpp`.

## Two shared headers underneath were the real obstacle

**`numerics/error_free_ops.hpp` included `<iomanip>`, `<string>` and `<sstream>` and used none of them.** 532 lines of pure error-free-transformation arithmetic carrying three stream headers. It backs `dd`, `qd`, all three cascades, `ereal` and `elreal` — every one of them was paying for it. 59,835 lines and 4 I/O-family down to 25,240 and 0.

`dd_impl.hpp` took the full `native/ieee754.hpp` for `scale()`, which is bit manipulation; re-pointed at `ieee754_core.hpp` and `manipulators_core.hpp` (#1425).

## `#pragma once`

`dd/manipulators.hpp` had none. It only surfaced as *redefinition* errors once `attributes.hpp` needed it — including the same header from both `attributes.hpp` and the umbrella redefined `type_tag`, `to_pair`, `to_triple` and `to_binary`. It was one of **9 headers tree-wide** without one; now 8. `dd/manipulators.hpp` and `dd/attributes.hpp` were also not self-contained (the #1422 class), fixed here because they are in the subtree being split.

## Verification

- Core gate passes on gcc and clang, with `#error` tripwires on the stream include guards. The gate uses **exact dyadic identities** — my first version asserted `(1/3)*3 == 1`, which fails for ordinary double-double rounding reasons and would have been a false alarm.
- `static/highprecision/dd`: **29 pass, 0 fail**, both compilers
- Every `api.cpp` in the tree: **55 pass, 0 fail**, both compilers
- `static/appenv/multifile` — which links `dd.cpp` and `qd.cpp` into one program — links and runs clean. Worth noting for #1424: this multi-TU test exists for dd and qd but has no counterpart for `edecimal`/`erational`, which is why their link errors went unseen.
- IWYU sweep clean: **0 gaps across all 12 headers**
- ASCII clean

Part of #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream input and output support for double-double values, including formatting options and parse-error handling.
  * Added a streamlined core header for double-double arithmetic and related functionality.

* **Improvements**
  * Reduced unnecessary dependencies and separated core, string-formatting, and stream functionality.
  * Preserved decimal parsing and diagnostic output through lightweight interfaces.
  * Corrected explicit standard-library header dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->