### PR TITLE
refactor(areal): split areal into core / manipulators / iostream / debug (#1334)

### DIFF
--- a/include/sw/universal/number/areal/areal.hpp
+++ b/include/sw/universal/number/areal/areal.hpp
@@ -15,28 +15,27 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 ///  BEHAVIORAL COMPILATION SWITCHES
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable/disable the ability to use literals in binary logic and arithmetic operators
-#if !defined(AREAL_ENABLE_LITERALS)
-// default is to enable them
-#define AREAL_ENABLE_LITERALS 1
-#endif
-
-////////////////////////////////////////////////////////////////////////////////////////
-// enable throwing specific exceptions for integer arithmetic errors
-// left to application to enable
-#if !defined(AREAL_THROW_ARITHMETIC_EXCEPTION)
-// default is to use std::cerr for signalling an error
-#define AREAL_THROW_ARITHMETIC_EXCEPTION 0
-#endif
+///
+/// AREAL_ENABLE_LITERALS and AREAL_THROW_ARITHMETIC_EXCEPTION now default in
+/// areal_impl.hpp, beside the code they govern, so that a translation unit which includes
+/// core.hpp directly gets the same defaults this umbrella used to supply (#1334, #1436).
+/// Defining either before this header still wins, as before.
+///
+/// TRACE_CONVERSION, which switches on the conversion tracing, has always defaulted in
+/// areal_impl.hpp; its <iostream> include now sits inside that guard too.
 
 ////////////////////////////////////////////////////////////////////////////////////////
 /// INCLUDE FILES that make up the library
-#include <universal/number/areal/exceptions.hpp>
-#include <universal/number/areal/areal_impl.hpp>
-#include <universal/number/areal/numeric_limits.hpp>
+// layer 1: the arithmetic core (#1334). Include core.hpp directly in a translation
+// unit that only computes -- it pulls no <iostream>/<sstream>/<iomanip>.
+#include <universal/number/areal/core.hpp>
+
+// layer 2a: the string producers -- to_string, to_binary, to_hex, pretty_print, color_print
 #include <universal/number/areal/manipulators.hpp>
+// layer 2b: the <iostream> half -- operator<< / operator>>
+#include <universal/number/areal/iostream.hpp>
+// layer 3: introspection -- constexprClassParameters
+#include <universal/number/areal/debug.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////////////
 /// math functions

--- a/include/sw/universal/number/areal/areal_impl.hpp
+++ b/include/sw/universal/number/areal/areal_impl.hpp
@@ -1,7 +1,21 @@
 #pragma once
-#include <iostream>   // std::cout/cerr used below (#1334: include what you use)
+
+// Behavioural switches default HERE, beside the code they govern, rather than in the
+// areal.hpp umbrella: including core.hpp directly would otherwise leave them undefined,
+// #if would evaluate them as 0, and the switch would silently flip on that path -- the
+// trap #1390 hit with POSIT_ENABLE_LITERALS (#1334, #1436).
+#if !defined(AREAL_ENABLE_LITERALS)
+#define AREAL_ENABLE_LITERALS 1
+#endif
+#if !defined(AREAL_THROW_ARITHMETIC_EXCEPTION)
+#define AREAL_THROW_ARITHMETIC_EXCEPTION 0
+#endif
+
+#include <cstdio>     // std::printf/fprintf; keeps <iostream> out of the core
+#include <iosfwd>     // std::ostream/std::istream in the friend declarations. UNCONDITIONAL:
+                      // the declarations exist whether or not tracing is on, so this must not
+                      // sit inside the TRACE_CONVERSION guard below.
 #include <universal/utility/icf_array_bounds.hpp>
-#include <sstream>
 #include <string>
 // areal_impl.hpp: implementation of an arbitrary configuration fixed-size floating-point representation with an uncertainty bit to represent a faithful floating-point system
 //
@@ -12,10 +26,20 @@
 #include <cassert>
 #include <limits>
 
-#include <universal/native/ieee754.hpp>
+#include <universal/native/ieee754_core.hpp>   // the stream-free half of <universal/native/ieee754.hpp>
 #include <universal/native/subnormal.hpp>
 #include <universal/utility/find_msb.hpp>
+// The text headers the trace blocks need, and ONLY they need: every to_binary() call in
+// this header sits inside `#if TRACE_CONVERSION`. native/integers.hpp supplies
+// to_binary(Integer) and carries <sstream>; native/manipulators.hpp supplies
+// to_binary(float)/to_binary(double), which the core's ieee754_core.hpp deliberately
+// omits. Leaving them unconditional kept three I/O-family headers in the graph of every
+// areal translation unit (#1334). debug.hpp includes integers.hpp in its own right.
+#if TRACE_CONVERSION
 #include <universal/native/integers.hpp>
+#include <universal/native/ieee754.hpp>   // to_binary(float)/to_binary(double): the text
+                                          // half of ieee754, which ieee754_core.hpp omits
+#endif
 #include <universal/internal/blockbinary/blockbinary.hpp>
 #include <universal/internal/blocktriple/blocktriple.hpp>
 #include <universal/number/shared/nan_encoding.hpp>
@@ -26,8 +50,16 @@
 #ifndef THROW_ARITHMETIC_EXCEPTION
 #define THROW_ARITHMETIC_EXCEPTION 0
 #endif
+// TRACE_CONVERSION: the trace statements below print, so they need <iostream>. They are
+// compiled only when tracing is actually switched on, and the include now moves inside the
+// guard with them -- an unconditional <iostream> here put four stream headers into the
+// graph of every translation unit that touched an areal (#1334, the same move cfloat's
+// trace includes got in #1417/#1418).
 #ifndef TRACE_CONVERSION
 #define TRACE_CONVERSION 0
+#endif
+#if TRACE_CONVERSION
+#include <iostream>
 #endif
 
 #include <universal/internal/bit_manipulation.hpp>
@@ -1269,7 +1301,10 @@ public:
 	/// <param name="stringRep">decimal scientific notation of a real number to be assigned</param>
 	/// <returns>reference to this areal</returns>
 	inline areal& assign(const std::string& stringRep) {
-		std::cout << "assign TBD\n";
+		// std::printf rather than std::cout: same destination, same text, and it keeps
+		// <iostream> out of the core (#1334). stdout ordering with std::cout is
+		// guaranteed while sync_with_stdio is on, which is the default.
+		std::printf("assign TBD\n");
 		return *this;
 	}
 
@@ -1473,25 +1508,11 @@ public:
 	}
 
 	// helper debug function, can remove/deprecate
