### PR TITLE
refactor(dd_cascade): split the cascades and floatcascade into core / manipulators / iostream (#1334)

### DIFF
--- a/include/sw/universal/internal/floatcascade/floatcascade.hpp
+++ b/include/sw/universal/internal/floatcascade/floatcascade.hpp
@@ -11,7 +11,9 @@
 #include <cctype>
 #include <cmath>
 #include <cstdint>
-#include <iostream>
+#include <limits>       // std::numeric_limits
+#include <cstdio>       // fprintf(stderr,...) for the diagnostics (#1334)
+#include <iosfwd>       // std::ostream in the operator<< friend declaration
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -20,7 +22,8 @@
 // supporting types and functions
 #include <universal/utility/bit_cast.hpp>
 #include <universal/utility/decimal_to_binary.hpp>
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>          // extractFields/ieee754_parameter (#1334)
+#include <universal/native/manipulators_core.hpp>   // scale(), without the to_triple/to_hex text layer
 #include <universal/numerics/error_free_ops.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/shared/infinite_encoding.hpp>
@@ -216,15 +219,10 @@ public:
 	template<size_t M>
     friend std::string to_tuple(const floatcascade<M>& fc);
 
-    friend std::ostream& operator<<(std::ostream& os, const floatcascade& fc) {
-        os << "floatcascade<" << N << ">[";
-        for (size_t i = 0; i < N; ++i) {
-            if (i > 0) os << ", ";
-            os << fc.e[i];
-        }
-        os << "] ~ " << fc.to_double();
-        return os;
-    }
+    // Declared, not defined: the definition is in floatcascade/iostream.hpp so the
+    // arithmetic core needs only <iosfwd> (#1334).
+    template<size_t M>
+    friend std::ostream& operator<<(std::ostream& os, const floatcascade<M>& fc);
 
 private:
 
@@ -300,110 +298,6 @@ private:
 
 };
 
-template<size_t N>
-std::string to_tuple(const floatcascade<N>& fc) {
-    std::stringstream ss;
-	ss << std::scientific;
-	//ss.setprecision(17); // max precision of double
-    ss << "{ ";
-    for (size_t i = 0; i < N; ++i) {
-        if (i > 0) ss << ", ";
-        ss << fc.e[i];
-    }
-    ss << '}';
-    return ss.str();
-}
-
-template<size_t N>
-std::string to_scientific(const floatcascade<N>& fc,
-    int precision = N * 17,
-    bool showpos = false,
-    bool uppercase = false,
-    bool trailing_zeros = true) {
-    // precondition: fc is a normalized floatcascade
-
-    // Handle special cases early
-    if (fc.isnan(NAN_TYPE_QUIET)) return std::string("qNaN");
-    if (fc.isnan(NAN_TYPE_SIGNALLING)) return std::string("sNaN");
-    if (fc.isinf(INF_TYPE_POSITIVE)) return std::string("Inf");
-    if (fc.isinf(INF_TYPE_NEGATIVE)) return std::string("-Inf");
-    if (fc.iszero()) return std::string(showpos ? "+0.0e+0" : "0.0e+0");
-
-    // Step 1: Estimate exponent from the most significant non-zero component
-    double hi = fc[0];
-    int exp10 = static_cast<int>(std::floor(std::log10(std::abs(hi))));
-    if (!std::isfinite(exp10)) exp10 = 0; // handle log10(0) = -inf case
-    double scale = std::pow(10.0, -exp10);
-
-	// Step 2: Scale all components so we are in the range [0.0, 10.0)
-    double scaled[N];
-    for (size_t i = 0; i < N; ++i) {
-        scaled[i] = fc[i] * scale;
-    }
-    double acc = 0.0;
-    for (size_t i = 0; (i < N) && (i < 3); ++i) acc += scaled[i];
-	bool negative = std::signbit(acc);
-	acc = std::abs(acc);
-
-    // Step 3: Generate digits iteratively
-    std::string digits;
-	digits.reserve(static_cast<size_t>(precision) + 2); // leading digit + precision digits
-
-    for (int i = 0; i <= precision; ++i) {
-        int digit = static_cast<int>(acc);
-		if (digit > 9) digit = 9; // defensive clamp
-        digits.push_back(static_cast<char>('0' + digit));
-        acc = (acc - digit) * 10.0;
-    }
-
-	// Step 4: Round last digit and propagate carry (with exponent adjustment)
-    if (acc >= 5.0) {
-		int i = precision;
-        for (; i >= 0 && digits[i] == '9'; --i) {
-			digits[i] = '0';
-        }
-        if (i >= 0) {
-            digits[i] += 1; // increment this digit
-        }
-        else {
-			// overflowed the leading digit: 9.99... 9 -> 10.0...0
-            digits.insert(digits.begin(), '1');
-            exp10 += 1;
-		}
-    }
-
-    // Step 5: Format string
-    std::string result;
-    if (negative) result += '-';
-    else if (showpos) result += '+';
-
-    result += digits[0]; // leading digit
-    result += '.';
-    if (precision > 0) {
-        result.append(digits.begin() + 1, digits.begin() + 1 + precision);
-        if (trailing_zeros) {
-            // digits already has length precision + 1
-        }
-        else {
-			// trim trailing zeros after decimal point
-            while (!result.empty() && result.back() == '0') {
-                result.pop_back();
-			}
-            if (!result.empty() && result.back() == '.') {
-                result.pop_back(); // remove decimal point if no digits follow
-			}
-        }
-    }
-    else {
-		result += '0'; // no precision requested, just add a zero
-    }
-
-    result += uppercase ? "E" : "e";
-    result += (exp10 >= 0 ? "+" : "-");
-    result += std::to_string(std::abs(exp10));
-
-    return result;
-}
 
 
 // Core expansion operations - the "engine" for all cascade operations
