### PR TITLE
refactor(dfloat): split dfloat into core / manipulators / iostream (#1334)

### DIFF
--- a/include/sw/universal/internal/blockbinary/manipulators.hpp
+++ b/include/sw/universal/internal/blockbinary/manipulators.hpp
@@ -6,16 +6,21 @@
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
 //
-// The <iomanip> half of blockbinary's text layer (#1334): type_tag, to_binary,
-// to_hex, to_decimal -- everything that returns a std::string. blockbinary.hpp
-// holds the arithmetic and needs none of it, which is what keeps <sstream> and
-// <iomanip> out of every number system that builds on blockbinary.
+// The <iomanip> half of blockbinary's text layer (#1334): type_tag, to_binary and
+// to_hex -- the string producers that format through a std::stringstream.
+// blockbinary.hpp holds the arithmetic and needs none of it, which is what keeps
+// <sstream> and <iomanip> out of every number system that builds on blockbinary.
+// to_decimal() concatenates rather than streams and now lives in to_decimal.hpp,
+// included below so this header's surface is unchanged.
 #include <cstdint>
 #include <iomanip>
 #include <sstream>
 #include <string>
 #include <typeinfo>
 #include <universal/internal/blockbinary/blockbinary.hpp>
+#include <universal/internal/blockbinary/to_decimal.hpp>   // to_decimal moved out (#1334): it
+                                                           // concatenates a string and needs no
+                                                           // stream, so a core can include it alone
 
 namespace sw { namespace universal {
 // Generate a type tag for blockbinary
@@ -62,48 +67,6 @@ std::string to_hex(const blockbinary<nbits, BlockType, NumberType>& number, bool
 		if (nibbleMarker && n > 0 && ((n * 4ll) % bitsInBlock) == 0) ss << '\'';
 	}
 	return ss.str();
-}
-
-// decimal string conversion
-template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
-std::string to_decimal(const blockbinary<nbits, BlockType, NumberType>& number) {
-	if (number.iszero()) return "0";
-
-	std::string result;
-	blockbinary<nbits, BlockType, NumberType> dividend(number);
-	bool isNegative = false;
-
-	// Handle negative numbers for signed types
-	if constexpr (NumberType == BinaryNumberType::Signed) {
-		if (dividend.isneg()) {
-			isNegative = true;
-			dividend.twosComplement(); // Convert to positive
-		}
-	}
-
-	// Repeatedly divide by 10 and collect remainders
-	blockbinary<nbits, BlockType, NumberType> ten(10);
-	while (!dividend.iszero()) {
-		if constexpr (nbits <= 64) {
-			// For smaller sizes, use native division to avoid complexity
-			uint64_t temp = dividend.to_ull();
-			uint64_t remainder = temp % 10;
-			result = char('0' + remainder) + result;
-			dividend = temp / 10;
-		} else {
-			// For larger sizes, use blockbinary division operators
-			blockbinary<nbits, BlockType, NumberType> remainder = dividend % ten;
-			uint64_t digit = remainder.to_ull();
-			result = char('0' + digit) + result;
-			dividend /= ten;
-		}
-	}
-
-	if (isNegative) {
-		result = "-" + result;
-	}
-
-	return result;
 }
 
 }} // namespace sw::universal

--- a/include/sw/universal/internal/blockbinary/to_decimal.hpp
+++ b/include/sw/universal/internal/blockbinary/to_decimal.hpp
@@ -17,6 +17,7 @@
 // I/O-family headers.
 //
 // manipulators.hpp includes this file, so every existing caller is unaffected.
+#include <cstdint>   // uint64_t in the digit-extraction loop
 #include <string>
 #include <universal/internal/blockbinary/blockbinary.hpp>
 

