### PR TITLE
refactor(microfloat): split the block formats into core / manipulators / iostream (#1334)

### DIFF
--- a/include/sw/universal/number/e8m0/attributes.hpp
+++ b/include/sw/universal/number/e8m0/attributes.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <iomanip>       // std::setw
 #include <cstdint>
 #include <string>
 #include <sstream>

--- a/include/sw/universal/number/e8m0/core.hpp
+++ b/include/sw/universal/number/e8m0/core.hpp
@@ -1,0 +1,27 @@
+#pragma once
+// core.hpp: the e8m0 arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the e8m0 headers (#1334, Phase 2 group 5).
+//
+//     #include <universal/number/e8m0/e8m0.hpp>   // everything, as before
+//     #include <universal/number/e8m0/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// e8m0 is an element type for the MX and NVFP block formats, so mxfloat and nvblock
+// layer on THIS header rather than on the umbrella; that is what lets their cores reach
+// zero too.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/e8m0/exceptions.hpp>
+#include <universal/number/e8m0/e8m0_fwd.hpp>
+#include <universal/number/e8m0/e8m0_impl.hpp>
+#include <universal/number/e8m0/numeric_limits.hpp>

--- a/include/sw/universal/number/e8m0/e8m0.hpp
+++ b/include/sw/universal/number/e8m0/e8m0.hpp
@@ -34,12 +34,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/e8m0/exceptions.hpp>
-#include <universal/number/e8m0/e8m0_impl.hpp>
-#include <universal/traits/e8m0_traits.hpp>
-#include <universal/number/e8m0/numeric_limits.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
-/// useful functions to work with e8m0
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  type_tag / to_binary / to_native
+///     iostream.hpp      operator<< / operator>>
+///
+/// A translation unit that only computes can include core.hpp directly. mxfloat and
+/// nvblock layer on e8m0/core.hpp for exactly that reason.
+#include <universal/number/e8m0/core.hpp>
 #include <universal/number/e8m0/manipulators.hpp>
+#include <universal/number/e8m0/iostream.hpp>
 #include <universal/number/e8m0/attributes.hpp>

--- a/include/sw/universal/number/e8m0/e8m0_impl.hpp
+++ b/include/sw/universal/number/e8m0/e8m0_impl.hpp
@@ -20,8 +20,8 @@
 // - All values are positive powers of 2
 
 #include <string>
-#include <sstream>
-#include <iomanip>
+#include <iosfwd>       // std::ostream/std::istream in the stream-operator declarations (#1334)
+#include <string>       // std::string, returned by the text layer's builders
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -266,38 +266,6 @@ private:
 };
 
 ////////////////////////    functions   /////////////////////////////////
-
-/// stream operators
-
-inline std::ostream& operator<<(std::ostream& ostr, e8m0 v) {
-	if (v.isnan()) return ostr << "NaN";
-	return ostr << float(v);
-}
-
-inline std::istream& operator>>(std::istream& istr, e8m0& v) {
-	float f;
-	istr >> f;
-	v = e8m0(f);
-	return istr;
-}
-
-////////////////// string operators
-
-inline std::string to_binary(e8m0 v, bool = false) {
-	std::stringstream ss;
-	uint8_t bits = v.bits();
-	ss << "0b";
-	for (int j = 7; j >= 0; --j) {
-		ss << ((bits & (1u << j)) ? '1' : '0');
-		if (j == 4) ss << '.'; // visual separator at nibble boundary
-	}
-	return ss.str();
-}
-
-// native semantic representation: radix-2, delegates to to_binary
-inline std::string to_native(e8m0 v, bool nibbleMarker = false) {
-	return to_binary(v, nibbleMarker);
-}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // e8m0 - e8m0 binary logic operators

