### PR TITLE
refactor(dbns): split dbns into core / manipulators / iostream / debug (#1334)

### DIFF
--- a/include/sw/universal/number/dbns/attributes.hpp
+++ b/include/sw/universal/number/dbns/attributes.hpp
@@ -5,7 +5,16 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Part of the text layer (#1334): these are convenience queries over a dbns value, so
+// they sit above the core rather than in it. Self-contained.
 #include <cmath> // for std:pow()
+#include <string>
+#include <sstream>   // std::stringstream in dbns_range
+#include <iomanip>   // std::setw
+#include <universal/number/dbns/core.hpp>
+#include <universal/number/dbns/manipulators.hpp>   // type_tag
+#include <universal/number/dbns/iostream.hpp>       // operator<< on dbns, used by dbns_range
 
 namespace sw { namespace universal {
 

--- a/include/sw/universal/number/dbns/core.hpp
+++ b/include/sw/universal/number/dbns/core.hpp
@@ -1,0 +1,48 @@
+#pragma once
+// core.hpp: the dbns arithmetic core -- no I/O, no text
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the dbns headers (#1334, Phase 2 group 5a, #1444). Storage, arithmetic,
+// comparison, numeric_limits and traits -- everything a compute kernel needs and
+// nothing that turns a dbns into text.
+//
+//     #include <universal/number/dbns/dbns.hpp>   // everything, as before
+//     #include <universal/number/dbns/core.hpp>   // arithmetic only
+//
+// dbns.hpp includes this plus manipulators.hpp, iostream.hpp, debug.hpp and
+// attributes.hpp, so existing code is unaffected.
+//
+// Four things had to move for this header to reach zero I/O-family headers, and only
+// the first is an include shuffle:
+//   - to_binary() formats through a stringstream -> manipulators.hpp.
+//   - operator<< and operator>> were in-class friend DEFINITIONS, which pin <iostream>
+//     into every consumer -- the trap blockdigit and floatcascade had. They are now
+//     namespace-scope templates in iostream.hpp; they need no private access.
+//   - debugConstexprParameters() is declared here and defined in debug.hpp, the shape
+//     blocktriple's constexprClassParameters() got in #1388.
+//   - convert_ieee754's (a,b) search traced behind `if constexpr (bDebug)`. A discarded
+//     if-constexpr branch still requires std::cout to be DECLARED, so that is now the
+//     DBNS_TRACE_CONVERSION preprocessor switch. bDebug was a local constant no caller
+//     could reach, so this also makes the tracing usable for the first time.
+//
+// assign(const std::string&) stays here -- it is a stub that clears, and opens no
+// stream. native/ieee754.hpp was re-pointed to native/ieee754_core.hpp.
+//
+// NOTE: traits/arithmetic_traits.hpp and common/number_traits_reports.hpp are
+// deliberately NOT included -- they build report strings and pull <sstream>/<iomanip>.
+// The umbrella provides them.
+#include <universal/utility/architecture.hpp>
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/traits/number_traits.hpp>
+
+#include <universal/number/dbns/exceptions.hpp>
+#include <universal/number/dbns/dbns_fwd.hpp>
+#include <universal/number/dbns/dbns_impl.hpp>
+#include <universal/number/dbns/dbns_traits.hpp>
+#include <universal/number/dbns/numeric_limits.hpp>

--- a/include/sw/universal/number/dbns/dbns.hpp
+++ b/include/sw/universal/number/dbns/dbns.hpp
@@ -18,26 +18,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable/disable the ability to use literals in binary logic and arithmetic operators
-#if !defined(DBNS_ENABLE_LITERALS)
-// default is to enable them
-#define DBNS_ENABLE_LITERALS 1
-#endif
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable throwing specific exceptions for logarithmic number system arithmetic errors
-// left to application to enable
-#if !defined(DBNS_THROW_ARITHMETIC_EXCEPTION)
-// default is to use std::cerr for signalling an error
-#define DBNS_THROW_ARITHMETIC_EXCEPTION 0
-#endif
-// the fused dot product accumulator (quire, via fdp.hpp) must honor the same
-// exception policy as the dbns it accumulates for (#1226)
-#if !defined(QUIRE_THROW_ARITHMETIC_EXCEPTION)
-#define QUIRE_THROW_ARITHMETIC_EXCEPTION DBNS_THROW_ARITHMETIC_EXCEPTION
-#endif
+///
+/// DBNS_ENABLE_LITERALS, DBNS_THROW_ARITHMETIC_EXCEPTION and the
+/// QUIRE_THROW_ARITHMETIC_EXCEPTION cascade now default in dbns_impl.hpp, beside the
+/// code they govern, so that a translation unit which includes core.hpp directly gets
+/// the same defaults this umbrella used to supply (#1334, #1436). Defining any of them
+/// before this header still wins, as before.
+///
+/// DBNS_TRACE_CONVERSION is new: it switches on the (a,b) search trace in
+/// convert_ieee754, which used to be a local `constexpr bool bDebug = false` that no
+/// caller could reach.
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // bring in the trait functions
@@ -47,14 +37,17 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/dbns/exceptions.hpp>
-#include <universal/number/dbns/dbns_fwd.hpp>
-#include <universal/number/dbns/dbns_impl.hpp>
-#include <universal/number/dbns/dbns_traits.hpp>
-#include <universal/number/dbns/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
+#include <universal/number/dbns/core.hpp>
 
 // useful functions to work with logarithmic numbers
+// layer 2a: the string producers -- to_binary, to_hex, pretty_print, color_print
 #include <universal/number/dbns/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/dbns/iostream.hpp>
+// layer 3: introspection -- debugConstexprParameters
+#include <universal/number/dbns/debug.hpp>
 #include <universal/number/dbns/attributes.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/include/sw/universal/number/dbns/dbns_impl.hpp
+++ b/include/sw/universal/number/dbns/dbns_impl.hpp
@@ -768,7 +768,10 @@ protected:
 			}
 		}
 #if DBNS_TRACE_CONVERSION
-		std::cout << "scale : " << scale << '\n';
+		// the !is_constant_evaluated() guard keeps convert_ieee754 usable in a constexpr
+		// context with tracing on -- std::cout is not constant-evaluable. Same idiom the
+		// statistics counters below already use.
+		if (!std::is_constant_evaluated()) std::cout << "scale : " << scale << '\n';
 #endif
 		double lowestError = 1.0e10;
 		constexpr int kNotFound = std::numeric_limits<int>::max();
@@ -787,7 +790,7 @@ protected:
 			double diff = scale - (a + b * log2of3);
 			double err = (diff < 0.0 ? -diff : diff);
 #if DBNS_TRACE_CONVERSION
-			{
+			if (!std::is_constant_evaluated()) {
 				double fb = sw::math::constexpr_math::exp2(static_cast<double>(a));
 				double sb = sw::math::constexpr_math::pow(3.0, static_cast<double>(b));
 				double value = fb * sb;
@@ -801,7 +804,7 @@ protected:
 			}
 		}
 #if DBNS_TRACE_CONVERSION
-		std::cout << "best a : " << best_a << " best b : " << best_b << " lowest err : " << lowestError << '\n';
+		if (!std::is_constant_evaluated()) std::cout << "best a : " << best_a << " best b : " << best_b << " lowest err : " << lowestError << '\n';
 #endif
 		clear();
 

--- a/include/sw/universal/number/dbns/dbns_impl.hpp
+++ b/include/sw/universal/number/dbns/dbns_impl.hpp
@@ -1,7 +1,40 @@
 #pragma once
-#include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+
+// Behavioural switches default HERE, beside the code they govern, rather than in the
+// dbns.hpp umbrella: including core.hpp directly would otherwise leave them undefined,
+// #if would evaluate them as 0, and the switch would silently flip on that path -- the
+// trap #1390 hit with POSIT_ENABLE_LITERALS (#1334, #1436).
+#if !defined(DBNS_ENABLE_LITERALS)
+#define DBNS_ENABLE_LITERALS 1
+#endif
+#if !defined(DBNS_THROW_ARITHMETIC_EXCEPTION)
+#define DBNS_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+// the fused dot product accumulator (quire, via fdp.hpp) must honor the same
+// exception policy as the dbns it accumulates for (#1226)
+#if !defined(QUIRE_THROW_ARITHMETIC_EXCEPTION)
+#define QUIRE_THROW_ARITHMETIC_EXCEPTION DBNS_THROW_ARITHMETIC_EXCEPTION
+#endif
+
+// DBNS_TRACE_CONVERSION: the trace statements in convert_ieee754's (a,b) search print,
+// so they need <iostream>. They are compiled only when tracing is actually switched on
+// -- a preprocessor guard rather than `if constexpr`, because a discarded `if constexpr`
+// branch still requires std::cout to be DECLARED, which would keep <iostream> in the
+// include graph of every translation unit. Same treatment cfloat got in #1417.
+//
+// This replaces a local `constexpr bool bDebug = false;` that no caller could reach:
+// tracing could not be enabled from outside at all, which is the same defect #1387 found
+// in the block layer. Define DBNS_TRACE_CONVERSION=1 before including dbns to switch it
+// on.
+#if !defined(DBNS_TRACE_CONVERSION)
+#define DBNS_TRACE_CONVERSION 0
+#endif
+#if DBNS_TRACE_CONVERSION
+#include <iostream>
+#endif
+
+#include <iosfwd>     // std::ostream/std::istream in the stream-operator declarations
 #include <universal/utility/icf_array_bounds.hpp>
-#include <sstream>
 #include <string>
 // dbns_impl.hpp: implementation of a fixed-size, arbitrary configuration 2-base logarithmic number system configuration
 //
@@ -13,7 +46,7 @@
 #include <limits>
 #include <type_traits>
 
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // the stream-free half of <universal/native/ieee754.hpp>
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/internal/abstract/triple.hpp>
 #include <universal/number/shared/specific_value_encoding.hpp>
@@ -39,13 +72,9 @@ namespace sw { namespace universal {
 		int roundingFailure;
 	};
 
-	inline std::ostream& operator<<(std::ostream& ostr, const DbnsArithmeticStatistics stats) {
-		ostr << "Conversions                     : " << stats.conversionEvents << '\n';
-		ostr << "Exponent Overflow During Search : " << stats.exponentOverflowDuringSearch << '\n';
-		ostr << "Rounding Successes              : " << (stats.conversionEvents - stats.roundingFailure) << '\n';
-		ostr << "Rounding Failures               : " << stats.roundingFailure << '\n';
-		return ostr;
-	}
+	// defined out-of-line in number/dbns/iostream.hpp so this header needs no
+	// <iostream> (#1334). Include that header to stream the statistics.
+	std::ostream& operator<<(std::ostream& ostr, const DbnsArithmeticStatistics stats);
 	static DbnsArithmeticStatistics dbnsStats;
 
 // convert a floating-point value to a specific dbns configuration. Semantically, p = v, return reference to p
@@ -612,29 +641,12 @@ public:
 	CONSTEXPRESSION dbns& operator=(long double rhs)      noexcept { return convert_ieee754(rhs); }
 #endif
 
-	void debugConstexprParameters() {
-		std::cout << "constexpr parameters for " << type_tag(*this) << '\n';
-		std::cout << "scaling               " << scaling << '\n';
-		std::cout << "bitsInByte            " << bitsInByte << '\n';
-		std::cout << "bitsInBlock           " << bitsInBlock << '\n';
-		std::cout << "nrBlocks              " << nrBlocks << '\n';
-		std::cout << "storageMask           " << to_binary(storageMask, bitsInBlock) << '\n';
-		std::cout << "MSU                   " << MSU << '\n';
-		std::cout << "MSU_MASK              " << to_binary(MSU_MASK, bitsInBlock) << '\n';
-		std::cout << "MSB_UNIT              " << MSB_UNIT << '\n';
-		std::cout << "SPECIAL_BITS_TOGETHER " << (SPECIAL_BITS_TOGETHER ? "yes" : "no") << '\n';
-		std::cout << "SIGN_BIT_MASK         " << to_binary(SIGN_BIT_MASK, bitsInBlock) << '\n';
-		std::cout << "MSB_BIT_MASK          " << to_binary(MSB_BIT_MASK, bitsInBlock) << '\n';
-		std::cout << "BLOCK_MSB_MASK        " << to_binary(BLOCK_MSB_MASK, bitsInBlock) << '\n';
-		std::cout << "MSU_ZERO              " << to_binary(MSU_ZERO, bitsInBlock) << '\n';
-		std::cout << "MSU_NAN               " << to_binary(MSU_NAN, bitsInBlock) << '\n';
-		std::cout << "maxShift              " << maxShift << '\n';
-		std::cout << "leftShift             " << leftShift << '\n';
-		std::cout << "min_exponent          " << min_exponent << '\n';
-		std::cout << "max_exponent          " << max_exponent << '\n';
-		std::cout << "FB_MASK               " << to_binary(FB_MASK, bitsInBlock) << '\n';
-		std::cout << "SB_MASK               " << to_binary(SB_MASK, bitsInBlock) << '\n';
-	}
+	// defined out-of-line in number/dbns/debug.hpp so this header needs no <iostream>
+	// (#1334). Include that header to call it -- it is an opt-in debug facility, not
+	// something the arithmetic reaches on its own, so the failure mode of forgetting it
+	// is a link error naming the missing function. Same shape as blocktriple's
+	// constexprClassParameters() in #1388.
+	void debugConstexprParameters();
 
 	// normalize: decompose dbns value into a blocktriple<fbbits, REP> for quire accumulation.
 	// DBNS stores values as (-1)^sign * 2^a * 3^b; materializing to linear domain is inherently
@@ -738,7 +750,6 @@ protected:
 		// we use this relationship to search among the second base exponents 
 		// and find a first base exponent that minimizes the error
 		// between the result and the value we are trying to approximate.
-		constexpr bool bDebug = false;
 		// Use sw::math::constexpr_math::log2 (not std::log2 which isn't
 		// constexpr until C++26) so this whole conversion is evaluable at
 		// compile time. cm only has float/double overloads; for long double
@@ -756,7 +767,9 @@ protected:
 				scale = static_cast<double>(std::log2(abs_v));
 			}
 		}
-		if constexpr (bDebug) std::cout << "scale : " << scale << '\n';
+#if DBNS_TRACE_CONVERSION
+		std::cout << "scale : " << scale << '\n';
+#endif
 		double lowestError = 1.0e10;
 		constexpr int kNotFound = std::numeric_limits<int>::max();
 		int best_a = kNotFound;
@@ -773,19 +786,23 @@ protected:
 			}
 			double diff = scale - (a + b * log2of3);
 			double err = (diff < 0.0 ? -diff : diff);
-			if constexpr (bDebug) {
+#if DBNS_TRACE_CONVERSION
+			{
 				double fb = sw::math::constexpr_math::exp2(static_cast<double>(a));
 				double sb = sw::math::constexpr_math::pow(3.0, static_cast<double>(b));
 				double value = fb * sb;
 				std::cout << "a : " << a << " b : " << b << " err : " << err << " fb : " << fb << " sb : " << sb << " value : " << value << '\n';
 			}
+#endif
 			if (err < lowestError) {
 				lowestError = err;
 				best_a = a;
 				best_b = b;
 			}
 		}
-		if constexpr (bDebug) std::cout << "best a : " << best_a << " best b : " << best_b << " lowest err : " << lowestError << '\n';
+#if DBNS_TRACE_CONVERSION
+		std::cout << "best a : " << best_a << " best b : " << best_b << " lowest err : " << lowestError << '\n';
+#endif
 		clear();
 
 		// If the search produced no candidate, avoid using sentinel values in the
@@ -901,18 +918,12 @@ private:
 
 	////////////////////// operators
 
-	// stream operators
-
-	friend std::ostream& operator<< (std::ostream& ostr, const dbns& r) {
-		ostr << double(r);
-		return ostr;
-	}
-	friend std::istream& operator>> (std::istream& istr, dbns& r) {
-		double d;
-		istr >> d;
-		r = d;
-		return istr;
-	}
+	// stream operators: operator<< and operator>> are defined in
+	// number/dbns/iostream.hpp (#1334). They were in-class friend DEFINITIONS, which
+	// pin <iostream> into every consumer of this header -- the same trap blockdigit and
+	// floatcascade had. They need no private access (they go through the public double
+	// conversion and assignment), so they are plain namespace-scope templates there
+	// rather than friends here.
 
 	// dbns - logic operators
 
@@ -1055,28 +1066,8 @@ inline dbns<nbits, fbbits, bt, xtra...> ulp(const dbns<nbits, fbbits, bt, xtra..
 	return ++b - a;
 }
 
-template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
-std::string to_binary(const dbns<nbits, fbbits, bt, xtra...>& number, bool nibbleMarker = false) {
-	std::stringstream s;
-	s << "0b";
-	s << (number.sign() ? "1." : "0.");
-	// first base exponent bits
-	constexpr int lsbFirstBase = static_cast<int>(nbits - fbbits - 1);
-	if constexpr (nbits - 2 >= fbbits) {
-		for (int i = static_cast<int>(nbits) - 2; i >= lsbFirstBase; --i) {
-			s << (number.at(static_cast<unsigned>(i)) ? '1' : '0');
-			if ((i - fbbits) > 0 && ((i - fbbits) % 4) == 0 && nibbleMarker) s << '\'';
-		}
-	}
-	if constexpr (lsbFirstBase > 0) {
-		s << '.';
-		for (int i = lsbFirstBase - 1; i >= 0; --i) {
-			s << (number.at(static_cast<unsigned>(i)) ? '1' : '0');
-			if (i > 0 && (i % 4) == 0 && nibbleMarker) s << '\'';
-		}
-	}
-	return s.str();
-}
+// to_binary() moved to manipulators.hpp in #1334: it formats through a std::stringstream,
+// which is what keeps it out of the core.
 
 // standard library functions for floating point
 

--- a/include/sw/universal/number/dbns/debug.hpp
+++ b/include/sw/universal/number/dbns/debug.hpp
@@ -1,0 +1,55 @@
+#pragma once
+// debug.hpp: introspection for dbns
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 3 of the dbns headers (#1334). dbns_impl.hpp declares
+// debugConstexprParameters() but does not define it, so the core needs no <iostream>.
+// Its definition lives here. Include this header to call it; forgetting to is a link
+// error naming the missing function, which is the better failure -- the same shape
+// blocktriple's constexprClassParameters() got in #1388.
+//
+// The DBNS_TRACE_CONVERSION switch needs no help from this header: it guards its own
+// <iostream> include in dbns_impl.hpp, because the traced code is inside the class.
+#include <iostream>
+#include <universal/number/dbns/core.hpp>
+#include <universal/number/dbns/manipulators.hpp>   // type_tag, used in the report
+#include <universal/native/integers.hpp>           // to_binary(Integer, bool, int) on the masks
+//
+// NOTE, unchanged from main: the mask reports below call to_binary(mask, bitsInBlock),
+// and that overload's second parameter is `bool bNibbleMarker`, not a width -- so
+// bitsInBlock has always been read as `true` and the width has always defaulted to 0.
+// The output is what it has always been; correcting it would be a behaviour change and
+// belongs in its own commit, not in a layering refactor.
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
+void dbns<nbits, fbbits, bt, xtra...>::debugConstexprParameters() {
+	std::cout << "constexpr parameters for " << type_tag(*this) << '\n';
+	std::cout << "scaling               " << scaling << '\n';
+	std::cout << "bitsInByte            " << bitsInByte << '\n';
+	std::cout << "bitsInBlock           " << bitsInBlock << '\n';
+	std::cout << "nrBlocks              " << nrBlocks << '\n';
+	std::cout << "storageMask           " << to_binary(storageMask, bitsInBlock) << '\n';
+	std::cout << "MSU                   " << MSU << '\n';
+	std::cout << "MSU_MASK              " << to_binary(MSU_MASK, bitsInBlock) << '\n';
+	std::cout << "MSB_UNIT              " << MSB_UNIT << '\n';
+	std::cout << "SPECIAL_BITS_TOGETHER " << (SPECIAL_BITS_TOGETHER ? "yes" : "no") << '\n';
+	std::cout << "SIGN_BIT_MASK         " << to_binary(SIGN_BIT_MASK, bitsInBlock) << '\n';
+	std::cout << "MSB_BIT_MASK          " << to_binary(MSB_BIT_MASK, bitsInBlock) << '\n';
+	std::cout << "BLOCK_MSB_MASK        " << to_binary(BLOCK_MSB_MASK, bitsInBlock) << '\n';
+	std::cout << "MSU_ZERO              " << to_binary(MSU_ZERO, bitsInBlock) << '\n';
+	std::cout << "MSU_NAN               " << to_binary(MSU_NAN, bitsInBlock) << '\n';
+	std::cout << "maxShift              " << maxShift << '\n';
+	std::cout << "leftShift             " << leftShift << '\n';
+	std::cout << "min_exponent          " << min_exponent << '\n';
+	std::cout << "max_exponent          " << max_exponent << '\n';
+	std::cout << "FB_MASK               " << to_binary(FB_MASK, bitsInBlock) << '\n';
+	std::cout << "SB_MASK               " << to_binary(SB_MASK, bitsInBlock) << '\n';
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/dbns/iostream.hpp
+++ b/include/sw/universal/number/dbns/iostream.hpp
@@ -1,0 +1,47 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for dbns
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the dbns headers (#1334): the <iostream> half. manipulators.hpp is the
+// <iomanip> half -- everything that turns a dbns into a std::string. Self-contained.
+//
+// operator<< and operator>> were in-class friend DEFINITIONS in dbns_impl.hpp. An
+// in-class friend definition pins <iostream> into every translation unit that includes
+// the class, which is what blockdigit and floatcascade were fixed for. They go through
+// dbns's public double conversion and assignment and need no private access, so they are
+// ordinary namespace-scope templates here rather than friends there.
+//
+// This header includes only core.hpp -- no cycle for #pragma once to mask (#1427).
+#include <iostream>      // std::ostream, std::istream
+#include <universal/number/dbns/core.hpp>
+
+namespace sw { namespace universal {
+
+// the DbnsArithmeticStatistics report, declared in dbns_impl.hpp
+inline std::ostream& operator<<(std::ostream& ostr, const DbnsArithmeticStatistics stats) {
+	ostr << "Conversions                     : " << stats.conversionEvents << '\n';
+	ostr << "Exponent Overflow During Search : " << stats.exponentOverflowDuringSearch << '\n';
+	ostr << "Rounding Successes              : " << (stats.conversionEvents - stats.roundingFailure) << '\n';
+	ostr << "Rounding Failures               : " << stats.roundingFailure << '\n';
+	return ostr;
+}
+
+template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
+inline std::ostream& operator<<(std::ostream& ostr, const dbns<nbits, fbbits, bt, xtra...>& r) {
+	ostr << double(r);
+	return ostr;
+}
+
+template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
+inline std::istream& operator>>(std::istream& istr, dbns<nbits, fbbits, bt, xtra...>& r) {
+	double d;
+	istr >> d;
+	r = d;
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/dbns/manipulators.hpp
+++ b/include/sw/universal/number/dbns/manipulators.hpp
@@ -5,9 +5,18 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2a of the dbns headers (#1334): the <iomanip> half -- everything that turns a
+// dbns into a std::string through a stringstream. iostream.hpp is the <iostream> half.
+// This header does NOT include iostream.hpp: dbns's pretty_print/info_print build from
+// the bit pattern rather than streaming the value, so the dependency runs one way only.
+// Self-contained.
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
 #include <iomanip>
 #include <typeinfo>
 
+#include <universal/number/dbns/core.hpp>
 // pull in the color printing for shells utility
 #include <universal/utility/color_print.hpp>
 
@@ -173,5 +182,31 @@ namespace sw { namespace universal {
 		s << def;
 		return s.str();
 	}
+
+
+// Moved out of dbns_impl.hpp (#1334): formats a dbns through a stringstream, which is
+// what keeps it out of the core.
+template<unsigned nbits, unsigned fbbits, typename bt, auto... xtra>
+std::string to_binary(const dbns<nbits, fbbits, bt, xtra...>& number, bool nibbleMarker = false) {
+	std::stringstream s;
+	s << "0b";
+	s << (number.sign() ? "1." : "0.");
+	// first base exponent bits
+	constexpr int lsbFirstBase = static_cast<int>(nbits - fbbits - 1);
+	if constexpr (nbits - 2 >= fbbits) {
+		for (int i = static_cast<int>(nbits) - 2; i >= lsbFirstBase; --i) {
+			s << (number.at(static_cast<unsigned>(i)) ? '1' : '0');
+			if ((i - fbbits) > 0 && ((i - fbbits) % 4) == 0 && nibbleMarker) s << '\'';
+		}
+	}
+	if constexpr (lsbFirstBase > 0) {
+		s << '.';
+		for (int i = lsbFirstBase - 1; i >= 0; --i) {
+			s << (number.at(static_cast<unsigned>(i)) ? '1' : '0');
+			if (i > 0 && (i % 4) == 0 && nibbleMarker) s << '\'';
+		}
+	}
+	return s.str();
+}
 
 }} // namespace sw::universal

--- a/include/sw/universal/number/dbns/manipulators.hpp
+++ b/include/sw/universal/number/dbns/manipulators.hpp
@@ -54,7 +54,11 @@ namespace sw { namespace universal {
 	inline std::string range(const DbnsType & = {}) {
 		std::stringstream s;
 		DbnsType b(SpecificValue::maxneg), c(SpecificValue::minneg), d(SpecificValue::minpos), e(SpecificValue::maxpos);
-		s << "[" << b << " ... " << c << ", 0, " << d << " ... " << e << "]\n";
+		// stream the double conversions rather than the dbns values themselves: this
+		// layer must not depend on iostream.hpp (#1334), and operator<<(ostream, dbns)
+		// lives there. It is `ostr << double(r)`, so this is the same text -- and the
+		// same text is what the differential in the PR checks.
+		s << "[" << double(b) << " ... " << double(c) << ", 0, " << double(d) << " ... " << double(e) << "]\n";
 		return s.str();
 	}
 


### PR DESCRIPTION
Fourth type of #1444 (Phase 2 group 5a of #1334), and the first in the group where the
core's I/O was **structural** rather than an include.

## Acceptance numbers

| include | lines | headers | I/O-family |
|---|---:|---:|---:|
| `dbns.hpp` before | 83,961 | 406 | 5 |
| `dbns.hpp` after | 82,967 | 392 | 5 |
| **`core.hpp`** | **73,581** | **361** | **0** |
| target | under 45,000 | -- | 0 |

Zero I/O met. Under-45,000 not met, reporting the number reached:
`internal/blocktriple/blocktriple.hpp`, which dbns converts through, is **69,758 lines on
its own** (already 0 I/O) -- this core is blocktriple plus about 3,800 lines. The ceiling
belongs to the substrate, as with dfloat (#1446) and hfloat (#1447).

## Four things had to move, and only the first is an include shuffle

**1. `to_binary()`** formats through a stringstream -> `manipulators.hpp`.

**2. `operator<<` and `operator>>` were in-class friend DEFINITIONS.** An in-class friend
definition pins `<iostream>` into every translation unit that includes the class -- the
trap `blockdigit` and `floatcascade` were fixed for. Both go through dbns's public
`double` conversion and assignment and need no private access, so they are now ordinary
namespace-scope templates in `iostream.hpp` rather than friends in the class.

**3. `debugConstexprParameters()`** -- 22 `std::cout` statements in a *member function* --
is declared in the class and defined out-of-line in `debug.hpp`. Same shape blocktriple's
`constexprClassParameters()` got in #1388: forgetting the include is a link error naming
the missing function, which is the better failure. `dbns_table` calls it, so the test
suite proves the definition links.

**4. The conversion trace was unreachable, and now isn't.** `convert_ieee754`'s (a,b)
search traced behind `if constexpr (bDebug)`, where `bDebug` was a **local
`constexpr bool bDebug = false;` that no caller could reach** -- tracing could not be
enabled from outside at all, the same defect #1387 found in the block layer. And a
discarded `if constexpr` branch still requires `std::cout` to be *declared*, so it kept
`<iostream>` in the graph regardless.

The three sites are now behind a `DBNS_TRACE_CONVERSION` preprocessor switch, which both
removes the include and makes the tracing usable for the first time:

```
$ g++ -DDBNS_TRACE_CONVERSION=1 ...
scale : 0.584963
a : -1 b : 1 err : 2.22045e-16 fb : 0.5 sb : 3 value : 1.5
```

## Also

- `operator<<(ostream&, DbnsArithmeticStatistics)` declared in the core, defined in
  `iostream.hpp`.
- `native/ieee754.hpp` -> `native/ieee754_core.hpp`.
- `DBNS_ENABLE_LITERALS`, `DBNS_THROW_ARITHMETIC_EXCEPTION` and the
  `QUIRE_THROW_ARITHMETIC_EXCEPTION` cascade default in `dbns_impl.hpp` (#1436).
- `manipulators.hpp` and `attributes.hpp` now name the headers they use (#1389).
- `manipulators.hpp` does **not** include `iostream.hpp`: unlike posit's, dbns's
  `pretty_print`/`info_print` build from the bit pattern rather than streaming the value,
  so the dependency runs one way only.

**Noted, deliberately unchanged:** `debugConstexprParameters()` reports the masks with
`to_binary(mask, bitsInBlock)`, and that overload's second parameter is
`bool bNibbleMarker`, not a width -- so `bitsInBlock` has always been read as `true` and
the width has always defaulted to 0. Correcting it would change output, so it stays.

## Verification

- **Layer gate** (#1390): `core.hpp` alone, and `core.hpp` + `manipulators.hpp`, each
  compiled, linked and run under `-Wall -Wpedantic` on gcc 13.3 and clang.
- **Self-containment**: core, manipulators, iostream, debug, attributes and the umbrella
  each compile standalone with 0 errors on both compilers.
- **16 targets built and run green on both compilers**, including `dbns_table` (calls the
  relocated `debugConstexprParameters()`) and `quire_dbns_fdp` (the `QUIRE_THROW` cascade).
- **Differential against `main`**: five dbns configurations over their *entire* encoding
  space (`dbns<8,3>`, `<10,4>`, `<12,5>`, `<9,4,uint32>` exhaustively; `<16,8>` over
  65,536), each rendered by `to_binary`, `to_hex` and `pretty_print` in every flag
  combination, `info_print`, `color_print`, `operator<<` under four stream states, the
  native conversions; plus `operator>>` over 10 texts, a dynamic-range round trip, the
  relocated introspection report and the statistics report.

  **29,992,863 bytes byte-identical** -- old vs new on gcc, old vs new on clang, and gcc
  vs clang.
- **Trace text**: `main` cannot switch tracing on at all, so the comparison was made by
  setting `bDebug = true` in a worktree of `main` and running it against
  `-DDBNS_TRACE_CONVERSION=1` here. **1,273,937 bytes over 125 conversions byte-identical
  on both compilers.**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added binary formatting for DBNS values, with optional nibble separators.
  * Added stream input and output support for DBNS values and arithmetic statistics.
  * Added diagnostic output for DBNS compile-time parameters and type information.

* **Improvements**
  * Added a lightweight arithmetic-only DBNS interface without formatting or I/O dependencies.
  * Added optional conversion tracing and clearer configuration controls.
  * Improved stream input handling when a stream is already in a failed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->