-	void constexprClassParameters() const {
-		std::cout << "nbits             : " << nbits << '\n';
-		std::cout << "es                : " << es << std::endl;
-		std::cout << "ALLONES           : " << to_binary(ALLONES, bitsInBlock, true) << '\n';
-		std::cout << "BLOCK_MASK        : " << to_binary(BLOCK_MASK, bitsInBlock, true) << '\n';
-		std::cout << "nrBlocks          : " << nrBlocks << '\n';
-		std::cout << "bits in MSU       : " << bitsInMSU << '\n';
-		std::cout << "MSU               : " << MSU << '\n';
-		std::cout << "MSU MASK          : " << to_binary(MSU_MASK, bitsInBlock, true) << '\n';
-		std::cout << "SIGN_BIT_MASK     : " << to_binary(SIGN_BIT_MASK, bitsInBlock, true) << '\n';
-		std::cout << "LSB_BIT_MASK      : " << to_binary(LSB_BIT_MASK, bitsInBlock, true) << '\n';
-		std::cout << "MSU CAPTURES E    : " << (MSU_CAPTURES_E ? "yes\n" : "no\n");
-		std::cout << "EXP_SHIFT         : " << EXP_SHIFT << '\n';
-		std::cout << "MSU EXP MASK      : " << to_binary(MSU_EXP_MASK, bitsInBlock, true) << '\n';
-		std::cout << "EXP_BIAS          : " << EXP_BIAS << '\n';
-		std::cout << "MAX_EXP           : " << MAX_EXP << '\n';
-		std::cout << "MIN_EXP_NORMAL    : " << MIN_EXP_NORMAL << '\n';
-		std::cout << "MIN_EXP_SUBNORMAL : " << MIN_EXP_SUBNORMAL << '\n';
-	}
+	// defined out-of-line in number/areal/debug.hpp so this header needs no <iostream>
+	// (#1334). Include that header to call it -- forgetting to is a link error naming the
+	// missing function, the same shape blocktriple's constexprClassParameters() got in
+	// #1388.
+	void constexprClassParameters() const;
 
 	// extract the exponent field from the encoding
 	inline constexpr void exponent(blockbinary<es, bt>& e) const {
@@ -2165,33 +2186,9 @@ constexpr void convert(const blocktriple<srcbits, op, bt>& src, areal<nbits, es,
 }
 
 ////////////////////// operators
-template<unsigned nbits, unsigned es, typename bt>
-inline std::ostream& operator<<(std::ostream& ostr, const areal<nbits,es,bt>& v) {
-	// TODO: make it a native conversion
-	double d = double(v);
-	bool ubit = v.at(0);
-	if (ubit) {
-		if (v.isnan()) {
-			ostr << '[' << d << ']';
-		}
-		else {
-			areal<nbits, es, bt> next(v);
-			++next;
-			double dnext = double(next);
-			ostr << '(' << d << ", " << dnext << ')';
-		}
-	}
-	else { // exact value
-		ostr << '[' << d << ']';
-	}
-	return ostr;
-}
-
-template<unsigned nnbits, unsigned nes, typename nbt>
-inline std::istream& operator>>(std::istream& istr, const areal<nnbits,nes,nbt>& v) {
-	istr >> v._fraction;
-	return istr;
-}
+// operator<< and operator>> moved to iostream.hpp in #1334. They stay friends of the
+// class (declared above) because operator>> reaches _fraction directly; only their
+// DEFINITIONS move, which is what lets this header get by with <iosfwd>.
 
 // areal-specific equality: bit-pattern equality, intentionally diverging
 // from IEEE-754 in two cases:
@@ -2301,34 +2298,8 @@ constexpr areal<nbits, es, bt> operator/(const areal<nbits, es, bt>& lhs, const 
 	return ratio;
 }
 
-// convert to std::string
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string to_string(const areal<nbits,es,bt>& v) {
-	std::stringstream s;
-	if (v.iszero()) {
-		s << " zero b";
-		return s.str();
-	}
-	else if (v.isinf()) {
-		s << " infinite b";
-		return s.str();
-	}
-//	s << "(" << (v.sign() ? "-" : "+") << "," << v.scale() << "," << v.fraction() << ")";
-	return s.str();
-}
-
-// transform areal to a binary representation
-template<unsigned nbits, unsigned es, typename bt>
-inline std::string to_binary(const areal<nbits, es, bt>& number, bool nibbleMarker = false) {
-	std::stringstream ss;
-	ss << 'b';
-	unsigned index = nbits;
-	for (unsigned i = 0; i < nbits; ++i) {
-		ss << (number.at(--index) ? '1' : '0');
-		if (index > 0 && (index % 4) == 0 && nibbleMarker) ss << '\'';
-	}
-	return ss.str();
-}
+// to_string() and to_binary() moved to manipulators.hpp in #1334: both format through a
+// std::stringstream, which is what keeps them out of the core.
 
 /// Magnitude of a scientific notation value (equivalent to turning the sign bit off).
 template<unsigned nbits, unsigned es, typename bt>

--- a/include/sw/universal/number/areal/core.hpp
+++ b/include/sw/universal/number/areal/core.hpp
@@ -1,0 +1,42 @@
+#pragma once
+// core.hpp: the areal arithmetic core -- no I/O, no text
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 1 of the areal headers (#1334, Phase 2 group 5a, #1444). Storage, arithmetic,
+// comparison and numeric_limits -- everything a compute kernel needs and nothing that
+// turns an areal into text.
+//
+//     #include <universal/number/areal/areal.hpp>   // everything, as before
+//     #include <universal/number/areal/core.hpp>    // arithmetic only
+//
+// areal.hpp includes this plus manipulators.hpp, iostream.hpp and debug.hpp, so existing
+// code is unaffected.
+//
+// areal had the largest std::cout population of group 5a -- 51 sites -- and almost all of
+// them were already behind the TRACE_CONVERSION switch. What kept <iostream> in every
+// graph was that the INCLUDE sat outside the guard. Four changes:
+//   - <iostream> moved inside `#if TRACE_CONVERSION`, where the code that needs it lives.
+//   - constexprClassParameters() is declared in the class and defined in debug.hpp, the
+//     shape blocktriple's got in #1388.
+//   - operator<< and operator>> keep their friend DECLARATIONS here (operator>> reaches
+//     _fraction directly); only the definitions move to iostream.hpp, which is what lets
+//     this header get by with <iosfwd>.
+//   - assign()'s "assign TBD" stub prints with std::printf rather than std::cout: same
+//     destination, same text, no stream header.
+//
+// to_string() and to_binary() are free functions that format through a stringstream, so
+// they are manipulators.hpp's. This is the same criterion applied everywhere in the epic
+// -- a builder that opens a stream is text; one that concatenates is core -- and areal's
+// to_string opens one.
+//
+// native/ieee754.hpp was re-pointed to native/ieee754_core.hpp.
+#include <universal/utility/bit_cast.hpp>
+#include <universal/utility/long_double.hpp>
+
+#include <universal/number/areal/exceptions.hpp>
+#include <universal/number/areal/areal_impl.hpp>
+#include <universal/number/areal/numeric_limits.hpp>

--- a/include/sw/universal/number/areal/debug.hpp
+++ b/include/sw/universal/number/areal/debug.hpp
@@ -1,0 +1,44 @@
+#pragma once
+// debug.hpp: introspection for areal
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 3 of the areal headers (#1334). areal_impl.hpp declares
+// constexprClassParameters() but does not define it, so the core needs no <iostream>.
+// Its definition lives here. Include this header to call it; forgetting to is a link
+// error naming the missing function, which is the better failure -- the same shape
+// blocktriple's constexprClassParameters() got in #1388.
+//
+// The TRACE_CONVERSION switch needs no help from this header: it guards its own
+// <iostream> include in areal_impl.hpp, because the traced code is inside the class.
+#include <iostream>
+#include <universal/number/areal/core.hpp>
+#include <universal/native/integers.hpp>   // to_binary(Integer, int, bool) on the masks
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned es, typename bt>
+void areal<nbits, es, bt>::constexprClassParameters() const {
+	std::cout << "nbits             : " << nbits << '\n';
+	std::cout << "es                : " << es << std::endl;
+	std::cout << "ALLONES           : " << to_binary(ALLONES, bitsInBlock, true) << '\n';
+	std::cout << "BLOCK_MASK        : " << to_binary(BLOCK_MASK, bitsInBlock, true) << '\n';
+	std::cout << "nrBlocks          : " << nrBlocks << '\n';
+	std::cout << "bits in MSU       : " << bitsInMSU << '\n';
+	std::cout << "MSU               : " << MSU << '\n';
+	std::cout << "MSU MASK          : " << to_binary(MSU_MASK, bitsInBlock, true) << '\n';
+	std::cout << "SIGN_BIT_MASK     : " << to_binary(SIGN_BIT_MASK, bitsInBlock, true) << '\n';
+	std::cout << "LSB_BIT_MASK      : " << to_binary(LSB_BIT_MASK, bitsInBlock, true) << '\n';
+	std::cout << "MSU CAPTURES E    : " << (MSU_CAPTURES_E ? "yes\n" : "no\n");
+	std::cout << "EXP_SHIFT         : " << EXP_SHIFT << '\n';
+	std::cout << "MSU EXP MASK      : " << to_binary(MSU_EXP_MASK, bitsInBlock, true) << '\n';
+	std::cout << "EXP_BIAS          : " << EXP_BIAS << '\n';
+	std::cout << "MAX_EXP           : " << MAX_EXP << '\n';
+	std::cout << "MIN_EXP_NORMAL    : " << MIN_EXP_NORMAL << '\n';
+	std::cout << "MIN_EXP_SUBNORMAL : " << MIN_EXP_SUBNORMAL << '\n';
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/areal/iostream.hpp
+++ b/include/sw/universal/number/areal/iostream.hpp
@@ -1,0 +1,50 @@
+#pragma once
+// iostream.hpp: stream insertion and extraction for areal
+//
+// Copyright (C) 2017 Stillwater Supercomputing, Inc.
+// SPDX-License-Identifier: MIT
+//
+// This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2b of the areal headers (#1334): the <iostream> half. manipulators.hpp is the
+// <iomanip> half -- everything that turns an areal into a std::string. Self-contained.
+//
+// areal_impl.hpp keeps the friend DECLARATIONS for these two (operator>> reaches
+// _fraction directly, so friendship is real here, unlike dbns); only the definitions
+// live here, which is what lets the core get by with <iosfwd>.
+//
+// This header includes only core.hpp -- no cycle for #pragma once to mask (#1427).
+#include <iostream>      // std::ostream, std::istream
+#include <universal/number/areal/core.hpp>
+
+namespace sw { namespace universal {
+
+template<unsigned nbits, unsigned es, typename bt>
+inline std::ostream& operator<<(std::ostream& ostr, const areal<nbits,es,bt>& v) {
+	// TODO: make it a native conversion
+	double d = double(v);
+	bool ubit = v.at(0);
+	if (ubit) {
+		if (v.isnan()) {
+			ostr << '[' << d << ']';
+		}
+		else {
+			areal<nbits, es, bt> next(v);
+			++next;
+			double dnext = double(next);
+			ostr << '(' << d << ", " << dnext << ')';
+		}
+	}
+	else { // exact value
+		ostr << '[' << d << ']';
+	}
+	return ostr;
+}
+
+template<unsigned nnbits, unsigned nes, typename nbt>
+inline std::istream& operator>>(std::istream& istr, const areal<nnbits,nes,nbt>& v) {
+	istr >> v._fraction;
+	return istr;
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/areal/manipulators.hpp
+++ b/include/sw/universal/number/areal/manipulators.hpp
@@ -5,9 +5,18 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
+//
+// Layer 2a of the areal headers (#1334): the <iomanip> half -- everything that turns an
+// areal into a std::string through a stringstream. iostream.hpp is the <iostream> half.
+// This header does NOT include iostream.hpp: areal's builders format from the bit
+// pattern rather than streaming the value, so the dependency runs one way only.
+// Self-contained.
+#include <string>        // std::string
+#include <sstream>       // std::stringstream
 #include <iomanip>
 #include <typeinfo>  // for typeid()
 
+#include <universal/number/areal/core.hpp>
 // pull in the color printing for shells utility
 #include <universal/utility/color_print.hpp>
 
@@ -148,5 +157,36 @@ std::string color_print(const areal<nbits, es, bt>& r) {
 	return str.str();
 }
 
-}} // namespace sw::universal
 
+// Moved out of areal_impl.hpp (#1334): both format an areal through a stringstream,
+// which is what keeps them out of the core.
+// convert to std::string
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string to_string(const areal<nbits,es,bt>& v) {
+	std::stringstream s;
+	if (v.iszero()) {
+		s << " zero b";
+		return s.str();
+	}
+	else if (v.isinf()) {
+		s << " infinite b";
+		return s.str();
+	}
+//	s << "(" << (v.sign() ? "-" : "+") << "," << v.scale() << "," << v.fraction() << ")";
+	return s.str();
+}
+
+// transform areal to a binary representation
+template<unsigned nbits, unsigned es, typename bt>
+inline std::string to_binary(const areal<nbits, es, bt>& number, bool nibbleMarker = false) {
+	std::stringstream ss;
+	ss << 'b';
+	unsigned index = nbits;
+	for (unsigned i = 0; i < nbits; ++i) {
+		ss << (number.at(--index) ? '1' : '0');
+		if (index > 0 && (index % 4) == 0 && nibbleMarker) ss << '\'';
+	}
+	return ss.str();
+}
+
+}} // namespace sw::universal

--- a/include/sw/universal/number/areal/numeric_limits.hpp
+++ b/include/sw/universal/number/areal/numeric_limits.hpp
@@ -5,7 +5,12 @@
 // SPDX-License-Identifier: MIT
 //
 // This file is part of the universal numbers project, which is released under an MIT Open Source license.
-#include <universal/number/areal/areal.hpp>
+// areal_impl.hpp, NOT the areal.hpp umbrella (#1334). This header is part of the core,
+// and the umbrella includes the core -- so including the umbrella back from here made a
+// cycle that #pragma once merely masked, dragging manipulators.hpp and iostream.hpp into
+// every core-only translation unit and keeping all five I/O-family headers in the graph.
+// numeric_limits needs the complete type and nothing else.
+#include <universal/number/areal/areal_impl.hpp>
 namespace std {
 
 template <unsigned nbits, unsigned es, typename bt> 


### PR DESCRIPTION
Last type of #1444 (Phase 2 group 5a of #1334). areal had the group's largest `std::cout`
population -- 51 sites -- and almost all of them were already correctly guarded.

## Acceptance numbers

| include | lines | headers | I/O-family |
|---|---:|---:|---:|
| `areal.hpp` before | 83,655 | 386 | 5 |
| `areal.hpp` after | 82,620 | 372 | 5 |
| **`core.hpp`** | **73,412** | **345** | **0** |
| target | under 45,000 | -- | 0 |

Zero I/O met. Under-45,000 not met, reporting the number reached:
`internal/blocktriple/blocktriple.hpp` is **69,758 lines on its own** (already 0 I/O), so
this core is blocktriple plus about 3,650. Same ceiling dbns hit (#1449).

## The 51 cout sites were not the problem -- the include was

**49 of them already sat behind areal's `TRACE_CONVERSION` switch**, which was already
externally settable: the defect #1387 found elsewhere is genuinely absent here. What kept
four I/O-family headers in every areal translation unit was that the
`#include <iostream>` sat **outside** the guard. It now sits inside it, with the code that
needs it -- the same move cfloat's trace includes got in #1417/#1418.

The remaining two:

- **`constexprClassParameters()`**, a member function with 19 `cout` statements, is
  declared in the class and defined out-of-line in `debug.hpp` -- the #1388 shape.
- **`assign()`'s "assign TBD" stub** prints with `std::printf` instead of `std::cout`:
  same destination, same text, no stream header.

## Two structural finds, and both cost the core its zero

**1. `numeric_limits.hpp` included the `areal.hpp` UMBRELLA.** Since the umbrella includes
the core, that is a cycle -- `core -> numeric_limits -> umbrella -> manipulators +
iostream` -- that `#pragma once` merely masked. It left `core.hpp` measuring **82,614
lines with all five I/O-family headers, seven lines short of the umbrella itself**. It now
includes `areal_impl.hpp`, which is what it actually needs.

This is the #1427 trap from the other direction: there, `iostream.hpp` included
`manipulators.hpp` back; here a *core* header reached the umbrella. Worth checking for in
the remaining types.

**2. `native/integers.hpp`, which carries `<sstream>`, was unconditional but is used only
by the trace blocks.** It moved inside the guard -- along with `native/ieee754.hpp`,
because the trace calls `to_binary(float)`, which lives in the text half of ieee754 that
the core's `ieee754_core.hpp` deliberately omits. **Without that second include
`TRACE_CONVERSION=1` stopped compiling** -- a regression this PR introduced, caught by the
trace gate, and verified against `main` (which compiles it fine) before fixing.

## Also

- `to_string()` and `to_binary()` are free functions formatting through a stringstream ->
  `manipulators.hpp`.
- `operator<<`/`operator>>` keep their friend **declarations** in the class (`operator>>`
  reaches `_fraction` directly, so friendship is real here, unlike dbns); only the
  definitions move to `iostream.hpp`, which is what lets the core get by with `<iosfwd>`.
- `native/ieee754.hpp` -> `native/ieee754_core.hpp`; `AREAL_ENABLE_LITERALS` and
  `AREAL_THROW_ARITHMETIC_EXCEPTION` default in `areal_impl.hpp` (#1436);
  `manipulators.hpp` now names the headers it uses (#1389).

## Verification

- **Layer gate**: `core.hpp` alone, and `core.hpp` + `manipulators.hpp`, each compiled,
  linked and run under `-Wall -Wpedantic` on gcc 13.3 and clang. The second gate
  **instantiates every manipulator** rather than merely including the header -- the
  strengthening #1449 forced after `range()` reached review with an undetected dependency
  on `iostream.hpp`.
- **Trace gate**: `TRACE_CONVERSION=1` compiles and prints on both compilers. This is what
  caught find 2.
- **Self-containment**: core, manipulators, iostream, debug, numeric_limits, table and the
  umbrella each compile standalone with 0 errors on both compilers.
- **26 targets built and run green on both compilers**, including `edu_tables_areals` and
  the education example, which exercise the text layers.
- **Differential against `main`**: five configurations over their *entire* encoding space
  (`areal<8,2>`, `<12,4>`, `<16,5>`, `<16,8>` exhaustively; `<20,6>` over 65,536), each
  rendered by `to_binary` (both nibble settings), `to_string`, `to_hex` (three settings),
  `hex_print`, `pretty_print`, `color_print`, `info_print`, `operator<<` under four stream
  states, the native conversions and the predicates; plus a dynamic-range round trip, the
  relocated `constexprClassParameters()` report and the `assign()` stub.

  **72,780,424 bytes byte-identical** -- old vs new on gcc, old vs new on clang, and gcc
  vs clang.
- **Trace text**: unlike dbns, `main` can switch areal's tracing on as shipped, so the
  comparison is direct. **67,398 bytes over 129 conversions across two configurations,
  byte-identical on both compilers.**

## Found, not fixed

`components(areal)` does not compile: `blockbinary<v.fbits> f;` uses a non-static member
in a constant expression, and it calls a `decode()` overload that does not exist. It fails
**identically on `main`** -- nothing in the tree instantiates it. Same class as
`type_field(bfloat16)` in #1445; both want one issue about manipulator templates that no
test ever instantiates.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated stream input/output support for areal values, including exact values, uncertainty intervals, and NaN.
  - Added string and binary formatting utilities, with optional nibble separators for binary output.
  - Added debugging output for compile-time configuration and representation details.

- **Refactor**
  - Separated arithmetic, formatting, stream I/O, and debugging functionality into focused headers while preserving existing areal capabilities.
  - Improved header self-containment and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->