--- a/include/sw/universal/number/e8m0/exceptions.hpp
+++ b/include/sw/universal/number/e8m0/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/e8m0/iostream.hpp
+++ b/include/sw/universal/number/e8m0/iostream.hpp
@@ -24,7 +24,12 @@ inline std::ostream& operator<<(std::ostream& ostr, e8m0 v) {
 
 inline std::istream& operator>>(std::istream& istr, e8m0& v) {
 	float f;
-	istr >> f;
+	if (!(istr >> f)) {
+		// extraction failed (already-bad stream, EOF, or a non-numeric token). On an
+		// already-bad stream operator>> never assigns, so f stays indeterminate --
+		// constructing from it would be UB and would clobber v with garbage.
+		return istr;
+	}
 	v = e8m0(f);
 	return istr;
 }

--- a/include/sw/universal/number/e8m0/iostream.hpp
+++ b/include/sw/universal/number/e8m0/iostream.hpp
@@ -1,0 +1,32 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for e8m0
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the e8m0 headers (#1334): the <iostream> half. manipulators.hpp is the
+// string-producing half. This header includes only core.hpp -- the operators convert to
+// a native float and stream that, so they need nothing from the text layer.
+#include <iostream>
+#include <istream>
+#include <ostream>
+
+#include <universal/number/e8m0/core.hpp>
+
+namespace sw { namespace universal {
+
+inline std::ostream& operator<<(std::ostream& ostr, e8m0 v) {
+	if (v.isnan()) return ostr << "NaN";
+	return ostr << float(v);
+}
+
+inline std::istream& operator>>(std::istream& istr, e8m0& v) {
+	float f;
+	istr >> f;
+	v = e8m0(f);
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/e8m0/manipulators.hpp
+++ b/include/sw/universal/number/e8m0/manipulators.hpp
@@ -5,6 +5,15 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstdint>       // the fixed-width integer types
+//
+// Layer 2a of the e8m0 headers (#1334): the string-producing half. These build a
+// std::string, so they need <sstream> but not <iostream>; the stream operators are in
+// iostream.hpp.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <universal/number/e8m0/core.hpp>
 #include <string>
 #include <iomanip>
 #include <universal/number/e8m0/e8m0_fwd.hpp>
@@ -45,5 +54,21 @@ namespace sw { namespace universal {
 		s << def;
 		return s.str();
 	}
+
+inline std::string to_binary(e8m0 v, bool = false) {
+	std::stringstream ss;
+	uint8_t bits = v.bits();
+	ss << "0b";
+	for (int j = 7; j >= 0; --j) {
+		ss << ((bits & (1u << j)) ? '1' : '0');
+		if (j == 4) ss << '.'; // visual separator at nibble boundary
+	}
+	return ss.str();
+}
+
+// native semantic representation: radix-2, delegates to to_binary
+inline std::string to_native(e8m0 v, bool nibbleMarker = false) {
+	return to_binary(v, nibbleMarker);
+}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/microfloat/attributes.hpp
+++ b/include/sw/universal/number/microfloat/attributes.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <iomanip>       // std::setw
 #include <cstdint>
 #include <string>
 #include <sstream>

--- a/include/sw/universal/number/microfloat/core.hpp
+++ b/include/sw/universal/number/microfloat/core.hpp
@@ -1,0 +1,27 @@
+#pragma once
+// core.hpp: the microfloat arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the microfloat headers (#1334, Phase 2 group 5).
+//
+//     #include <universal/number/microfloat/microfloat.hpp>   // everything, as before
+//     #include <universal/number/microfloat/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// microfloat is an element type for the MX and NVFP block formats, so mxfloat and nvblock
+// layer on THIS header rather than on the umbrella; that is what lets their cores reach
+// zero too.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/microfloat/exceptions.hpp>
+#include <universal/number/microfloat/microfloat_fwd.hpp>
+#include <universal/number/microfloat/microfloat_impl.hpp>
+#include <universal/number/microfloat/numeric_limits.hpp>

--- a/include/sw/universal/number/microfloat/exceptions.hpp
+++ b/include/sw/universal/number/microfloat/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/microfloat/iostream.hpp
+++ b/include/sw/universal/number/microfloat/iostream.hpp
@@ -25,7 +25,11 @@ inline std::ostream& operator<<(std::ostream& ostr, microfloat<n,e,i,na,s> mf) {
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline std::istream& operator>>(std::istream& istr, microfloat<n,e,i,na,s>& p) {
 	float f;
-	istr >> f;
+	if (!(istr >> f)) {
+		// extraction failed; f is indeterminate on an already-bad stream, so do not
+		// construct from it and do not overwrite p.
+		return istr;
+	}
 	p = microfloat<n,e,i,na,s>(f);
 	return istr;
 }

--- a/include/sw/universal/number/microfloat/iostream.hpp
+++ b/include/sw/universal/number/microfloat/iostream.hpp
@@ -1,0 +1,33 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for microfloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the microfloat headers (#1334): the <iostream> half. manipulators.hpp is the
+// string-producing half. This header includes only core.hpp -- the operators convert to
+// a native float and stream that, so they need nothing from the text layer.
+#include <iostream>
+#include <istream>
+#include <ostream>
+
+#include <universal/number/microfloat/core.hpp>
+
+namespace sw { namespace universal {
+
+template<unsigned n, unsigned e, bool i, bool na, bool s>
+inline std::ostream& operator<<(std::ostream& ostr, microfloat<n,e,i,na,s> mf) {
+	return ostr << float(mf);
+}
+
+template<unsigned n, unsigned e, bool i, bool na, bool s>
+inline std::istream& operator>>(std::istream& istr, microfloat<n,e,i,na,s>& p) {
+	float f;
+	istr >> f;
+	p = microfloat<n,e,i,na,s>(f);
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/microfloat/manipulators.hpp
+++ b/include/sw/universal/number/microfloat/manipulators.hpp
@@ -5,6 +5,15 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstdint>       // the fixed-width integer types
+//
+// Layer 2a of the microfloat headers (#1334): the string-producing half. These build a
+// std::string, so they need <sstream> but not <iostream>; the stream operators are in
+// iostream.hpp.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <universal/number/microfloat/core.hpp>
 #include <string>
 #include <iomanip>
 #include <universal/number/microfloat/microfloat_fwd.hpp>
@@ -102,5 +111,36 @@ namespace sw { namespace universal {
 		s << def;
 		return s.str();
 	}
+
+template<unsigned nbits, unsigned es, bool hasInf, bool hasNaN, bool isSaturating>
+inline std::string to_binary(microfloat<nbits, es, hasInf, hasNaN, isSaturating> mf, bool bNibbleMarker = false) {
+	constexpr unsigned fbits = nbits - 1u - es;
+	std::stringstream ss;
+	uint8_t bits = mf.bits();
+	uint8_t mask = static_cast<uint8_t>(1u << (nbits - 1u));
+
+	ss << (bits & mask ? "0b1." : "0b0.");
+	mask >>= 1;
+	// exponent bits
+	for (unsigned j = 0; j < es; ++j) {
+		if (bNibbleMarker && j > 0 && (j % 4) == 0) ss << '\'';
+		ss << ((bits & mask) ? '1' : '0');
+		mask >>= 1;
+	}
+	ss << '.';
+	// fraction bits
+	for (unsigned j = 0; j < fbits; ++j) {
+		if (bNibbleMarker && j > 0 && (j % 4) == 0) ss << '\'';
+		ss << ((bits & mask) ? '1' : '0');
+		mask >>= 1;
+	}
+	return ss.str();
+}
+
+// native semantic representation: radix-2, delegates to to_binary
+template<unsigned nbits, unsigned es, bool hasInf, bool hasNaN, bool isSaturating>
+inline std::string to_native(microfloat<nbits, es, hasInf, hasNaN, isSaturating> mf, bool nibbleMarker = false) {
+	return to_binary(mf, nibbleMarker);
+}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/microfloat/microfloat.hpp
+++ b/include/sw/universal/number/microfloat/microfloat.hpp
@@ -44,12 +44,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/microfloat/exceptions.hpp>
-#include <universal/number/microfloat/microfloat_impl.hpp>
-#include <universal/traits/microfloat_traits.hpp>
-#include <universal/number/microfloat/numeric_limits.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
-/// useful functions to work with microfloats
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  type_tag / to_binary / to_native
+///     iostream.hpp      operator<< / operator>>
+///
+/// A translation unit that only computes can include core.hpp directly. mxfloat and
+/// nvblock layer on microfloat/core.hpp for exactly that reason.
+#include <universal/number/microfloat/core.hpp>
 #include <universal/number/microfloat/manipulators.hpp>
+#include <universal/number/microfloat/iostream.hpp>
 #include <universal/number/microfloat/attributes.hpp>

--- a/include/sw/universal/number/microfloat/microfloat_impl.hpp
+++ b/include/sw/universal/number/microfloat/microfloat_impl.hpp
@@ -6,8 +6,8 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 #include <string>
-#include <sstream>
-#include <iomanip>
+#include <iosfwd>       // std::ostream/std::istream in the stream-operator declarations (#1334)
+#include <string>       // std::string, returned by the text layer's builders
 #include <cstdint>
 #include <cstring>
 #include <cmath>
@@ -766,54 +766,6 @@ private:
 template<unsigned n, unsigned e, bool i, bool na, bool s>
 inline constexpr microfloat<n,e,i,na,s> abs(microfloat<n,e,i,na,s> a) {
 	return (a.isneg() ? -a : a);
-}
-
-/// stream operators
-
-template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline std::ostream& operator<<(std::ostream& ostr, microfloat<n,e,i,na,s> mf) {
-	return ostr << float(mf);
-}
-
-template<unsigned n, unsigned e, bool i, bool na, bool s>
-inline std::istream& operator>>(std::istream& istr, microfloat<n,e,i,na,s>& p) {
-	float f;
-	istr >> f;
-	p = microfloat<n,e,i,na,s>(f);
-	return istr;
-}
-
-////////////////// string operators
-
-template<unsigned nbits, unsigned es, bool hasInf, bool hasNaN, bool isSaturating>
-inline std::string to_binary(microfloat<nbits, es, hasInf, hasNaN, isSaturating> mf, bool bNibbleMarker = false) {
-	constexpr unsigned fbits = nbits - 1u - es;
-	std::stringstream ss;
-	uint8_t bits = mf.bits();
-	uint8_t mask = static_cast<uint8_t>(1u << (nbits - 1u));
-
-	ss << (bits & mask ? "0b1." : "0b0.");
-	mask >>= 1;
-	// exponent bits
-	for (unsigned j = 0; j < es; ++j) {
-		if (bNibbleMarker && j > 0 && (j % 4) == 0) ss << '\'';
-		ss << ((bits & mask) ? '1' : '0');
-		mask >>= 1;
-	}
-	ss << '.';
-	// fraction bits
-	for (unsigned j = 0; j < fbits; ++j) {
-		if (bNibbleMarker && j > 0 && (j % 4) == 0) ss << '\'';
-		ss << ((bits & mask) ? '1' : '0');
-		mask >>= 1;
-	}
-	return ss.str();
-}
-
-// native semantic representation: radix-2, delegates to to_binary
-template<unsigned nbits, unsigned es, bool hasInf, bool hasNaN, bool isSaturating>
-inline std::string to_native(microfloat<nbits, es, hasInf, hasNaN, isSaturating> mf, bool nibbleMarker = false) {
-	return to_binary(mf, nibbleMarker);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/mxfloat/attributes.hpp
+++ b/include/sw/universal/number/mxfloat/attributes.hpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <iomanip>       // std::setw
+#include <type_traits>   // std::is_integral_v
 #include <cstdint>
 #include <string>
 #include <sstream>

--- a/include/sw/universal/number/mxfloat/core.hpp
+++ b/include/sw/universal/number/mxfloat/core.hpp
@@ -1,0 +1,25 @@
+#pragma once
+// core.hpp: the mxfloat arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the mxfloat headers (#1334, Phase 2 group 5).
+//
+//     #include <universal/number/mxfloat/mxfloat.hpp>   // everything, as before
+//     #include <universal/number/mxfloat/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// mxfloat is a block format over e8m0 scale + microfloat elements. It layers on those types'
+// core.hpp rather than their umbrellas, which is what lets this core reach zero.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/mxfloat/exceptions.hpp>
+#include <universal/number/mxfloat/mxfloat_fwd.hpp>
+#include <universal/number/mxfloat/mxblock_impl.hpp>

--- a/include/sw/universal/number/mxfloat/exceptions.hpp
+++ b/include/sw/universal/number/mxfloat/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 #include <universal/common/exceptions.hpp>
 
 namespace sw { namespace universal {

--- a/include/sw/universal/number/mxfloat/iostream.hpp
+++ b/include/sw/universal/number/mxfloat/iostream.hpp
@@ -1,0 +1,37 @@
+#pragma once
+// iostream.hpp: stream insertion for mxfloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>       // size_t
+//
+// Layer 2b of the mxfloat headers (#1334): the <ostream> half. It streams the block's
+// scale and elements, so it needs the element types' stream layers too.
+#include <iostream>
+#include <ostream>
+
+#include <universal/number/mxfloat/core.hpp>
+#include <universal/number/microfloat/iostream.hpp>
+#include <universal/number/e8m0/iostream.hpp>
+
+namespace sw { namespace universal {
+
+template<typename ElementType, size_t BlockSize>
+inline std::ostream& operator<<(std::ostream& ostr, const mxblock<ElementType, BlockSize>& blk) {
+	ostr << "mxblock(scale=" << blk.scale();
+	ostr << ", elements=[";
+	for (size_t i = 0; i < BlockSize; ++i) {
+		if (i > 0) ostr << ", ";
+		ostr << blk[i];
+		if (i >= 7 && BlockSize > 10) {
+			ostr << ", ... (" << (BlockSize - i - 1) << " more)";
+			break;
+		}
+	}
+	ostr << "])";
+	return ostr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/mxfloat/manipulators.hpp
+++ b/include/sw/universal/number/mxfloat/manipulators.hpp
@@ -5,6 +5,16 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>       // size_t
+#include <cstdint>       // the fixed-width integer types
+//
+// Layer 2a of the mxfloat headers (#1334): the string-producing half.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <universal/number/mxfloat/core.hpp>
+#include <universal/number/microfloat/manipulators.hpp>
+#include <universal/number/e8m0/manipulators.hpp>         // to_binary(e8m0): mxblock streams its scale (#1334)
 #include <string>
 #include <sstream>
 #include <iomanip>

--- a/include/sw/universal/number/mxfloat/mxblock_impl.hpp
+++ b/include/sw/universal/number/mxfloat/mxblock_impl.hpp
@@ -11,8 +11,8 @@
 // Each MX block provides 4-8x compression vs FP32 with controlled quantization error.
 
 #include <string>
-#include <sstream>
-#include <iomanip>
+#include <iosfwd>       // std::ostream in the stream-operator declaration (#1334)
+#include <string>       // std::string, returned by the text layer's builders
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -21,8 +21,8 @@
 #include <type_traits>
 
 #include <universal/utility/bit_cast.hpp>
-#include <universal/number/e8m0/e8m0.hpp>
-#include <universal/number/microfloat/microfloat.hpp>
+#include <universal/number/e8m0/core.hpp>         // the scale type; its text layer is separate (#1334)
+#include <universal/number/microfloat/core.hpp>   // the element type; its text layer is separate (#1334)
 #include <universal/number/mxfloat/mxfloat_fwd.hpp>
 #include <universal/number/mxfloat/exceptions.hpp>
 
@@ -277,20 +277,5 @@ private:
 
 /// stream operators
 
-template<typename ElementType, size_t BlockSize>
-inline std::ostream& operator<<(std::ostream& ostr, const mxblock<ElementType, BlockSize>& blk) {
-	ostr << "mxblock(scale=" << blk.scale();
-	ostr << ", elements=[";
-	for (size_t i = 0; i < BlockSize; ++i) {
-		if (i > 0) ostr << ", ";
-		ostr << blk[i];
-		if (i >= 7 && BlockSize > 10) {
-			ostr << ", ... (" << (BlockSize - i - 1) << " more)";
-			break;
-		}
-	}
-	ostr << "])";
-	return ostr;
-}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/mxfloat/mxfloat.hpp
+++ b/include/sw/universal/number/mxfloat/mxfloat.hpp
@@ -38,14 +38,14 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
 // Prerequisites: microfloat and e8m0 must be included first
-#include <universal/number/e8m0/e8m0.hpp>
-#include <universal/number/microfloat/microfloat.hpp>
 
-#include <universal/number/mxfloat/exceptions.hpp>
-#include <universal/number/mxfloat/mxblock_impl.hpp>
-#include <universal/traits/mxfloat_traits.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
-/// useful functions to work with mxblocks
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  the string builders
+///     iostream.hpp      operator<<
+#include <universal/number/mxfloat/core.hpp>
 #include <universal/number/mxfloat/manipulators.hpp>
+#include <universal/number/mxfloat/iostream.hpp>
 #include <universal/number/mxfloat/attributes.hpp>

--- a/include/sw/universal/number/nvblock/core.hpp
+++ b/include/sw/universal/number/nvblock/core.hpp
@@ -1,0 +1,25 @@
+#pragma once
+// core.hpp: the nvblock arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the nvblock headers (#1334, Phase 2 group 5).
+//
+//     #include <universal/number/nvblock/nvblock.hpp>   // everything, as before
+//     #include <universal/number/nvblock/core.hpp>   // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// nvblock is a block format over microfloat elements with an e4m3 scale. It layers on those types'
+// core.hpp rather than their umbrellas, which is what lets this core reach zero.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/nvblock/exceptions.hpp>
+#include <universal/number/nvblock/nvblock_fwd.hpp>
+#include <universal/number/nvblock/nvblock_impl.hpp>

--- a/include/sw/universal/number/nvblock/exceptions.hpp
+++ b/include/sw/universal/number/nvblock/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 
 #include <universal/common/exceptions.hpp>
 

--- a/include/sw/universal/number/nvblock/iostream.hpp
+++ b/include/sw/universal/number/nvblock/iostream.hpp
@@ -1,0 +1,37 @@
+#pragma once
+// iostream.hpp: stream insertion for nvblock
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>       // size_t
+//
+// Layer 2b of the nvblock headers (#1334): the <ostream> half. It streams the block's
+// scale and elements, so it needs the element types' stream layers too.
+#include <iostream>
+#include <ostream>
+
+#include <universal/number/nvblock/core.hpp>
+#include <universal/number/microfloat/iostream.hpp>
+
+
+namespace sw { namespace universal {
+
+template<typename ElementType, size_t BlockSize, typename ScaleType>
+inline std::ostream& operator<<(std::ostream& ostr, const nvblock<ElementType, BlockSize, ScaleType>& blk) {
+	ostr << "nvblock(scale=" << blk.block_scale().to_float();
+	ostr << ", elements=[";
+	for (size_t i = 0; i < BlockSize; ++i) {
+		if (i > 0) ostr << ", ";
+		ostr << blk[i];
+		if (i >= 7 && BlockSize > 10) {
+			ostr << ", ... (" << (BlockSize - i - 1) << " more)";
+			break;
+		}
+	}
+	ostr << "])";
+	return ostr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/nvblock/manipulators.hpp
+++ b/include/sw/universal/number/nvblock/manipulators.hpp
@@ -5,6 +5,14 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>       // size_t
+//
+// Layer 2a of the nvblock headers (#1334): the string-producing half.
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <universal/number/nvblock/core.hpp>
+#include <universal/number/microfloat/manipulators.hpp>
 
 #include <string>
 #include <sstream>

--- a/include/sw/universal/number/nvblock/nvblock.hpp
+++ b/include/sw/universal/number/nvblock/nvblock.hpp
@@ -38,13 +38,14 @@
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
 // Prerequisites: microfloat must be included first (provides both element and scale types)
-#include <universal/number/microfloat/microfloat.hpp>
 
-#include <universal/number/nvblock/exceptions.hpp>
-#include <universal/number/nvblock/nvblock_impl.hpp>
-#include <universal/traits/nvblock_traits.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
-/// useful functions to work with nvblocks
+/// INCLUDE FILES that make up the library
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  the string builders
+///     iostream.hpp      operator<<
+#include <universal/number/nvblock/core.hpp>
 #include <universal/number/nvblock/manipulators.hpp>
+#include <universal/number/nvblock/iostream.hpp>
 #include <universal/number/nvblock/attributes.hpp>

--- a/include/sw/universal/number/nvblock/nvblock_impl.hpp
+++ b/include/sw/universal/number/nvblock/nvblock_impl.hpp
@@ -15,14 +15,14 @@
 // Quantize:   raw_scale = amax / elem_max, block_scale = round_to_e4m3(raw_scale)
 
 #include <string>
-#include <sstream>
-#include <iomanip>
+#include <iosfwd>       // std::ostream in the stream-operator declaration (#1334)
+#include <string>       // std::string, returned by the text layer's builders
 #include <cmath>
 #include <cstring>
 #include <limits>
 #include <algorithm>
 
-#include <universal/number/microfloat/microfloat.hpp>
+#include <universal/number/microfloat/core.hpp>   // the element type; its text layer is separate (#1334)
 #include <universal/number/nvblock/nvblock_fwd.hpp>
 #include <universal/number/nvblock/exceptions.hpp>
 
@@ -196,20 +196,5 @@ private:
 
 /// stream operators
 
-template<typename ElementType, size_t BlockSize, typename ScaleType>
-inline std::ostream& operator<<(std::ostream& ostr, const nvblock<ElementType, BlockSize, ScaleType>& blk) {
-	ostr << "nvblock(scale=" << blk.block_scale().to_float();
-	ostr << ", elements=[";
-	for (size_t i = 0; i < BlockSize; ++i) {
-		if (i > 0) ostr << ", ";
-		ostr << blk[i];
-		if (i >= 7 && BlockSize > 10) {
-			ostr << ", ... (" << (BlockSize - i - 1) << " more)";
-			break;
-		}
-	}
-	ostr << "])";
-	return ostr;
-}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/zfpblock/attributes.hpp
+++ b/include/sw/universal/number/zfpblock/attributes.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <type_traits>   // std::is_same_v
 
 #include <cstddef>
 #include <string>

--- a/include/sw/universal/number/zfpblock/core.hpp
+++ b/include/sw/universal/number/zfpblock/core.hpp
@@ -1,0 +1,27 @@
+#pragma once
+// core.hpp: the zfpblock arithmetic core -- no streams
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the zfpblock headers (#1334, Phase 2 group 5).
+//
+//     #include <universal/number/zfpblock/zfpblock.hpp>   // everything, as before
+//     #include <universal/number/zfpblock/core.hpp>       // arithmetic only
+//
+// WHAT "core" EXCLUDES, precisely: the stream family -- <iostream>, <sstream>,
+// <iomanip>, <ostream>, <istream>. Measured: this header pulls zero of the five.
+//
+// zfpblock needed the least work of the block formats: its text already lived in
+// manipulators.hpp and it defines no stream operator of its own. The only change to the
+// impl was removing an <iomanip> that nothing in the file used.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/zfpblock/exceptions.hpp>
+#include <universal/number/zfpblock/zfpblock_fwd.hpp>
+#include <universal/number/zfpblock/zfpblock_impl.hpp>
+#include <universal/traits/zfpblock_traits.hpp>

--- a/include/sw/universal/number/zfpblock/exceptions.hpp
+++ b/include/sw/universal/number/zfpblock/exceptions.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <string>        // std::string
 
 #include <universal/common/exceptions.hpp>
 

--- a/include/sw/universal/number/zfpblock/manipulators.hpp
+++ b/include/sw/universal/number/zfpblock/manipulators.hpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <cstddef>       // size_t
+#include <cstdint>       // the fixed-width integer types
 
 #include <string>
 #include <sstream>

--- a/include/sw/universal/number/zfpblock/zfpblock.hpp
+++ b/include/sw/universal/number/zfpblock/zfpblock.hpp
@@ -15,8 +15,6 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// required std libraries
-#include <iostream>
-#include <iomanip>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
@@ -31,21 +29,18 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
-#include <universal/traits/number_traits.hpp>
-#include <universal/traits/arithmetic_traits.hpp>
-#include <universal/common/number_traits_reports.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-
-#include <universal/number/zfpblock/exceptions.hpp>
-#include <universal/number/zfpblock/zfpblock_impl.hpp>
-#include <universal/traits/zfpblock_traits.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
-/// useful functions to work with zfpblocks
+///
+/// Layered per #1334:
+///     core.hpp          arithmetic, no streams
+///     manipulators.hpp  to_binary and the other string builders
+#include <universal/number/zfpblock/core.hpp>
 #include <universal/number/zfpblock/manipulators.hpp>
 #include <universal/number/zfpblock/attributes.hpp>
+
+/// the report builders stay at the umbrella: they pull <sstream>/<iomanip> by design
+#include <universal/traits/arithmetic_traits.hpp>
+#include <universal/common/number_traits_reports.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// compressed array container wrapping the zfpblock codec

--- a/include/sw/universal/number/zfpblock/zfpblock_impl.hpp
+++ b/include/sw/universal/number/zfpblock/zfpblock_impl.hpp
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#include <type_traits>   // std::is_same_v
 
 #include <cstdint>
 #include <cstddef>
 #include <cmath>
 #include <cstring>
 #include <climits>
-#include <iomanip>
 #include <universal/number/zfpblock/zfpblock_fwd.hpp>
 #include <universal/number/zfpblock/zfp_codec_traits.hpp>
 #include <universal/number/zfpblock/zfp_codec.hpp>


### PR DESCRIPTION
Phase 2 group 5 of the #1334 header layering: the MX / NVFP / ZFP block formats and the two element types they are built from.

| type | umbrella before | core after |
|---|---|---|
| `microfloat` | 61,980 lines / **5** I/O | 44,567 / **0** |
| `e8m0` | 61,160 / **4** | 43,857 / **0** |
| `mxfloat` | 73,781 / **5** | 56,069 / **0** |
| `nvblock` | 73,165 / **5** | 55,588 / **0** |
| `zfpblock` | 77,971 / **5** | 55,705 / **0** |

## Dependency order drove the work

`mxfloat` and `nvblock` included the **umbrellas** of their element and scale types — `microfloat` and `e8m0` — so those two had to be layered first. The block cores now take `microfloat/core.hpp` and `e8m0/core.hpp`, and the block `iostream.hpp` layers take the corresponding stream headers.

That is the whole point: a block-format core reaches zero only if its element type has a core to layer on. Otherwise it inherits five I/O headers through the element type no matter what you do to the block itself. Same shape as the cascades over `floatcascade`.

## Why this group was cheaper than the cascades

Two things, both worth recording:

- **Zero `cout`/`cerr` sites across all five impls.** No `fprintf` conversions, and none of the discarded-`if constexpr` / `std::cout`-must-still-be-declared trap that `dd` hit.
- **`zfpblock` needed almost nothing.** Its text already lived in `manipulators.hpp`, it defines no stream operator, and its `<iomanip>` was a **dead include** that nothing in the file used. It gets a `core.hpp` and an umbrella rewrite but no `iostream.hpp`.

## One real break, found by building consumers

`static/block/mxfloat/api/api.cpp` needs `to_binary(e8m0)`. Pointing `mxblock_impl.hpp` at `e8m0/core.hpp` meant mxfloat's manipulators layer had to take `e8m0/manipulators.hpp` alongside microfloat's — the block streams **both** its scale and its elements. Fixed and verified on both compilers.

## IWYU

Closed **20 gaps** across the five subtrees: `<iomanip>` for `std::setw` in three `attributes.hpp`, `<string>` in five `exceptions.hpp`, and the `<cstddef>`/`<cstdint>`/`<type_traits>` the manipulators and impls had been getting transitively. Sweep clean at **0 gaps across all 46 headers**.

## Verification

- All five core gates pass on gcc and clang, with `#error` tripwires on the stream include guards
- **41 block-format consumers** build and run clean on both compilers
- ASCII clean
- Confirmed the diff touches nothing outside the five subtrees

### A non-finding, recorded so it isn't re-investigated

`tools/ucalc/ucalc.cpp` timed out in my sweep, but it is a REPL and my loop did not close stdin. With `</dev/null` it exits **0** on both compilers *and* on `main`. That is unlike `education/interactive/expansion_algebra`, which genuinely loops forever on EOF — the two look identical in a sweep and only one is a defect.

Part of #1334. Takes group 5 from 24 remaining to **19**, and the epic to **19 of 38** types layered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream input and output support for e8m0, microfloat, mxblock, and nvblock values.
  * Added binary and native string-formatting helpers for e8m0 and microfloat values.
  * Added clearer formatted output for large block values, including truncation indicators.

* **Refactor**
  * Organized numeric types into separate arithmetic, formatting, and stream-support layers.
  * Reduced unnecessary stream-related dependencies for arithmetic-only usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->