@@ -1923,7 +1817,7 @@ void floatcascade<N>::to_digits(std::vector<char>& s, int& exponent, int precisi
 
     // Use full floatcascade comparison (not just r[0]) to match dd behavior
     if ((r >= _ten) || (r < _one)) {
-        std::cerr << "to_digits() failed to compute exponent\n";
+        std::fprintf(stderr, "to_digits() failed to compute exponent\n");
         return;
     }
 
@@ -1981,7 +1875,7 @@ void floatcascade<N>::to_digits(std::vector<char>& s, int& exponent, int precisi
     }
 
     if (s[0] <= '0') {
-        std::cerr << "to_digits() non-positive leading digit\n";
+        std::fprintf(stderr, "to_digits() non-positive leading digit\n");
         return;
     }
 
@@ -2148,7 +2042,7 @@ std::string floatcascade<N>::to_string(
                 from_string = atof(s.c_str());
                 // if this ratio is large, then the string has not been fixed
                 if (std::fabs(from_string / e[0]) > 3.0) {
-                    std::cerr << "re-rounding unsuccessful in fixed point fix\n";
+                    std::fprintf(stderr, "re-rounding unsuccessful in fixed point fix\n");
                 }
             }
         }
@@ -2463,7 +2357,7 @@ inline floatcascade<N> pown(const floatcascade<N>& a, int n) {
     // Handle special cases
     if (abs_n == 0) {
         if (a.iszero()) {
-            std::cerr << "pown: 0^0 is undefined\n";
+            std::fprintf(stderr, "pown: 0^0 is undefined\n");
             result[0] = std::numeric_limits<double>::quiet_NaN();
             for (size_t i = 1; i < N; ++i) result[i] = 0.0;
             return result;

--- a/include/sw/universal/internal/floatcascade/iostream.hpp
+++ b/include/sw/universal/internal/floatcascade/iostream.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// iostream.hpp: stream insertion for floatcascade
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the floatcascade headers (#1334): the <ostream> half.
+//
+// floatcascade.hpp declares this operator as a friend template so the arithmetic core
+// needs only <iosfwd>; the definition lives here. It was previously an in-class friend
+// DEFINITION, which is what forced <iostream> into every consumer of the cascade
+// substrate -- dd_cascade, td_cascade, qd_cascade and the floatcascade tests.
+#include <ostream>
+#include <cstddef>      // size_t
+#include <universal/internal/floatcascade/floatcascade.hpp>
+
+namespace sw { namespace universal {
+
+template<size_t N>
+inline std::ostream& operator<<(std::ostream& os, const floatcascade<N>& fc) {
+	os << "floatcascade<" << N << ">[";
+	for (size_t i = 0; i < N; ++i) {
+		if (i > 0) os << ", ";
+		os << fc[i];
+	}
+	os << "] ~ " << fc.to_double();
+	return os;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/internal/floatcascade/manipulators.hpp
+++ b/include/sw/universal/internal/floatcascade/manipulators.hpp
@@ -1,0 +1,128 @@
+#pragma once
+// manipulators.hpp: string builders for floatcascade -- the text half
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2a of the floatcascade headers (#1334), matching blockbinary's and blockdigit's
+// shape. to_tuple() and to_scientific() build a std::string through a std::stringstream,
+// so they need <sstream> but not <iostream>; the stream insertion operator is in
+// iostream.hpp.
+#include <string>
+#include <sstream>
+#include <ios>          // std::scientific / std::showpos / std::uppercase
+#include <cstddef>      // size_t
+#include <cmath>        // std::abs on the exponent
+#include <universal/internal/floatcascade/floatcascade.hpp>
+
+namespace sw { namespace universal {
+
+
+template<size_t N>
+std::string to_tuple(const floatcascade<N>& fc) {
+    std::stringstream ss;
+	ss << std::scientific;
+	//ss.setprecision(17); // max precision of double
+    ss << "{ ";
+    for (size_t i = 0; i < N; ++i) {
+        if (i > 0) ss << ", ";
+        ss << fc.e[i];
+    }
+    ss << '}';
+    return ss.str();
+}
+
+template<size_t N>
+std::string to_scientific(const floatcascade<N>& fc,
+    int precision = N * 17,
+    bool showpos = false,
+    bool uppercase = false,
+    bool trailing_zeros = true) {
+    // precondition: fc is a normalized floatcascade
+
+    // Handle special cases early
+    if (fc.isnan(NAN_TYPE_QUIET)) return std::string("qNaN");
+    if (fc.isnan(NAN_TYPE_SIGNALLING)) return std::string("sNaN");
+    if (fc.isinf(INF_TYPE_POSITIVE)) return std::string("Inf");
+    if (fc.isinf(INF_TYPE_NEGATIVE)) return std::string("-Inf");
+    if (fc.iszero()) return std::string(showpos ? "+0.0e+0" : "0.0e+0");
+
+    // Step 1: Estimate exponent from the most significant non-zero component
+    double hi = fc[0];
+    int exp10 = static_cast<int>(std::floor(std::log10(std::abs(hi))));
+    if (!std::isfinite(exp10)) exp10 = 0; // handle log10(0) = -inf case
+    double scale = std::pow(10.0, -exp10);
+
+	// Step 2: Scale all components so we are in the range [0.0, 10.0)
+    double scaled[N];
+    for (size_t i = 0; i < N; ++i) {
+        scaled[i] = fc[i] * scale;
+    }
+    double acc = 0.0;
+    for (size_t i = 0; (i < N) && (i < 3); ++i) acc += scaled[i];
+	bool negative = std::signbit(acc);
+	acc = std::abs(acc);
+
+    // Step 3: Generate digits iteratively
+    std::string digits;
+	digits.reserve(static_cast<size_t>(precision) + 2); // leading digit + precision digits
+
+    for (int i = 0; i <= precision; ++i) {
+        int digit = static_cast<int>(acc);
+		if (digit > 9) digit = 9; // defensive clamp
+        digits.push_back(static_cast<char>('0' + digit));
+        acc = (acc - digit) * 10.0;
+    }
+
+	// Step 4: Round last digit and propagate carry (with exponent adjustment)
+    if (acc >= 5.0) {
+		int i = precision;
+        for (; i >= 0 && digits[i] == '9'; --i) {
+			digits[i] = '0';
+        }
+        if (i >= 0) {
+            digits[i] += 1; // increment this digit
+        }
+        else {
+			// overflowed the leading digit: 9.99... 9 -> 10.0...0
+            digits.insert(digits.begin(), '1');
+            exp10 += 1;
+		}
+    }
+
+    // Step 5: Format string
+    std::string result;
+    if (negative) result += '-';
+    else if (showpos) result += '+';
+
+    result += digits[0]; // leading digit
+    result += '.';
+    if (precision > 0) {
+        result.append(digits.begin() + 1, digits.begin() + 1 + precision);
+        if (trailing_zeros) {
+            // digits already has length precision + 1
+        }
+        else {
+			// trim trailing zeros after decimal point
+            while (!result.empty() && result.back() == '0') {
+                result.pop_back();
+			}
+            if (!result.empty() && result.back() == '.') {
+                result.pop_back(); // remove decimal point if no digits follow
+			}
+        }
+    }
+    else {
+		result += '0'; // no precision requested, just add a zero
+    }
+
+    result += uppercase ? "E" : "e";
+    result += (exp10 >= 0 ? "+" : "-");
+    result += std::to_string(std::abs(exp10));
+
+    return result;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/dd_cascade/attributes.hpp
+++ b/include/sw/universal/number/dd_cascade/attributes.hpp
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <limits>       // std::numeric_limits
+#include <universal/number/dd_cascade/core.hpp>
+#include <universal/number/dd_cascade/iostream.hpp>   // the range reporters stream dd_cascade values through operator<<
 #include <cmath>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/dd_cascade/core.hpp
+++ b/include/sw/universal/number/dd_cascade/core.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// core.hpp: the dd_cascade arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the dd_cascade headers (#1334, Phase 2).
+//
+//     #include <universal/number/dd_cascade/dd_cascade.hpp>   // everything, as before
+//     #include <universal/number/dd_cascade/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// Same division as dd (#1426) and qd (#1427): to_string() and parse() stay HERE.
+// parse() is what assign(const std::string&) calls, and to_string() concatenates a
+// std::string without ever opening a stream -- it only takes std::streamsize and
+// std::ios_base flags, which is what <ios> is for.
+//
+// The substrate, internal/floatcascade/floatcascade.hpp, is layered the same way: its
+// to_tuple()/to_scientific() builders and its operator<< are separate headers now, which
+// is what lets this core reach zero.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/dd_cascade/exceptions.hpp>
+#include <universal/number/dd_cascade/dd_cascade_fwd.hpp>
+#include <universal/number/dd_cascade/dd_cascade_impl.hpp>
+#include <universal/number/dd_cascade/numeric_limits.hpp>

--- a/include/sw/universal/number/dd_cascade/dd_cascade.hpp
+++ b/include/sw/universal/number/dd_cascade/dd_cascade.hpp
@@ -13,8 +13,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// required std libraries
-#include <iostream>
-#include <iomanip>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
@@ -53,23 +51,27 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
-#include <universal/traits/number_traits.hpp>
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  type_tag / to_binary / to_triple
+///     iostream.hpp      operator<< / operator>>
+///
+/// A translation unit that only computes can include core.hpp directly and skip the
+/// stream headers entirely. to_string() and parse() are in the CORE, not the text
+/// layers: assign(const std::string&) calls parse(), and to_string() concatenates a
+/// std::string without ever touching a stream.
+#include <universal/number/dd_cascade/core.hpp>
+#include <universal/traits/dd_cascade_traits.hpp>
+#include <universal/number/dd_cascade/manipulators.hpp>
+#include <universal/number/dd_cascade/iostream.hpp>
+#include <universal/number/dd_cascade/attributes.hpp>
+
+/// the report builders stay at the umbrella: they pull <sstream>/<iomanip> by design
 #include <universal/traits/arithmetic_traits.hpp>
 #include <universal/common/number_traits_reports.hpp>
 
-////////////////////////////////////////////////////////////////////////////////////////
-/// INCLUDE FILES that make up the library
-#include <universal/number/dd_cascade/exceptions.hpp>
-#include <universal/number/dd_cascade/dd_cascade_fwd.hpp>
-#include <universal/number/dd_cascade/dd_cascade_impl.hpp>
-#include <universal/number/dd_cascade/numeric_limits.hpp>
-#include <universal/traits/dd_cascade_traits.hpp>
-// useful functions to work with double-doubles
-#include <universal/number/dd_cascade/manipulators.hpp>
-#include <universal/number/dd_cascade/attributes.hpp>
-
-///////////////////////////////////////////////////////////////////////////////////////
-/// mathematical constants library
 #include <universal/number/dd_cascade/math/constants/dd_cascade_constants.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/dd_cascade/dd_cascade_impl.hpp
+++ b/include/sw/universal/number/dd_cascade/dd_cascade_impl.hpp
@@ -10,14 +10,17 @@
 #include <bit>
 #include <cctype>
 #include <cmath>
-#include <iostream>
-#include <iomanip>
+#include <cstdint>      // std::uint64_t
+#include <limits>       // std::numeric_limits
+#include <ios>          // std::streamsize / std::ios_base, in the to_string() signature
+#include <iosfwd>       // std::ostream/std::istream in the forward declarations (#1334)
+#include <cstdio>       // fprintf(stderr,...) for the diagnostics
 #include <string>
-#include <sstream>
 #include <type_traits>
 #include <vector>
 #include <universal/utility/bit_cast.hpp>
-#include <universal/internal/floatcascade/floatcascade.hpp>
+#include <universal/internal/floatcascade/floatcascade.hpp>   // the arithmetic substrate; its text and
+                                                              // stream layers are separate headers now (#1334)
 
 namespace sw::universal {
 
@@ -600,19 +603,6 @@ protected:
     // fully resolved at the point of declaration.)
 
     // Stream output - uses floatcascade-based to_string with proper formatting
-    friend std::ostream& operator<<(std::ostream& ostr, const dd_cascade& v) {
-        std::ios_base::fmtflags fmt = ostr.flags();
-        std::streamsize precision = ostr.precision();
-        std::streamsize width = ostr.width();
-        char fillChar = ostr.fill();
-        bool showpos = fmt & std::ios_base::showpos;
-        bool uppercase = fmt & std::ios_base::uppercase;
-        bool fixed = fmt & std::ios_base::fixed;
-        bool scientific = fmt & std::ios_base::scientific;
-        bool internal = fmt & std::ios_base::internal;
-        bool left = fmt & std::ios_base::left;
-        return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
-    }
 };
 
 ////////////////////////  precomputed constants of note  /////////////////////////////////
@@ -890,7 +880,7 @@ inline dd_cascade pown(const dd_cascade& a, int n) {
 	switch (N) {
 	case 0:
 		if (a.iszero()) {
-			std::cerr << "pown: invalid argument\n";
+			std::fprintf(stderr, "pown: invalid argument\n");
 			errno = EDOM;
 			return dd_cascade(SpecificValue::qnan);
 		}
@@ -959,19 +949,6 @@ inline bool parse(const std::string& number, dd_cascade& value) {
 	return false;
 }
 
-// stream in an ASCII decimal floating-point format and assign it to a dd_cascade
-inline std::istream& operator>>(std::istream& istr, dd_cascade& v) {
-	std::string txt;
-	if (!(istr >> txt)) {
-		// extraction failed (already-bad stream or EOF); failbit is set by >>.
-		return istr;
-	}
-	if (!parse(txt, v)) {
-		std::cerr << "unable to parse -" << txt << "- into a dd_cascade value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
-}
 
 
 } // namespace sw::universal

--- a/include/sw/universal/number/dd_cascade/exceptions.hpp
+++ b/include/sw/universal/number/dd_cascade/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>       // std::string, the exception message type
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/dd_cascade/iostream.hpp
+++ b/include/sw/universal/number/dd_cascade/iostream.hpp
@@ -1,0 +1,56 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for dd_cascade
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the dd_cascade headers (#1334): the <iostream> half.
+//
+// operator<< was an in-class friend DEFINITION, which is what forced <iostream> into the
+// arithmetic core. It is a plain free function here: it only calls the PUBLIC to_string()
+// member, so it never needed friendship. operator>> reports a parse failure on std::cerr,
+// which is why <iostream> belongs at this layer.
+//
+// to_string() and parse() stay in the CORE: assign(const std::string&) calls parse(), and
+// to_string() concatenates a std::string without ever opening a stream.
+#include <iostream>
+#include <istream>
+#include <ostream>
+#include <string>
+#include <ios>           // std::ios_base flags, std::ios::failbit
+
+#include <universal/number/dd_cascade/core.hpp>
+
+namespace sw { namespace universal {
+
+inline std::ostream& operator<<(std::ostream& ostr, const dd_cascade& v) {
+    std::ios_base::fmtflags fmt = ostr.flags();
+    std::streamsize precision = ostr.precision();
+    std::streamsize width = ostr.width();
+    char fillChar = ostr.fill();
+    bool showpos = fmt & std::ios_base::showpos;
+    bool uppercase = fmt & std::ios_base::uppercase;
+    bool fixed = fmt & std::ios_base::fixed;
+    bool scientific = fmt & std::ios_base::scientific;
+    bool internal = fmt & std::ios_base::internal;
+    bool left = fmt & std::ios_base::left;
+    return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
+}
+
+// stream in an ASCII decimal floating-point format and assign it to a dd_cascade
+inline std::istream& operator>>(std::istream& istr, dd_cascade& v) {
+	std::string txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit is set by >>.
+		return istr;
+	}
+	if (!parse(txt, v)) {
+		std::cerr << "unable to parse -" << txt << "- into a dd_cascade value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/dd_cascade/manipulators.hpp
+++ b/include/sw/universal/number/dd_cascade/manipulators.hpp
@@ -5,6 +5,16 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <cstdint>
+#include <cstddef>
+#include <cassert>
+#include <cmath>
+#include <universal/number/dd_cascade/core.hpp>
+#include <universal/number/dd_cascade/iostream.hpp>   // the text builders format dd_cascade values THROUGH operator<<,
+                                                    // which is defined there, not in the core (#1334)
 #include <iomanip>
 #include <sstream>
 #include <universal/native/integers.hpp>  // for hex_print

--- a/include/sw/universal/number/qd_cascade/attributes.hpp
+++ b/include/sw/universal/number/qd_cascade/attributes.hpp
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <limits>       // std::numeric_limits
+#include <universal/number/qd_cascade/core.hpp>
+#include <universal/number/qd_cascade/iostream.hpp>   // the range reporters stream qd_cascade values through operator<<
 #include <cmath>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/qd_cascade/core.hpp
+++ b/include/sw/universal/number/qd_cascade/core.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// core.hpp: the qd_cascade arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the qd_cascade headers (#1334, Phase 2).
+//
+//     #include <universal/number/qd_cascade/qd_cascade.hpp>   // everything, as before
+//     #include <universal/number/qd_cascade/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// Same division as dd (#1426) and qd (#1427): to_string() and parse() stay HERE.
+// parse() is what assign(const std::string&) calls, and to_string() concatenates a
+// std::string without ever opening a stream -- it only takes std::streamsize and
+// std::ios_base flags, which is what <ios> is for.
+//
+// The substrate, internal/floatcascade/floatcascade.hpp, is layered the same way: its
+// to_tuple()/to_scientific() builders and its operator<< are separate headers now, which
+// is what lets this core reach zero.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/qd_cascade/exceptions.hpp>
+#include <universal/number/qd_cascade/qd_cascade_fwd.hpp>
+#include <universal/number/qd_cascade/qd_cascade_impl.hpp>
+#include <universal/number/qd_cascade/numeric_limits.hpp>

--- a/include/sw/universal/number/qd_cascade/exceptions.hpp
+++ b/include/sw/universal/number/qd_cascade/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>       // std::string, the exception message type
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/qd_cascade/iostream.hpp
+++ b/include/sw/universal/number/qd_cascade/iostream.hpp
@@ -1,0 +1,56 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for qd_cascade
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the qd_cascade headers (#1334): the <iostream> half.
+//
+// operator<< was an in-class friend DEFINITION, which is what forced <iostream> into the
+// arithmetic core. It is a plain free function here: it only calls the PUBLIC to_string()
+// member, so it never needed friendship. operator>> reports a parse failure on std::cerr,
+// which is why <iostream> belongs at this layer.
+//
+// to_string() and parse() stay in the CORE: assign(const std::string&) calls parse(), and
+// to_string() concatenates a std::string without ever opening a stream.
+#include <iostream>
+#include <istream>
+#include <ostream>
+#include <string>
+#include <ios>           // std::ios_base flags, std::ios::failbit
+
+#include <universal/number/qd_cascade/core.hpp>
+
+namespace sw { namespace universal {
+
+inline std::ostream& operator<<(std::ostream& ostr, const qd_cascade& v) {
+    std::ios_base::fmtflags fmt = ostr.flags();
+    std::streamsize precision = ostr.precision();
+    std::streamsize width = ostr.width();
+    char fillChar = ostr.fill();
+    bool showpos = fmt & std::ios_base::showpos;
+    bool uppercase = fmt & std::ios_base::uppercase;
+    bool fixed = fmt & std::ios_base::fixed;
+    bool scientific = fmt & std::ios_base::scientific;
+    bool internal = fmt & std::ios_base::internal;
+    bool left = fmt & std::ios_base::left;
+    return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
+}
+
+// stream in an ASCII decimal floating-point format and assign it to a qd_cascade
+inline std::istream& operator>>(std::istream& istr, qd_cascade& v) {
+	std::string txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit is set by >>.
+		return istr;
+	}
+	if (!parse(txt, v)) {
+		std::cerr << "unable to parse -" << txt << "- into a qd_cascade value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/qd_cascade/manipulators.hpp
+++ b/include/sw/universal/number/qd_cascade/manipulators.hpp
@@ -5,6 +5,20 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <cstdint>
+#include <cstddef>
+#include <cassert>
+#include <cmath>
+#include <universal/native/ieee754.hpp>   // for the NON-TEMPLATE color_print(double) in ieee754_double.hpp.
+                                         // ieee754_core.hpp deliberately omits it; it is an exact match that
+                                         // outranks the color_print<Real> template, so losing it changed both
+                                         // overload resolution AND the printed format (#1334).
+#include <universal/number/qd_cascade/core.hpp>
+#include <universal/number/qd_cascade/iostream.hpp>   // the text builders format qd_cascade values THROUGH operator<<,
+                                                    // which is defined there, not in the core (#1334)
 #include <iostream>
 #include <iomanip>
 #include <sstream>

--- a/include/sw/universal/number/qd_cascade/qd_cascade.hpp
+++ b/include/sw/universal/number/qd_cascade/qd_cascade.hpp
@@ -13,8 +13,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// required std libraries
-#include <iostream>
-#include <iomanip>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
@@ -43,24 +41,27 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
-#include <universal/traits/number_traits.hpp>
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  type_tag / to_binary / to_triple
+///     iostream.hpp      operator<< / operator>>
+///
+/// A translation unit that only computes can include core.hpp directly and skip the
+/// stream headers entirely. to_string() and parse() are in the CORE, not the text
+/// layers: assign(const std::string&) calls parse(), and to_string() concatenates a
+/// std::string without ever touching a stream.
+#include <universal/number/qd_cascade/core.hpp>
+#include <universal/traits/qd_cascade_traits.hpp>
+#include <universal/number/qd_cascade/manipulators.hpp>
+#include <universal/number/qd_cascade/iostream.hpp>
+#include <universal/number/qd_cascade/attributes.hpp>
+
+/// the report builders stay at the umbrella: they pull <sstream>/<iomanip> by design
 #include <universal/traits/arithmetic_traits.hpp>
 #include <universal/common/number_traits_reports.hpp>
 
-////////////////////////////////////////////////////////////////////////////////////////
-/// INCLUDE FILES that make up the library
-#include <universal/number/qd_cascade/exceptions.hpp>
-#include <universal/number/qd_cascade/qd_cascade_fwd.hpp>
-#include <universal/number/qd_cascade/qd_cascade_impl.hpp>
-#include <universal/number/qd_cascade/numeric_limits.hpp>
-#include <universal/traits/qd_cascade_traits.hpp>
-
-// useful functions to work with quad-doubles
-#include <universal/number/qd_cascade/manipulators.hpp>
-#include <universal/number/qd_cascade/attributes.hpp>
-
-///////////////////////////////////////////////////////////////////////////////////////
-/// mathematical constants library
 #include <universal/number/qd_cascade/math/constants/qd_cascade_constants.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/qd_cascade/qd_cascade_impl.hpp
+++ b/include/sw/universal/number/qd_cascade/qd_cascade_impl.hpp
@@ -10,12 +10,17 @@
 #include <bit>
 #include <cctype>
 #include <cmath>
-#include <iostream>
+#include <cstdint>      // std::uint64_t
+#include <limits>       // std::numeric_limits
+#include <ios>          // std::streamsize / std::ios_base, in the to_string() signature
+#include <iosfwd>       // std::ostream/std::istream in the forward declarations (#1334)
+#include <cstdio>       // fprintf(stderr,...) for the diagnostics
 #include <string>
 #include <type_traits>
 #include <vector>
 #include <universal/utility/bit_cast.hpp>
-#include <universal/internal/floatcascade/floatcascade.hpp>
+#include <universal/internal/floatcascade/floatcascade.hpp>   // the arithmetic substrate; its text and
+                                                              // stream layers are separate headers now (#1334)
 
 namespace sw::universal {
 
@@ -606,19 +611,6 @@ public:
 
 private:
     // Stream output - uses to_string with formatting extraction
-    friend std::ostream& operator<<(std::ostream& ostr, const qd_cascade& v) {
-        std::ios_base::fmtflags fmt = ostr.flags();
-        std::streamsize precision = ostr.precision();
-        std::streamsize width = ostr.width();
-        char fillChar = ostr.fill();
-        bool showpos = fmt & std::ios_base::showpos;
-        bool uppercase = fmt & std::ios_base::uppercase;
-        bool fixed = fmt & std::ios_base::fixed;
-        bool scientific = fmt & std::ios_base::scientific;
-        bool internal = fmt & std::ios_base::internal;
-        bool left = fmt & std::ios_base::left;
-        return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
-    }
 };
 
 ////////////////////////  precomputed constants of note  /////////////////////////////////
@@ -840,19 +832,6 @@ inline bool parse(const std::string& number, qd_cascade& value) {
 	return false;
 }
 
-// stream in an ASCII decimal floating-point format and assign it to a qd_cascade
-inline std::istream& operator>>(std::istream& istr, qd_cascade& v) {
-	std::string txt;
-	if (!(istr >> txt)) {
-		// extraction failed (already-bad stream or EOF); failbit is set by >>.
-		return istr;
-	}
-	if (!parse(txt, v)) {
-		std::cerr << "unable to parse -" << txt << "- into a qd_cascade value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
-}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // qd_cascade constants

--- a/include/sw/universal/number/td_cascade/attributes.hpp
+++ b/include/sw/universal/number/td_cascade/attributes.hpp
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <limits>       // std::numeric_limits
+#include <universal/number/td_cascade/core.hpp>
+#include <universal/number/td_cascade/iostream.hpp>   // the range reporters stream td_cascade values through operator<<
 #include <cmath>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/td_cascade/core.hpp
+++ b/include/sw/universal/number/td_cascade/core.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// core.hpp: the td_cascade arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the td_cascade headers (#1334, Phase 2).
+//
+//     #include <universal/number/td_cascade/td_cascade.hpp>   // everything, as before
+//     #include <universal/number/td_cascade/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// Same division as dd (#1426) and qd (#1427): to_string() and parse() stay HERE.
+// parse() is what assign(const std::string&) calls, and to_string() concatenates a
+// std::string without ever opening a stream -- it only takes std::streamsize and
+// std::ios_base flags, which is what <ios> is for.
+//
+// The substrate, internal/floatcascade/floatcascade.hpp, is layered the same way: its
+// to_tuple()/to_scientific() builders and its operator<< are separate headers now, which
+// is what lets this core reach zero.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/td_cascade/exceptions.hpp>
+#include <universal/number/td_cascade/td_cascade_fwd.hpp>
+#include <universal/number/td_cascade/td_cascade_impl.hpp>
+#include <universal/number/td_cascade/numeric_limits.hpp>

--- a/include/sw/universal/number/td_cascade/exceptions.hpp
+++ b/include/sw/universal/number/td_cascade/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>       // std::string, the exception message type
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/td_cascade/iostream.hpp
+++ b/include/sw/universal/number/td_cascade/iostream.hpp
@@ -1,0 +1,56 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for td_cascade
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the td_cascade headers (#1334): the <iostream> half.
+//
+// operator<< was an in-class friend DEFINITION, which is what forced <iostream> into the
+// arithmetic core. It is a plain free function here: it only calls the PUBLIC to_string()
+// member, so it never needed friendship. operator>> reports a parse failure on std::cerr,
+// which is why <iostream> belongs at this layer.
+//
+// to_string() and parse() stay in the CORE: assign(const std::string&) calls parse(), and
+// to_string() concatenates a std::string without ever opening a stream.
+#include <iostream>
+#include <istream>
+#include <ostream>
+#include <string>
+#include <ios>           // std::ios_base flags, std::ios::failbit
+
+#include <universal/number/td_cascade/core.hpp>
+
+namespace sw { namespace universal {
+
+inline std::ostream& operator<<(std::ostream& ostr, const td_cascade& v) {
+    std::ios_base::fmtflags fmt = ostr.flags();
+    std::streamsize precision = ostr.precision();
+    std::streamsize width = ostr.width();
+    char fillChar = ostr.fill();
+    bool showpos = fmt & std::ios_base::showpos;
+    bool uppercase = fmt & std::ios_base::uppercase;
+    bool fixed = fmt & std::ios_base::fixed;
+    bool scientific = fmt & std::ios_base::scientific;
+    bool internal = fmt & std::ios_base::internal;
+    bool left = fmt & std::ios_base::left;
+    return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
+}
+
+// stream in an ASCII decimal floating-point format and assign it to a td_cascade
+inline std::istream& operator>>(std::istream& istr, td_cascade& v) {
+    std::string txt;
+    if (!(istr >> txt)) {
+        // extraction failed (already-bad stream or EOF); failbit is set by >>.
+        return istr;
+    }
+    if (!parse(txt, v)) {
+        std::cerr << "unable to parse -" << txt << "- into a td_cascade value\n";
+        istr.setstate(std::ios::failbit);
+    }
+    return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/td_cascade/manipulators.hpp
+++ b/include/sw/universal/number/td_cascade/manipulators.hpp
@@ -5,6 +5,20 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <cstdint>
+#include <cstddef>
+#include <cassert>
+#include <cmath>
+#include <universal/native/ieee754.hpp>   // for the NON-TEMPLATE color_print(double) in ieee754_double.hpp.
+                                         // ieee754_core.hpp deliberately omits it; it is an exact match that
+                                         // outranks the color_print<Real> template, so losing it changed both
+                                         // overload resolution AND the printed format (#1334).
+#include <universal/number/td_cascade/core.hpp>
+#include <universal/number/td_cascade/iostream.hpp>   // the text builders format td_cascade values THROUGH operator<<,
+                                                    // which is defined there, not in the core (#1334)
 #include <iostream>
 #include <iomanip>
 #include <sstream>

--- a/include/sw/universal/number/td_cascade/td_cascade.hpp
+++ b/include/sw/universal/number/td_cascade/td_cascade.hpp
@@ -13,8 +13,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// required std libraries
-#include <iostream>
-#include <iomanip>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
@@ -43,23 +41,27 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
-#include <universal/traits/number_traits.hpp>
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  type_tag / to_binary / to_triple
+///     iostream.hpp      operator<< / operator>>
+///
+/// A translation unit that only computes can include core.hpp directly and skip the
+/// stream headers entirely. to_string() and parse() are in the CORE, not the text
+/// layers: assign(const std::string&) calls parse(), and to_string() concatenates a
+/// std::string without ever touching a stream.
+#include <universal/number/td_cascade/core.hpp>
+#include <universal/traits/td_cascade_traits.hpp>
+#include <universal/number/td_cascade/manipulators.hpp>
+#include <universal/number/td_cascade/iostream.hpp>
+#include <universal/number/td_cascade/attributes.hpp>
+
+/// the report builders stay at the umbrella: they pull <sstream>/<iomanip> by design
 #include <universal/traits/arithmetic_traits.hpp>
 #include <universal/common/number_traits_reports.hpp>
 
-////////////////////////////////////////////////////////////////////////////////////////
-/// INCLUDE FILES that make up the library
-#include <universal/number/td_cascade/exceptions.hpp>
-#include <universal/number/td_cascade/td_cascade_fwd.hpp>
-#include <universal/number/td_cascade/td_cascade_impl.hpp>
-#include <universal/number/td_cascade/numeric_limits.hpp>
-#include <universal/traits/td_cascade_traits.hpp>
-// useful functions to work with double-doubles
-#include <universal/number/td_cascade/manipulators.hpp>
-#include <universal/number/td_cascade/attributes.hpp>
-
-///////////////////////////////////////////////////////////////////////////////////////
-/// mathematical constants library
 #include <universal/number/td_cascade/math/constants/td_cascade_constants.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/td_cascade/td_cascade_fwd.hpp
+++ b/include/sw/universal/number/td_cascade/td_cascade_fwd.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>       // std::string, in the parse() declaration below
 
 namespace sw { namespace universal {
 

--- a/include/sw/universal/number/td_cascade/td_cascade_impl.hpp
+++ b/include/sw/universal/number/td_cascade/td_cascade_impl.hpp
@@ -10,12 +10,17 @@
 #include <bit>
 #include <cctype>
 #include <cmath>
-#include <iostream>
+#include <cstdint>      // std::uint64_t
+#include <limits>       // std::numeric_limits
+#include <ios>          // std::streamsize / std::ios_base, in the to_string() signature
+#include <iosfwd>       // std::ostream/std::istream in the forward declarations (#1334)
+#include <cstdio>       // fprintf(stderr,...) for the diagnostics
 #include <string>
 #include <type_traits>
 #include <vector>
 #include <universal/utility/bit_cast.hpp>
-#include <universal/internal/floatcascade/floatcascade.hpp>
+#include <universal/internal/floatcascade/floatcascade.hpp>   // the arithmetic substrate; its text and
+                                                              // stream layers are separate headers now (#1334)
 
 namespace sw::universal {
 
@@ -590,19 +595,6 @@ public:
 
 private:
     // Stream output - uses to_string with formatting extraction
-    friend std::ostream& operator<<(std::ostream& ostr, const td_cascade& v) {
-        std::ios_base::fmtflags fmt = ostr.flags();
-        std::streamsize precision = ostr.precision();
-        std::streamsize width = ostr.width();
-        char fillChar = ostr.fill();
-        bool showpos = fmt & std::ios_base::showpos;
-        bool uppercase = fmt & std::ios_base::uppercase;
-        bool fixed = fmt & std::ios_base::fixed;
-        bool scientific = fmt & std::ios_base::scientific;
-        bool internal = fmt & std::ios_base::internal;
-        bool left = fmt & std::ios_base::left;
-        return ostr << v.to_string(precision, width, fixed, scientific, internal, left, showpos, uppercase, fillChar);
-    }
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -786,19 +778,6 @@ inline bool parse(const std::string& number, td_cascade& value) {
     return false;
 }
 
-// stream in an ASCII decimal floating-point format and assign it to a td_cascade
-inline std::istream& operator>>(std::istream& istr, td_cascade& v) {
-    std::string txt;
-    if (!(istr >> txt)) {
-        // extraction failed (already-bad stream or EOF); failbit is set by >>.
-        return istr;
-    }
-    if (!parse(txt, v)) {
-        std::cerr << "unable to parse -" << txt << "- into a td_cascade value\n";
-        istr.setstate(std::ios::failbit);
-    }
-    return istr;
-}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // td_cascade constants

--- a/internal/floatcascade/api/api.cpp
+++ b/internal/floatcascade/api/api.cpp
@@ -9,6 +9,8 @@
 #include <iostream>
 
 #include <universal/internal/floatcascade/floatcascade.hpp>
+#include <universal/internal/floatcascade/manipulators.hpp>   // to_tuple / to_scientific (#1334)
+#include <universal/internal/floatcascade/iostream.hpp>       // operator<<(ostream, floatcascade) (#1334)
 #include <universal/verification/test_suite.hpp>
 
 

--- a/internal/floatcascade/api/floatcascade.cpp
+++ b/internal/floatcascade/api/floatcascade.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <iomanip>
 #include <universal/internal/floatcascade/floatcascade.hpp>
+#include <universal/internal/floatcascade/iostream.hpp>   // operator<<(ostream, floatcascade) (#1334)
 
 using namespace sw::universal;
 

--- a/internal/floatcascade/arithmetic/multiplication_precision.cpp
+++ b/internal/floatcascade/arithmetic/multiplication_precision.cpp
@@ -34,6 +34,7 @@
 
 #include <universal/utility/directives.hpp>
 #include <universal/internal/floatcascade/floatcascade.hpp>
+#include <universal/internal/floatcascade/iostream.hpp>   // operator<<(ostream, floatcascade) (#1334)
 #include <universal/number/qd/qd.hpp>
 #include <universal/number/qd_cascade/qd_cascade.hpp>
 #include <universal/verification/test_suite.hpp>


### PR DESCRIPTION
> Supersedes #1428, which GitHub closed automatically when its base branch (`refactor/issue-1334-qd-split`)
> was deleted on merging #1427. A closed PR whose base is gone cannot be reopened, so this is the same
> branch re-proposed against `main`. Nothing about the content changed.

Final phase of the #1334 header layering: `dd_cascade`, `td_cascade`, `qd_cascade`, and the `floatcascade` substrate they share.

| header | lines | I/O-family |
|---|---:|---:|
| `internal/floatcascade/floatcascade.hpp` | 66,387 | **0** (was 84,315 / 5) |
| `dd_cascade/core.hpp` | 75,580 | **0** (umbrella 87,005 / 5) |
| `td_cascade/core.hpp` | 75,387 | **0** (umbrella 87,245 / 5) |
| `qd_cascade/core.hpp` | 75,466 | **0** (umbrella 87,347 / 5) |

## The substrate was the real work

`floatcascade.hpp` defined `operator<<` as an **in-class friend definition**, which is what pinned `<iostream>` into every consumer — all three cascade types plus the floatcascade tests. It is now a friend *declaration* (so the core needs only `<iosfwd>`) with the definition out-of-line in `floatcascade/iostream.hpp`, and `to_tuple()`/`to_scientific()` moved to `floatcascade/manipulators.hpp`.

The three cascade types had the identical in-class-friend pattern. Since their `to_string()` is **public**, `operator<<` never needed friendship at all and became a plain free function in each type's `iostream.hpp`.

Because that operator is a template, a clean `-fsyntax-only` proves nothing — it is not instantiated until used. So it was instantiated and the output diffed against `main`: **byte-identical**, including the `fc.e[i]` → `fc[i]` substitution (`operator[]` is literally `return e[i];`).

## Same division as dd and qd

`to_string()` and `parse()` stay in the **core**: `parse()` is what `assign(const std::string&)` calls, and `to_string()` concatenates a `std::string` without ever opening a stream — it only *takes* `std::streamsize` and `std::ios_base` flags, which is what `<ios>` is for. Diagnostics moved to `fprintf(stderr, ...)`, the Phase 0 idiom; the four in `floatcascade.hpp` included.

`manipulators.hpp` and `attributes.hpp` include `iostream.hpp` for the reason established in #1426/#1427: their builders format the type *through* `operator<<`, which is declared in the core but defined in the stream layer. Not a cycle — `iostream.hpp` includes only `core.hpp`.

## The `color_print` trap, carried over from #1427

`td_cascade` and `qd_cascade` format each limb with `color_print(number[i])` where `number[i]` is a `double`. The intended target is the **non-template** `color_print(double)` in `native/ieee754_double.hpp`, which `ieee754_core.hpp` deliberately omits. Re-pointing the impls at the core header removed it, `double` converted implicitly to the cascade type, and the function recursed until the stack died — the same crash that took down Linux CI on #1427.

Both now take `native/ieee754.hpp` in their **text** layer, restoring exact overload resolution. Binding `color_print<double>` explicitly is *not* equivalent — it selects the `color_print<Real>` template and prints a different format:

```
color_print(d)          0b0.0111'1111'1111.1000'...     <- non-template, ieee754_double.hpp
color_print<double>(d)  0011111111111000...             <- template, native/manipulators.hpp
```

Verified that `color_print` output is byte-identical to `main` both through the umbrella and with `manipulators.hpp` as the only include. `dd_cascade` was never affected.

## IWYU

Closed **21 gaps** across the four subtrees: `<limits>`, `<cstdint>`, `<cstddef>`, `<cassert>`, `<cmath>`, and `<string>` in three `exceptions.hpp` plus `td_cascade_fwd.hpp` — which had the same `parse(const std::string&)`-without-`<string>` defect as `qd_fwd.hpp` in #1427. Sweep clean at **0 gaps across all 34 headers**; every header already carried `#pragma once`.

## Verification

- All three core gates pass on gcc and clang, with `#error` tripwires on the stream include guards and **exact dyadic identities** so assertions do not depend on cascade rounding
- floatcascade consumers, `static/highprecision`, `applications/precision/tapered` and every `api.cpp`: see the summary in the PR checks
- `static/appenv/multifile` (multi-TU) links and runs clean
- ASCII clean


## Fixes since the first CI run

Linux CI on #1428 failed on three consumers of the functions this PR moves:

```
internal/floatcascade/api/api.cpp:50: error: 'to_scientific' was not declared in this scope

undefined reference to `operator<< <4ul>(std::ostream&, floatcascade<4ul> const&)'
  internal/floatcascade/api/floatcascade.cpp
  internal/floatcascade/arithmetic/multiplication_precision.cpp
```

`to_tuple()`/`to_scientific()` moved to `floatcascade/manipulators.hpp` and `operator<<` to `floatcascade/iostream.hpp`; these three were never updated. Fixed.

This is the third time in the epic that moving an `operator<<` produced link errors in exactly the translation units that stream the type — `positional_impl.hpp` and the blockdigit api test were the first two. `-fsyntax-only` cannot see it; it needs a build-and-link pass over every consumer.

Local sweep after the fix, both compilers: **126 pass, 0 fail**, plus one timeout on `education/interactive/expansion_algebra/expansion_algebra_tutorial.cpp` — an interactive menu that loops forever on EOF. Verified byte-for-byte identical behaviour on `main`, so it is pre-existing and unrelated; it does not affect CI because the Education targets are not built in the CI_LITE tier.

This completes Phase 2 of #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
