### PR TITLE
refactor(bfloat16): split bfloat16 into core / manipulators / iostream (#1334)

### DIFF
--- a/include/sw/universal/number/bfloat16/attributes.hpp
+++ b/include/sw/universal/number/bfloat16/attributes.hpp
@@ -5,9 +5,18 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-#include <cstdint>  
+//
+// Part of the text layer (#1334): sign(), scale() and significant() are pure
+// bit inspection, but bfloat_range() streams bfloat16 values through a
+// stringstream, so this header sits above iostream.hpp and is not included by
+// core.hpp. Self-contained: <iomanip> for std::setw was used but never named.
+#include <cstdint>
 #include <string>
 #include <sstream>
+#include <iomanip>   // std::setw
+#include <universal/number/bfloat16/core.hpp>
+#include <universal/number/bfloat16/manipulators.hpp>   // type_tag
+#include <universal/number/bfloat16/iostream.hpp>       // operator<< on bfloat16, used by bfloat_range
 
 namespace sw { namespace universal {  
 

--- a/include/sw/universal/number/bfloat16/bfloat16.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16.hpp
@@ -20,21 +20,11 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable/disable the ability to use literals in binary logic and arithmetic operators
-#if !defined(BFLOAT_ENABLE_LITERALS)
-// default is to enable them
-#define BFLOAT_ENABLE_LITERALS 1
-#endif
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable throwing specific exceptions for integer arithmetic errors
-// left to application to enable
-#if !defined(BFLOAT_THROW_ARITHMETIC_EXCEPTION)
-// default is to use std::cerr for signalling an error
-#define BFLOAT_THROW_ARITHMETIC_EXCEPTION 0
-#endif
+///
+/// BFLOAT_ENABLE_LITERALS and BFLOAT_THROW_ARITHMETIC_EXCEPTION now default in
+/// bfloat16_impl.hpp, beside the code they govern, so that a translation unit which
+/// includes core.hpp directly gets the same defaults this umbrella used to supply
+/// (#1334, #1436). Defining either before this header still wins, as before.
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
@@ -44,14 +34,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/bfloat16/exceptions.hpp>
-#include <universal/number/bfloat16/bfloat16_impl.hpp>
-#include <universal/traits/bfloat16_traits.hpp>
-#include <universal/number/bfloat16/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
+#include <universal/number/bfloat16/core.hpp>
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// useful functions to work with bfloats
+// layer 2a: the string producers -- parse, to_binary, to_hex, to_triple, color_print
 #include <universal/number/bfloat16/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/bfloat16/iostream.hpp>
 #include <universal/number/bfloat16/attributes.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
+++ b/include/sw/universal/number/bfloat16/bfloat16_impl.hpp
@@ -5,13 +5,22 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-#include <cctype>
+
+// Behavioural switches default HERE, beside the code they govern, rather than in the
+// bfloat16.hpp umbrella: including core.hpp directly would otherwise leave them
+// undefined, #if would evaluate them as 0, and the switch would silently flip on that
+// path -- the trap #1390 hit with POSIT_ENABLE_LITERALS (#1334, #1436).
+#if !defined(BFLOAT_ENABLE_LITERALS)
+#define BFLOAT_ENABLE_LITERALS 1
+#endif
+#if !defined(BFLOAT_THROW_ARITHMETIC_EXCEPTION)
+#define BFLOAT_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+
+#include <cmath>         // std::floor, used by isinteger()
 #include <cstdint>
+#include <cstdio>        // fprintf(stderr,...) for the diagnostics; keeps <iostream> out of the core
 #include <string>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
-#include <regex>
 
 #include <universal/utility/bit_cast.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
@@ -24,8 +33,6 @@ namespace sw { namespace universal {
 
 	// forward reference
 	inline bfloat16 abs(bfloat16);
-	inline bfloat16 sqrt(bfloat16);
-	inline bfloat16 floor(bfloat16);
 
 // bfloat16 is Google's Brain Float type
 class bfloat16 {
@@ -325,27 +332,27 @@ public:
 						// consume this delimiting character
 						break;
 					default:
-						std::cerr << "string contained a non-standard character: " << c << '\n';
+						std::fprintf(stderr, "string contained a non-standard character: %c\n", c);
 						return *this;
 					}
 				}
 			}
 			else {
-				std::cerr << "string must start with 0b: instead input pattern was " << str << '\n';
+				std::fprintf(stderr, "string must start with 0b: instead input pattern was %s\n", str.c_str());
 				return *this;
 			}
 		}
 		else {
-			std::cerr << "string is too short\n";
+			std::fprintf(stderr, "string is too short\n");
 			return *this;
 		}
 
 		if (nrBits != nbits) {
-			std::cerr << "number of bits in the string is " << nrBits << " and needs to be " << nbits << '\n';
+			std::fprintf(stderr, "number of bits in the string is %u and needs to be %u\n", nrBits, static_cast<unsigned>(nbits));
 			return *this;
 		}
 		if (nrDots != 2) {
-			std::cerr << "number of segment delimiters in string is " << nrDots << " and needs to be 2 for a cfloat<>\n";
+			std::fprintf(stderr, "number of segment delimiters in string is %u and needs to be 2 for a cfloat<>\n", nrDots);
 			return *this;
 		}
 
@@ -359,7 +366,7 @@ public:
 				++field;
 				if (field == 2) { // just finished parsing exponent field: we can now check the number of exponent bits
 					if (nrExponentBits != es) {
-						std::cerr << "provided binary string representation does not contain " << es << " exponent bits. Found " << nrExponentBits << ". Reset to 0\n";
+						std::fprintf(stderr, "provided binary string representation does not contain %u exponent bits. Found %d. Reset to 0\n", static_cast<unsigned>(es), nrExponentBits);
 						clear();
 						return *this;
 					}
@@ -373,7 +380,7 @@ public:
 			}
 		}
 		if (field != 2) {
-			std::cerr << "provided binary string did not contain three fields separated by '.': Reset to 0\n";
+			std::fprintf(stderr, "provided binary string did not contain three fields separated by '.': Reset to 0\n");
 			clear();
 			return *this;
 		}
@@ -385,10 +392,14 @@ public:
 	constexpr bool isone()     const noexcept { return (_bits == 0x3F80u); }
 	constexpr bool isodd()     const noexcept { return (_bits & 0x0001u); }
 	constexpr bool iseven()    const noexcept { return !isodd(); }
-	// not constexpr because of floor()
+	// not constexpr because of std::floor()
 	bool isinteger() const noexcept {
 		if (isnan() || isinf()) return false;
-		return (floor(*this) == *this);
+		// this is sw::universal::floor(bfloat16) inlined -- that overload is
+		// bfloat16(std::floor(float(x))) and lives in mathlib, which the core does not
+		// include (#1334). bfloat16 -> float is exact, so the two agree bit for bit.
+		float f = float(*this);
+		return std::floor(f) == f;
 	}
 	constexpr bool ispos()     const noexcept { return !isneg(); }
 	constexpr bool isneg()     const noexcept { return (_bits & 0x8000u); }
@@ -487,93 +498,10 @@ inline bfloat16 abs(bfloat16 a) {
 }
 
 
-/// stream operators
-
-// parse a bfloat16 ASCII format and make a binary bfloat16 out of it
-inline bool parse(const std::string& number, bfloat16& value) {
-	// Detect nan / inf / infinity tokens (case-insensitive, optional sign).
-	{
-		std::string t;
-		t.reserve(number.size());
-		for (char c : number) {
-			t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
-		}
-		bool negative = !t.empty() && t.front() == '-';
-		std::string body = t;
-		if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
-		if (body == "nan") {
-			value.setnan(NAN_TYPE_QUIET);
-			return true;
-		}
-		if (body == "inf" || body == "infinity") {
-			value.setinf(negative);
-			return true;
-		}
-	}
-	// Decimal floating-point: bfloat16 has only 7 explicit mantissa bits,
-	// so std::istringstream's double extraction is more than enough
-	// precision -- the value gets immediately rounded into the bfloat16
-	// encoding via convert_ieee754.
-	std::istringstream ss(number);
-	double d;
-	ss >> d;
-	if (ss.fail()) return false;
-	ss >> std::ws;
-	if (!ss.eof()) return false;
-	value = d;
-	return true;
-}
-
-// generate an bfloat16 format ASCII format
-inline std::ostream& operator<<(std::ostream& ostr, bfloat16 bf) {
-	return ostr << float(bf);
-}
-
-// read an ASCII bfloat16 format
-inline std::istream& operator>>(std::istream& istr, bfloat16& p) {
-	std::string txt;
-	if (!(istr >> txt)) {
-		// extraction failed (already-bad stream or EOF); failbit set by >>.
-		return istr;
-	}
-	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a bfloat16 value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
-}
-
-////////////////// string operators
-
-inline std::string to_binary(bfloat16 bf, bool bNibbleMarker = false) {
-	std::stringstream s;
-	unsigned short bits = bf.bits();
-	unsigned short mask = 0x8000u;
-	s << (bits & mask ? "0b1." : "0x0.");
-	mask >>= 1;
-	// exponent bits
-	for (unsigned i = 0; i < 8; ++i) {
-		if (bNibbleMarker && (4 == i)) {
-			s << '\'';
-		}
-		s << (bits & mask ? '1' : '0');
-		mask >>= 1;
-	}
-	s << '.';
-	for (unsigned i = 0; i < 7; ++i) {
-		if (bNibbleMarker && (3 == i)) {
-			s << '\'';
-		}	
-		s << (bits & mask ? '1' : '0');
-		mask >>= 1;
-	}
-	return s.str();
-}
-
-// native semantic representation: radix-2, delegates to to_binary
-inline std::string to_native(bfloat16 v, bool nibbleMarker = false) {
-	return to_binary(v, nibbleMarker);
-}
+// parse(), operator<<, operator>>, to_binary() and to_native() moved out of the core
+// in #1334: parse() and to_binary() build strings through a stringstream and live in
+// manipulators.hpp; the stream operators live in iostream.hpp. bfloat16.hpp includes
+// both, so callers that use them are unaffected.
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // bfloat16 - bfloat16 binary logic operators

--- a/include/sw/universal/number/bfloat16/core.hpp
+++ b/include/sw/universal/number/bfloat16/core.hpp
@@ -1,0 +1,37 @@
+#pragma once
+// core.hpp: the bfloat16 arithmetic core -- no I/O, no text
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the bfloat16 headers (#1334, Phase 2 group 5a, #1444). Storage,
+// arithmetic, comparison, numeric_limits and traits -- everything a compute kernel
+// needs and nothing that turns a bfloat16 into text.
+//
+//     #include <universal/number/bfloat16/bfloat16.hpp>   // everything, as before
+//     #include <universal/number/bfloat16/core.hpp>       // arithmetic only
+//
+// bfloat16.hpp includes this plus manipulators.hpp, iostream.hpp and attributes.hpp,
+// so existing code is unaffected.
+//
+// assign(const std::string&) stays here: it walks a "0b...." pattern with plain
+// std::string operations and reports malformed input through fprintf(stderr, ...),
+// so it needs no stream. The istringstream-based parse() -- used only by operator>>
+// -- is the text layer's, declared in bfloat16_fwd.hpp and defined in
+// manipulators.hpp, exactly as cfloat and posit do it.
+//
+// NOTE: traits/arithmetic_traits.hpp and common/number_traits_reports.hpp are
+// deliberately NOT included -- they build report strings and pull <sstream>/<iomanip>.
+// The umbrella provides them.
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/traits/number_traits.hpp>
+
+#include <universal/number/bfloat16/exceptions.hpp>
+#include <universal/number/bfloat16/bfloat16_fwd.hpp>
+#include <universal/number/bfloat16/bfloat16_impl.hpp>
+#include <universal/traits/bfloat16_traits.hpp>
+#include <universal/number/bfloat16/numeric_limits.hpp>

--- a/include/sw/universal/number/bfloat16/iostream.hpp
+++ b/include/sw/universal/number/bfloat16/iostream.hpp
@@ -1,0 +1,45 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for bfloat16
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the bfloat16 headers (#1334): the <iostream> half. manipulators.hpp is
+// the <iomanip> half -- everything that turns a bfloat16 into a std::string.
+// Self-contained.
+//
+// The dependency runs iostream -> manipulators here, because operator>> extracts a
+// token and hands it to parse(). manipulators.hpp does NOT include this header back:
+// its string builders format from the bit pattern, never through operator<<, so there
+// is no cycle for #pragma once to mask (the trap caught on #1427).
+#include <ios>           // std::ios::failbit
+#include <iostream>      // std::ostream, std::istream, std::cerr
+#include <string>        // std::string
+
+#include <universal/number/bfloat16/core.hpp>
+#include <universal/number/bfloat16/manipulators.hpp>   // parse()
+
+namespace sw { namespace universal {
+
+// generate an bfloat16 format ASCII format
+inline std::ostream& operator<<(std::ostream& ostr, bfloat16 bf) {
+	return ostr << float(bf);
+}
+
+// read an ASCII bfloat16 format
+inline std::istream& operator>>(std::istream& istr, bfloat16& p) {
+	std::string txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a bfloat16 value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/bfloat16/manipulators.hpp
+++ b/include/sw/universal/number/bfloat16/manipulators.hpp
@@ -5,14 +5,95 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-#include <string>
-#include <iomanip>
+//
+// Layer 2a of the bfloat16 headers (#1334): the <iomanip> half -- everything that
+// turns a bfloat16 into a std::string. iostream.hpp is the <iostream> half.
+// Self-contained: it names every header it uses rather than relying on the umbrella's
+// include order.
+#include <cctype>        // std::tolower, used by parse()
+#include <cstdint>       // the fixed-width integer types
+#include <string>        // std::string
+#include <sstream>       // std::stringstream, std::istringstream
+#include <iomanip>       // std::hex
 #include <universal/internal/blockbinary/blockbinary.hpp>
+#include <universal/number/bfloat16/core.hpp>
 #include <universal/number/bfloat16/bfloat16_fwd.hpp>
+#include <universal/traits/bfloat16_traits.hpp>   // is_bfloat16, used by type_field
 // pull in the color printing for shells utility
 #include <universal/utility/color_print.hpp>
 
 namespace sw { namespace universal {
+
+// Moved out of bfloat16_impl.hpp (#1334): these turn text into a bfloat16 and a
+// bfloat16 into text through a stringstream, which is what keeps them out of the core.
+
+// parse a bfloat16 ASCII format and make a binary bfloat16 out of it
+inline bool parse(const std::string& number, bfloat16& value) {
+	// Detect nan / inf / infinity tokens (case-insensitive, optional sign).
+	{
+		std::string t;
+		t.reserve(number.size());
+		for (char c : number) {
+			t.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+		}
+		bool negative = !t.empty() && t.front() == '-';
+		std::string body = t;
+		if (!body.empty() && (body.front() == '+' || body.front() == '-')) body.erase(0, 1);
+		if (body == "nan") {
+			value.setnan(NAN_TYPE_QUIET);
+			return true;
+		}
+		if (body == "inf" || body == "infinity") {
+			value.setinf(negative);
+			return true;
+		}
+	}
+	// Decimal floating-point: bfloat16 has only 7 explicit mantissa bits,
+	// so std::istringstream's double extraction is more than enough
+	// precision -- the value gets immediately rounded into the bfloat16
+	// encoding via convert_ieee754.
+	std::istringstream ss(number);
+	double d;
+	ss >> d;
+	if (ss.fail()) return false;
+	ss >> std::ws;
+	if (!ss.eof()) return false;
+	value = d;
+	return true;
+}
+
+////////////////// string operators
+
+inline std::string to_binary(bfloat16 bf, bool bNibbleMarker = false) {
+	std::stringstream s;
+	unsigned short bits = bf.bits();
+	unsigned short mask = 0x8000u;
+	s << (bits & mask ? "0b1." : "0x0.");
+	mask >>= 1;
+	// exponent bits
+	for (unsigned i = 0; i < 8; ++i) {
+		if (bNibbleMarker && (4 == i)) {
+			s << '\'';
+		}
+		s << (bits & mask ? '1' : '0');
+		mask >>= 1;
+	}
+	s << '.';
+	for (unsigned i = 0; i < 7; ++i) {
+		if (bNibbleMarker && (3 == i)) {
+			s << '\'';
+		}	
+		s << (bits & mask ? '1' : '0');
+		mask >>= 1;
+	}
+	return s.str();
+}
+
+// native semantic representation: radix-2, delegates to to_binary
+inline std::string to_native(bfloat16 v, bool nibbleMarker = false) {
+	return to_binary(v, nibbleMarker);
+}
+
 
 	// Generate a type tag for bfloat16
 	inline std::string type_tag(const bfloat16& = {}) {


### PR DESCRIPTION
First type of #1444 (Phase 2 group 5a of #1334). `bfloat16` gets a `core.hpp` that
pulls none of the five I/O-family headers.

## Acceptance numbers

gcc 13.3, `-std=c++20`, `tools/scripts/measure-include-cost.sh`:

| include | lines | headers | I/O-family |
|---|---:|---:|---:|
| `bfloat16.hpp` before | 93,035 | 377 | 5 |
| `bfloat16.hpp` after | 63,751 | 341 | 5 |
| **`core.hpp`** | **44,559** | **247** | **0** |
| target | under 45,000 | -- | 0 |

The umbrella keeps its name and still includes every layer, so no caller changes
(compatibility decision (a), unchanged).

## What moved

- **`parse()`, `to_binary()`, `to_native()`** build strings through a `stringstream`
  and are now in `manipulators.hpp`. `parse()` was already declared in
  `bfloat16_fwd.hpp`, so the forward surface is unchanged.
- **`operator<<`, `operator>>`** are now in `iostream.hpp`. The dependency runs
  `iostream -> manipulators` here, because `operator>>` hands its token to `parse()`.
  `manipulators.hpp` does not include `iostream.hpp` back -- its builders format from
  the bit pattern, never through `operator<<` -- so there is no cycle for
  `#pragma once` to mask (the trap caught on #1427).
- **`assign(const std::string&)` stays in the core**, per the layer contract: it walks
  a `"0b...."` pattern with plain `std::string` operations. Its seven `std::cerr`
  diagnostics became `fprintf(stderr, ...)`, the Phase 0 idiom, which is what lets the
  core drop `<iostream>`.
- **`BFLOAT_ENABLE_LITERALS` and `BFLOAT_THROW_ARITHMETIC_EXCEPTION`** now default in
  `bfloat16_impl.hpp`, beside the code they govern, so a core-only TU gets the same
  defaults the umbrella supplied. That is #1436's fix applied up front, so bfloat16
  never joins that list.

## One real change, deliberate

`isinteger()` called `sw::universal::floor(bfloat16)`, which lives in `mathlib` and so
is not in the core -- an `-Wundefined-inline` warning on the core path and a link error
waiting for the first core-only caller. No other merged core has one. That overload is
`bfloat16(std::floor(float(x)))`, and `bfloat16 -> float` is exact, so it is inlined as
`std::floor(f) == f`. Same predicate, bit for bit; the differential below covers all
65,536 encodings.

## Two incidental finds, include hygiene rather than layering

- `bfloat16_impl.hpp` included **`<regex>` and used none of it**. Removing it is most of
  the umbrella's 93,035 -> 63,751 drop; the split itself accounts for the rest.
- `attributes.hpp` used `std::setw` without `<iomanip>`, and reached `type_tag` and
  `operator<<` through the umbrella's include order. It now names what it uses (#1389).

## Verification

**Layer gate** (#1390's requirement -- the umbrella building proves nothing): a TU
including `core.hpp` alone, and a TU including `core.hpp` + `manipulators.hpp`, each
compiled, linked and run under `-Wall -Wpedantic` on **gcc 13.3 and clang**. Both clean,
both pass.

**Targets built and run, both compilers** -- 27 in total, green:

- the 13 `bfloat16` test targets (`api`, `arithmetic`, `attributes`, `constants`,
  `exponent`, `fma`, `mathlib`, `pow`, `round_to_nearest_even`, `scale`,
  `string_parse`, `traits`, `cfloat_bfloat16`)
- 14 downstream consumers that **link** the type, which is the only way to catch a
  moved `operator<<`: `el_block_eft_two_{sum,mult,div}`, `el_zbcl_{cons_take,
  from_native,zero_overlap_prefix}`, `el_arith_class_arithmetic`, `el_math_constants`,
  `multifile`, `utility_test_has_fma_trait`, `utility_test_generic_fma_kernel`,
  `play_closure_of_8bit_systems`, `ucalc`, `accuracy_characterize`

**Differential against `main`**, built from a worktree so both header sets are real:
all 65,536 encodings through `to_binary` (both nibble settings), `to_native`, `to_hex`
(three settings), `hex_print`, `to_triple` (both), `color_print` (both), `operator<<`
(two precisions), `sign`, `scale`, `significant`, `isinteger`, `isnan`, `isinf`; plus
`parse()` and `operator>>` over 22 decimal texts including the failure paths; plus
`assign()` over every diagnostic path.

**26,413,230 bytes of stdout and all seven stderr diagnostics byte-identical, on gcc
and on clang.** The stderr comparison is what proves the `std::cerr` -> `fprintf`
conversion; all seven format conversions fire in the probe.

## Found, not fixed

`type_field(bfloat16)` reads `BfloatType::fbits`, which `bfloat16` does not define (it
has `nbits` and `es` only). It fails to compile the moment it is instantiated, and does
so **identically on `main`** -- the template is simply never instantiated anywhere in
the tree. Not this PR's to change; worth its own issue.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream input and output support for bfloat16 values.
  * Added parsing for case-insensitive NaN and infinity values with complete-input validation.
  * Added binary and native string representations for bfloat16 values.

* **Improvements**
  * Improved bfloat16 header organization and self-containment.
  * Separated core arithmetic functionality from text parsing and formatting utilities.
  * Added clearer handling of invalid stream input and arithmetic configuration defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->