### PR TITLE
fix: cfloat include edits

### DIFF
--- a/include/sw/universal/common/show_representations.hpp
+++ b/include/sw/universal/common/show_representations.hpp
@@ -1,0 +1,33 @@
+// show_representations.hpp: show output of different manipulators
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////////////
+/// required std libraries
+#include <ostream>
+#include <iomanip>
+
+namespace sw {
+    namespace universal {
+
+// ShowRepresentations prints the different output formats for the Scalar type
+template<typename Scalar>
+void ShowRepresentations(std::ostream& ostr, Scalar f) {
+	auto defaultPrecision = ostr.precision(); // save stream state
+
+	constexpr int max_digits10 = std::numeric_limits<Scalar>::max_digits10; 	// floating-point attribute for printing scientific format
+
+	Scalar v(f); // convert to target cfloat
+	ostr << "scientific   : " << std::setprecision(max_digits10) << v << '\n';
+	ostr << "triple form  : " << to_triple(v) << '\n';
+	ostr << "binary form  : " << to_binary(v, true) << '\n';
+	ostr << "color coded  : " << color_print(v) << '\n';
+
+	ostr << std::setprecision(defaultPrecision);
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/cfloat/cfloat.hpp
+++ b/include/sw/universal/number/cfloat/cfloat.hpp
@@ -7,17 +7,17 @@
 #pragma once
 
 ////////////////////////////////////////////////////////////////////////////////////////
-///  COMPILATION DIRECTIVES TO DIFFERENT COMPILERS
+/// required std libraries
 #include <ostream>       // std::ostream in the report helpers
 #include <iomanip>       // std::setprecision
 #include <cstdint>       // the fixed-width integer types
 #include <limits>        // std::numeric_limits
+
+////////////////////////////////////////////////////////////////////////////////////////
+///  COMPILATION DIRECTIVES TO DIFFERENT COMPILERS
 #include <universal/utility/architecture.hpp>
 #include <universal/utility/bit_cast.hpp>
 #include <universal/utility/long_double.hpp>
-
-////////////////////////////////////////////////////////////////////////////////////////
-/// required std libraries 
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
@@ -64,7 +64,7 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// layer 1: the arithmetic core. Include core.hpp directly in a translation
 // unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
 #include <universal/number/cfloat/core.hpp>
 
@@ -84,7 +84,7 @@
 #include <universal/number/cfloat/mathext.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////
-/// fused dot product / quire accumulation support (quire_mul), matching posit.hpp
+/// fused dot product / quire accumulation support (quire_mul)
 #include <universal/number/cfloat/fdp.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -103,24 +103,44 @@ using fp16     = half;
 using single   = cfloat< 32, 8, uint32_t, true, false, false>;
 using fp32     = single;
 // IEEE-754 double precision floating-point
-using duble    = cfloat< 64, 11, uint32_t, true, false, false>;
+using duble    = cfloat< 64, 11, uint64_t, true, false, false>;
 using fp64     = duble;
 // IEEE-754 extended precision floating-point
-using xtndd    = cfloat< 80, 11, uint32_t, true, false, false>;
+using xtndd    = cfloat< 80, 11, uint64_t, true, false, false>;
 using fp80     = xtndd;
 // IEEE-754 quad (128bit) precision floating-point
 using quad     = cfloat<128, 15, uint32_t, true, false, false>;
 using fp128    = quad;
 // IEEE-754 octo (256bit) precision floating-point
-using octo     = cfloat<256, 19, uint32_t, true, false, false>;
+using octo     = cfloat<256, 19, uint64_t, true, false, false>;
 using fp256    = octo;
 
 // DL
 // Google brain float
 using bfloat_t = cfloat<16, 8, std::uint16_t, true, false, false>;
+
+// Microsoft float specializations
 using msfp8    = cfloat<8, 2, std::uint8_t, false, false, false>;
 using msfp9    = cfloat<9, 3, std::uint16_t, false, false, false>;
+
+// AMD float specializations
 using amd24    = cfloat<24, 8, std::uint32_t, false, false, false>;
+
+// NVIDIA float specializations
+// TensorFloat-32 (TF32) is a numeric floating point format designed for Tensor Core 
+// running on certain Nvidia GPUs. It was first implemented in the Ampere architecture.
+// TensorFloat-32 combines the 8-bit exponent size of IEEE single precision with the 
+// 10-bit mantissa size of half precision for a total of 19 bits per number. It is 
+// comparable to the bfloat16 format, which uses a 7-bit mantissa.
+using tf32 = cfloat<19, 8, std::uint32_t, true, false, false>;
+// The 19-significant-bit format fits within a double word (32 bits), and while it 
+// lacks precision compared with a normal 32-bit IEEE 754 floating-point number, 
+// it provides much faster computation, up to 8 times on a A100 (compared to a V100 using FP32).
+//
+// Stored in the same space as FP32, it is not a distinct storage format, but a specification 
+// for reduced-precision FP32 multiply–accumulate operations. FP32 inputs are rounded to TF32, 
+// multiplied to produce a 21-bit product (including the implicit msbit, this is an 11×11→22-bit multiply), 
+// and summed into a standard FP32 accumulator.
 
 // FP8 formats for DL
 // By default we enable both subnormals and max-exponent values
@@ -131,22 +151,6 @@ using fp8e4m3  = cfloat<8, 4, std::uint8_t, true, true, false>;
 using fp8e5m2  = cfloat<8, 5, std::uint8_t, true, true, false>;
 
 // helpers
-
-// ShowRepresentations prints the different output formats for the Scalar type
-// TODO: guard with cfloat trait
-template<typename Scalar>
-void ShowRepresentations(std::ostream& ostr, Scalar f) {
-	auto defaultPrecision = ostr.precision(); // save stream state
-
-	constexpr int max_digits10 = std::numeric_limits<Scalar>::max_digits10; 	// floating-point attribute for printing scientific format
-
-	Scalar v(f); // convert to target cfloat
-	ostr << "scientific   : " << std::setprecision(max_digits10) << v << '\n';
-	ostr << "triple form  : " << to_triple(v) << '\n';
-	ostr << "binary form  : " << to_binary(v, true) << '\n';
-	ostr << "color coded  : " << color_print(v) << '\n';
-
-	ostr << std::setprecision(defaultPrecision);
-}
+// none yet
 
 }}  // namespace sw::universal


### PR DESCRIPTION
Rearranging the include header and removing unused helper from the umbrella header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for NVIDIA TF32-compatible floating-point values.
  - Added a formatter for scientific, triple, binary, and color-coded scalar representations.
- **Improvements**
  - Updated extended floating-point types to use 64-bit storage.
  - Formatting now uses maximum decimal precision and restores the stream’s original precision afterward.
  - Improved compatibility by ensuring required standard-library definitions are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->