--- a/include/sw/universal/internal/blockbinary/to_decimal.hpp
+++ b/include/sw/universal/internal/blockbinary/to_decimal.hpp
@@ -1,0 +1,67 @@
+#pragma once
+// to_decimal.hpp: decimal string conversion for blockbinary
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Split out of internal/blockbinary/manipulators.hpp (#1334). to_decimal() builds its
+// result by prepending characters to a std::string -- it never opens a stream -- but it
+// shared a header with type_tag/to_binary/to_hex, which do, and which therefore pull
+// <iomanip> and <sstream>: 50,808 lines and four of the five I/O-family headers.
+//
+// That is the same contract that keeps to_string() in a number system's core. A core
+// that needs to render its significand as decimal digits (dfloat's str(), and its
+// wide-path double conversion) can now include this header alone and stay at zero
+// I/O-family headers.
+//
+// manipulators.hpp includes this file, so every existing caller is unaffected.
+#include <string>
+#include <universal/internal/blockbinary/blockbinary.hpp>
+
+namespace sw { namespace universal {
+
+// decimal string conversion
+template<unsigned nbits, typename BlockType, BinaryNumberType NumberType>
+std::string to_decimal(const blockbinary<nbits, BlockType, NumberType>& number) {
+	if (number.iszero()) return "0";
+
+	std::string result;
+	blockbinary<nbits, BlockType, NumberType> dividend(number);
+	bool isNegative = false;
+
+	// Handle negative numbers for signed types
+	if constexpr (NumberType == BinaryNumberType::Signed) {
+		if (dividend.isneg()) {
+			isNegative = true;
+			dividend.twosComplement(); // Convert to positive
+		}
+	}
+
+	// Repeatedly divide by 10 and collect remainders
+	blockbinary<nbits, BlockType, NumberType> ten(10);
+	while (!dividend.iszero()) {
+		if constexpr (nbits <= 64) {
+			// For smaller sizes, use native division to avoid complexity
+			uint64_t temp = dividend.to_ull();
+			uint64_t remainder = temp % 10;
+			result = char('0' + remainder) + result;
+			dividend = temp / 10;
+		} else {
+			// For larger sizes, use blockbinary division operators
+			blockbinary<nbits, BlockType, NumberType> remainder = dividend % ten;
+			uint64_t digit = remainder.to_ull();
+			result = char('0' + digit) + result;
+			dividend /= ten;
+		}
+	}
+
+	if (isNegative) {
+		result = "-" + result;
+	}
+
+	return result;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/dfloat/attributes.hpp
+++ b/include/sw/universal/number/dfloat/attributes.hpp
@@ -5,6 +5,16 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Part of the text layer (#1334): dfloat_range() streams dfloat values through a
+// stringstream, so this header sits above iostream.hpp and is not included by core.hpp.
+// Self-contained: <string>, <sstream> and <iomanip> were all used but never named.
+#include <string>
+#include <sstream>
+#include <iomanip>   // std::setw
+#include <universal/number/dfloat/core.hpp>
+#include <universal/number/dfloat/manipulators.hpp>   // type_tag
+#include <universal/number/dfloat/iostream.hpp>       // operator<< on dfloat, used by dfloat_range
 
 namespace sw { namespace universal {
 

--- a/include/sw/universal/number/dfloat/core.hpp
+++ b/include/sw/universal/number/dfloat/core.hpp
@@ -1,0 +1,47 @@
+#pragma once
+// core.hpp: the dfloat arithmetic core -- no I/O, no text
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the dfloat headers (#1334, Phase 2 group 5a, #1444). Storage, arithmetic,
+// comparison, numeric_limits and traits -- everything a compute kernel needs and
+// nothing that turns a dfloat into text.
+//
+//     #include <universal/number/dfloat/dfloat.hpp>   // everything, as before
+//     #include <universal/number/dfloat/core.hpp>     // arithmetic only
+//
+// dfloat.hpp includes this plus manipulators.hpp, iostream.hpp and attributes.hpp, so
+// existing code is unaffected.
+//
+// WHAT STAYS HERE, and why. str(), sig_to_string() and assign(const std::string&) build
+// and consume std::string by concatenation and never open a stream -- that is the layer
+// contract, the same one that keeps to_string() in every other core. parse() stays too:
+// unlike cfloat's and bfloat16's, dfloat's parse() is a pure character-grammar validator
+// that ends in value.assign(number), with no istringstream anywhere, so it is arithmetic
+// surface rather than text.
+//
+// Reaching zero I/O-family headers took two substrate re-points, not just an include
+// shuffle:
+//   - internal/blockbinary/manipulators.hpp -> internal/blockbinary/to_decimal.hpp.
+//     str() renders the significand with to_decimal(), which concatenates, but it shared
+//     a header with type_tag/to_binary/to_hex, which stream: 50,808 lines and four of
+//     the five. to_decimal.hpp is 33,308 and zero.
+//   - native/ieee754.hpp -> native/ieee754_core.hpp, the stream-free half.
+//
+// NOTE: traits/arithmetic_traits.hpp and common/number_traits_reports.hpp are
+// deliberately NOT included -- they build report strings and pull <sstream>/<iomanip>.
+// The umbrella provides them.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/traits/number_traits.hpp>
+
+#include <universal/number/dfloat/exceptions.hpp>
+#include <universal/number/dfloat/dfloat_fwd.hpp>
+#include <universal/number/dfloat/dfloat_impl.hpp>
+#include <universal/traits/dfloat_traits.hpp>
+#include <universal/number/dfloat/numeric_limits.hpp>

--- a/include/sw/universal/number/dfloat/dfloat.hpp
+++ b/include/sw/universal/number/dfloat/dfloat.hpp
@@ -18,39 +18,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable/disable the ability to use literals in binary logic and arithmetic operators
-#if !defined(DFLOAT_ENABLE_LITERALS)
-// default is to enable them
-#define DFLOAT_ENABLE_LITERALS 1
-#endif
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable throwing specific exceptions for arithmetic errors
-// left to application to enable
-#if !defined(DFLOAT_THROW_ARITHMETIC_EXCEPTION)
-// default is to use std::cerr for signalling an error
-#define DFLOAT_THROW_ARITHMETIC_EXCEPTION 0
-#define DFLOAT_EXCEPT noexcept
-#else
-#if DFLOAT_THROW_ARITHMETIC_EXCEPTION
-#define DFLOAT_EXCEPT
-#else
-#define DFLOAT_EXCEPT noexcept
-#endif
-#endif
+///
+/// DFLOAT_ENABLE_LITERALS, DFLOAT_THROW_ARITHMETIC_EXCEPTION, DFLOAT_EXCEPT and
+/// DFLOAT_NATIVE_SQRT now default in dfloat_impl.hpp, beside the code they govern, so
+/// that a translation unit which includes core.hpp directly gets the same defaults this
+/// umbrella used to supply (#1334, #1436). Defining any of them before this header still
+/// wins, as before.
+///
 // NOTE: blockbinary does not currently consume BLOCKBINARY_THROW_ARITHMETIC_EXCEPTION.
 // dfloat's own divide-by-zero check at the dfloat layer handles the throw-vs-NaN
 // branch; blockbinary's divide silently zero-fills.  If/when blockbinary gains
 // a throw path we should add a DFLOAT_... -> BLOCKBINARY_... cascade here.
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable native sqrt implementation
-//
-#if !defined(DFLOAT_NATIVE_SQRT)
-#define DFLOAT_NATIVE_SQRT 0
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
@@ -60,15 +38,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/dfloat/exceptions.hpp>
-#include <universal/number/dfloat/dfloat_fwd.hpp>
-#include <universal/number/dfloat/dfloat_impl.hpp>
-#include <universal/traits/dfloat_traits.hpp>
-#include <universal/number/dfloat/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
+#include <universal/number/dfloat/core.hpp>
 
 // useful functions to work with dfloats
-#include <universal/number/dfloat/attributes.hpp>
+// layer 2a: the string producers -- to_binary, to_native, type_tag, color_print
 #include <universal/number/dfloat/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/dfloat/iostream.hpp>
+#include <universal/number/dfloat/attributes.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////
 /// elementary math functions library

--- a/include/sw/universal/number/dfloat/dfloat_impl.hpp
+++ b/include/sw/universal/number/dfloat/dfloat_impl.hpp
@@ -36,7 +36,9 @@
 #include <cstdlib>       // std::strtod in the wide significand path
 #include <cstring>
 #include <cmath>
+#include <limits>        // std::numeric_limits
 #include <string>
+#include <type_traits>   // std::is_constant_evaluated, std::enable_if
 #include <algorithm>
 
 // supporting types and functions

--- a/include/sw/universal/number/dfloat/dfloat_impl.hpp
+++ b/include/sw/universal/number/dfloat/dfloat_impl.hpp
@@ -5,18 +5,42 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-#include <universal/internal/blockbinary/manipulators.hpp>   // to_decimal on the significand (#1334)
+
+// Behavioural switches default HERE, beside the code they govern, rather than in the
+// dfloat.hpp umbrella: including core.hpp directly would otherwise leave them
+// undefined, #if would evaluate them as 0, and the switch would silently flip on that
+// path -- the trap #1390 hit with POSIT_ENABLE_LITERALS (#1334, #1436).
+#if !defined(DFLOAT_ENABLE_LITERALS)
+#define DFLOAT_ENABLE_LITERALS 1
+#endif
+#if !defined(DFLOAT_THROW_ARITHMETIC_EXCEPTION)
+#define DFLOAT_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+#if !defined(DFLOAT_EXCEPT)
+#if DFLOAT_THROW_ARITHMETIC_EXCEPTION
+#define DFLOAT_EXCEPT
+#else
+#define DFLOAT_EXCEPT noexcept
+#endif
+#endif
+#if !defined(DFLOAT_NATIVE_SQRT)
+#define DFLOAT_NATIVE_SQRT 0
+#endif
+
+#include <universal/internal/blockbinary/to_decimal.hpp>   // to_decimal on the significand: str()
+                                                           // and the wide double path need it, and
+                                                           // it concatenates rather than streams,
+                                                           // so the core can have it (#1334)
+#include <cctype>        // std::isspace, std::tolower in assign() and parse()
 #include <cstdint>
+#include <cstdlib>       // std::strtod in the wide significand path
 #include <cstring>
 #include <cmath>
 #include <string>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
 #include <algorithm>
 
 // supporting types and functions
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // the stream-free half of <universal/native/ieee754.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/shared/infinite_encoding.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
@@ -1299,64 +1323,9 @@ void divide(const dfloat<ndigits, es, Encoding, BlockType>& a, const dfloat<ndig
 	quotient /= b;
 }
 
-template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
-inline std::string to_binary(const dfloat<ndigits, es, Encoding, BlockType>& number, bool nibbleMarker = false) {
-	using Dfloat = dfloat<ndigits, es, Encoding, BlockType>;
-	std::stringstream s;
-
-	// sign bit
-	s << "0b" << (number.sign() ? '1' : '0') << '.';
-
-	// combination field (5 bits)
-	unsigned combStart = Dfloat::nbits - 2;
-	for (unsigned i = 0; i < Dfloat::combBits; ++i) {
-		s << (number.getbit(combStart - i) ? '1' : '0');
-	}
-	s << '.';
-
-	// exponent continuation (es bits)
-	unsigned expStart = Dfloat::nbits - 1 - 1 - Dfloat::combBits;
-	for (unsigned i = 0; i < es; ++i) {
-		s << (number.getbit(expStart - i) ? '1' : '0');
-	}
-	s << '.';
-
-	// trailing significand (t bits, MSB first)
-	for (int i = static_cast<int>(Dfloat::t) - 1; i >= 0; --i) {
-		s << (number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
-		if (nibbleMarker && i > 0 && (i % 4 == 0)) s << '\'';
-	}
-
-	return s.str();
-}
-
-// native semantic representation: radix-10, shows decimal coefficient and exponent
-// Format: +DDDDDDDDDDDDDDDDe+EEE (fixed-width for visual alignment)
-template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
-inline std::string to_native(const dfloat<ndigits, es, Encoding, BlockType>& number, bool = false) {
-	using Dfloat = dfloat<ndigits, es, Encoding, BlockType>;
-	std::stringstream s;
-
-	if (number.isnan()) { s << "NaN"; return s.str(); }
-	if (number.isinf()) { s << (number.sign() ? "-inf" : "+inf"); return s.str(); }
-	if (number.iszero()) {
-		s << (number.sign() ? '-' : '+');
-		s << std::string(ndigits, '0') << "e+0";
-		return s.str();
-	}
-
-	bool sign; int exp; typename Dfloat::significand_t sig;
-	number.unpack(sign, exp, sig);
-
-	s << (sign ? '-' : '+');
-
-	// Convert significand to decimal string, left-pad to ndigits
-	std::string digits = Dfloat::sig_to_string(sig);
-	while (digits.size() < ndigits) digits = "0" + digits;
-
-	s << digits << 'e' << std::showpos << exp;
-	return s.str();
-}
+// to_binary() and to_native() moved to manipulators.hpp in #1334: both format through a
+// std::stringstream, which is what keeps them out of the core. str(), sig_to_string()
+// and parse() stay here -- they concatenate strings and open no stream.
 
 ////////////////////////    DFLOAT functions   /////////////////////////////////
 
@@ -1374,65 +1343,8 @@ constexpr dfloat<ndigits, es, Encoding, BlockType> fabs(dfloat<ndigits, es, Enco
 }
 
 
-////////////////////////  stream operators   /////////////////////////////////
-
-// generate a dfloat format ASCII format
-template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
-inline std::ostream& operator<<(std::ostream& ostr, const dfloat<ndigits, es, Encoding, BlockType>& i) {
-	using Dfloat = dfloat<ndigits, es, Encoding, BlockType>;
-	using FmtMode = typename Dfloat::FmtMode;
-
-	std::streamsize prec = ostr.precision();
-	std::streamsize width = ostr.width();
-	std::ios_base::fmtflags ff = ostr.flags();
-
-	// Map iostream format flags to dfloat FmtMode
-	FmtMode mode = FmtMode::automatic;
-	bool scientific = (ff & std::ios_base::scientific) == std::ios_base::scientific;
-	bool fixed      = (ff & std::ios_base::fixed) == std::ios_base::fixed;
-	if (scientific && !fixed) mode = FmtMode::scientific;
-	else if (fixed && !scientific) mode = FmtMode::fixed;
-
-	// Default to ndigits precision so all stored digits are shown.
-	// The iostream default precision is 6, which would silently truncate
-	// exact decimal digits. Only use the stream precision when the user
-	// has explicitly set scientific or fixed mode.
-	size_t effective_prec = (scientific || fixed)
-		? static_cast<size_t>(prec)
-		: 0;  // 0 tells str() to use ndigits
-
-	std::string representation = i.str(effective_prec, mode);
-
-	// Handle setw and alignment
-	std::streamsize repWidth = static_cast<std::streamsize>(representation.size());
-	if (width > repWidth) {
-		std::streamsize diff = width - repWidth;
-		char fill = ostr.fill();
-		if ((ff & std::ios_base::left) == std::ios_base::left) {
-			representation.append(static_cast<size_t>(diff), fill);
-		}
-		else {
-			representation.insert(0, static_cast<size_t>(diff), fill);
-		}
-	}
-
-	return ostr << representation;
-}
-
-// read an ASCII dfloat format
-template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
-inline std::istream& operator>>(std::istream& istr, dfloat<ndigits, es, Encoding, BlockType>& p) {
-	std::string txt;
-	if (!(istr >> txt)) {
-		// extraction failed (already-bad stream or EOF); failbit set by >>.
-		return istr;
-	}
-	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into a dfloat value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
-}
+// operator<< and operator>> moved to iostream.hpp in #1334. dfloat.hpp includes it, so
+// callers that stream a dfloat are unaffected.
 
 ////////////////// string operators
 

--- a/include/sw/universal/number/dfloat/iostream.hpp
+++ b/include/sw/universal/number/dfloat/iostream.hpp
@@ -13,6 +13,7 @@
 // str(), which is a core member, and operator>> hands its token to parse(), which is
 // also core -- so unlike bfloat16 there is no dependency on manipulators.hpp at all,
 // and certainly no cycle for #pragma once to mask (the trap caught on #1427).
+#include <cstddef>       // size_t
 #include <ios>           // std::streamsize, std::ios_base, std::ios::failbit
 #include <iostream>      // std::ostream, std::istream, std::cerr
 #include <string>        // std::string

--- a/include/sw/universal/number/dfloat/iostream.hpp
+++ b/include/sw/universal/number/dfloat/iostream.hpp
@@ -1,0 +1,84 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for dfloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the dfloat headers (#1334): the <iostream> half. manipulators.hpp is the
+// <iomanip> half -- everything that turns a dfloat into a std::string. Self-contained.
+//
+// This header includes only core.hpp. operator<< formats through the dfloat's own
+// str(), which is a core member, and operator>> hands its token to parse(), which is
+// also core -- so unlike bfloat16 there is no dependency on manipulators.hpp at all,
+// and certainly no cycle for #pragma once to mask (the trap caught on #1427).
+#include <ios>           // std::streamsize, std::ios_base, std::ios::failbit
+#include <iostream>      // std::ostream, std::istream, std::cerr
+#include <string>        // std::string
+
+#include <universal/number/dfloat/core.hpp>
+
+namespace sw { namespace universal {
+
+////////////////////////  stream operators   /////////////////////////////////
+
+// generate a dfloat format ASCII format
+template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
+inline std::ostream& operator<<(std::ostream& ostr, const dfloat<ndigits, es, Encoding, BlockType>& i) {
+	using Dfloat = dfloat<ndigits, es, Encoding, BlockType>;
+	using FmtMode = typename Dfloat::FmtMode;
+
+	std::streamsize prec = ostr.precision();
+	std::streamsize width = ostr.width();
+	std::ios_base::fmtflags ff = ostr.flags();
+
+	// Map iostream format flags to dfloat FmtMode
+	FmtMode mode = FmtMode::automatic;
+	bool scientific = (ff & std::ios_base::scientific) == std::ios_base::scientific;
+	bool fixed      = (ff & std::ios_base::fixed) == std::ios_base::fixed;
+	if (scientific && !fixed) mode = FmtMode::scientific;
+	else if (fixed && !scientific) mode = FmtMode::fixed;
+
+	// Default to ndigits precision so all stored digits are shown.
+	// The iostream default precision is 6, which would silently truncate
+	// exact decimal digits. Only use the stream precision when the user
+	// has explicitly set scientific or fixed mode.
+	size_t effective_prec = (scientific || fixed)
+		? static_cast<size_t>(prec)
+		: 0;  // 0 tells str() to use ndigits
+
+	std::string representation = i.str(effective_prec, mode);
+
+	// Handle setw and alignment
+	std::streamsize repWidth = static_cast<std::streamsize>(representation.size());
+	if (width > repWidth) {
+		std::streamsize diff = width - repWidth;
+		char fill = ostr.fill();
+		if ((ff & std::ios_base::left) == std::ios_base::left) {
+			representation.append(static_cast<size_t>(diff), fill);
+		}
+		else {
+			representation.insert(0, static_cast<size_t>(diff), fill);
+		}
+	}
+
+	return ostr << representation;
+}
+
+// read an ASCII dfloat format
+template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
+inline std::istream& operator>>(std::istream& istr, dfloat<ndigits, es, Encoding, BlockType>& p) {
+	std::string txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into a dfloat value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/dfloat/manipulators.hpp
+++ b/include/sw/universal/number/dfloat/manipulators.hpp
@@ -5,11 +5,27 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-
+//
+// Layer 2a of the dfloat headers (#1334): the <iomanip> half -- everything that turns a
+// dfloat into a std::string through a stringstream. iostream.hpp is the <iostream> half.
+// Self-contained: it names every header it uses rather than relying on the umbrella's
+// include order, which is how it reached Color, type_tag and <sstream> before.
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
+#include <iomanip>       // std::setw
 // pull in type_tag overloads for native integer block types
 #include <universal/native/integer_type_tag.hpp>
+#include <universal/number/dfloat/core.hpp>
+// blockbinary's own string producers (type_tag, to_binary, to_hex). dfloat_impl.hpp used
+// to include this and so handed them to every dfloat translation unit; the core now takes
+// only to_decimal.hpp, so the include lives here to keep the umbrella's surface identical
+// (#1334).
+#include <universal/internal/blockbinary/manipulators.hpp>
+// pull in the color printing for shells utility
+#include <universal/utility/color_print.hpp>
 
 namespace sw { namespace universal {
+
 
 	
 	// Generate a type tag for this decimal encoding
@@ -113,5 +129,68 @@ namespace sw { namespace universal {
 		}
 		return s.str();
 	}
+
+
+// Moved out of dfloat_impl.hpp (#1334): these format a dfloat through a stringstream,
+// which is what keeps them out of the core.
+
+template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
+inline std::string to_binary(const dfloat<ndigits, es, Encoding, BlockType>& number, bool nibbleMarker = false) {
+	using Dfloat = dfloat<ndigits, es, Encoding, BlockType>;
+	std::stringstream s;
+
+	// sign bit
+	s << "0b" << (number.sign() ? '1' : '0') << '.';
+
+	// combination field (5 bits)
+	unsigned combStart = Dfloat::nbits - 2;
+	for (unsigned i = 0; i < Dfloat::combBits; ++i) {
+		s << (number.getbit(combStart - i) ? '1' : '0');
+	}
+	s << '.';
+
+	// exponent continuation (es bits)
+	unsigned expStart = Dfloat::nbits - 1 - 1 - Dfloat::combBits;
+	for (unsigned i = 0; i < es; ++i) {
+		s << (number.getbit(expStart - i) ? '1' : '0');
+	}
+	s << '.';
+
+	// trailing significand (t bits, MSB first)
+	for (int i = static_cast<int>(Dfloat::t) - 1; i >= 0; --i) {
+		s << (number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
+		if (nibbleMarker && i > 0 && (i % 4 == 0)) s << '\'';
+	}
+
+	return s.str();
+}
+
+// native semantic representation: radix-10, shows decimal coefficient and exponent
+// Format: +DDDDDDDDDDDDDDDDe+EEE (fixed-width for visual alignment)
+template<unsigned ndigits, unsigned es, DecimalEncoding Encoding, typename BlockType>
+inline std::string to_native(const dfloat<ndigits, es, Encoding, BlockType>& number, bool = false) {
+	using Dfloat = dfloat<ndigits, es, Encoding, BlockType>;
+	std::stringstream s;
+
+	if (number.isnan()) { s << "NaN"; return s.str(); }
+	if (number.isinf()) { s << (number.sign() ? "-inf" : "+inf"); return s.str(); }
+	if (number.iszero()) {
+		s << (number.sign() ? '-' : '+');
+		s << std::string(ndigits, '0') << "e+0";
+		return s.str();
+	}
+
+	bool sign; int exp; typename Dfloat::significand_t sig;
+	number.unpack(sign, exp, sig);
+
+	s << (sign ? '-' : '+');
+
+	// Convert significand to decimal string, left-pad to ndigits
+	std::string digits = Dfloat::sig_to_string(sig);
+	while (digits.size() < ndigits) digits = "0" + digits;
+
+	s << digits << 'e' << std::showpos << exp;
+	return s.str();
+}
 
 }} // namespace sw::universal


### PR DESCRIPTION
Second type of #1444 (Phase 2 group 5a of #1334) -- and the one that needed a substrate
split first.

## Acceptance numbers

gcc 13.3, `-std=c++20`:

| include | lines | headers | I/O-family |
|---|---:|---:|---:|
| `dfloat.hpp` before | 77,924 | 390 | 5 |
| `dfloat.hpp` after | 76,512 | 377 | 5 |
| **`core.hpp`** | **58,787** | **295** | **0** |
| target | under 45,000 | -- | 0 |

**Zero I/O-family headers -- the binary criterion -- is met. The under-45,000-lines
criterion is not, and this reports the number reached rather than moving the bar.** The
two shared substrates a dfloat core cannot do without, `native/ieee754_core.hpp` (43,486)
and `internal/blockbinary/to_decimal.hpp` (33,308), **already total 44,846 together before
dfloat contributes a single line**. That ceiling belongs to the substrate, not to this
type. For scale, the merged cores sit at cfloat 78,330, fixpnt 78,123, posit 77,430,
lns 74,762; dfloat lands in the better half of them.

## The substrate: `internal/blockbinary/to_decimal.hpp` (new)

`to_decimal()` builds its result by prepending characters to a `std::string` and **never
opens a stream** -- but it shared `manipulators.hpp` with `type_tag`, `to_binary` and
`to_hex`, which do, and which therefore pull `<iomanip>` and `<sstream>`: **50,808 lines
and four of the five I/O-family headers.**

dfloat's `str()` renders its significand with `to_decimal()`, and `str()` is core by the
layer contract -- the same contract that keeps `to_string()` in every other core. So the
core could not reach zero while that one function was trapped in a streaming header.

Split out: **33,308 lines, 0 I/O.** `manipulators.hpp` includes it, so every existing
caller is unaffected.

This is the `rational` precedent (#1425) taken one step further. rational hit the same
header and could move its only consumer (`to_binary(rational<>)`) out of the core --
dfloat cannot, because the consumer is `str()`.

## What moved in dfloat

- **`to_binary()`, `to_native()`** format through a `stringstream` -> `manipulators.hpp`.
- **`operator<<`, `operator>>`** -> `iostream.hpp`, which includes **only `core.hpp`**:
  `operator<<` formats through the core member `str()` and `operator>>` hands its token to
  `parse()`. Unlike bfloat16 (#1445), there is no dependency on `manipulators.hpp` at all.
- **`parse()` stays in the core.** Unlike cfloat's and bfloat16's, dfloat's `parse()` is a
  pure character-grammar validator ending in `value.assign(number)` -- no `istringstream`
  anywhere -- so it is arithmetic surface, not text. Same contract, opposite answer,
  because the code is genuinely different.
- `native/ieee754.hpp` -> `native/ieee754_core.hpp`.
- `DFLOAT_ENABLE_LITERALS`, `DFLOAT_THROW_ARITHMETIC_EXCEPTION`, `DFLOAT_EXCEPT` and
  `DFLOAT_NATIVE_SQRT` now default in `dfloat_impl.hpp` beside the code they govern, so a
  core-only TU gets the same defaults the umbrella supplied (#1436 applied up front).

## Surface preserved

`dfloat_impl.hpp` had been handing blockbinary's `type_tag`/`to_binary`/`to_hex` to every
dfloat translation unit through its `manipulators` include. The core now takes only
`to_decimal.hpp`, so `dfloat/manipulators.hpp` picks that include up and the umbrella's
surface is byte-for-byte what it was.

`manipulators.hpp` and `attributes.hpp` had **no includes at all** -- they reached
`std::stringstream`, `std::setw`, `Color`, `type_tag` and `operator<<` entirely through
the umbrella's include order. Both now name what they use (#1389).

## Verification

- **Layer gate** (#1390): a TU including `core.hpp` alone, and one including
  `core.hpp` + `manipulators.hpp`, each compiled, linked and run under `-Wall -Wpedantic`
  on gcc 13.3 and clang.
- **Self-containment**: core, manipulators, iostream, attributes, the umbrella, and both
  blockbinary headers each compile standalone with 0 errors on both compilers.
  `dfloat_impl.hpp` and the two block test-suite headers still fail standalone -- but
  *identically on `main`* (dfloat_impl 254 errors there, 208 here), the known
  guarded-but-not-self-contained class, so not a regression.
- **25 targets built and run green on both compilers**: the 14 dfloat tests, the
  blockbinary and `to_decimal` consumers the substrate split reaches (`bb_api`,
  `bb_conversion`, `bb_logic`, `bb_bit_patterns`, `bb_decimal_converter`, `bt_decimal`,
  `conversions_decimal_boundary`, `conversions_to_decimal`,
  `play_float_to_decimal_string`), plus `multifile` and `ucalc`.
- **Every header in the tree** that includes `blockbinary/manipulators.hpp` or the new
  `to_decimal.hpp` syntax-checked on both compilers.
- **Differential against `main`**, built from a worktree: all five standard aliases
  (`decimal32/64/128` and the two DPD variants) over 64 encodings each through
  `to_binary`, `to_native`, `color_print`, `components`, `str`, and `operator<<` under
  five stream states; plus `parse`/`assign`/`operator>>`/string-ctor over 29 decimal texts
  including every failure path; plus blockbinary `to_decimal` over 81 signed values and a
  128-bit shifting sweep.

  **884,204 bytes of stdout and all 20 stderr diagnostics byte-identical, on gcc and on
  clang.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added decimal string conversion for block binary values, including zero, negative, and wide-precision numbers.
  - Added binary and native-format string representations for dfloat values, including zero, infinity, and NaN.
  - Added stream input and output support for dfloat values, including formatting controls and invalid-input handling.

- **Improvements**
  - Improved organization of arithmetic, formatting, conversion, and stream functionality for more consistent use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->