### PR TITLE
docs: changelog and session log for the header-layering rollout (#1334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,13 +145,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **`erational` and `edecimal` could not be used from two translation units ([#1424](https://github.com/stillwater-sc/universal/issues/1424) / PR [#1430](https://github.com/stillwater-sc/universal/pull/1430))** -- non-template free functions **defined** in headers without `inline`. Each including translation unit emits its own strong definition, so one TU is fine and two collide:
 
-    ```
+    ```text
     $ g++ -std=c++20 -Iinclude/sw a.cpp b.cpp     # both #include erational.hpp
     multiple definition of `sw::universal::ltrim(std::string&)'
     ... 68 in total
     ```
 
-    `erational` 68 duplicate symbols to 0, `edecimal` 12 to 0, and `dfloat` 1 to 0 -- `dfloat` is not in the issue and came from sweeping all 38 number systems with a two-TU link; the other 37 were already clean. Offenders were found **by symbol rather than by pattern**: compile with `-g`, then `nm -C --defined-only -l` filtered to the strong (non-weak) global text symbols, which is exactly the ODR-violating set. 69 definition sites, including `ltrim`/`rtrim` in the widely-included `string/strmanip.hpp` and the whole of erational's mathlib. Every test in the suite is single-TU, which is why this survived.
+    `erational` 68 duplicate symbols to 0, `edecimal` 12 to 0, and `dfloat` 1 to 0 -- `dfloat` is not in the issue and came from sweeping all 38 number systems with a two-TU link; the other 37 were already clean. Offenders were found **by symbol rather than by pattern**: compile with `-g`, then `nm -C --defined-only -l` filtered to the strong (non-weak) global text symbols, which is exactly the ODR-violating set. 69 definition sites, including `ltrim`/`rtrim` in the widely-included `string/strmanip.hpp` and the whole of erational's mathlib. No multi-translation-unit test covered these three types -- `static/appenv/multifile` is the only test in the suite that links several TUs together, and it did not include them -- which is why this survived.
 
 * **Six `table.hpp` headers were not self-contained, and 7 headers had no include guard ([#1422](https://github.com/stillwater-sc/universal/issues/1422) / PRs [#1421](https://github.com/stillwater-sc/universal/pull/1421), [#1431](https://github.com/stillwater-sc/universal/pull/1431))** -- each used its type, its `to_binary()` and its stream operator with no include that provides them, so they compiled only behind a prior include. As the first Universal header in a translation unit: `cfloat` 47 errors, `areal` 8, `lns` 8, `dbns` 7, `takum` 6, `fixpnt` 6 -- all now 0. The guards were verified to work rather than assumed: three of the seven newly guarded headers still error when included twice, but with counts *identical* to a single include (7/7, 22/22, 73/73), so the guard is doing its job and those headers are simply not self-contained, which is a separate defect and was left alone.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* **A compute kernel no longer pays for I/O: 22 of 38 number systems layered (Epic [#1334](https://github.com/stillwater-sc/universal/issues/1334) / PRs [#1416](https://github.com/stillwater-sc/universal/pull/1416)-[#1435](https://github.com/stillwater-sc/universal/pull/1435))** -- each layered type now offers a `core.hpp` that pulls **zero** of the five I/O-family headers (`<iostream>`, `<sstream>`, `<iomanip>`, `<ostream>`, `<istream>`), alongside `manipulators.hpp` (the string builders) and `iostream.hpp` (the stream operators). The umbrella `<universal/number/T/T.hpp>` is unchanged, so existing code needs no edit:
+
+    ```cpp
+    #include <universal/number/posit/posit.hpp>   // unchanged: everything
+    #include <universal/number/posit/core.hpp>    // new: arithmetic only, no I/O
+    ```
+
+    | type | core | umbrella | | type | core | umbrella |
+    |---|---:|---:|---|---|---:|---:|
+    | `integer` | 48,328 | 103,498 | | `edecimal` | 73,040 | 77,265 |
+    | `e8m0` | 43,857 | 61,144 | | `dd` | 73,665 | 85,110 |
+    | `microfloat` | 44,567 | 61,922 | | `qd` | 73,739 | 86,931 |
+    | `faithful` | 46,983 | 64,058 | | `erational` | 74,434 | 82,739 |
+    | `takum` | 49,429 | 70,706 | | `lns` | 74,762 | 89,944 |
+    | `interval` | 55,016 | 71,958 | | `td_cascade` | 75,384 | 87,240 |
+    | `nvblock` | 55,588 | 73,044 | | `qd_cascade` | 75,469 | 87,347 |
+    | `zfpblock` | 55,705 | 77,789 | | `dd_cascade` | 75,583 | 87,006 |
+    | `mxfloat` | 56,069 | 73,614 | | `posit` | 77,430 | 114,007 |
+    | `rational` | 59,633 | 78,042 | | `fixpnt` | 78,123 | 108,901 |
+    | `quire` | 72,139 | 81,368 | | `cfloat` | 78,330 | 114,629 |
+
+    **The cost was almost never in the type being split.** Four shared headers were the binding constraint, and each paid out across many types at once. `native/manipulators_core.hpp` is new: `sign()`, `scale()`, `fraction()` and the field accessors are mask-and-shift on the IEEE encoding but shared a header with `to_triple()`/`to_hex()`/`color_print()`, so **seven** number systems were dragging four stream headers in to reach `scale()`. `numerics/error_free_ops.hpp` included `<iomanip>`, `<string>` and `<sstream>` and used **none of them** -- 532 lines of error-free-transformation arithmetic billed to `dd`, `qd`, all three cascades, `ereal` and `elreal` (59,835 lines / 4 I/O to 25,240 / 0). `internal/blockdigit` and `internal/floatcascade` both defined `operator<<` as an *in-class friend definition*, which pins `<iostream>` into every consumer; both are now declarations with the definition out-of-line. And `mxfloat`/`nvblock` included the *umbrellas* of their element types, so `microfloat` and `e8m0` had to be layered first.
+
+    Two contract decisions are worth knowing when reading the headers. **`to_string()` and `parse()` stay in the core**: `parse()` backs `assign(const std::string&)`, and `to_string()` concatenates a `std::string` without ever opening a stream -- it only *takes* `std::streamsize`, which is what `<ios>` is for. And for `dd`/`qd`/the cascades the dependency runs **manipulators -> iostream**, the opposite of `fixpnt`, because their builders format values through `operator<<`; `iostream.hpp` therefore includes only `core.hpp`, since including `manipulators.hpp` back makes a cycle that `#pragma once` merely masks.
+
+* **A link-time regression guard for header-defined functions ([#1424](https://github.com/stillwater-sc/universal/issues/1424) / PR [#1430](https://github.com/stillwater-sc/universal/pull/1430))** -- `static/appenv/multifile` is the only test that compiles several translation units and links them, and it covered eleven types but not `edecimal`, `erational` or `dfloat` -- precisely the three that turned out to be broken. Adding them takes the linked set from 12 to 15 TUs. The guard was checked to actually guard rather than merely pass: removing one `inline` again makes the link fail with `multiple definition of quotient(edecimal const&, edecimal const&)`, and restoring it links clean.
+
 * **`elreal` refines without a host ceiling, on every host ([#1051](https://github.com/stillwater-sc/universal/issues/1051), [#1363](https://github.com/stillwater-sc/universal/issues/1363) / PRs [#1361](https://github.com/stillwater-sc/universal/pull/1361), [#1362](https://github.com/stillwater-sc/universal/pull/1362), [#1366](https://github.com/stillwater-sc/universal/pull/1366))** -- every host was capped by its *exponent range*, not by its precision: `float` stopped at 37 decimal digits, `bfloat16` at 33, `half` at 20, and `double` at 307 -- which is `1022 * log10(2)`, its own subnormal wall. All four now grow linearly with depth and stop only where the caller stops pulling. The fix is one rule applied at every error-free transform: **normalise the OPERANDS, not the results**. An EFT run at the operands' natural scale has already lost bits to the subnormal range by the time it returns, and normalising its outputs cannot put them back; `block::normalise()` rescales `v` into `[1,2)` and folds the scale it was carrying into the wide `integer<256>` exponent added in [#1061](https://github.com/stillwater-sc/universal/issues/1061), exactly, leaving the value invariant. The three `min_exponent + 2k` refinement floors are gone with it.
 
   | host | k | before | after | blocks | digits/block |
@@ -115,6 +142,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **cfloat integer conversion test suite** -- `VerifyInteger2CfloatConversion` and `VerifyCfloat2IntegerConversion` in `cfloat_test_suite.hpp` with exhaustive coverage for 8/10/12/16-bit cfloats ([#684](https://github.com/stillwater-sc/universal/issues/684), [#685](https://github.com/stillwater-sc/universal/pull/685))
 
 ### Fixed
+
+* **`erational` and `edecimal` could not be used from two translation units ([#1424](https://github.com/stillwater-sc/universal/issues/1424) / PR [#1430](https://github.com/stillwater-sc/universal/pull/1430))** -- non-template free functions **defined** in headers without `inline`. Each including translation unit emits its own strong definition, so one TU is fine and two collide:
+
+    ```
+    $ g++ -std=c++20 -Iinclude/sw a.cpp b.cpp     # both #include erational.hpp
+    multiple definition of `sw::universal::ltrim(std::string&)'
+    ... 68 in total
+    ```
+
+    `erational` 68 duplicate symbols to 0, `edecimal` 12 to 0, and `dfloat` 1 to 0 -- `dfloat` is not in the issue and came from sweeping all 38 number systems with a two-TU link; the other 37 were already clean. Offenders were found **by symbol rather than by pattern**: compile with `-g`, then `nm -C --defined-only -l` filtered to the strong (non-weak) global text symbols, which is exactly the ODR-violating set. 69 definition sites, including `ltrim`/`rtrim` in the widely-included `string/strmanip.hpp` and the whole of erational's mathlib. Every test in the suite is single-TU, which is why this survived.
+
+* **Six `table.hpp` headers were not self-contained, and 7 headers had no include guard ([#1422](https://github.com/stillwater-sc/universal/issues/1422) / PRs [#1421](https://github.com/stillwater-sc/universal/pull/1421), [#1431](https://github.com/stillwater-sc/universal/pull/1431))** -- each used its type, its `to_binary()` and its stream operator with no include that provides them, so they compiled only behind a prior include. As the first Universal header in a translation unit: `cfloat` 47 errors, `areal` 8, `lns` 8, `dbns` 7, `takum` 6, `fixpnt` 6 -- all now 0. The guards were verified to work rather than assumed: three of the seven newly guarded headers still error when included twice, but with counts *identical* to a single include (7/7, 22/22, 73/73), so the guard is doing its job and those headers are simply not self-contained, which is a separate defect and was left alone.
+
+* **`color_print` recursed until the stack died, on `qd`, `td_cascade` and `qd_cascade` (PRs [#1427](https://github.com/stillwater-sc/universal/pull/1427), [#1429](https://github.com/stillwater-sc/universal/pull/1429))** -- `color_print(const qd&)` formats each limb with `color_print(r[i])` on a `double`, whose intended target is the **non-template** `color_print(double)` in `native/ieee754_double.hpp`. Re-pointing the impls at `ieee754_core.hpp`, which deliberately omits it, removed that overload; the `double` converted implicitly back to `qd` and the function called itself. Linux CI caught it as a SegFault in 1 of 894 tests on both gcc and clang. Worth recording that the *obvious* fix is wrong: binding `color_print<double>` explicitly stops the recursion but selects a different function -- the `color_print<Real>` template -- which prints `0011111111111000...` where the non-template prints `0b0.0111'1111'1111.1000'...`, trading a crash for a silent output change that no test asserts on. The fix is the include, not the call site.
+
+* **`sqrt(edecimal)` reported a negative argument on every call (PR [#1423](https://github.com/stillwater-sc/universal/pull/1423))** -- the `#else` of the `EDECIMAL_THROW_ARITHMETIC_EXCEPTION` guard sat outside the sign test, so `sqrt(edecimal(144))` returned 12 and still wrote `decimal_negative_sqrt_arg` to stderr. The report is now inside `if (f.isneg())`, and the non-throwing path returns zero rather than building from `std::sqrt(-x)`.
+
+* **`operator>>` assigned from an indeterminate value on `e8m0` and `microfloat` (PR [#1433](https://github.com/stillwater-sc/universal/pull/1433))** -- both did `istr >> f; v = e8m0(f);` unconditionally. On an already-bad stream `operator>>` never reaches the conversion, so `f` stays indeterminate: constructing from it is undefined behaviour and clobbers the destination. Both now return early without touching it, matching the idiom `edecimal`, `erational`, `dd` and `qd` already use.
+
+* **`dd/manipulators.hpp` and `qd/manipulators.hpp` had no `#pragma once` (PRs [#1426](https://github.com/stillwater-sc/universal/pull/1426), [#1427](https://github.com/stillwater-sc/universal/pull/1427))** -- which surfaced not as a double-include problem but as *redefinition* errors for `type_tag`, `to_pair`, `to_triple` and `to_binary` the moment `attributes.hpp` needed the header alongside the umbrella.
 
 * **elreal's division was capped three independent ways** -- each cap looked like the type's limit until the one beneath it was removed:
   - **A host-derived depth constant** ([#1371](https://github.com/stillwater-sc/universal/issues/1371) / PR [#1374](https://github.com/stillwater-sc/universal/pull/1374)) -- `div_online`'s dense path pinned its Newton reciprocal to `(-min_exponent - 2*k) / k`, so every division by a multi-block value stopped at 17 blocks (~271 digits) on `double` and 3 (~22 digits) on `float`, however deep the caller pulled. Same mistaken premise the ceiling work removed elsewhere; this one survived the sweep because it is a target *depth* rather than a guard. `div_online` now takes the depth as a parameter, `operator/=` passes `precision()` plus a guard, and the Payne-Hanek reduction passes the `reddepth` it had already computed and then ignored.

--- a/docs/sessions/2026-08-28_header_layering_rollout_and_the_bugs_it_found.md
+++ b/docs/sessions/2026-08-28_header_layering_rollout_and_the_bugs_it_found.md
@@ -80,7 +80,7 @@ target is the **non-template** `color_print(double)` in `native/ieee754_double.h
 the recursion but selects a *different function* -- the `color_print<Real>` template -- which prints
 a different format:
 
-```
+```text
 color_print(d)          0b0.0111'1111'1111.1000'...     <- non-template, ieee754_double.hpp
 color_print<double>(d)  0011111111111000...             <- template, native/manipulators.hpp
 ```
@@ -102,7 +102,7 @@ it had been killed and never flushed its log.
 
 `erational` and `edecimal` could not be used from **two translation units**:
 
-```
+```text
 $ g++ -std=c++20 -Iinclude/sw a.cpp b.cpp     # both #include erational.hpp
 multiple definition of `sw::universal::ltrim(std::string&)'
 ... 68 in total
@@ -129,7 +129,9 @@ A regression test nobody has watched fail proves nothing.
 ### 4. Headers that only worked behind a prior include (#1422)
 
 Every `number/*/table.hpp` used its type, its `to_binary()` and its stream operator with no include
-that provides them: cfloat 47 errors as the sole include, areal 8, lns 8, dbns 7, takum 6, all to 0.
+that provides them. As the sole Universal include: cfloat 47 errors, areal 8, lns 8, dbns 7,
+takum 6 and fixpnt 6 -- six headers, all now 0. fixpnt's was fixed in #1421 when that type was
+split; the other five in #1431.
 Seven headers tree-wide had no include guard at all, now 0. The guards were verified to *work* --
 three of the seven still error when double-included, but with counts identical to a single include
 (7/7, 22/22, 73/73), so they are guarded and merely not self-contained, which is a different defect

--- a/docs/sessions/2026-08-28_header_layering_rollout_and_the_bugs_it_found.md
+++ b/docs/sessions/2026-08-28_header_layering_rollout_and_the_bugs_it_found.md
@@ -1,0 +1,209 @@
+# Development Session: Header Layering Rollout, and the Bugs It Found
+
+**Date:** 2026-08-27 (into 2026-08-28)
+**Branches:** per-issue branches off `main`, all merged: PRs #1416, #1417, #1418, #1419, #1420, #1421, #1423, #1425, #1426, #1427, #1429, #1430, #1431, #1432, #1433, #1435, #1437.
+**Focus:** Roll #1334's core/manipulators/iostream layering across the number systems, and fix what the rollout exposed.
+**Status:** Epic #1334 at **22 of 38 types layered**; issues #1422 and #1424 closed; #1434 and #1436 filed.
+
+## Session Overview
+
+Epic #1334 gives each number system a `core.hpp` that pulls **zero** of the five I/O-family
+headers (`<iostream>`, `<sstream>`, `<iomanip>`, `<ostream>`, `<istream>`), so a compute kernel
+does not pay for text formatting it never calls. The session took the rollout from 8 types to 22
+and completed Phase 2 groups 1-4 plus most of group 5.
+
+The layering itself was mechanical. What made the session worth writing down is that **the cost
+was almost never in the type being split** -- it was in a shared header underneath it -- and that
+each group surfaced a class of defect that had nothing to do with layering and that the existing
+test suite structurally could not see.
+
+| Group | Types | The thing underneath it |
+|---|---|---|
+| cfloat | `cfloat` | -- |
+| logarithmic | `lns`, `takum`, `takum_log` | -- |
+| static + elastic | `fixpnt`, `edecimal`, `rational`, `erational` | `native/manipulators_core.hpp`, `blockdigit` |
+| multi-component | `dd`, `qd`, 3 cascades | `numerics/error_free_ops.hpp`, `floatcascade` |
+| block formats | `microfloat`, `e8m0`, `mxfloat`, `nvblock`, `zfpblock` | element types must be layered first |
+| wrappers | `quire`, `interval`, `faithful` | substrates already clean from Phase N |
+
+## The rule: split the substrate before the type
+
+A type's core cannot reach zero while it includes another type's *umbrella*. Four shared headers
+were the binding constraint, and each one paid out across many types at once:
+
+- **`native/manipulators_core.hpp`** (new). `sign()`, `scale()`, `exponent()`, `fraction()` and the
+  `fieldBits()` accessors are mask-and-shift on the IEEE encoding, but they shared a header with
+  `to_triple()`, `to_hex()` and `color_print()`, which pull four stream headers. `scale()` is called
+  from `rational`, `dd`, `qd`, `ereal`, `efloat`, `faithful` and `floatcascade` -- **seven** number
+  systems dragging four stream headers in to reach a function that does nothing but mask and shift.
+  Same split as `ieee754_core.hpp` out of `ieee754.hpp`. 25,964 lines, 0 I/O.
+- **`numerics/error_free_ops.hpp`** included `<iomanip>`, `<string>` and `<sstream>` and used **none
+  of them** -- 532 lines of pure error-free-transformation arithmetic carrying three stream headers,
+  billed to `dd`, `qd`, all three cascades, `ereal` and `elreal`. 59,835 lines / 4 I/O to 25,240 / 0.
+- **`internal/blockdigit`** and **`internal/floatcascade`** both defined `operator<<` as an
+  **in-class friend definition**, which pins `<iostream>` into every consumer. Made a declaration
+  (`<iosfwd>` suffices) with the definition out-of-line in a new `iostream.hpp`. blockdigit backs
+  blockoctal/blockdecimal/blockhexadecimal/positional/rational; floatcascade backs all three cascades.
+- **Element types before block formats.** `mxfloat` and `nvblock` included the *umbrellas* of
+  `microfloat` and `e8m0`. Their cores now take `microfloat/core.hpp` and `e8m0/core.hpp`.
+
+## The layer contract, as it settled
+
+**`to_string()` and `parse()` stay in the CORE.** This was the main judgement call, made when `dd`
+became the first type whose text layer was *member* functions. `parse()` is what
+`assign(const std::string&)` calls, so it is arithmetic surface. `to_string()` concatenates a
+`std::string` directly -- it never opens a stream; it only *takes* `std::streamsize` and
+`std::ios_base` flags, which is what `<ios>` is for. Only free stream operators and `sstream`-based
+builders move out.
+
+**For `dd`/`qd`/cascades the dependency runs `manipulators -> iostream`,** the opposite of `fixpnt`,
+because their string builders format values *through* `operator<<`. `iostream.hpp` must therefore
+include **only** `core.hpp`; including `manipulators.hpp` back makes a cycle that `#pragma once`
+merely masks, leaving visibility dependent on include order (caught by review on #1427).
+
+**`<string>`, `<map>` and `<cstdio>` are in-scope for a core** and `<iostream>` is not. `<cstdio>`
+backs `fprintf(stderr, ...)`, the Phase 0 idiom adopted so diagnostics need no stream header.
+
+## Four bug classes the rollout exposed
+
+None are layering bugs. All were pre-existing; the split made them visible.
+
+### 1. `color_print` infinite recursion -- a SegFault in CI
+
+`color_print(const qd&)` formats each limb with `color_print(r[i])` on a `double`. The intended
+target is the **non-template** `color_print(double)` in `native/ieee754_double.hpp`, which
+`ieee754_core.hpp` deliberately omits. Re-pointing the impl removed it from the overload set, the
+`double` converted implicitly back to `qd`, and the function called itself until the stack died --
+1 test of 894, on both gcc and clang.
+
+**The first fix was wrong and is the lesson.** Binding `color_print<double>(r[i])` explicitly stops
+the recursion but selects a *different function* -- the `color_print<Real>` template -- which prints
+a different format:
+
+```
+color_print(d)          0b0.0111'1111'1111.1000'...     <- non-template, ieee754_double.hpp
+color_print<double>(d)  0011111111111000...             <- template, native/manipulators.hpp
+```
+
+That would have traded a crash for a silent output change, and no test asserts on `color_print`'s
+text. The correct fix is the *include*, not the call site. Affected `qd`, `td_cascade`,
+`qd_cascade`; `dd` and `dd_cascade` were safe because they already wrote `color_print<double>`
+before the split.
+
+### 2. Moving an `operator<<` produces link errors, not compile errors
+
+Three separate times -- `positional_impl.hpp`, the blockdigit api test, and three floatcascade
+consumers -- moving a stream operator out of a header produced `undefined reference` in exactly the
+translation units that stream the type. `-fsyntax-only` cannot see this; it needs a build-and-link
+pass over every consumer. The third occurrence reached CI because the sweep that would have caught
+it had been killed and never flushed its log.
+
+### 3. ODR: header-defined free functions without `inline` (#1424)
+
+`erational` and `edecimal` could not be used from **two translation units**:
+
+```
+$ g++ -std=c++20 -Iinclude/sw a.cpp b.cpp     # both #include erational.hpp
+multiple definition of `sw::universal::ltrim(std::string&)'
+... 68 in total
+```
+
+| type | duplicate symbols |
+|---|---:|
+| `erational` | 68 -> 0 |
+| `edecimal` | 12 -> 0 |
+| `dfloat` | 1 -> 0 |
+
+`dfloat` is not in the issue -- it came from sweeping all 38 number systems with a two-TU link.
+Offenders were located **by symbol, not by pattern**: compile with `-g`, then
+`nm -C --defined-only -l` filtered to the strong (non-weak) global text symbols, which *is* the
+ODR-violating set. 69 definition sites; `inline` applied to those lines only.
+
+**Why it survived is the important half.** `static/appenv/multifile` is the one test that compiles
+several TUs and links them, and it covered eleven types -- but not `edecimal`, `erational` or
+`dfloat`. Precisely the three that were broken. Adding them takes the linked set from 12 to 15 TUs.
+The guard was then checked to actually guard: removing one `inline` again makes the link fail with
+`multiple definition of quotient(edecimal const&, edecimal const&)`, and restoring it links clean.
+A regression test nobody has watched fail proves nothing.
+
+### 4. Headers that only worked behind a prior include (#1422)
+
+Every `number/*/table.hpp` used its type, its `to_binary()` and its stream operator with no include
+that provides them: cfloat 47 errors as the sole include, areal 8, lns 8, dbns 7, takum 6, all to 0.
+Seven headers tree-wide had no include guard at all, now 0. The guards were verified to *work* --
+three of the seven still error when double-included, but with counts identical to a single include
+(7/7, 22/22, 73/73), so they are guarded and merely not self-contained, which is a different defect
+and was left alone.
+
+## Final state
+
+Twenty-two types, every core measured at **0 of 5** I/O-family headers:
+
+| type | core | umbrella | | type | core | umbrella |
+|---|---:|---:|---|---|---:|---:|
+| `integer` | 48,328 | 103,498 | | `qd` | 73,739 | 86,931 |
+| `e8m0` | 43,857 | 61,144 | | `edecimal` | 73,040 | 77,265 |
+| `microfloat` | 44,567 | 61,922 | | `dd` | 73,665 | 85,110 |
+| `faithful` | 46,983 | 64,058 | | `erational` | 74,434 | 82,739 |
+| `takum` | 49,429 | 70,706 | | `lns` | 74,762 | 89,944 |
+| `interval` | 55,016 | 71,958 | | `td_cascade` | 75,384 | 87,240 |
+| `nvblock` | 55,588 | 73,044 | | `qd_cascade` | 75,469 | 87,347 |
+| `zfpblock` | 55,705 | 77,789 | | `dd_cascade` | 75,583 | 87,006 |
+| `mxfloat` | 56,069 | 73,614 | | `posit` | 77,430 | 114,007 |
+| `rational` | 59,633 | 78,042 | | `fixpnt` | 78,123 | 108,901 |
+| `quire` | 72,139 | 81,368 | | `cfloat` | 78,330 | 114,629 |
+
+Substrates, all 0 I/O: `native/manipulators_core` 25,964 -- `numerics/error_free_ops` 25,240 --
+`native/ieee754_core` 43,486 -- `internal/blockdigit` 45,062 -- `internal/floatcascade` 66,388.
+
+## Filed, deliberately not fixed
+
+Both are real and both change behaviour or span merged subtrees, so neither belongs inside a
+layering refactor:
+
+- **#1434** -- `to_binary(e8m0)` ignores its `nibbleMarker` parameter: `to_binary(v,false)` and
+  `to_binary(v,true)` are byte-identical, and `mxfloat`/`nvblock` both forward a flag that is
+  dropped. Not a one-liner: the convention in the same subtree is that `.` is the *field* separator
+  (unconditional) and `'` is the *nibble* marker, so honouring the flag means choosing both whether
+  to emit and which character -- either answer changes default output.
+- **#1436** -- seven merged cores (`edecimal`, `fixpnt`, `posit`, `takum`, `rational`, `erational`,
+  `qd`) do not define their own `*_THROW_ARITHMETIC_EXCEPTION`. Nothing is broken: `#if` on an
+  undefined identifier evaluates to 0, the intended default, and `-Wundef` is not in the project's
+  flags. The costs are a `-Wundef` diagnostic and the core's configuration depending on an include
+  the epic tells callers they do not need. `quire`'s fix in #1435 is the pattern to copy.
+
+## Process notes worth keeping
+
+**Three generated artifacts were committed by accident** -- an empty `all.tsv` (caught before push),
+three table dumps that reached `main` (#1432), and two mandelbrot `.ppm` images that reached `main`
+in #1435 (#1437). All three came from running tests in the repo root so `git add -A` swept the
+output. `.gitignore` is the backstop; the fix is running tests from a scratch directory.
+
+**Cascade files leaked into #1427.** `git stash push -- <paths>` stashes only *modified* files; the
+new untracked cascade headers followed the branch switch and `git add -A` took them. CI passed
+because nothing included them -- it was findable only by reading the merge's file list. Checking
+that a diff is confined to its subtree is now routine.
+
+**A stacked PR dies when its base branch is deleted.** #1428 was based on the qd branch to get
+concurrent CI; merging #1427 with `--delete-branch` closed it, and GitHub will not reopen a PR whose
+base is gone. Reopened as #1429 against `main`.
+
+**Sweep hygiene**, all learned the hard way: run every test binary as `timeout N <bin> </dev/null`
+(without `</dev/null` a REPL waits forever -- `tools/ucalc` exits 0 with stdin closed and is *not* a
+bug; without `timeout`, `education/interactive/expansion_algebra` hangs the whole sweep and *is* a
+real pre-existing defect, and the two are indistinguishable unless you do both); the Bash tool caps
+at 600 s so longer sweeps must run in the background *and be waited for* before pushing; run one
+sweep at a time, since a stale one tests stale code and misleads; never `pkill -f` a pattern that
+appears in your own command line, which was every mysterious `exit 144`.
+
+**Always re-verify after a rebase.** Mid-rebase measurements are garbage -- `dd/core.hpp` briefly
+measured 6 lines. And rebasing a branch whose commits are already squashed into `main` conflicts;
+cherry-picking just the new commits is the way through.
+
+## Next
+
+16 types remain in group 5. Largest: `elreal` 143k, `efloat` 107k, `ereal` 105k, `einteger` 94k,
+`bfloat16` 93k. `convert` is already at 0 I/O and needs only confirmation.
+
+Before starting the elastic reals: a long-lived local stash `feat/issue-928-elreal-mccleeary` holds
+WIP on `ereal_impl.hpp` and will conflict.


### PR DESCRIPTION
Wrap-up for the 2026-08-27/28 session.

**CHANGELOG.md** — entries added to the existing `Unreleased` → `Added` and `Unreleased` → `Fixed` sections (not new headings, so the surrounding elreal/cascade entries keep their place):

*Added* — the layering itself, with the measured core/umbrella table for all 22 types, and the link-time regression guard from #1424.

*Fixed* — the five defects the rollout exposed: the ODR violations, the non-self-contained `table.hpp` headers, the `color_print` recursion, `sqrt(edecimal)` reporting on every call, `operator>>` assigning from an indeterminate value, and the two missing `#pragma once`.

**`docs/sessions/2026-08-28_header_layering_rollout_and_the_bugs_it_found.md`** — the longer form, following the house style of the recent session docs.

All measurements were **re-taken on `main` after the final merge**, not copied forward from the individual PRs.

### What the write-up leads with

That the cost was almost never in the type being split. Four shared headers were the binding constraint and each paid out across many types at once:

- `native/manipulators_core.hpp` — `scale()` is mask-and-shift but shared a header with `to_triple`/`to_hex`/`color_print`, so **seven** number systems pulled four stream headers to reach it
- `numerics/error_free_ops.hpp` — included `<iomanip>`, `<string>`, `<sstream>` and used **none**; billed to dd, qd, three cascades, ereal, elreal
- `blockdigit` and `floatcascade` — in-class friend `operator<<` *definitions* pinning `<iostream>` into every consumer

And the four defect classes it exposed, none of them layering bugs, all invisible to the existing suite: the `color_print` recursion that SegFaulted CI (and whose obvious fix silently changes output), `operator<<` moves producing link errors `-fsyntax-only` cannot see, 81 ODR symbols invisible to a single-TU suite, and headers that only ever worked behind a prior include.

Docs only — no source or header is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the unreleased changelog’s multi-translation-unit test coverage and labeled the ODR regression example for readability.
  - Added a development-session record covering header-layering progress across 22 number-system types.
  - Documented issues uncovered during the rollout, including formatting recursion, missing stream definitions, duplicate definitions, and incomplete standalone table headers.
  - Recorded deferred follow-up work, process findings, and remaining rollout considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->