### PR TITLE
fix(edecimal): add inline to header-defined free functions, and guard it (#1424)

### DIFF
--- a/include/sw/universal/number/dfloat/manipulators.hpp
+++ b/include/sw/universal/number/dfloat/manipulators.hpp
@@ -13,7 +13,7 @@ namespace sw { namespace universal {
 
 	
 	// Generate a type tag for this decimal encoding
-	std::string type_tag(const DecimalEncoding encoding = {}) {
+	inline std::string type_tag(const DecimalEncoding encoding = {}) {
 		std::stringstream s;
 		switch (encoding) {
 		case DecimalEncoding::BCD:

--- a/include/sw/universal/number/edecimal/edecimal_impl.hpp
+++ b/include/sw/universal/number/edecimal/edecimal_impl.hpp
@@ -653,17 +653,17 @@ inline edecimal operator>>(const edecimal& lhs, int shift) {
 
 	// edecimal - edecimal logic operators
 // equality test
-bool operator==(const edecimal& lhs, const edecimal& rhs) {
+inline bool operator==(const edecimal& lhs, const edecimal& rhs) {
 	if (lhs.size() != rhs.size()) return false;
 	bool areEqual = std::equal(lhs.begin(), lhs.end(), rhs.begin()) && lhs.sign() == rhs.sign();
 	return areEqual;
 }
 // inequality test
-bool operator!=(const edecimal& lhs, const edecimal& rhs) {
+inline bool operator!=(const edecimal& lhs, const edecimal& rhs) {
 	return !operator==(lhs, rhs);
 }
 // less-than test
-bool operator<(const edecimal& lhs, const edecimal& rhs) {
+inline bool operator<(const edecimal& lhs, const edecimal& rhs) {
 	if (lhs.sign() != rhs.sign()) {
 		return lhs.sign() ? true : false;
 	}
@@ -686,15 +686,15 @@ bool operator<(const edecimal& lhs, const edecimal& rhs) {
 	return false;
 }
 // greater-than test
-bool operator>(const edecimal& lhs, const edecimal& rhs) {
+inline bool operator>(const edecimal& lhs, const edecimal& rhs) {
 	return operator<(rhs, lhs);
 }
 // less-or-equal test
-bool operator<=(const edecimal& lhs, const edecimal& rhs) {
+inline bool operator<=(const edecimal& lhs, const edecimal& rhs) {
 	return operator<(lhs, rhs) || operator==(lhs, rhs);
 }
 // greater-or-equal test
-bool operator>=(const edecimal& lhs, const edecimal& rhs) {
+inline bool operator>=(const edecimal& lhs, const edecimal& rhs) {
 	return !operator<(lhs, rhs);
 }
 
@@ -741,7 +741,7 @@ inline bool operator>=(long lhs, const edecimal& rhs) {
 ///////////////////////////////////////////////////////////////////////
 // 
 // find largest multiplier of rhs being less or equal to lhs by subtraction; assumes 0*rhs <= lhs <= 9*rhs 
-edecimal findLargestMultiple(const edecimal& lhs, const edecimal& rhs) {
+inline edecimal findLargestMultiple(const edecimal& lhs, const edecimal& rhs) {
 	// check argument assumption	assert(0 <= lhs && lhs >= 9 * rhs);
 	edecimal remainder = lhs;
 	remainder.setpos();
@@ -772,7 +772,7 @@ struct decintdiv {
 };
 
 // divide integer edecimal a and b and return result argument
-decintdiv decint_divide(const edecimal& _a, const edecimal& _b) {
+inline decintdiv decint_divide(const edecimal& _a, const edecimal& _b) {
 	if (_b.iszero()) {
 #if EDECIMAL_THROW_ARITHMETIC_EXCEPTION
 		throw edecimal_integer_divide_by_zero{};
@@ -829,11 +829,11 @@ decintdiv decint_divide(const edecimal& _a, const edecimal& _b) {
 }
 
 // return quotient of a edecimal integer division
-edecimal quotient(const edecimal& _a, const edecimal& _b) {
+inline edecimal quotient(const edecimal& _a, const edecimal& _b) {
 	return decint_divide(_a, _b).quot;
 }
 // return remainder of a edecimal integer division
-edecimal remainder(const edecimal& _a, const edecimal& _b) {
+inline edecimal remainder(const edecimal& _a, const edecimal& _b) {
 	return decint_divide(_a, _b).rem;
 }
 

--- a/include/sw/universal/number/erational/erational_impl.hpp
+++ b/include/sw/universal/number/erational/erational_impl.hpp
@@ -603,30 +603,30 @@ inline erational operator/(const erational& lhs, const erational& rhs) {
 /// erational - erational logic operators
 
 // equality test
-bool operator==(const erational& lhs, const erational& rhs) {
+inline bool operator==(const erational& lhs, const erational& rhs) {
 	return lhs.numerator == rhs.numerator && lhs.denominator == rhs.denominator;
 }
 // inequality test
-bool operator!=(const erational& lhs, const erational& rhs) {
+inline bool operator!=(const erational& lhs, const erational& rhs) {
 	return !operator==(lhs, rhs);
 }
 // less-than test
-bool operator<(const erational& lhs, const erational& rhs) {
+inline bool operator<(const erational& lhs, const erational& rhs) {
 	// a/b < c/d  => ad / bd < cb / bd => ad < cb
 	edecimal ad = lhs.numerator * rhs.denominator;
 	edecimal bc = lhs.denominator * rhs.numerator;
 	return ad < bc;
 }
 // greater-than test
-bool operator>(const erational& lhs, const erational& rhs) {
+inline bool operator>(const erational& lhs, const erational& rhs) {
 	return operator<(rhs, lhs);
 }
 // less-or-equal test
-bool operator<=(const erational& lhs, const erational& rhs) {
+inline bool operator<=(const erational& lhs, const erational& rhs) {
 	return operator<(lhs, rhs) || operator==(lhs, rhs);
 }
 // greater-or-equal test
-bool operator>=(const erational& lhs, const erational& rhs) {
+inline bool operator>=(const erational& lhs, const erational& rhs) {
 	return !operator<(lhs, rhs);
 }
 
@@ -674,7 +674,7 @@ inline bool operator>=(long lhs, const erational& rhs) {
 
 
 // find largest multiplier of rhs being less or equal to lhs by subtraction; assumes 0*rhs <= lhs <= 9*rhs 
-erational findLargestMultiple_(const erational& lhs, const erational& rhs) {
+inline erational findLargestMultiple_(const erational& lhs, const erational& rhs) {
 	erational multiplier;
 
 	return multiplier;
@@ -689,7 +689,7 @@ struct erationalintdiv {
 };
 
 // divide integer erational a and b and return result argument
-erationalintdiv erational_divide(const erational& lhs, const erational& rhs) {
+inline erationalintdiv erational_divide(const erational& lhs, const erational& rhs) {
 	if (rhs.iszero()) {
 #if ERATIONAL_THROW_ARITHMETIC_EXCEPTION
 		throw erational_divide_by_zero{};
@@ -706,11 +706,11 @@ erationalintdiv erational_divide(const erational& lhs, const erational& rhs) {
 }
 
 // return quotient of a erational integer division
-erational quotient(const erational& _a, const erational& _b) {
+inline erational quotient(const erational& _a, const erational& _b) {
 	return erational_divide(_a, _b).quot;
 }
 // return remainder of a erational integer division
-erational remainder(const erational& _a, const erational& _b) {
+inline erational remainder(const erational& _a, const erational& _b) {
 	return erational_divide(_a, _b).rem;
 }
 

--- a/include/sw/universal/number/erational/math/classify.hpp
+++ b/include/sw/universal/number/erational/math/classify.hpp
@@ -9,7 +9,7 @@
 namespace sw { namespace universal {
 
 	// STD LIB function for IEEE floats: Categorizes floating point value arg into the following categories: zero, subnormal, normal, infinite, NAN, or implementation-defined category.
-	int fpclassify(const erational& a) {
+	inline int fpclassify(const erational& a) {
 		return std::fpclassify(double(a));
 	}
 	

--- a/include/sw/universal/number/erational/math/complex.hpp
+++ b/include/sw/universal/number/erational/math/complex.hpp
@@ -28,11 +28,11 @@ namespace sw { namespace universal {
 	  return std::complex< erational >(x.real(), -x.imag());
 	}
 
-	bool isnan(std::complex< erational > x) {
+	inline bool isnan(std::complex< erational > x) {
 		return (isnan(x.real()) || isnan(x.imag()));
 	}
 
-	bool isinf(std::complex< erational > x) {
+	inline bool isinf(std::complex< erational > x) {
 		return (isinf(x.real()) || isinf(x.imag()));
 	}
 

--- a/include/sw/universal/number/erational/math/error_and_gamma.hpp
+++ b/include/sw/universal/number/erational/math/error_and_gamma.hpp
@@ -9,12 +9,12 @@
 namespace sw { namespace universal {
 
 	// Compute the error function erf(x) = 2 over sqrt(PI) times Integral from 0 to x of e ^ (-t)^2 dt
-	erational erf(erational x) {
+	inline erational erf(erational x) {
 		return erational(std::erf(double(x)));
 	}
 
 	// Compute the complementary error function: 1 - erf(x)
-	erational erfc(erational x) {
+	inline erational erfc(erational x) {
 		return erational(std::erfc(double(x)));
 	}
 

--- a/include/sw/universal/number/erational/math/exponent.hpp
+++ b/include/sw/universal/number/erational/math/exponent.hpp
@@ -13,7 +13,7 @@ namespace sw { namespace universal {
 // correctly rounded for every input value. Anything less sacrifices bitwise reproducibility of results.
 
 // Base-e exponential function
-erational exp(erational x) {
+inline erational exp(erational x) {
 	if (isnan(x)) return x;
 	erational p;
 	p = std::exp(double(x));
@@ -21,7 +21,7 @@ erational exp(erational x) {
 }
 
 // Base-2 exponential function
-erational exp2(erational x) {
+inline erational exp2(erational x) {
 	if (isnan(x)) return x;
 	erational p;
 	p = std::exp2(double(x));
@@ -29,12 +29,12 @@ erational exp2(erational x) {
 }
 
 // Base-10 exponential function
-erational exp10(erational x) {
+inline erational exp10(erational x) {
 	return erational(std::pow(10.0, double(x)));
 }
 		
 // Base-e exponential function exp(x)-1
-erational expm1(erational x) {
+inline erational expm1(erational x) {
 	return erational(std::expm1(double(x)));
 }
 

--- a/include/sw/universal/number/erational/math/fractional.hpp
+++ b/include/sw/universal/number/erational/math/fractional.hpp
@@ -9,15 +9,15 @@
 
 namespace sw { namespace universal {
 
-	erational fmod(erational x, erational y) {
+	inline erational fmod(erational x, erational y) {
 		return erational(std::fmod(double(x), double(y)));
 	}
 
-	erational remainder(erational x, erational y) {
+	inline erational remainder(erational x, erational y) {
 		return erational(std::remainder(double(x), double(y)));
 	}
 
-	erational frac(erational x) {
+	inline erational frac(erational x) {
 		return erational(double(x)-long(x));
 	}
 

--- a/include/sw/universal/number/erational/math/hyperbolic.hpp
+++ b/include/sw/universal/number/erational/math/hyperbolic.hpp
@@ -12,32 +12,32 @@ namespace sw { namespace universal {
 // One radian is equivalent to 180/PI degrees
 
 // hyperbolic sine of an angle of x radians
-erational sinh(erational x) {
+inline erational sinh(erational x) {
 	return erational(std::sinh(double(x)));
 }
 
 // hyperbolic cosine of an angle of x radians
-erational cosh(erational x) {
+inline erational cosh(erational x) {
 	return erational(std::cosh(double(x)));
 }
 
 // hyperbolic tangent of an angle of x radians
-erational tanh(erational x) {
+inline erational tanh(erational x) {
 	return erational(std::tanh(double(x)));
 }
 
 // hyperbolic cotangent of an angle of x radians
-erational atanh(erational x) {
+inline erational atanh(erational x) {
 	return erational(std::atanh(double(x)));
 }
 
 // hyperbolic cosecant of an angle of x radians
-erational acosh(erational x) {
+inline erational acosh(erational x) {
 	return erational(std::acosh(double(x)));
 }
 
 // hyperbolic secant of an angle of x radians
-erational asinh(erational x) {
+inline erational asinh(erational x) {
 	return erational(std::asinh(double(x)));
 }
 

--- a/include/sw/universal/number/erational/math/hypot.hpp
+++ b/include/sw/universal/number/erational/math/hypot.hpp
@@ -42,16 +42,16 @@ hypot(INFINITY, NAN) returns +8, but sqrt(INFINITY*INFINITY+NAN*NAN) returns NaN
 
 namespace sw { namespace universal {
 
-erational hypot(erational x, erational y) {
+inline erational hypot(erational x, erational y) {
 	return erational(std::hypot(double(x),double(y)));
 }
 
-erational hypotf(erational x, erational y) {
+inline erational hypotf(erational x, erational y) {
 	return erational(std::hypotf(float(x),float(y)));
 }
 
 #if LONG_DOUBLE_SUPPORT
-erational hypotl(erational x, erational y) {
+inline erational hypotl(erational x, erational y) {
 	return erational(std::hypotl((long double)(x),(long double)(y)));
 }
 #endif

--- a/include/sw/universal/number/erational/math/logarithm.hpp
+++ b/include/sw/universal/number/erational/math/logarithm.hpp
@@ -10,22 +10,22 @@
 namespace sw { namespace universal {
 
 	// Natural logarithm of x
-	erational log(erational x) {
+	inline erational log(erational x) {
 		return erational(std::log(double(x)));
 	}
 
 	// Binary logarithm of x
-	erational log2(erational x) {
+	inline erational log2(erational x) {
 		return erational(std::log2(double(x)));
 	}
 
 	// Decimal logarithm of x
-	erational log10(erational x) {
+	inline erational log10(erational x) {
 		return erational(std::log10(double(x)));
 	}
 		
 	// Natural logarithm of 1+x
-	erational log1p(erational x) {
+	inline erational log1p(erational x) {
 		return erational(std::log1p(double(x)));
 	}
 

--- a/include/sw/universal/number/erational/math/minmax.hpp
+++ b/include/sw/universal/number/erational/math/minmax.hpp
@@ -9,11 +9,11 @@
 
 namespace sw { namespace universal {
 
-	erational min(erational x, erational y) {
+	inline erational min(erational x, erational y) {
 		return erational(std::min(double(x), double(y)));
 	}
 
-	erational max(erational x, erational y) {
+	inline erational max(erational x, erational y) {
 		return erational(std::max(double(x), double(y)));
 	}
 

--- a/include/sw/universal/number/erational/math/next.hpp
+++ b/include/sw/universal/number/erational/math/next.hpp
@@ -25,7 +25,7 @@ Return Value
 	- And math_errhandling has MATH_ERREXCEPT set: FE_OVERFLOW is raised.
 */
 
-erational nextafter(erational x, erational target) {
+inline erational nextafter(erational x, erational target) {
 	if (x == target) return target;
 
 		if (x > target) {
@@ -38,7 +38,7 @@ erational nextafter(erational x, erational target) {
 	return x;
 }
 		
-erational nexttoward(erational x, erational target) {
+inline erational nexttoward(erational x, erational target) {
 	if (x == target) return x;
 
 		if (x > target) {

--- a/include/sw/universal/number/erational/math/pow.hpp
+++ b/include/sw/universal/number/erational/math/pow.hpp
@@ -9,15 +9,15 @@
 
 namespace sw { namespace universal {
 
-	erational pow(erational x, erational y) {
+	inline erational pow(erational x, erational y) {
 		return erational(std::pow(double(x), double(y)));
 	}
 		
-	erational pow(erational x, int y) {
+	inline erational pow(erational x, int y) {
 		return erational(std::pow(double(x), double(y)));
 	}
 		
-	erational pow(erational x, double y) {
+	inline erational pow(erational x, double y) {
 		return erational(std::pow(double(x), y));
 	}
 

--- a/include/sw/universal/number/erational/math/trigonometry.hpp
+++ b/include/sw/universal/number/erational/math/trigonometry.hpp
@@ -14,52 +14,52 @@ namespace sw { namespace universal {
 // One radian is equivalent to 180/PI degrees
 
 // sine of an angle of x radians
-erational sin(erational x) {
+inline erational sin(erational x) {
 	return erational(std::sin(double(x)));
 }
 
 // cosine of an angle of x radians
-erational cos(erational x) {
+inline erational cos(erational x) {
 	return erational(std::cos(double(x)));
 }
 
 // tangent of an angle of x radians
-erational tan(erational x) {
+inline erational tan(erational x) {
 	return erational(std::tan(double(x)));
 }
 
 // cotangent of an angle of x radians
-erational atan(erational x) {
+inline erational atan(erational x) {
 	return erational(std::atan(double(x)));
 }
 		
 // Arc tangent with two parameters
-erational atan2(erational y, erational x) {
+inline erational atan2(erational y, erational x) {
 	return erational(std::atan2(double(y),double(x)));
 }
 
 // cosecant of an angle of x radians
-erational acos(erational x) {
+inline erational acos(erational x) {
 	return erational(std::acos(double(x)));
 }
 
 // secant of an angle of x radians
-erational asin(erational x) {
+inline erational asin(erational x) {
 	return erational(std::asin(double(x)));
 }
 
 // cotangent an angle of x radians
-erational cot(erational x) {
+inline erational cot(erational x) {
 	return erational(std::tan(sw::universal::d_pi_2-double(x)));
 }
 
 // secant of an angle of x radians
-erational sec(erational x) {
+inline erational sec(erational x) {
 	return erational(1.0/std::cos(double(x)));
 }
 
 // cosecant of an angle of x radians
-erational csc(erational x) {
+inline erational csc(erational x) {
 	return erational(1.0/std::sin(double(x)));
 }
 

--- a/include/sw/universal/number/erational/math/truncate.hpp
+++ b/include/sw/universal/number/erational/math/truncate.hpp
@@ -10,22 +10,22 @@
 namespace sw { namespace universal {
 
 	// Truncate value by rounding toward zero, returning the nearest integral value that is not larger in magnitude than x
-	erational trunc(erational x) {
+	inline erational trunc(erational x) {
 		return erational(std::trunc(double(x)));
 	}
 
 	// Round to nearest: returns the integral value that is nearest to x, with halfway cases rounded away from zero
-	erational round(erational x) {
+	inline erational round(erational x) {
 		return erational(std::round(double(x)));
 	}
 
 	// Round x downward, returning the largest integral value that is not greater than x
-	erational floor(erational x) {
+	inline erational floor(erational x) {
 		return erational(std::floor(double(x)));
 	}
 
 	// Round x upward, returning the smallest integral value that is greater than x
-	erational ceil(erational x) {
+	inline erational ceil(erational x) {
 		return erational(std::ceil(double(x)));
 	}
 

--- a/include/sw/universal/string/strmanip.hpp
+++ b/include/sw/universal/string/strmanip.hpp
@@ -9,7 +9,7 @@
 namespace sw { namespace universal {
 
 // remove white space from the left side of the string
-std::string& ltrim(std::string& s)
+inline std::string& ltrim(std::string& s)
 {
 	auto it = std::find_if(s.begin(), s.end(),
 		[](char c) {
@@ -20,7 +20,7 @@ std::string& ltrim(std::string& s)
 }
 
 // remove white space at the right side of the string
-std::string& rtrim(std::string& s) {
+inline std::string& rtrim(std::string& s) {
 	auto it = std::find_if(s.rbegin(), s.rend(),
 		[](char c) {
 		return !std::isspace<char>(c, std::locale::classic());

--- a/static/appenv/multifile/dfloats.cpp
+++ b/static/appenv/multifile/dfloats.cpp
@@ -1,0 +1,21 @@
+// dfloats.cpp: compilation test to check arithmetic type usage in application environments
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Linked against main.cpp to catch ODR violations. dfloat's type_tag(DecimalEncoding) was
+// a non-template free function defined in a header without inline (#1424).
+#include <universal/number/dfloat/dfloat.hpp>
+#include <vector>
+
+using Decimal32 = sw::universal::decimal32;
+
+Decimal32 dfloatSum(const std::vector<double>& values) {
+	Decimal32 sum(0);
+	for (size_t i = 0; i < values.size(); ++i) {
+		sum += Decimal32(values[i]);
+	}
+	return sum;
+}

--- a/static/appenv/multifile/edecimals.cpp
+++ b/static/appenv/multifile/edecimals.cpp
@@ -1,0 +1,27 @@
+// edecimals.cpp: compilation test to check arithmetic type usage in application environments
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// This translation unit exists to be LINKED against main.cpp: a header that defines a
+// non-template free function without inline compiles fine in one TU and fails at link
+// time with two. edecimal had 12 such symbols (#1424) and no multifile coverage, which
+// is exactly why they went unnoticed.
+#include <universal/number/edecimal/edecimal.hpp>
+#include <vector>
+
+using Decimal = sw::universal::edecimal;
+
+Decimal edecimalPolynomial(const std::vector<int>& coef, const Decimal& x) {
+	if (coef.size() < 2) return Decimal(0);
+
+	Decimal v = coef[0];
+	Decimal xn = 1;
+	for (size_t i = 1; i < coef.size(); ++i) {
+		xn *= x;
+		v += Decimal(coef[i]) * xn;
+	}
+	return v;
+}

--- a/static/appenv/multifile/erationals.cpp
+++ b/static/appenv/multifile/erationals.cpp
@@ -1,0 +1,25 @@
+// erationals.cpp: compilation test to check arithmetic type usage in application environments
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Linked against main.cpp to catch ODR violations that a single translation unit cannot
+// see. erational had 68 duplicate symbols before #1424 -- its whole mathlib plus the
+// comparison operators -- and no multifile coverage.
+#include <universal/number/erational/erational.hpp>
+#include <vector>
+
+using Rational = sw::universal::erational;
+
+Rational erationalSum(const std::vector<int>& numerators, int denominator) {
+	Rational sum(0);
+	for (size_t i = 0; i < numerators.size(); ++i) {
+		Rational term;
+		term = numerators[i];
+		term /= Rational(denominator);
+		sum += term;
+	}
+	return sum;
+}


### PR DESCRIPTION
`erational` and `edecimal` could not be used from **two translation units**. Any program that included their umbrella twice and linked them failed:

```
$ g++ -std=c++20 -Iinclude/sw a.cpp b.cpp     # both #include erational.hpp
multiple definition of `sw::universal::ltrim(std::string&)'
... 68 in total
```

Cause: non-template free functions **defined** in headers without `inline`. Each including translation unit emits its own strong definition, so one TU is fine and two collide.

| type | duplicate symbols | after |
|---|---:|---:|
| `erational` | 68 | **0** |
| `edecimal` | 12 | **0** |
| `dfloat` | 1 | **0** |

`dfloat` is **not in the issue** — sweeping all 38 number systems with a two-TU link turned up `type_tag(DecimalEncoding)` in `dfloat/manipulators.hpp`. The other 37 were already clean.

## How the offenders were found

By symbol, not by pattern. Compile with `-g`, then `nm -C --defined-only -l` and keep the **strong (non-weak) global text symbols** — exactly the set that violates ODR — each with its source file and line. That gave 69 definition sites:

- 10 each in `edecimal_impl.hpp` and `erational_impl.hpp` (the comparison operators, `quotient`, `remainder`, `decint_divide`, `findLargestMultiple`)
- 44 across erational's mathlib (`sin`, `cos`, `exp`, `log`, `floor`, `hypot`, `erf`, …)
- `ltrim`/`rtrim` in the widely-included `string/strmanip.hpp`
- `dfloat`'s `type_tag`

`inline` was applied to those lines only — nothing added speculatively.

## Why it survived, and the fix for that

`static/appenv/multifile` is the **one** test that compiles several translation units and links them. It covered areals, bfloat16, cfloats, dbns, dd, fixpnts, integers, logs, posits, qd and unums — but **not edecimal, erational or dfloat**. Precisely the three that were broken. Every other test in the suite is single-TU and cannot see this class of defect at all.

Added `edecimals.cpp`, `erationals.cpp` and `dfloats.cpp` there; the CMake glob picks them up, taking the linked set from **12 to 15** translation units.

**The guard was checked to actually guard, not merely to pass.** Removing the `inline` from edecimal's `quotient()` again makes the multifile link fail with

```
multiple definition of `sw::universal::quotient(edecimal const&, edecimal const&)'
```

and restoring it links clean. A regression test that has never been observed to fail is not evidence of anything.

## Verification

- Two-TU link clean for **all 38** number systems
- `static/appenv/multifile` links and runs on gcc and clang (15 TUs)
- **106 pass, 0 fail** on both compilers across everything mentioning `edecimal`, `erational`, `dfloat` or `strmanip`, plus every `api.cpp`
- ASCII clean

Closes #1424.

🤖 Generated with [Claude Code](https://claude.com/claude-code)