### PR TITLE
refactor(hfloat): split hfloat into core / manipulators / iostream (#1334)

### DIFF
--- a/include/sw/universal/number/hfloat/attributes.hpp
+++ b/include/sw/universal/number/hfloat/attributes.hpp
@@ -5,6 +5,16 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Part of the text layer (#1334): hfloat_range() streams hfloat values through a
+// stringstream, so this header sits above iostream.hpp and is not included by core.hpp.
+// Self-contained: <string>, <sstream> and <iomanip> were all used but never named.
+#include <string>
+#include <sstream>
+#include <iomanip>   // std::setw
+#include <universal/number/hfloat/core.hpp>
+#include <universal/number/hfloat/manipulators.hpp>   // type_tag
+#include <universal/number/hfloat/iostream.hpp>       // operator<< on hfloat, used by hfloat_range
 
 namespace sw { namespace universal {
 

--- a/include/sw/universal/number/hfloat/core.hpp
+++ b/include/sw/universal/number/hfloat/core.hpp
@@ -1,0 +1,44 @@
+#pragma once
+// core.hpp: the hfloat arithmetic core -- no I/O, no text
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the hfloat headers (#1334, Phase 2 group 5a, #1444). Storage, arithmetic,
+// comparison, numeric_limits and traits -- everything a compute kernel needs and
+// nothing that turns an hfloat into text.
+//
+//     #include <universal/number/hfloat/hfloat.hpp>   // everything, as before
+//     #include <universal/number/hfloat/core.hpp>     // arithmetic only
+//
+// hfloat.hpp includes this plus manipulators.hpp, iostream.hpp and attributes.hpp, so
+// existing code is unaffected.
+//
+// WHAT STAYS HERE, and why:
+//   - str() is core surface: operator<< formats through it. It used to build its result
+//     with a stringstream, which was the single reason this core would have needed
+//     <sstream>; it now reaches the same formatter through snprintf("%.*g"). See the
+//     note on str() in hfloat_impl.hpp.
+//   - parse() converts through utility/decimal_to_binary.hpp, which is already at zero
+//     I/O-family headers, so it is arithmetic surface rather than text -- the same call
+//     dfloat's parse() got (#1446), and the opposite of cfloat's and bfloat16's, whose
+//     parse() runs an istringstream.
+//
+// native/ieee754.hpp was re-pointed to native/ieee754_core.hpp, its stream-free half.
+//
+// NOTE: traits/arithmetic_traits.hpp and common/number_traits_reports.hpp are
+// deliberately NOT included -- they build report strings and pull <sstream>/<iomanip>.
+// The umbrella provides them.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/traits/number_traits.hpp>
+
+#include <universal/number/hfloat/exceptions.hpp>
+#include <universal/number/hfloat/hfloat_fwd.hpp>
+#include <universal/number/hfloat/hfloat_impl.hpp>
+#include <universal/traits/hfloat_traits.hpp>
+#include <universal/number/hfloat/numeric_limits.hpp>

--- a/include/sw/universal/number/hfloat/hfloat.hpp
+++ b/include/sw/universal/number/hfloat/hfloat.hpp
@@ -17,25 +17,11 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable/disable the ability to use literals in binary logic and arithmetic operators
-#if !defined(HFLOAT_ENABLE_LITERALS)
-#define HFLOAT_ENABLE_LITERALS 1
-#endif
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable throwing specific exceptions for arithmetic errors
-#if !defined(HFLOAT_THROW_ARITHMETIC_EXCEPTION)
-#define HFLOAT_THROW_ARITHMETIC_EXCEPTION 0
-#define HFLOAT_EXCEPT noexcept
-#else
-#if HFLOAT_THROW_ARITHMETIC_EXCEPTION
-#define HFLOAT_EXCEPT
-#else
-#define HFLOAT_EXCEPT noexcept
-#endif
-#endif
+///
+/// HFLOAT_ENABLE_LITERALS, HFLOAT_THROW_ARITHMETIC_EXCEPTION and HFLOAT_EXCEPT now
+/// default in hfloat_impl.hpp, beside the code they govern, so that a translation unit
+/// which includes core.hpp directly gets the same defaults this umbrella used to supply
+/// (#1334, #1436). Defining any of them before this header still wins, as before.
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
@@ -45,15 +31,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/hfloat/exceptions.hpp>
-#include <universal/number/hfloat/hfloat_fwd.hpp>
-#include <universal/number/hfloat/hfloat_impl.hpp>
-#include <universal/traits/hfloat_traits.hpp>
-#include <universal/number/hfloat/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
+#include <universal/number/hfloat/core.hpp>
 
 // useful functions to work with hfloats
-#include <universal/number/hfloat/attributes.hpp>
+// layer 2a: the string producers -- to_binary, to_hex, to_native, type_tag, color_print
 #include <universal/number/hfloat/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/hfloat/iostream.hpp>
+#include <universal/number/hfloat/attributes.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////
 /// elementary math functions library

--- a/include/sw/universal/number/hfloat/hfloat_impl.hpp
+++ b/include/sw/universal/number/hfloat/hfloat_impl.hpp
@@ -23,19 +23,38 @@
 //   Long:     hfloat<14, 7> = 1+7+56 = 64 bits
 //   Extended: hfloat<28, 7> = 1+7+112 = 120 bits (stored in 128)
 
+
+// Behavioural switches default HERE, beside the code they govern, rather than in the
+// hfloat.hpp umbrella: including core.hpp directly would otherwise leave them
+// undefined, #if would evaluate them as 0, and the switch would silently flip on that
+// path -- the trap #1390 hit with POSIT_ENABLE_LITERALS (#1334, #1436).
+#if !defined(HFLOAT_ENABLE_LITERALS)
+#define HFLOAT_ENABLE_LITERALS 1
+#endif
+#if !defined(HFLOAT_THROW_ARITHMETIC_EXCEPTION)
+#define HFLOAT_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+#if !defined(HFLOAT_EXCEPT)
+#if HFLOAT_THROW_ARITHMETIC_EXCEPTION
+#define HFLOAT_EXCEPT
+#else
+#define HFLOAT_EXCEPT noexcept
+#endif
+#endif
+
 #include <cctype>
 #include <cstdint>
+#include <cstdio>        // std::snprintf in str(); keeps <sstream> out of the core
 #include <cstring>
 #include <cmath>
+#include <limits>        // std::numeric_limits
 #include <string>
 #include <string_view>
-#include <sstream>
-#include <iostream>
-#include <iomanip>
+#include <type_traits>
 #include <algorithm>
 
 // supporting types and functions
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // the stream-free half of <universal/native/ieee754.hpp>
 #include <universal/utility/decimal_to_binary.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
 #include <universal/number/shared/infinite_encoding.hpp>
@@ -591,16 +610,28 @@ public:
 	}
 
 	// convert to string
+	//
+	// This was `std::stringstream ss; if (nrDigits) ss << std::setprecision(nrDigits);
+	// ss << d;`. That is the only reason hfloat's core would have needed <sstream>, and
+	// str() is core surface -- operator<< formats through it. std::ostream's
+	// `defaultfloat` presentation of a double IS printf's %g at the stream's precision
+	// (which defaults to 6), so snprintf("%.*g") is the same formatter reached without a
+	// stream -- the <cstdio> idiom Phase 0 adopted. Verified byte-identical over 604,742
+	// (value, precision) pairs spanning the full double exponent range on gcc and clang;
+	// see the differential in the PR (#1334, #1444).
 	std::string str(size_t nrDigits = 0) const {
 		if (iszero()) return sign() ? std::string("-0") : std::string("0");
 
 		double d = convert_to_double();
-		std::stringstream ss;
-		if (nrDigits > 0) {
-			ss << std::setprecision(static_cast<int>(nrDigits));
-		}
-		ss << d;
-		return ss.str();
+		constexpr size_t maxPrecision = 512;   // guard the size_t -> int narrowing
+		const int precision = (nrDigits > 0)
+			? static_cast<int>(nrDigits < maxPrecision ? nrDigits : maxPrecision)
+			: 6;                               // std::ios_base's default precision
+		const int len = std::snprintf(nullptr, 0, "%.*g", precision, d);
+		if (len < 0) return std::string{};
+		std::string text(static_cast<size_t>(len), '\0');
+		std::snprintf(text.data(), static_cast<size_t>(len) + 1u, "%.*g", precision, d);
+		return text;
 	}
 
 	///////////////////////////////////////////////////////////////////
@@ -932,72 +963,10 @@ private:
 };
 
 
-////////////////////////    helper functions   /////////////////////////////////
-
-template<unsigned ndigits, unsigned es, typename BlockType>
-inline std::string to_binary(const hfloat<ndigits, es, BlockType>& number, bool nibbleMarker = false) {
-	using Hfloat = hfloat<ndigits, es, BlockType>;
-	std::stringstream s;
-
-	// sign bit
-	s << "0b" << (number.sign() ? '1' : '0') << '.';
-
-	// exponent field (es bits)
-	unsigned expStart = Hfloat::nbits - 2;
-	for (unsigned i = 0; i < es; ++i) {
-		s << (number.getbit(expStart - i) ? '1' : '0');
-	}
-	s << '.';
-
-	// fraction field (fbits bits, show in hex-digit groups)
-	for (int i = static_cast<int>(Hfloat::fbits) - 1; i >= 0; --i) {
-		s << (number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
-		if (nibbleMarker && i > 0 && (i % 4 == 0)) s << '\'';
-	}
-
-	return s.str();
-}
-
-template<unsigned ndigits, unsigned es, typename BlockType>
-inline std::string to_hex(const hfloat<ndigits, es, BlockType>& number) {
-	std::stringstream s;
-
-	s << (number.sign() ? '-' : '+');
-	s << "0x0.";
-
-	// Read exponent and fraction directly from bit storage. unpack() returns
-	// the fraction as uint64_t, which loses bits for wide configs
-	// (hfloat_extended has fbits=112); the legacy `frac_val >> (i*4)` loop
-	// below also had UB for i*4 >= 64, producing wrapped/duplicated digits.
-	// MSB-first left-fold to assemble the exponent field; safe for any es.
-	using Hfloat = hfloat<ndigits, es, BlockType>;
-	unsigned exp_field = 0;
-	unsigned expStart  = Hfloat::nbits - 2;
-	for (unsigned i = 0; i < es; ++i) {
-		exp_field = (exp_field << 1) | (number.getbit(expStart - i) ? 1u : 0u);
-	}
-	int exp_val = static_cast<int>(exp_field) - Hfloat::bias;
-
-	for (int i = static_cast<int>(ndigits) - 1; i >= 0; --i) {
-		unsigned hex_digit = 0;
-		for (unsigned b = 0; b < 4u; ++b) {
-			if (number.getbit(static_cast<unsigned>(i) * 4u + b)) {
-				hex_digit |= (1u << b);
-			}
-		}
-		s << "0123456789ABCDEF"[hex_digit];
-	}
-	s << " * 16^" << exp_val;
-
-	return s.str();
-}
-
-
-// native semantic representation: radix-16, delegates to to_hex
-template<unsigned ndigits, unsigned es, typename BlockType>
-inline std::string to_native(const hfloat<ndigits, es, BlockType>& v, bool = false) {
-	return to_hex(v);
-}
+// to_binary(), to_hex() and to_native() moved to manipulators.hpp in #1334: all three
+// format through a std::stringstream, which is what keeps them out of the core. str()
+// and parse() stay here -- str() now formats with snprintf, and parse() converts through
+// decimal_to_binary, so neither opens a stream.
 
 ////////////////////////    HFLOAT functions   /////////////////////////////////
 
@@ -1015,33 +984,8 @@ inline constexpr hfloat<ndigits, es, BlockType> fabs(hfloat<ndigits, es, BlockTy
 }
 
 
-////////////////////////  stream operators   /////////////////////////////////
-
-template<unsigned ndigits, unsigned es, typename BlockType>
-inline std::ostream& operator<<(std::ostream& ostr, const hfloat<ndigits, es, BlockType>& i) {
-	std::stringstream ss;
-	std::streamsize prec = ostr.precision();
-	std::streamsize width = ostr.width();
-	std::ios_base::fmtflags ff;
-	ff = ostr.flags();
-	ss.flags(ff);
-	ss << std::setw(width) << std::setprecision(prec) << i.str(size_t(prec));
-	return ostr << ss.str();
-}
-
-template<unsigned ndigits, unsigned es, typename BlockType>
-inline std::istream& operator>>(std::istream& istr, hfloat<ndigits, es, BlockType>& p) {
-	std::string txt;
-	if (!(istr >> txt)) {
-		// extraction failed (already-bad stream or EOF); failbit set by >>.
-		return istr;
-	}
-	if (!parse(txt, p)) {
-		std::cerr << "unable to parse -" << txt << "- into an hfloat value\n";
-		istr.setstate(std::ios::failbit);
-	}
-	return istr;
-}
+// operator<< and operator>> moved to iostream.hpp in #1334. hfloat.hpp includes it, so
+// callers that stream an hfloat are unaffected.
 
 ////////////////// string operators
 

--- a/include/sw/universal/number/hfloat/iostream.hpp
+++ b/include/sw/universal/number/hfloat/iostream.hpp
@@ -1,0 +1,53 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for hfloat
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the hfloat headers (#1334): the <iostream> half. manipulators.hpp is the
+// <iomanip> half -- everything that turns an hfloat into a std::string. Self-contained.
+//
+// This header includes only core.hpp. operator<< formats through the core member str()
+// and operator>> hands its token to parse(), which is also core, so there is no
+// dependency on manipulators.hpp and no cycle for #pragma once to mask (#1427).
+#include <ios>           // std::streamsize, std::ios_base, std::ios::failbit
+#include <iomanip>       // std::setw, std::setprecision
+#include <iostream>      // std::ostream, std::istream, std::cerr
+#include <sstream>       // std::stringstream in operator<<
+#include <string>        // std::string
+
+#include <universal/number/hfloat/core.hpp>
+
+namespace sw { namespace universal {
+
+////////////////////////  stream operators   /////////////////////////////////
+
+template<unsigned ndigits, unsigned es, typename BlockType>
+inline std::ostream& operator<<(std::ostream& ostr, const hfloat<ndigits, es, BlockType>& i) {
+	std::stringstream ss;
+	std::streamsize prec = ostr.precision();
+	std::streamsize width = ostr.width();
+	std::ios_base::fmtflags ff;
+	ff = ostr.flags();
+	ss.flags(ff);
+	ss << std::setw(width) << std::setprecision(prec) << i.str(size_t(prec));
+	return ostr << ss.str();
+}
+
+template<unsigned ndigits, unsigned es, typename BlockType>
+inline std::istream& operator>>(std::istream& istr, hfloat<ndigits, es, BlockType>& p) {
+	std::string txt;
+	if (!(istr >> txt)) {
+		// extraction failed (already-bad stream or EOF); failbit set by >>.
+		return istr;
+	}
+	if (!parse(txt, p)) {
+		std::cerr << "unable to parse -" << txt << "- into an hfloat value\n";
+		istr.setstate(std::ios::failbit);
+	}
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/hfloat/manipulators.hpp
+++ b/include/sw/universal/number/hfloat/manipulators.hpp
@@ -5,11 +5,22 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-
+//
+// Layer 2a of the hfloat headers (#1334): the <iomanip> half -- everything that turns an
+// hfloat into a std::string through a stringstream. iostream.hpp is the <iostream> half.
+// Self-contained: it names every header it uses rather than relying on the umbrella's
+// include order.
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
+#include <iomanip>       // std::setw
 // pull in type_tag overloads for native integer block types
 #include <universal/native/integer_type_tag.hpp>
+#include <universal/number/hfloat/core.hpp>
+// pull in the color printing for shells utility
+#include <universal/utility/color_print.hpp>
 
 namespace sw { namespace universal {
+
 
 	// Generate a type tag for this hfloat
 	template<unsigned ndigits, unsigned es, typename bt>
@@ -110,5 +121,74 @@ namespace sw { namespace universal {
 		}
 		return s.str();
 	}
+
+
+// Moved out of hfloat_impl.hpp (#1334): these format an hfloat through a stringstream,
+// which is what keeps them out of the core.
+
+template<unsigned ndigits, unsigned es, typename BlockType>
+inline std::string to_binary(const hfloat<ndigits, es, BlockType>& number, bool nibbleMarker = false) {
+	using Hfloat = hfloat<ndigits, es, BlockType>;
+	std::stringstream s;
+
+	// sign bit
+	s << "0b" << (number.sign() ? '1' : '0') << '.';
+
+	// exponent field (es bits)
+	unsigned expStart = Hfloat::nbits - 2;
+	for (unsigned i = 0; i < es; ++i) {
+		s << (number.getbit(expStart - i) ? '1' : '0');
+	}
+	s << '.';
+
+	// fraction field (fbits bits, show in hex-digit groups)
+	for (int i = static_cast<int>(Hfloat::fbits) - 1; i >= 0; --i) {
+		s << (number.getbit(static_cast<unsigned>(i)) ? '1' : '0');
+		if (nibbleMarker && i > 0 && (i % 4 == 0)) s << '\'';
+	}
+
+	return s.str();
+}
+
+template<unsigned ndigits, unsigned es, typename BlockType>
+inline std::string to_hex(const hfloat<ndigits, es, BlockType>& number) {
+	std::stringstream s;
+
+	s << (number.sign() ? '-' : '+');
+	s << "0x0.";
+
+	// Read exponent and fraction directly from bit storage. unpack() returns
+	// the fraction as uint64_t, which loses bits for wide configs
+	// (hfloat_extended has fbits=112); the legacy `frac_val >> (i*4)` loop
+	// below also had UB for i*4 >= 64, producing wrapped/duplicated digits.
+	// MSB-first left-fold to assemble the exponent field; safe for any es.
+	using Hfloat = hfloat<ndigits, es, BlockType>;
+	unsigned exp_field = 0;
+	unsigned expStart  = Hfloat::nbits - 2;
+	for (unsigned i = 0; i < es; ++i) {
+		exp_field = (exp_field << 1) | (number.getbit(expStart - i) ? 1u : 0u);
+	}
+	int exp_val = static_cast<int>(exp_field) - Hfloat::bias;
+
+	for (int i = static_cast<int>(ndigits) - 1; i >= 0; --i) {
+		unsigned hex_digit = 0;
+		for (unsigned b = 0; b < 4u; ++b) {
+			if (number.getbit(static_cast<unsigned>(i) * 4u + b)) {
+				hex_digit |= (1u << b);
+			}
+		}
+		s << "0123456789ABCDEF"[hex_digit];
+	}
+	s << " * 16^" << exp_val;
+
+	return s.str();
+}
+
+
+// native semantic representation: radix-16, delegates to to_hex
+template<unsigned ndigits, unsigned es, typename BlockType>
+inline std::string to_native(const hfloat<ndigits, es, BlockType>& v, bool = false) {
+	return to_hex(v);
+}
 
 }} // namespace sw::universal


### PR DESCRIPTION
Third type of #1444 (Phase 2 group 5a of #1334).

## Acceptance numbers

gcc 13.3, `-std=c++20`:

| include | lines | headers | I/O-family |
|---|---:|---:|---:|
| `hfloat.hpp` before | 78,566 | 399 | 5 |
| `hfloat.hpp` after | 77,199 | 385 | 5 |
| **`core.hpp`** | **59,518** | **304** | **0** |
| target | under 45,000 | -- | 0 |

Zero I/O is met. Under-45,000 is not, and this reports the number reached rather than
moving the bar: `utility/decimal_to_binary.hpp`, which `parse()` converts through, is
**57,369 lines on its own** (already at 0 I/O), so this core sits within 2,200 lines of
its single largest dependency. Same shape as dfloat (#1446) -- the ceiling belongs to the
substrate, not the type.

## `str()` had to be reimplemented -- this PR's one real change

hfloat's `str()` is core surface (`operator<<` formats through it), but unlike dfloat's,
which concatenates, it built its result with a stringstream:

```cpp
std::stringstream ss;
if (nrDigits > 0) ss << std::setprecision(nrDigits);
ss << d;
```

That one function was the **only** reason this core would have needed `<sstream>`.

`std::ostream`'s `defaultfloat` presentation of a `double` *is* printf's `%g` at the
stream's precision (which defaults to 6), so `str()` now reaches the same formatter
through `snprintf("%.*g")` -- the `<cstdio>` idiom Phase 0 adopted -- with a two-pass call
so arbitrary precision still works, and a clamp on the `size_t` -> `int` narrowing.

**Verified, not assumed.** A standalone harness compared the two formulations over
**604,742 (value, precision) pairs** -- the full double exponent range from 1e-320 to
1e308, 40 mantissas per decade, precisions 0 through 60, plus every boundary value
(`min`, `max`, `denorm_min`, signed zeros) -- with **zero mismatches on gcc and clang**.
The differential below then compares **184,176 further `str()` renderings in situ**.

One observable difference remains, and it is deliberate: a stringstream carries the
**global locale** while `snprintf` uses the **C locale**, so a program that calls
`std::locale::global` with a non-C numeric facet would previously have seen a localised
decimal separator from `str()` and now will not. Nothing in the tree sets one, and for a
library rendering a hexadecimal float's value the C locale is the defensible answer --
but it is a real difference and should be a conscious call, not a silent one.

## What else moved

- **`to_binary()`, `to_hex()`, `to_native()`** format through a stringstream ->
  `manipulators.hpp`.
- **`operator<<`, `operator>>`** -> `iostream.hpp`, which includes **only `core.hpp`**:
  `operator<<` formats through `str()` and `operator>>` hands its token to `parse()`, both
  core, so there is no dependency on `manipulators.hpp` at all.
- **`parse()` stays in the core.** It converts through `utility/decimal_to_binary.hpp`,
  already at 0 I/O, so it is arithmetic surface -- the same call dfloat's `parse()` got,
  and the opposite of cfloat's and bfloat16's, which run an `istringstream`.
- `native/ieee754.hpp` -> `native/ieee754_core.hpp`.
- `HFLOAT_ENABLE_LITERALS`, `HFLOAT_THROW_ARITHMETIC_EXCEPTION` and `HFLOAT_EXCEPT` now
  default in `hfloat_impl.hpp` beside the code they govern (#1436 applied up front).
- `manipulators.hpp` and `attributes.hpp` had **no includes at all** -- they reached
  `std::stringstream`, `std::setw`, `Color`, `type_tag` and `operator<<` entirely through
  the umbrella's include order. Both now name what they use (#1389).

## Verification

- **Layer gate** (#1390): `core.hpp` alone, and `core.hpp` + `manipulators.hpp`, each
  compiled, linked and run under `-Wall -Wpedantic` on gcc 13.3 and clang.
- **Self-containment**: core, manipulators, iostream, attributes and the umbrella each
  compile standalone with 0 errors on both compilers.
- **12 targets built and run green on both compilers**: the 10 hfloat tests plus `ucalc`
  and `ucalc_regression`.
- **Differential against `main`**, from a worktree: hfp32 and hfp64 across *every*
  exponent code against 24 fraction patterns; all three formats across 155 decades x 4
  mantissas driven through `parse()`; each row rendered by `to_binary` (both nibble
  settings), `to_hex`, `to_native`, `color_print`, **`str()` at 23 precisions**,
  `operator<<` under six stream states, plus negation, square and double.

  **7,896,511 bytes of stdout and all 30 stderr diagnostics byte-identical** -- old vs new
  on gcc, old vs new on clang, *and* gcc vs clang.

  The cross-compiler check earned its place: the first version of the probe built hfp128
  encodings with `uint64_t(e) << 120`, which is UB, and gcc and clang duly disagreed on
  5,890 lines. That was the probe, not the headers -- `setbits(uint64_t)` cannot reach
  hfp128's exponent field at bits 120..126 at all -- and the wide format is now driven
  through `parse()` instead.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream input and output support for hfloat values, including preservation of formatting settings.
  * Added binary, hexadecimal, and native-format string representations for hfloat values.
  * Improved parsing error reporting when reading hfloat values from streams.

* **Refactor**
  * Organized hfloat functionality into more focused components, improving compatibility for arithmetic-only use cases.
  * Improved string conversion reliability and efficiency while preserving existing interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->